### PR TITLE
Pin ruff to a version where the cache dir doesn't fail

### DIFF
--- a/zavod/setup.py
+++ b/zavod/setup.py
@@ -60,7 +60,7 @@ setup(
             "mypy",
             "flake8>=2.6.0",
             "pytest",
-            "ruff",
+            "ruff==0.1.11",
             "pytest-cov",
             "lxml-stubs",
             "coverage>=4.1",


### PR DESCRIPTION
v0.1.12 released 9 hours ago breaks with

```
(jdb)-(10:24 AM Fri Jan 12)-(~/projects/opensanctions/opensanctions/zavod):
 (main) $ make lint
ruff zavod/
ruff failed
  Cause: Failed to create cache file '/home/jdb/projects/opensanctions/opensanctions/zavod/.ruff_cache/0.1.12/7231087642530478940'
  Cause: No such file or directory (os error 2)
make: *** [Makefile:9: lint] Error 2
```