### PR TITLE
Update Kazakh terrorism sanctions crawler to new source URL

### DIFF
--- a/opensanctions/crawlers/kz_afmrk_sanctions.py
+++ b/opensanctions/crawlers/kz_afmrk_sanctions.py
@@ -5,6 +5,11 @@ from opensanctions import helpers as h
 
 FORMATS = ["%d.%m.%Y"]
 
+def parse_start_date(text: str) -> str | None:
+    if text and text.startswith("включен от"):
+        start_date = text.replace("включен от ", "").strip()
+        return h.parse_date(start_date, FORMATS)
+
 
 def make_entity(context: Context, el, schema, entity_id):
     entity = context.make(schema)
@@ -14,6 +19,7 @@ def make_entity(context: Context, el, schema, entity_id):
 
     sanction = h.make_sanction(context, entity)
     sanction.add("summary", el.findtext("./correction"))
+    sanction.add("startDate", parse_start_date(el.findtext("./correction")))
     context.emit(sanction)
 
     return entity

--- a/opensanctions/crawlers/kz_afmrk_sanctions.py
+++ b/opensanctions/crawlers/kz_afmrk_sanctions.py
@@ -3,31 +3,51 @@ from pantomime.types import XML
 from opensanctions.core import Context
 from opensanctions import helpers as h
 
-FORMATS = ["%d.%m.%Y"]
+from urllib.parse import urljoin
 
-def parse_start_date(text: str) -> str | None:
+FORMATS = ["%d.%m.%Y"]
+CATEGORY1_PROGRAM = "Kazakh Terror Financing list"
+CATEGORY2_PROGRAM = "Participants in terrorist activities"
+CATEGORY1_URL = "xml_category_1/?status=acting"
+CATEGORY2_URL = "xml_category_2/?status=acting"
+CATEGORY1_EXPORT = "terrorism-financiers-source.xml"
+CATEGORY2_EXPORT = "terrorists-source.xml"
+
+
+def added_date_from_note(text: str) -> str | None:
+    # "Added from"
     if text and text.startswith("включен от"):
         start_date = text.replace("включен от ", "").strip()
         return h.parse_date(start_date, FORMATS)
 
 
-def make_entity(context: Context, el, schema, entity_id):
+def make_entity(context: Context, el, schema, entity_id, topics, program):
     entity = context.make(schema)
     entity.id = entity_id
     entity.add("notes", h.clean_note(el.findtext("./note")))
-    entity.add("topics", "sanction")
+    entity.add("topics", topics)
 
     sanction = h.make_sanction(context, entity)
     sanction.add("summary", el.findtext("./correction"))
-    sanction.add("startDate", parse_start_date(el.findtext("./correction")))
-    context.emit(sanction)
+    sanction.add("program", program)
+    listingDate = h.parse_date(el.findtext("./added_to_list"), FORMATS)
+    note_date = added_date_from_note(el.findtext("./correction"))
+    sanction.add("listingDate", listingDate or note_date)
 
+    context.emit(sanction)
     return entity
 
 
 def crawl(context: Context):
-    path = context.fetch_resource("source.xml", context.source.data.url)
-    context.export_resource(path, XML, title=context.SOURCE_TITLE)
+    crawl_financiers(context)
+    crawl_terrorists(context)
+
+
+def crawl_financiers(context: Context):
+    path = context.fetch_resource(
+        CATEGORY1_EXPORT, urljoin(context.source.data.url, CATEGORY1_URL)
+    )
+    context.export_resource(path, XML, title=CATEGORY1_PROGRAM)
 
     doc = context.parse_resource_xml(path)
     for el in doc.findall(".//person"):
@@ -38,7 +58,9 @@ def crawl(context: Context):
         iin = el.findtext("./iin")
         name = h.make_name(given_name=fname, middle_name=mname, last_name=lname)
         entity_id = context.make_id(name, bdate, iin)
-        entity = make_entity(context, el, "Person", entity_id)
+        entity = make_entity(
+            context, el, "Person", entity_id, "sanction", CATEGORY1_PROGRAM
+        )
         h.apply_name(entity, given_name=fname, middle_name=mname, last_name=lname)
         entity.add("innCode", iin)
         entity.add("birthDate", h.parse_date(bdate, FORMATS, bdate))
@@ -47,12 +69,43 @@ def crawl(context: Context):
     for el in doc.findall(".//org"):
         name = el.findtext(".//org_name")
         entity_id = context.make_id(el.findtext("./note"), name)
-        entity = make_entity(context, el, "Organization", entity_id)
+        entity = make_entity(
+            context, el, "Organization", entity_id, "sanction", CATEGORY1_PROGRAM
+        )
         for tag in (".//org_name", ".//org_name_en"):
             names = el.findtext(tag)
             if names is None:
                 continue
             names = names.split("; ")
             entity.add("name", names)
-
         context.emit(entity, target=True)
+
+
+def crawl_terrorists(context: Context):
+    # Note: This list specifies that it refers to individuals but uses organisation xml tags
+    path = context.fetch_resource(
+        CATEGORY2_EXPORT, urljoin(context.source.data.url, CATEGORY2_URL)
+    )
+    context.export_resource(path, XML, title=CATEGORY2_PROGRAM)
+
+    doc = context.parse_resource_xml(path)
+    for el in doc.findall(".//org"):
+        name = el.findtext(".//org_name")
+        iin = el.findtext("./org_iin")
+        identification = [name]
+        if iin:
+            identification.append(iin)
+        else:
+            identification.append(el.findtext("./note"))
+        entity_id = context.make_id(*identification)
+        entity = make_entity(
+            context,
+            el,
+            "Person",
+            entity_id,
+            ["sanction", "crime.terror"],
+            CATEGORY2_PROGRAM,
+        )
+        entity.add("name", name)
+        entity.add("innCode", iin)
+        context.emit(entity)

--- a/opensanctions/crawlers/kz_afmrk_sanctions.py
+++ b/opensanctions/crawlers/kz_afmrk_sanctions.py
@@ -40,7 +40,7 @@ def crawl(context: Context):
 
     for el in doc.findall(".//org"):
         name = el.findtext(".//org_name")
-        entity_id = context.make_id(el.findtext("./num"), name)
+        entity_id = context.make_id(el.findtext("./note"), name)
         entity = make_entity(context, el, "Organization", entity_id)
         for tag in (".//org_name", ".//org_name_en"):
             names = el.findtext(tag)

--- a/opensanctions/metadata/kz_afmrk_sanctions.yml
+++ b/opensanctions/metadata/kz_afmrk_sanctions.yml
@@ -1,14 +1,16 @@
 entry_point: opensanctions.crawlers.kz_afmrk_sanctions
-title: Kazakh Terror Financing list
+title: Kazakh Terrorist and Terror Financing list
 prefix: kzafm
 summary: >
-  A simple list of sanctioned individuals and entities published by the
+  A combination of two lists of sanctioned individuals and entities published by the
   Financial Monitoring Agency of Kazakhstan.
 description: |
-  In accordance with Article 12 of the Law of the Republic of Kazakhstan "On
+  The terror financing entities are included in accordance with Article 12 of the Law of the Republic of Kazakhstan "On
   Counteracting Legalization (Laundering) of Criminally Obtained Incomes and
   Financing of Terrorism", the list of organizations and persons associated
   with the financing of terrorism and extremism is published.
+
+  Some, if not all persons listed for participation in terrorism are by request of other countries.
 collections:
   - sanctions
   - default
@@ -25,7 +27,7 @@ publisher:
   url: https://www.gov.kz/memleket/entities/afm
   country: kz
   official: true
-url: https://websfm.kz/terrorism/1/acting
+url: https://websfm.kz/terrorism/acting
 data:
-  url: https://api.websfm.kz/v1/sanctions/sanction-terrorist-old/xml_category_1/?status=acting
+  url: https://api.websfm-pilot.kz/v1/sanctions/sanction-terrorist-old/
   format: xml

--- a/opensanctions/metadata/kz_afmrk_sanctions.yml
+++ b/opensanctions/metadata/kz_afmrk_sanctions.yml
@@ -1,5 +1,5 @@
 entry_point: opensanctions.crawlers.kz_afmrk_sanctions
-title: Kazakh Terrorist and Terror Financing list
+title: Kazakh Terrorist and Terror Financing lists
 prefix: kzafm
 summary: >
   A combination of two lists of sanctioned individuals and entities published by the

--- a/opensanctions/metadata/kz_afmrk_sanctions.yml
+++ b/opensanctions/metadata/kz_afmrk_sanctions.yml
@@ -27,7 +27,7 @@ publisher:
   url: https://www.gov.kz/memleket/entities/afm
   country: kz
   official: true
-url: https://websfm.kz/terrorism/acting
+url: https://websfm.kz/terrorism
 data:
-  url: https://api.websfm-pilot.kz/v1/sanctions/sanction-terrorist-old/
+  url: https://api.websfm-pilot.afmrk.gov.kz/v1/sanctions/sanction-terrorist-old/
   format: xml

--- a/opensanctions/metadata/kz_afmrk_sanctions.yml
+++ b/opensanctions/metadata/kz_afmrk_sanctions.yml
@@ -25,7 +25,7 @@ publisher:
   url: https://www.gov.kz/memleket/entities/afm
   country: kz
   official: true
-url: https://afmrk.gov.kz/ru/the-list-of-organizations-and-individuals-associa/
+url: https://websfm.kz/terrorism/1/acting
 data:
-  url: https://afmrk.gov.kz/blacklist/export/active/xml
+  url: https://api.websfm.kz/v1/sanctions/sanction-terrorist-old/xml_category_1/?status=acting
   format: xml


### PR DESCRIPTION
Also use note instead of num for org id because num appears not to be stable in the new XML (was it n the old?)

TODO:

- [x] parse sanction start date from `включен от 15.12.2016`