### PR TITLE
Added better docker-compose logic and Fixed issue with MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
+# SHELL specifies the shell used by Make. Bash is used for its array and string manipulation capabilities.
 SHELL := /bin/bash
-# Check if 'docker-compose' is available, if not, use 'docker compose'
-COMPOSE_CMD := $(docker-compose version >/dev/null 2>&1 && echo "docker-compose" || (docker compose version >/dev/null 2>&1 && echo "docker compose"))
 
-TS=$(shell date +%Y%m%d%H%M)
+# Check if 'docker-compose' is available, if not, use 'docker compose'.
+COMPOSE_CMD := $(if $(shell which docker-compose 2>/dev/null),docker-compose,docker compose)
 
 .PHONY: build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   app:
     build: .
     image: ghcr.io/opensanctions/opensanctions:latest
-    command: bash -c 'while !</dev/tcp/db/5432; do sleep 2; done; opensanctions crawl'
+    command: bash -c 'while !</dev/tcp/db/5432; do sleep 2; done; zavod --help'
     hostname: work
     environment:
       ZAVOD_DATABASE_URI: postgresql://os:os@db/opensanctions


### PR DESCRIPTION
After conducting tests on various environments using the Makefile, we encountered compatibility issues with ZSH and discrepancies between `docker-compose` and `docker compose`. This merge request addresses and resolves these issues.

Additionally, we've transitioned from the opensanctions docker to zavod. This decision was prompted by numerous instances where individuals tried to run the repository using `docker compose up`, only to encounter errors. This has led to several support tickets. To ensure a smooth experience and provide functioning examples for all users, we've made some modifications.
