### PR TITLE
Add crawler for Cayman Islands Legislative Assembly

### DIFF
--- a/datasets/ky/legislativeassembly/crawler.py
+++ b/datasets/ky/legislativeassembly/crawler.py
@@ -61,7 +61,8 @@ def crawl(context: Context):
                 # position if it exists.
                 if i == len(words) - 1:
                     new_pos += [w]
-                p += [" ".join(new_pos).removesuffix(" and").strip()]
+                full_new_pos = " ".join(new_pos).removesuffix(" and").strip()
+                p += [full_new_pos]
                 new_pos = [w]
             else:
                 # Add word to position description
@@ -106,7 +107,7 @@ def crawl(context: Context):
         for position in person["positions"]:
             pos = h.make_position(
                 context,
-                name=position,
+                name=position if "Member" not in position else "Member of Parliament",
                 country="Cayman Islands",
             )
             occupancy = h.make_occupancy(

--- a/datasets/ky/legislativeassembly/crawler.py
+++ b/datasets/ky/legislativeassembly/crawler.py
@@ -23,12 +23,24 @@ def crawl(context: Context):
 
     # After the following part we are next to the legislative positions
     initial_pad = page_text.find("You are here")
+    if initial_pad < 0:
+        context.log.warning(
+            "Couldn't find the initial block of content in the page. Maybe the page HTML changed."
+        )
     page_text = page_text[initial_pad:]
 
     # Find the indexes in the text were each position is written
     positions_idx = []
     for pos in positions:
-        positions_idx += [(pos, page_text.find(pos))]
+        position_in_page = page_text.find(pos)
+        if position_in_page < 0:
+            context.log.warning(
+                "Couldn't find the block of content for '{}' in the page. Maybe the page HTML changed.".format(
+                    pos
+                )
+            )
+        else:
+            positions_idx += [(pos, position_in_page)]
 
     def get_positions(s):
         """
@@ -120,6 +132,7 @@ def crawl(context: Context):
             )
             person_positions += [(pos, occupancy)]
 
+        person_proxy.add("sourceUrl", context.dataset.data.url)
         context.emit(person_proxy, target=True)
         for pos in person_positions:
             context.emit(pos[0])

--- a/datasets/ky/legislativeassembly/crawler.py
+++ b/datasets/ky/legislativeassembly/crawler.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from zavod import Context
+from zavod import helpers as h
+
+
+def crawl(context: Context):
+    api_response = context.fetch_html(context.dataset.data.url, cache_days=30)
+
+    # The list of positions sections that we are interested
+    positions = [
+        "Speaker of Parliament",
+        "Premier",
+        "Deputy Premier",
+        "Cabinet Ministers",
+        "Ex Officio",
+    ]
+
+    # The HTML is malformed and it's easier to parse the text content
+    # instead of the HTML
+    page_text = api_response.text_content()
+
+    # After the following part we are next to the legislative positions
+    initial_pad = page_text.find("You are here")
+    page_text = page_text[initial_pad:]
+
+    # Find the indexes in the text were each position is written
+    positions_idx = []
+    for pos in positions:
+        positions_idx += [(pos, page_text.find(pos))]
+
+    def get_positions(s):
+        """
+        Find information about positions from a string
+        """
+        positions_init = ["Minister", "Member", "Premier", "Deputy"]
+        p = []
+        new_pos = []
+
+        # Split text in words
+        words = s.split(" ")
+
+        advance = False
+        for i, w in enumerate(words):
+            # We need to advance when the position is Deputy, because
+            # the next word is Premier and the position is 'Deputy Premier'
+            # and not 'Deputy' and 'Premier'
+            if advance:
+                advance = False
+                new_pos += [w]
+                continue
+            if w == "Deputy":
+                advance = True
+
+            # We get all the subsequent words until we find a new word
+            # representing a position
+            if i > 0 and w in positions_init or i == len(words) - 1:
+                # We found another position, save what we have until now
+                # and start getting a new position. Remove ' and' from the
+                # position if it exists.
+                if i == len(words) - 1:
+                    new_pos += [w]
+                p += [" ".join(new_pos).removesuffix(" and").strip()]
+                new_pos = [w]
+            else:
+                # Add word to position description
+                new_pos += [w]
+        return p
+
+    persons = []
+    for i in range(len(positions_idx) - 1):
+        if positions_idx[i][0] != "Cabinet Ministers":
+            parts = (
+                page_text[positions_idx[i][1] : positions_idx[i + 1][1]]
+                .split("Hon.")[1]
+                .split(",")
+            )
+            new_person = {}
+            new_person["name"] = parts[0].strip()
+            positions = parts[1:]
+            new_person["positions"] = [
+                get_positions(p.replace("MP", "").strip())
+                for p in positions
+                if "MP" in p
+            ][0]
+            persons += [new_person]
+        else:
+            c = page_text[positions_idx[i][1] : positions_idx[i + 1][1]]
+            for cm in c.split("Hon.")[1:]:
+                cm_parts = cm.split("MP,")
+                new_person = {}
+                new_person["name"] = cm_parts[0].split(",")[0].strip()
+                new_person["positions"] = [
+                    p.strip() for p in "".join(cm_parts[1:]).strip().split(" and ")
+                ]
+
+                persons += [new_person]
+
+    for person in persons:
+        person_proxy = context.make("Person")
+        h.apply_name(person_proxy, full=person["name"])
+        # TODO: Make a better ID
+        person_proxy.id = "legislativeassembly-{}".format(
+            person["name"].replace(" ", "_")
+        )
+
+        person_positions = []
+        for position in person["positions"]:
+            pos = h.make_position(
+                context,
+                name=position,
+                country="Cayman Islands",
+            )
+            occupancy = h.make_occupancy(
+                context,
+                person_proxy,
+                pos,
+                True,
+                start_date="2021",
+                end_date="2025",
+            )
+            person_positions += [(pos, occupancy)]
+
+        context.emit(person_proxy, target=True)
+        for pos in person_positions:
+            context.emit(pos[0])
+            context.emit(pos[1])

--- a/datasets/ky/legislativeassembly/crawler.py
+++ b/datasets/ky/legislativeassembly/crawler.py
@@ -6,7 +6,7 @@ from zavod import helpers as h
 
 
 def crawl(context: Context):
-    api_response = context.fetch_html(context.dataset.data.url, cache_days=30)
+    request_response = context.fetch_html(context.dataset.data.url, cache_days=30)
 
     # The list of positions sections that we are interested
     positions = [
@@ -19,7 +19,7 @@ def crawl(context: Context):
 
     # The HTML is malformed and it's easier to parse the text content
     # instead of the HTML
-    page_text = api_response.text_content()
+    page_text = request_response.text_content()
 
     # After the following part we are next to the legislative positions
     initial_pad = page_text.find("You are here")
@@ -100,10 +100,7 @@ def crawl(context: Context):
     for person in persons:
         person_proxy = context.make("Person")
         h.apply_name(person_proxy, full=person["name"])
-        # TODO: Make a better ID
-        person_proxy.id = "legislativeassembly-{}".format(
-            person["name"].replace(" ", "_")
-        )
+        person_proxy.id = context.make_id(person["name"])
 
         person_positions = []
         for position in person["positions"]:

--- a/datasets/ky/legislativeassembly/ky_legislativeassembly.yml
+++ b/datasets/ky/legislativeassembly/ky_legislativeassembly.yml
@@ -1,0 +1,25 @@
+name: ky_legislativeassembly
+title: "legislativeassembly"
+url: http://www.legislativeassembly.ky/
+entry_point: crawler
+prefix: ky-la
+coverage:
+  frequency: monthly
+description: |
+  Elected members of the House of Parliament of the Cayman Islands from 2021-2025.
+publisher:
+    name: The Cayman Islands Legislative Assembly 
+    description: |
+      The House of Parliament of the Cayman Islands is a unicameral Legislature
+      comprising 21 Members, 19 of whom are the Elected Representatives for the
+      Islands' 19 constituencies: one each from West Bay Central, West Bay North,
+      West Bay South, West Bay West, George Town Central, George Town East, George
+      Town North, George Town South, George Town West, Prospect, Red Bay, Bodden
+      Town East, Bodden Town West, Newlands, Savannah, North Side, East End, Cayman
+      Brac East, Cayman Brac West & Little Cayman.
+    acronym: ky-legislative
+    country: ky
+    url: http://www.legislativeassembly.ky/portal/page/portal/lglhome/aboutus
+data:
+    url: "http://legislativeassembly.ky/portal/page/portal/lglhome/members/elected-2021-2025"
+    format: HTML

--- a/datasets/ky/legislativeassembly/ky_legislativeassembly.yml
+++ b/datasets/ky/legislativeassembly/ky_legislativeassembly.yml
@@ -1,5 +1,5 @@
 name: ky_legislativeassembly
-title: "legislativeassembly"
+title: "Cayman Islands Legislative Assembly"
 url: http://www.legislativeassembly.ky/
 entry_point: crawler
 prefix: ky-la


### PR DESCRIPTION
Related issue: #364

The following crawler gets the elected members from the Cayman Island Legislative Assembly. The first attempt was to parse the html using xmltree, but the html is malformed as you can see in the snippet below on the `<h3><li>` mixup instead of `<li><h3>`:


```
                        <li>
                            <h3>Hon. Andre M. Ebanks, MP,</h3> Minister for Financial Services &amp; Commerce and Minister for Investment, Innovation &amp; Social Development and Member of Parliament for West Bay South
                        </li>
                        <h3>
                            <li>Hon. Sabrina Turner, MP,
                        </li></h3> Minister for Health &amp; Wellness and Member of Parliament for Prospect
                        
                        <li>
                            <h3>Hon. Johany S. "Jay" Ebanks, MP,</h3> Minister for Planning, Agriculture, Housing, &amp; Infrastructure and Member of Parliament for North Side
                        </li>
```
 
The code convert the html page to text using the method .text_content(), parse its content and deals with details as:

 * there is almost a pattern in the positions of a member. Sometimes the different positions are separated by 'and', sometimes by space as "Premier and Minister for Sustainability and Climate Resiliency and Finance & Economic Development Member of Parliament for Newlands''.
 * most of the Minister information with multiple areas have a & as separator "Minister for Tourism & Ports", but there are exceptions as "Minister for Sustainability and Climate Resiliency"
 *  removes some additional information from the member's names as 'MP', 'Hon. ', etc