### PR TITLE
Add 'name' do publisher in data source metadata

### DIFF
--- a/zavod/docs/tutorial.md
+++ b/zavod/docs/tutorial.md
@@ -58,6 +58,7 @@ prefix: eu-fsf
 # This section provides information about the original publisher of the data,
 # often a government authority:
 publisher:
+    name: European Commission
     organization: European Commission
     authority: European Union External Action Service
     acronym: EEAS


### PR DESCRIPTION
If someone follow the current zavod tutorial, because there is no 'name' on the publisher, nomenklatura will fail to load the data source metadata.

```
  File "/home/aivuk/zavod/lib/python3.10/site-packages/nomenklatura/dataset/dataset.py", line 44, in __init__
    self.publisher = DataPublisher(pdata) if pdata is not None else None
  File "/home/aivuk/zavod/lib/python3.10/site-packages/nomenklatura/dataset/publisher.py", line 13, in __init__
    name = type_require(registry.string, data.get("name"))
  File "/home/aivuk/zavod/lib/python3.10/site-packages/nomenklatura/dataset/util.py", line 29, in type_require
    raise MetadataException("Invalid %s: %r" % (type_.name, value))
nomenklatura.exceptions.MetadataException: Invalid string: None
```
