### PR TITLE
AR parliament

### DIFF
--- a/datasets/ar/parliament/ar_parliament.yml
+++ b/datasets/ar/parliament/ar_parliament.yml
@@ -19,6 +19,6 @@ publisher: # TODO: double check what to write here
       Representatives elected directly by the people of the provinces and the city of Buenos Aires (art. 45 National Constitution)
     country: ar
     url: https://www.hcdn.gob.ar/diputados/
-data: # TODO: double check what to write here
+data:
     url: https://www.hcdn.gob.ar/diputados/
     format: HTML

--- a/datasets/ar/parliament/ar_parliament.yml
+++ b/datasets/ar/parliament/ar_parliament.yml
@@ -1,0 +1,24 @@
+name: ar_parliament
+title: Argentina Members of Parliament
+url: https://www.hcdn.gob.ar/diputados/
+entry_point: crawler
+prefix: ar-pep # TODO: double check if this is the correct prefix
+#coverage:
+#  frequency: daily
+#load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+summary: |
+  Members of the Parliament of Argentina.
+description: |
+  National Deputies (Members of the Parliament) - Representatives elected directly by the people of the provinces and
+  the city of Buenos Aires of Argentina as listed on the parliamentary website.
+publisher: # TODO: double check what to write here
+    name: Honorable Chamber of Deputies of the Argentine Nation
+    official: true
+    description: |
+      National Deputies
+      Representatives elected directly by the people of the provinces and the city of Buenos Aires (art. 45 National Constitution)
+    country: ar
+    url: https://www.hcdn.gob.ar/diputados/
+data: # TODO: double check what to write here
+    url: https://www.hcdn.gob.ar/diputados/
+    format: HTML

--- a/datasets/ar/parliament/ar_parliament.yml
+++ b/datasets/ar/parliament/ar_parliament.yml
@@ -3,9 +3,9 @@ title: Argentina Members of Parliament
 url: https://www.hcdn.gob.ar/diputados/
 entry_point: crawler
 prefix: ar-pep # TODO: double check if this is the correct prefix
-#coverage:
-#  frequency: daily
-#load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+coverage:
+  frequency: daily
+load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
 summary: |
   Members of the Parliament of Argentina.
 description: |

--- a/datasets/ar/parliament/crawler.py
+++ b/datasets/ar/parliament/crawler.py
@@ -120,8 +120,12 @@ def make_and_emit_person(context: Context, person_data: dict):
 
         # Emit person, position and occupancy
         context.emit(person, target=True)
-        context.emit(position)
-        context.emit(occupancy)
+        if occupancy:
+            context.log.info("Created Occupancy", occupancy)
+            context.emit(occupancy)
+        if position:
+            context.log.info("Created Position", position)
+            context.emit(position)
 
 
 def convert_date_format(date_string: str) -> str:

--- a/datasets/ar/parliament/crawler.py
+++ b/datasets/ar/parliament/crawler.py
@@ -1,51 +1,117 @@
-from zavod import Context
 from lxml import html, etree
+from datetime import datetime
 
-def parce_entity(context: Context, element):
-    # Initialize an empty dictionary to store the extracted data
-    entity_data = {}
+from zavod import Context
+from zavod import helpers as h
+# from zavod.logic.pep import categorise
 
-    # Extract the name. Assumes the name is in the second <td>, within an <a> tag
+def crawl_person(context: Context, element):
+    person = context.make("Person")
+
+    # Extract PEP's name, create id and add first properties
     name = element.xpath('.//td[2]/a/text()')
-    entity_data['name'] = name[0].strip() if name else 'Unknown'
+    if name:
+        person.id = context.make_id(name[0].strip())
+        person.add('name', name[0].strip())
+        person.add('alias', f"{name[0].strip().split(',')[1]} {name[0].strip().split(',')[0]}")
+        person.add("country", "ar")
+        h.apply_name(
+            person,
+            first_name=name[0].strip().split(',')[1],
+            last_name=name[0].strip().split(',')[0],
+        )
 
+    # Extract PEP's image url // TODO: find out if we need term
+    element_image_url = element.xpath('//tr/td[1]/img/@src')
+    image_url = element_image_url[0].strip() if element_image_url else None
+
+    # Extract link to PEP's personal page
     url_extension = element.xpath('.//td[2]/a/@href')
-    entity_data['url_extension'] = url_extension[0].strip() if url_extension else 'Unknown'
+    if url_extension:
+        url = context.dataset.data.url + url_extension[0].strip().replace('/diputados/', '')
+        person.add("sourceUrl", url)
+        crawl_personal_page(context, url, person)
+    else:
+        person.add("sourceUrl", context.dataset.data.url)
 
-    # Extract other details - district, term, term start and end dates, and block
-    # Adjust the indices of td elements based on the structure of your HTML
+    # Extract district and create position
     district = element.xpath('.//td[3]/text()')
-    entity_data['district'] = district[0].strip() if district else 'Unknown'
+    if district:
+        position = h.make_position(
+            context,
+            name="Member of National Congress of Argentina",
+            country="ar",
+            subnational_area=district[0].strip(),
+            # topics=[] TODO: find out what is topic and if needed
+        )
+    else:
+        position = h.make_position(
+            context,
+            name="Member of National Congress of Argentina",
+            country="ar",
+            # topics=[] TODO: find out what is topic and if needed
+        )
 
-    term = element.xpath('.//td[4]/text()')
-    entity_data['term'] = term[0].strip() if term else 'Unknown'
+    # Extract term // TODO: find out if we need term
+    element_term = element.xpath('.//td[4]/text()')
+    term = element_term[0].strip() if element_term else None
 
-    term_start = element.xpath('.//td[5]/text()')
-    entity_data['term_start'] = term_start[0].strip() if term_start else 'Unknown'
+    # Extract term start and end dates and add them to occupancy
+    element_term_start = element.xpath('.//td[5]/text()')
+    term_start = element_term_start[0].strip() if element_term_start else None
+    element_term_end = element.xpath('.//td[6]/text()')
+    term_end = element_term_end[0].strip() if element_term_end else None
+    # categorisation = categorise(context, position, True) # TODO: find out what is categorise and if we need it
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        start_date=term_start,
+        end_date=term_end,
+        # categorisation=categorisation,
+    )
 
-    term_end = element.xpath('.//td[6]/text()')
-    entity_data['term_end'] = term_end[0].strip() if term_end else 'Unknown'
-
+    # Extract political block and add to person
     block = element.xpath('.//td[7]/text()')
-    entity_data['block'] = block[0].strip() if block else 'Unknown'
+    if block:
+        person.add("political", block[0].strip())
 
-    return entity_data
+    context.log.info(f"enriched entity: {person}")
+    context.emit(person, target=True)
 
-def crawl_entity(context: Context, entity):
-    entity_url = context.dataset.data.url + entity['url_extension'].replace('/diputados/','')
-    context.log.info(f"Starting crawling entity {entity_url}")
-    response = context.http.get(entity_url)
+def crawl_personal_page(context: Context, url, person):
+    context.log.info(f"Starting crawling entity {url}")
+    response = context.http.get(url)
 
     # Parse the HTTP response into an lxml DOM:
     doc = html.fromstring(response.text)
 
-    save_text_to_file(doc, f"/opensanctions/data/{entity['name'].split(',')[0]}.txt")
-    context.log.info("Saved output.txt")
+    # Extract profession // TODO: find out if we need and can use profession
+    profession = doc.xpath('.//p[@class="encabezadoProfesion"]/span/text()')
+    entity_profession = profession[0].strip() if profession else None
+
+    # Extract date of birth
+    birth_date = doc.xpath('.//p[@class="encabezadoFecha"]/span/text()')
+    if birth_date:
+        person.add('birthDate', convert_date_format(birth_date[0].strip()))
+
+    # Extract email
+    email = doc.xpath('.//a[starts-with(@href, "mailto:")]/text()')
+    if email:
+        person.add('email', email[0].strip())
 
 def save_text_to_file(element, filename):
     text = etree.tostring(element, pretty_print=True, method="html").decode()
     with open(filename, 'w') as file:
         file.write(text)
+
+def convert_date_format(date_string):
+    # Parse the date string into a datetime object
+    date_obj = datetime.strptime(date_string, '%d/%m/%Y')
+
+    # Format the datetime object into the desired format
+    return date_obj.strftime('%Y-%m-%d')
 
 def crawl(context: Context):
     context.log.info("Starting crawling")
@@ -53,14 +119,13 @@ def crawl(context: Context):
 
     # Parse the HTTP response into an lxml DOM:
     doc = html.fromstring(response.text)
-
-    # Find all <tr> elements within <tbody>
-    for element in doc.xpath('//tbody/tr')[:10]:
-        ent = parce_entity(context, element)
-        context.log.info(f"parsed entity: {ent}")
-        crawl_entity(context, ent)
-
     context.log.info(f"This is 100 symbols of doc {doc[:100]}")
 
     save_text_to_file(doc, '/opensanctions/data/output.txt')
     context.log.info("Saved output.txt")
+
+    # Find all <tr> elements within <tbody>
+    for element in doc.xpath('//tbody/tr')[:10]:
+        crawl_person(context, element)
+
+

--- a/datasets/ar/parliament/crawler.py
+++ b/datasets/ar/parliament/crawler.py
@@ -1,0 +1,66 @@
+from zavod import Context
+from lxml import html, etree
+
+def parce_entity(context: Context, element):
+    # Initialize an empty dictionary to store the extracted data
+    entity_data = {}
+
+    # Extract the name. Assumes the name is in the second <td>, within an <a> tag
+    name = element.xpath('.//td[2]/a/text()')
+    entity_data['name'] = name[0].strip() if name else 'Unknown'
+
+    url_extension = element.xpath('.//td[2]/a/@href')
+    entity_data['url_extension'] = url_extension[0].strip() if url_extension else 'Unknown'
+
+    # Extract other details - district, term, term start and end dates, and block
+    # Adjust the indices of td elements based on the structure of your HTML
+    district = element.xpath('.//td[3]/text()')
+    entity_data['district'] = district[0].strip() if district else 'Unknown'
+
+    term = element.xpath('.//td[4]/text()')
+    entity_data['term'] = term[0].strip() if term else 'Unknown'
+
+    term_start = element.xpath('.//td[5]/text()')
+    entity_data['term_start'] = term_start[0].strip() if term_start else 'Unknown'
+
+    term_end = element.xpath('.//td[6]/text()')
+    entity_data['term_end'] = term_end[0].strip() if term_end else 'Unknown'
+
+    block = element.xpath('.//td[7]/text()')
+    entity_data['block'] = block[0].strip() if block else 'Unknown'
+
+    return entity_data
+
+def crawl_entity(context: Context, entity):
+    entity_url = context.dataset.data.url + entity['url_extension'].replace('/diputados/','')
+    context.log.info(f"Starting crawling entity {entity_url}")
+    response = context.http.get(entity_url)
+
+    # Parse the HTTP response into an lxml DOM:
+    doc = html.fromstring(response.text)
+
+    save_text_to_file(doc, f"/opensanctions/data/{entity['name'].split(',')[0]}.txt")
+    context.log.info("Saved output.txt")
+
+def save_text_to_file(element, filename):
+    text = etree.tostring(element, pretty_print=True, method="html").decode()
+    with open(filename, 'w') as file:
+        file.write(text)
+
+def crawl(context: Context):
+    context.log.info("Starting crawling")
+    response = context.http.get(context.dataset.data.url)
+
+    # Parse the HTTP response into an lxml DOM:
+    doc = html.fromstring(response.text)
+
+    # Find all <tr> elements within <tbody>
+    for element in doc.xpath('//tbody/tr')[:10]:
+        ent = parce_entity(context, element)
+        context.log.info(f"parsed entity: {ent}")
+        crawl_entity(context, ent)
+
+    context.log.info(f"This is 100 symbols of doc {doc[:100]}")
+
+    save_text_to_file(doc, '/opensanctions/data/output.txt')
+    context.log.info("Saved output.txt")

--- a/datasets/ar/parliament/crawler.py
+++ b/datasets/ar/parliament/crawler.py
@@ -12,6 +12,7 @@ def crawl_person(context: Context, element):
     name = element.xpath('.//td[2]/a/text()')
     if name:
         person.id = context.make_id(name[0].strip())
+        context.log.info(f"Made person's ID: {person}: {person.id}")
         person.add('name', name[0].strip())
         person.add('alias', f"{name[0].strip().split(',')[1]} {name[0].strip().split(',')[0]}")
         person.add("country", "ar")
@@ -30,9 +31,11 @@ def crawl_person(context: Context, element):
     if url_extension:
         url = context.dataset.data.url + url_extension[0].strip().replace('/diputados/', '')
         person.add("sourceUrl", url)
+        context.log.info(f"Added personal page as URL for {person}")
         crawl_personal_page(context, url, person)
     else:
         person.add("sourceUrl", context.dataset.data.url)
+        context.log.info(f"Added Parliament page as URL for {person}")
 
     # Extract district and create position
     district = element.xpath('.//td[3]/text()')


### PR DESCRIPTION
Rationale:
Argentina has recently seen a change in government and our information about their political personnel is outdated. One thing we need to scrape is https://www.hcdn.gob.ar/diputados/ - the list of members of parliament for the country. 

Changes:
- added basic metadata to describe the new dataset
- added crawler.py that crawles the parliament website and creates Person, Occupancy and Position for each member of parliament and emits it.

Test run:
![Screenshot 2024-01-05 at 11 30 05](https://github.com/opensanctions/opensanctions/assets/79859780/79654e35-c387-45c3-bfdb-26f7ba59846d)

☝️THIS IS A DRAFT. After review:
- remove excessive logging in the crawler
- review and finalise the metadata file