### PR TITLE
Distinguish between what we include and what they include

### DIFF
--- a/datasets/us/plural_legislators/us_plural_legislators.yml
+++ b/datasets/us/plural_legislators/us_plural_legislators.yml
@@ -7,11 +7,13 @@ deploy:
   schedule: "30 */6 * * *"
   memory: "1000Mi"
 summary: >
-  Open data on federal, state and local legislators in the United States of
-  America.
+  Open data on state legislators in the United States of America.
 description: |
+  This dataset includes members of US state legislatures and executives from the
+  OpenStates project.
+
   The OpenStates project is building and maintaining a fleet of scrapers to
-  collect data on legislators in the United States of America. This dataset
+  collect data on legislators in the United States of America. Their dataset
   includes data on legislators at the federal, state and local levels.
 
   The dataset is available under a CC-0 license, making it entirely free to


### PR DESCRIPTION
I got it exactly wrong - we only include state data at this time. But OpenStates contains federal, state, and local data.