### PR TITLE
Added docker compose v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-DOCKER=
+SHELL := /bin/bash
+# Check if 'docker-compose' is available, if not, use 'docker compose'
+COMPOSE_CMD := $(shell command -v docker-compose >/dev/null 2>&1 && echo "docker-compose" || (docker compose version >/dev/null 2>&1 && echo "docker compose"))
+
 TS=$(shell date +%Y%m%d%H%M)
 
 .PHONY: build
@@ -9,19 +12,19 @@ workdir:
 	mkdir -p data/postgres
 
 build:
-	docker-compose build --pull
+	$(COMPOSE_CMD) build --pull
 
 services:
-	docker-compose up -d --remove-orphans db
+	$(COMPOSE_CMD) up -d --remove-orphans db
 
 shell: build workdir services
-	docker-compose run --rm app bash
+	$(COMPOSE_CMD) run --rm app bash
 
 run: build workdir services
-	docker-compose run --rm app opensanctions run
+	$(COMPOSE_CMD) run --rm app opensanctions run
 
 stop:
-	docker-compose down --remove-orphans
+	$(COMPOSE_CMD) down --remove-orphans
 
 clean:
 	rm -rf data/datasets build dist .mypy_cache .pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 # Check if 'docker-compose' is available, if not, use 'docker compose'
-COMPOSE_CMD := $(shell command -v docker-compose >/dev/null 2>&1 && echo "docker-compose" || (docker compose version >/dev/null 2>&1 && echo "docker compose"))
+COMPOSE_CMD := $(docker-compose version >/dev/null 2>&1 && echo "docker-compose" || (docker compose version >/dev/null 2>&1 && echo "docker compose"))
 
 TS=$(shell date +%Y%m%d%H%M)
 


### PR DESCRIPTION
Docker Compose V2 (often referred to as "Compose V2") is a major version upgrade from the original Docker Compose (V1). Compose V2 was introduced as a technical preview in late 2020 and became generally available in 2021.

The significant change in Compose V2 is its integration into the Docker CLI. This means that instead of using the standalone `docker-compose` command, you can use `docker compose` (without the hyphen) as a subcommand of the Docker CLI. This change aimed to provide a more seamless and integrated experience for users.

So we converted the Makefile so that both users can use opensanctions.