### PR TITLE
Liechtenstein Posted Workers Act: Emit full name of sanctioned persons

### DIFF
--- a/datasets/li/posting_sanctions/crawler.py
+++ b/datasets/li/posting_sanctions/crawler.py
@@ -87,8 +87,7 @@ def parse_target(context: Context, name: str, address: Entity, date: str) -> Ent
         # "Wilhelm Alexander, Herr Alexander Wilhelm"
         given_name, family_name = " ".join(w[:-1]), w[-1]
     person.id = context.make_id("Person", given_name, family_name, gender)
-    person.add("firstName", given_name)
-    person.add("lastName", family_name)
+    h.apply_name(person, given_name=given_name, last_name=family_name)
     person.add("gender", gender)
     company_name = company_name.removeprefix(f"{family_name} {given_name}")
     company_name = company_name.removeprefix(",").strip()


### PR DESCRIPTION
After this change, [this list](https://www.opensanctions.org/search/?scope=li_entsg&schema=Person) should display full person names. Arguably this is a presentation issue, but other crawlers emit full names in addition to first and last names, so it seems best to be consistent across data sources.
