### PR TITLE
Brazilian PEPs

### DIFF
--- a/datasets/br/pep/br_pep.yaml
+++ b/datasets/br/pep/br_pep.yaml
@@ -1,0 +1,26 @@
+title: Brazil Politically Exposed Persons
+entry_point: crawler.py
+prefix: br-pep
+coverage:
+  frequency: daily
+load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+summary: >
+  This datasets encompass brazilian PEPs divulgated by the CGU
+description: |
+  This registry is presented in an open format and sourced from various sectors/entities of the Public Administration.
+  Key sources include the Federal Court of Accounts (TCU),
+  the Federal Chamber (Câmara Federal), the Federal Senate (Senado Federal),
+  the Ministry of Economy, the Office of the Comptroller General (CGU),
+  and other relevant entities.
+  It lists public agents who currently hold or
+  have held significant public offices, jobs, 
+  or functions within the last five years.
+publisher:
+  name: CGU (General Control Office of the Union)
+  url: https://portaldatransparencia.gov.br
+  official: true
+  country: "br"
+url: https://portaldatransparencia.gov.br/download-de-dados/pep
+data:
+  url: https://portaldatransparencia.gov.br/download-de-dados/pep
+  format: csv

--- a/datasets/br/pep/crawler.py
+++ b/datasets/br/pep/crawler.py
@@ -1,0 +1,124 @@
+import io
+import re
+import csv
+from typing import List
+from zipfile import ZipFile
+
+from zavod import Context
+from zavod import helpers as h
+from datetime import datetime
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+}
+
+
+def parse_date(date_string):
+    try:
+        return datetime.strptime(date_string, "%d/%m/%Y").strftime("%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def get_csv_url(context: Context) -> str:
+    """
+    Fetches the CSV URL from the main page.
+    The CSV URL is dynamically generated and changes every day
+    and is created by concatenating the base url
+    (the url in the metadata) with the date in the format YYYYMM (it doesn't include the day).
+
+    The date is in a script tag in the main page.
+
+    :param context: The context object.
+
+    :return: The URL of the CSV file.
+    """
+
+    # The header is necessary because the website blocks requests without a user agent.
+    doc = context.fetch_html(context.data_url, headers=HEADERS)
+    path = "//script"
+    date_pattern = re.compile(
+        r'"ano"\s*:\s*"(\d+)",\s*"mes"\s*:\s*"(\d+)",\s*"dia"\s*:\s*'
+    )
+    for script in doc.xpath(path):
+        if script.text:
+            match = date_pattern.search(script.text)
+            if match:
+                # we can ignore the day since it won't be used to build the url
+                year, month = match.groups()
+                return context.data_url + f"/{year}{month}"
+
+    raise ValueError("Data URL not found")
+
+
+def get_data(csv_url: str, context: Context) -> List[dict]:
+    """
+    Fetches the CSV file as a zip from the website decompresses it and parses it using the csv library
+    and returns the data as a list of dicts.
+
+    :param csv_url: The URL of the CSV file.
+    :param context: The context object.
+
+    :return: The data fetched from the website as a list of dicts.
+    """
+    # The header is necessary because the website blocks requests without a user agent.
+    response = context.fetch_response(csv_url, headers=HEADERS)
+    zip_file = ZipFile(io.BytesIO(response.content))
+    file_name = zip_file.namelist()[0]
+
+    csv_str = zip_file.read(file_name).decode("iso-8859-1")
+    lines = csv_str.splitlines()
+
+    reader = csv.DictReader(lines, delimiter=";")
+
+    return [row for row in reader]
+
+
+def create_entities(data: List[dict], context: Context) -> None:
+    """
+    Creates entities from the data fetched from the website.
+
+    :param data: The data fetched from the website as a list of dicts.
+    :param context: The context object.
+    """
+
+    for raw_entity in data:
+        person = context.make("Person")
+        # We can't use only the CPF (tax number) as an id because here it comes anonimized (12345678910 -> ***456789**)
+        person.id = context.make_id(raw_entity["CPF"] + raw_entity["Nome_PEP"])
+        person.add("name", raw_entity["Nome_PEP"])
+        person.add("taxNumber", raw_entity["CPF"])
+        person.add("country", "br")
+        person.add("topics", "role.pep")
+
+        position = h.make_position(context, name=raw_entity["Descrição_Função"])
+
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            True,
+            start_date=parse_date(raw_entity["Data_Início_Exercício"]),
+            end_date=parse_date(raw_entity["Data_Fim_Exercício"]),
+        )
+
+        context.emit(person, target=True)
+        context.emit(position)
+
+        if occupancy is not None:
+            context.emit(occupancy)
+
+
+def crawl(context: Context):
+    """
+    Entrypoint to the crawler.
+
+    The crawler works by first fetching the CSV URL from the main page. This is necessary because the CSV URL is
+    dynamically generated and changes every day. The CSV URL is then used to download the CSV file, which is then
+    parsed and the entities are created.
+
+    :param context: The context object.
+    """
+    csv_url = get_csv_url(context)
+    data = get_data(csv_url, context)
+    create_entities(data, context)


### PR DESCRIPTION
This PR introduces the Brazilian dataset of Politically Exposed Persons (PEPs), officially published by the Brazilian government. The dataset encompasses approximately 150,000 individuals who have occupied positions in the Brazilian government over the past five years. This timeframe aligns with the legal definition of a PEP in Brazil.