### PR TITLE
Add judicial administration from Cayman Islands

### DIFF
--- a/datasets/_collections/enrichers.yml
+++ b/datasets/_collections/enrichers.yml
@@ -11,20 +11,21 @@ summary: >
   entity of interest can be found.
 children:
   - cy_companies
+  - ext_cy_companies
   - cz_business_register
-  - ee_ariregister
+  - ext_cz_business_register
+  - ext_ee_ariregister
   - gb_coh_psc
+  - ext_gb_coh_psc
   - gleif
   - ext_gleif
   - icij_offshoreleaks
   - ext_icij_offshoreleaks
   - ext_lv_business_register
-  - md_companies
   - ext_md_companies
   # - nominatim
   - opencorporates
   - ru_egrul
   - ext_ru_egrul
-  - ua_edr
   - ext_ua_edr
   - wikidata

--- a/datasets/ky/judicial/crawler.py
+++ b/datasets/ky/judicial/crawler.py
@@ -66,9 +66,7 @@ def crawl(context: Context):
         judge_proxy = context.make("Person")
         h.apply_name(judge_proxy, full=new_judge["name"])
         # TODO: Make a better ID
-        judge_proxy.id = context.make_id(
-            new_judge["name"]
-        )
+        judge_proxy.id = context.make_id(new_judge["name"])
 
         judge_positions = []
         for position in new_judge["positions"]:

--- a/datasets/ky/judicial/crawler.py
+++ b/datasets/ky/judicial/crawler.py
@@ -66,8 +66,8 @@ def crawl(context: Context):
         judge_proxy = context.make("Person")
         h.apply_name(judge_proxy, full=new_judge["name"])
         # TODO: Make a better ID
-        judge_proxy.id = "judicial-admin-cayman-islands-{}".format(
-            new_judge["name"].replace(" ", "_")
+        judge_proxy.id = context.make_id(
+            new_judge["name"]
         )
 
         judge_positions = []

--- a/datasets/ky/judicial/crawler.py
+++ b/datasets/ky/judicial/crawler.py
@@ -12,45 +12,57 @@ def crawl(context: Context):
     request_response = context.fetch_html(context.dataset.data.url, cache_days=30)
 
     # Get current judges
-    current_judges_block = request_response.xpath("//div[contains(@class, 'accordian')]")[0]
-    current_judges = current_judges_block.xpath(".//div[contains(@class, 'fusion-panel')]")
+    current_judges_block = request_response.xpath(
+        "//div[contains(@class, 'accordian')]"
+    )[0]
+    current_judges = current_judges_block.xpath(
+        ".//div[contains(@class, 'fusion-panel')]"
+    )
 
     # First get the list of different types of courts
     courts = []
     for sm in request_response.xpath('.//ul[contains(@class,"sub-menu")]')[:2]:
-        for court in [s.text_content() for s in sm.xpath('./li/a/span')]:
+        for court in [s.text_content() for s in sm.xpath("./li/a/span")]:
             courts.append(court)
-            
+
     def filter_courts(t):
-        '''
+        """
         Giving a text block, filter the list of courts mentioned in the text
         or remove the excluded courts
-        '''
-        if 'all Divisions' in t:
-            if 'except the' not in t:
+        """
+        if "all Divisions" in t:
+            if "except the" not in t:
                 return courts
             else:
-                not_in = t.split('except the', maxsplit=1)[1].strip()
+                not_in = t.split("except the", maxsplit=1)[1].strip()
                 return [c for c in courts if c not in not_in]
-        elif 'to the' in t:
-            division = t.split('to the', maxsplit=1)[1].strip().replace(')','')
+        elif "to the" in t:
+            division = t.split("to the", maxsplit=1)[1].strip().replace(")", "")
             return [division]
-    
+
     judges = []
     for judge in current_judges:
         new_judge = {}
-        new_judge['name'] = judge.xpath('.//span[contains(@class, "fusion-toggle-heading")]')[0].text.replace('Hon. ', '').split(',')[0].replace(' CBE', '')
-        for line in judge.xpath('.//div[contains(@class, "panel-body")]')[0].text_content().splitlines():
-            if 'Assigned' in line:
-                new_judge['positions'] = filter_courts(line)
+        new_judge["name"] = (
+            judge.xpath('.//span[contains(@class, "fusion-toggle-heading")]')[0]
+            .text.replace("Hon. ", "")
+            .split(",")[0]
+            .replace(" CBE", "")
+        )
+        for line in (
+            judge.xpath('.//div[contains(@class, "panel-body")]')[0]
+            .text_content()
+            .splitlines()
+        ):
+            if "Assigned" in line:
+                new_judge["positions"] = filter_courts(line)
                 break
             else:
-                new_judge['positions'] = [] 
+                new_judge["positions"] = []
                 for c in courts:
                     if c in line:
-                        new_judge['positions'] += [c] 
-                        
-    
+                        new_judge["positions"] += [c]
+
         judges += [new_judge]
 
         judge_proxy = context.make("Person")
@@ -81,4 +93,3 @@ def crawl(context: Context):
         for pos in judge_positions:
             context.emit(pos[0])
             context.emit(pos[1])
-

--- a/datasets/ky/judicial/crawler.py
+++ b/datasets/ky/judicial/crawler.py
@@ -64,8 +64,8 @@ def crawl(context: Context):
         judges += [new_judge]
 
         judge_proxy = context.make("Person")
+        judge_proxy.add("sourceUrl", context.dataset.data.url)
         h.apply_name(judge_proxy, full=new_judge["name"])
-        # TODO: Make a better ID
         judge_proxy.id = context.make_id(new_judge["name"])
 
         judge_positions = []
@@ -75,17 +75,111 @@ def crawl(context: Context):
                 name="Judge for {}".format(position),
                 country="Cayman Islands",
             )
-            occupancy = h.make_occupancy(
+            occupancy = h.make_occupancy(context, judge_proxy, pos, True)
+            judge_positions += [(pos, occupancy)]
+
+        # If there is not information about the judge position
+        # we just add tje position 'Judge'
+        if len(judge_positions) == 0:
+            pos = h.make_position(
                 context,
-                judge_proxy,
-                pos,
-                True,
-                start_date="2021",
-                end_date="2025",
+                name="Judge",
+                country="Cayman Islands",
             )
+            occupancy = h.make_occupancy(context, judge_proxy, pos, True)
             judge_positions += [(pos, occupancy)]
 
         context.emit(judge_proxy, target=True)
         for pos in judge_positions:
             context.emit(pos[0])
             context.emit(pos[1])
+
+    # Get Chief Justice
+    chief_justice_url = "https://www.judicial.ky/judicial-administration/chief-justice"
+    request_response = context.fetch_html(chief_justice_url, cache_days=30)
+    chief_justice_name = (
+        request_response.xpath(
+            './/div[contains(@class, "fusion-flex-column-wrapper-legacy")]'
+        )[2]
+        .text_content()
+        .split(",")[0]
+        .replace("Hon. ", "")
+    )
+
+    judge_proxy = context.make("Person")
+    judge_proxy.add("sourceUrl", chief_justice_url)
+    h.apply_name(judge_proxy, full=chief_justice_name)
+    judge_proxy.id = context.make_id(chief_justice_name)
+
+    pos = h.make_position(
+        context,
+        name="Chief Justice",
+        country="Cayman Islands",
+    )
+    occupancy = h.make_occupancy(context, judge_proxy, pos, True)
+
+    context.emit(judge_proxy, target=True)
+    context.emit(pos)
+    context.emit(occupancy)
+
+    # Get President - Court of Appeal
+    president_court_url = (
+        "https://www.judicial.ky/judicial-administration/president-court-of-appeal"
+    )
+    request_response = context.fetch_html(president_court_url, cache_days=30)
+    president_court_name = (
+        request_response.xpath('.//h4[contains(@class, "panel-title")]')[0]
+        .text_content()
+        .split("Sir")[-1]
+        .strip()
+    )
+
+    judge_proxy = context.make("Person")
+    judge_proxy.add("sourceUrl", president_court_url)
+    h.apply_name(judge_proxy, full=president_court_name)
+    judge_proxy.id = context.make_id(president_court_name)
+
+    pos = h.make_position(
+        context,
+        name="President of the Court of Appeal",
+        country="Cayman Islands",
+    )
+    occupancy = h.make_occupancy(context, judge_proxy, pos, True)
+    context.emit(judge_proxy, target=True)
+    context.emit(pos)
+    context.emit(occupancy)
+
+    # Get Justices of Appeal
+    justices_of_appeal_url = (
+        "https://www.judicial.ky/judicial-administration/justices-of-appeal"
+    )
+    request_response = context.fetch_html(justices_of_appeal_url, cache_days=30)
+    current_justices_block = request_response.xpath(
+        './/div[contains(@class, "accordian")]'
+    )[0]
+
+    for justice in current_justices_block.xpath("//h4"):
+        judge_proxy = context.make("Person")
+        judge_proxy.add("sourceUrl", justices_of_appeal_url)
+
+        # Get name
+        justice_name = ""
+
+        justice_text = justice.text_content()
+        if "Sir" in justice_text:
+            justice_name = justice_text.split("Sir")[-1].strip()
+        else:
+            justice_name = justice_text.split("Hon.")[-1].replace("Justice", "").strip()
+
+        h.apply_name(judge_proxy, full=justice_name)
+        judge_proxy.id = context.make_id(justice_name)
+
+        pos = h.make_position(
+            context,
+            name="Justice of Appeal",
+            country="Cayman Islands",
+        )
+        occupancy = h.make_occupancy(context, judge_proxy, pos, True)
+        context.emit(judge_proxy, target=True)
+        context.emit(pos)
+        context.emit(occupancy)

--- a/datasets/ky/judicial/crawler.py
+++ b/datasets/ky/judicial/crawler.py
@@ -76,7 +76,7 @@ def crawl(context: Context):
         for position in new_judge["positions"]:
             pos = h.make_position(
                 context,
-                name=position,
+                name="Judge for {}".format(position),
                 country="Cayman Islands",
             )
             occupancy = h.make_occupancy(

--- a/datasets/ky/judicial/crawler.py
+++ b/datasets/ky/judicial/crawler.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from zavod import Context
+from zavod import helpers as h
+
+
+def crawl(context: Context):
+    request_response = context.fetch_html(context.dataset.data.url, cache_days=30)
+
+    # Get current judges
+    current_judges_block = request_response.xpath("//div[contains(@class, 'accordian')]")[0]
+    current_judges = current_judges_block.xpath(".//div[contains(@class, 'fusion-panel')]")
+
+    # First get the list of different types of courts
+    courts = []
+    for sm in request_response.xpath('.//ul[contains(@class,"sub-menu")]')[:2]:
+        for court in [s.text_content() for s in sm.xpath('./li/a/span')]:
+            courts.append(court)
+            
+    def filter_courts(t):
+        '''
+        Giving a text block, filter the list of courts mentioned in the text
+        or remove the excluded courts
+        '''
+        if 'all Divisions' in t:
+            if 'except the' not in t:
+                return courts
+            else:
+                not_in = t.split('except the', maxsplit=1)[1].strip()
+                return [c for c in courts if c not in not_in]
+        elif 'to the' in t:
+            division = t.split('to the', maxsplit=1)[1].strip().replace(')','')
+            return [division]
+    
+    judges = []
+    for judge in current_judges:
+        new_judge = {}
+        new_judge['name'] = judge.xpath('.//span[contains(@class, "fusion-toggle-heading")]')[0].text.replace('Hon. ', '').split(',')[0].replace(' CBE', '')
+        for line in judge.xpath('.//div[contains(@class, "panel-body")]')[0].text_content().splitlines():
+            if 'Assigned' in line:
+                new_judge['positions'] = filter_courts(line)
+                break
+            else:
+                new_judge['positions'] = [] 
+                for c in courts:
+                    if c in line:
+                        new_judge['positions'] += [c] 
+                        
+    
+        judges += [new_judge]
+
+        judge_proxy = context.make("Person")
+        h.apply_name(judge_proxy, full=new_judge["name"])
+        # TODO: Make a better ID
+        judge_proxy.id = "judicial-admin-cayman-islands-{}".format(
+            new_judge["name"].replace(" ", "_")
+        )
+
+        judge_positions = []
+        for position in new_judge["positions"]:
+            pos = h.make_position(
+                context,
+                name=position,
+                country="Cayman Islands",
+            )
+            occupancy = h.make_occupancy(
+                context,
+                judge_proxy,
+                pos,
+                True,
+                start_date="2021",
+                end_date="2025",
+            )
+            judge_positions += [(pos, occupancy)]
+
+        context.emit(judge_proxy, target=True)
+        for pos in judge_positions:
+            context.emit(pos[0])
+            context.emit(pos[1])
+

--- a/datasets/ky/judicial/ky_judicial.yml
+++ b/datasets/ky/judicial/ky_judicial.yml
@@ -1,5 +1,5 @@
 name: ky_judicial
-title: "judicial"
+title: "Senior judicial officers of the Cayman Islands"
 url: http://www.judicial.ky/
 entry_point: crawler
 prefix: ky-ja

--- a/datasets/ky/judicial/ky_judicial.yml
+++ b/datasets/ky/judicial/ky_judicial.yml
@@ -16,7 +16,6 @@ publisher:
       the Cayman Islands. The Judiciary is comprised of the following jurisdictions
       in ascending order within the hierarchy of the courts: The Summary Court, The
       Grand Court, Court of Appeal, Privy Council"
-    acronym: ky-judicial
     country: ky
     url: https://www.judicial.ky/judicial-administration/contacts
 data:

--- a/datasets/ky/judicial/ky_judicial.yml
+++ b/datasets/ky/judicial/ky_judicial.yml
@@ -1,0 +1,24 @@
+name: ky_judicial
+title: "judicial"
+url: http://www.judicial.ky/
+entry_point: crawler
+prefix: ky-ja
+coverage:
+  frequency: monthly
+description: |
+  Judicial Officers from Cayman Islands Judicial Administration
+publisher:
+    name: Cayman Islands Judicial Administration
+    description: |
+      "The Judiciary is one of three separate arms of Government. Its function
+      is to administer the law independently of the Executive and the Legislative
+      arms of Government; an independence that is safeguarded in the Constitution of
+      the Cayman Islands. The Judiciary is comprised of the following jurisdictions
+      in ascending order within the hierarchy of the courts: The Summary Court, The
+      Grand Court, Court of Appeal, Privy Council"
+    acronym: ky-judicial
+    country: ky
+    url: https://www.judicial.ky/judicial-administration/contacts
+data:
+    url: "https://www.judicial.ky/judicial-administration/judges"
+    format: HTML


### PR DESCRIPTION
The crawler gets all current Cayman Islands judges from  https://www.judicial.ky/judicial-administration/judges.

  1. The types of courts are extracted from the page menu.
  2. The courts types are used to generate the ocupancies. If a judge has the description "(Assigned to all Divisions)", all courts extracted on 1 will be assigned to the judge. If a judge has a description "(Assigned to all Divisions except the Financial Services Division)", all courts except Financial Services will be assigned to it. Some judges have the court information written on the text block. Two judges don't have the information written about a specific court.