### PR TITLE
Quick go at position name dedupe

### DIFF
--- a/contrib/posdedupe/posdedupe.py
+++ b/contrib/posdedupe/posdedupe.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+from sys import argv
+from typing import Dict, List
+from followthemoney import model
+from followthemoney.compare import compare
+from nomenklatura.judgement import Judgement
+from followthemoney.cli.util import path_entities
+from followthemoney.proxy import EntityProxy
+
+from zavod.dedupe import get_resolver
+
+
+def load_file(filename: str):
+    resolver = get_resolver()
+    countries: Dict[Dict[List[set]]] = defaultdict(lambda: defaultdict(set))
+
+    for entity in path_entities(filename, EntityProxy):
+        if not entity.schema.name == "Position":
+            continue
+
+        for country in entity.get("country"):
+            for name in entity.get("name"):
+                countries[country][name.lower()].add(entity.id)
+
+    for country in countries.values():
+        for names in country.values():
+            if len(names) == 1:
+                continue
+            first, *rest = names
+            for id in rest:
+                print("merging", first, id)
+                resolver.decide(first, id, Judgement.POSITIVE, user="position-dedupe")
+    resolver.save()
+
+
+if __name__ == "__main__":
+    load_file(argv[1])


### PR DESCRIPTION
Creates 296 resolver lines like

```json
https://www.opensanctions.org/entities/us-cia-cf513a07dfe99078ce9fe6faf43c5a3ccb456d50/
["us-cia-cf513a07dfe99078ce9fe6faf43c5a3ccb456d50", "us-cia-4fcd5efba8aa8fad47a8ef45dbe0707b102a6639", "positive", null, "position-dedupe", "2023-10-16T05:45"]
rupep-8d505677a92bb4e47cf33a7065145f77aad618c1
["NK-2Fy35cuCTwzM8yLmsxPZwt", "rupep-40553930d18911ffccdde4546861337d3237bf57", "positive", null, "position-dedupe", "2023-10-16T05:45"]
["NK-2Fy35cuCTwzM8yLmsxPZwt", "rupep-8d505677a92bb4e47cf33a7065145f77aad618c1", "positive", null, "position-dedupe", "2023-10-16T05:45"]
```
