### PR TITLE
[li-entsg] Revert feed parser back to HTML instead of XML

### DIFF
--- a/datasets/li/posting_sanctions/crawler.py
+++ b/datasets/li/posting_sanctions/crawler.py
@@ -1,3 +1,4 @@
+import lxml
 import re
 from datetime import datetime
 from typing import Optional
@@ -170,7 +171,8 @@ def parse_infractions(context: Context, doc) -> None:
 def crawl(context: Context):
     source_path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(source_path, "text/html", title="Source HTML file")
-    doc = context.parse_resource_xml(source_path)
+    with open(source_path, "r") as fh:
+        doc = lxml.html.fromstring(fh.read())  # invalid XML, need HTML parser
     if data_time := parse_data_time(doc):
         context.log.info(f"Parsing data version of {data_time}")
         context.data_time = data_time


### PR DESCRIPTION
Commit 542bc3d1d91f1231b74949e93023f8faec9fb834 had changed the parser for the upstream source from HTML to XML. However, the upstream data comes in a variant of HTML that cannot be parsed as valid XML.

Currently (before this present change), the following error gets reported on https://www.opensanctions.org/issues/li_entsg/:

```
Traceback (most recent call last):
File "/opensanctions/zavod/zavod/crawl.py", line 33, in crawl_dataset entry_point(context) File "/opensanctions/datasets/li/posting_sanctions/crawler.py", line 173, in crawl doc = context.parse_resource_xml(source_path) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opensanctions/zavod/zavod/context.py", line 329, in parse_resource_xml return etree.parse(fh) ^^^^^^^^^^^^^^^ File "src/lxml/etree.pyx", line 3541, in lxml.etree.parse File "src/lxml/parser.pxi", line 1900, in lxml.etree._parseDocument File "src/lxml/parser.pxi", line 1920, in lxml.etree._parseFilelikeDocument File "src/lxml/parser.pxi", line 1814, in lxml.etree._parseDocFromFilelike File "src/lxml/parser.pxi", line 1204, in lxml.etree._BaseParser._parseDocFromFilelike File "src/lxml/parser.pxi", line 618, in lxml.etree._ParserContext._handleParseResultDoc File "src/lxml/parser.pxi", line 728, in lxml.etree._handleParseResult File "src/lxml/parser.pxi", line 657, in lxml.etree._raiseParseError File "/data/datasets/li_entsg/source.html", line 37 lxml.etree.XMLSyntaxError: Opening and ending tag mismatch: link line 21 and head, line 37, column 8
```