### PR TITLE
Distrust future occupancy end dates if they are beyond the dataset coverage end

### DIFF
--- a/datasets/cu/inventario_legislatura/cu_inventario_legislatura.yml
+++ b/datasets/cu/inventario_legislatura/cu_inventario_legislatura.yml
@@ -3,6 +3,7 @@ entry_point: crawler.py
 prefix: cuinv
 coverage:
   frequency: monthly
+  end: 2024-04-09
 deploy:
   schedule: "0 0 * * 0"
 load_db_uri: ${OPENSANCTIONS_DATABASE_URI}

--- a/zavod/docs/tutorial.md
+++ b/zavod/docs/tutorial.md
@@ -21,6 +21,8 @@ companies into a database.
 
 ## Data source metadata
 
+This is a brief instruction. See the full [metadata documentation](metadata.md).
+
 Before programming a crawler script, you need to create a YAML file with some basic metadata to describe the new dataset. That information includes the dataset name (which is normally derived from the YAML file name), information about the source publisher and the source data URL.
 
 The metadata file must also include a reference to the entry point, the Python code that should be executed in order to crawl the source.

--- a/zavod/docs/tutorial.md
+++ b/zavod/docs/tutorial.md
@@ -21,8 +21,6 @@ companies into a database.
 
 ## Data source metadata
 
-This is a brief instruction. See the full [metadata documentation](metadata.md).
-
 Before programming a crawler script, you need to create a YAML file with some basic metadata to describe the new dataset. That information includes the dataset name (which is normally derived from the YAML file name), information about the source publisher and the source data URL.
 
 The metadata file must also include a reference to the entry point, the Python code that should be executed in order to crawl the source.
@@ -59,9 +57,7 @@ prefix: eu-fsf
 # This section provides information about the original publisher of the data,
 # often a government authority:
 publisher:
-    name: European Commission
-    organization: European Commission
-    authority: European Union External Action Service
+    name: European Union External Action Service
     acronym: EEAS
     country: eu
     url: https://eeas.europa.eu/topics/sanctions-policy/8442/consolidated-list-of-sanctions_en

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -56,10 +56,11 @@ class Context:
         self._timestamps: Optional[TimeStampIndex] = None
 
         self._data_time: datetime = settings.RUN_TIME
-        # If the dataset has a fixed end time, use that as the data time:
+        # If the dataset has a fixed end time which is in the past, use that as the data time:
         if dataset.coverage is not None and dataset.coverage.end is not None:
             prefix = DatePrefix(dataset.coverage.end)
-            self._data_time = prefix.dt or self._data_time
+            if prefix < DatePrefix(self.data_time):
+                self._data_time = prefix.dt or self._data_time
 
         self.lang: Optional[str] = None
         """Default language for statements emitted from this dataset"""

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -56,7 +56,8 @@ class Context:
         self._timestamps: Optional[TimeStampIndex] = None
 
         self._data_time: datetime = settings.RUN_TIME
-        # If the dataset has a fixed end time which is in the past, use that as the data time:
+        # If the dataset has a fixed end time which is in the past,
+        # use that as the data time:
         if dataset.coverage is not None and dataset.coverage.end is not None:
             if dataset.coverage.end < settings.RUN_TIME_ISO:
                 prefix = DatePrefix(dataset.coverage.end)

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -100,8 +100,8 @@ def make_occupancy(
     Occupancies are only returned if end_date is None or less than AFTER_OFFICE years
     after current_time. current_time defaults to the process start date and time.
 
-    Occupancy.status is set to 
-    
+    Occupancy.status is set to
+
     - `current` if `end_date` is `None` and `no_end_implies_current` is `True`, otherwise
       `status` will be `unknown`
     - `current` if `end_date` is some date in the future, unless the dataset
@@ -110,7 +110,7 @@ def make_occupancy(
 
     Args:
         context: The context to create the entity in.
-        person: The person holding the position. They will be added to the 
+        person: The person holding the position. They will be added to the
             `holder` property.
         position: The position held by the person. This will be added to the
             `post` property.
@@ -132,6 +132,13 @@ def make_occupancy(
         elif end_date > context.dataset.coverage.end:
             # Don't trust future end dates beyond the known coverage date of the datast.
             status = OccupancyStatus.UNKNOWN.value
+            context.log.warning(
+                "Future Occupancy end date is beyond the dataset coverage date. "
+                "Check if the source data is being updated.",
+                person=person.id,
+                position=position.id,
+                end_date=end_date,
+            )
         else:
             status = OccupancyStatus.CURRENT.value
     else:

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -100,6 +100,14 @@ def make_occupancy(
     Occupancies are only returned if end_date is None or less than AFTER_OFFICE years
     after current_time. current_time defaults to the process start date and time.
 
+    Occupancy.status is set to 
+    
+    - `current` if `end_date` is `None` and `no_end_implies_current` is `True`, otherwise
+      `status` will be `unknown`
+    - `current` if `end_date` is some date in the future, unless the dataset
+      `coverage.end` is a date in the past, in which case `status` will be `unknown`
+    - `ended` if `end_date` is some date in the past.
+
     Args:
         context: The context to create the entity in.
         person: The person holding the position. They will be added to the 
@@ -121,6 +129,9 @@ def make_occupancy(
     if end_date:
         if end_date < current_time.isoformat():
             status = OccupancyStatus.ENDED.value
+        elif end_date > context.dataset.coverage.end:
+            # Don't trust future end dates beyond the known coverage date of the datast.
+            status = OccupancyStatus.UNKNOWN.value
         else:
             status = OccupancyStatus.CURRENT.value
     else:

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -129,8 +129,12 @@ def make_occupancy(
     if end_date:
         if end_date < current_time.isoformat():
             status = OccupancyStatus.ENDED.value
-        elif end_date > context.dataset.coverage.end:
-            # Don't trust future end dates beyond the known coverage date of the datast.
+        elif (
+            context.dataset.coverage
+            and context.dataset.coverage.end
+            and current_time.isoformat() > context.dataset.coverage.end
+        ):
+            # Don't trust future end dates beyond the known coverage date of the dataset.
             status = OccupancyStatus.UNKNOWN.value
             context.log.warning(
                 "Future Occupancy end date is beyond the dataset coverage date. "

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -102,8 +102,8 @@ def make_occupancy(
 
     Occupancy.status is set to
 
-    - `current` if `end_date` is `None` and `no_end_implies_current` is `True`, otherwise
-      `status` will be `unknown`
+    - `current` if `end_date` is `None` and `no_end_implies_current` is `True`,
+      otherwise `status` will be `unknown`
     - `current` if `end_date` is some date in the future, unless the dataset
       `coverage.end` is a date in the past, in which case `status` will be `unknown`
     - `ended` if `end_date` is some date in the past.
@@ -134,7 +134,7 @@ def make_occupancy(
             and context.dataset.coverage.end
             and current_time.isoformat() > context.dataset.coverage.end
         ):
-            # Don't trust future end dates beyond the known coverage date of the dataset.
+            # Don't trust future end dates beyond the known coverage date of the dataset
             status = OccupancyStatus.UNKNOWN.value
             context.log.warning(
                 "Future Occupancy end date is beyond the dataset coverage date. "


### PR DESCRIPTION
I'm not totally sure about this yet - this results in `last_change` becoming fixed to a past date once `coverage.end` is reached, even though it might have changed. But perhaps if `make_occupancy` emitted a warning it's an ok compromise for now?

I think I'd feel better about a dedicated field in the metadata like `coverage.verification_due` or something, or hardcoding the date in the crawler until we see more instances where this is relevant.