### PR TITLE
support customizing Log's time zone through environment variables

### DIFF
--- a/zavod/zavod/logs.py
+++ b/zavod/zavod/logs.py
@@ -36,7 +36,7 @@ def configure_logging(level: int = logging.DEBUG) -> None:
             processor=structlog.processors.JSONRenderer(),
         )
     else:
-        processors.append(structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"))
+        processors.append(structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=settings.TIME_ZONE == "UTC"))
         formatter = structlog.stdlib.ProcessorFormatter(
             foreign_pre_chain=processors,
             processor=structlog.dev.ConsoleRenderer(

--- a/zavod/zavod/settings.py
+++ b/zavod/zavod/settings.py
@@ -22,6 +22,7 @@ DATA_PATH_ = env_str("ZAVOD_DATA_PATH", "data")
 DATA_PATH = Path(env_str("OPENSANCTIONS_DATA_PATH", DATA_PATH_)).resolve()
 
 # Per-run timestamp
+TIME_ZONE = env_str("TZ", "UTC")
 RUN_TIME = datetime.utcnow().replace(microsecond=0)
 RUN_TIME_ISO = RUN_TIME.isoformat(sep="T", timespec="seconds")
 RUN_DATE = RUN_TIME.date().isoformat()


### PR DESCRIPTION
Hello, thank you very much for your contribution to this project!

When I was using this project, I found that I specified the time zone through the `TZ` environment variable, but the output log was still in the UTC time zone!