### PR TITLE
Emit occupancy and position information about rupep PEPs

### DIFF
--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -87,7 +87,7 @@ def make_position(
 
 def make_occupancy(
     context: Context,
-    person: Entity,
+    person: Entity | str,
     position: Entity,
     no_end_implies_current: bool,
     current_time: datetime = settings.RUN_TIME,
@@ -100,9 +100,15 @@ def make_occupancy(
     Occupancies are only created if end_date is None or less than AFTER_OFFICE years
     after current_time. current_time defaults to the process start date and time.
     """
-    if end_date is None or end_date > h.backdate(current_time, AFTER_OFFICE):
+    after_office = h.backdate(current_time, AFTER_OFFICE)
+    if (
+        end_date is None
+        or (type(end_date) == list and any(d > after_office for d in end_date))
+        or (type(end_date) == str and  end_date > after_office)
+    ):
         occupancy = context.make("Occupancy")
-        parts = [person.id, position.id, start_date, end_date]
+        person_id = person if type(person) == str else person.id
+        parts = [person_id, position.id, start_date, end_date]
         occupancy.id = context.make_id(*parts)
         occupancy.add("holder", person)
         occupancy.add("post", position)


### PR DESCRIPTION
Very early stage - currently part of ru_rupep_companies which isn't actually part of the pep collection.

Assumes it's a PEP relationship if person is_pep and company is_state_company. So it includes positions that should probably be excluded, and potentially misses positions that should be included.

Only creates positions if english language relationship_type and company_name is available to concatenate with "of the".

- [ ] Are we happy with this general approach to position names?
- [ ] figure out how to create position names from russian when english isn't available
- [ ] figure out how to export these in the peps collection which currently doesn't include ru_rupep_companies
- [ ] figure out which positions we wanna include - should we start with relationship_type == last_position?