### PR TITLE
Crawler for Hong Kong Legislative Council members as PEPs

### DIFF
--- a/datasets/hk/legco/crawler.py
+++ b/datasets/hk/legco/crawler.py
@@ -1,0 +1,66 @@
+"""
+Crawler for extracting names and constituencies of Hong Kong
+Legislative Council members.
+"""
+
+from typing import Dict, Union, List
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.logic.pep import categorise
+
+MEMBER_URL_FORMAT = (
+    "https://app4.legco.gov.hk/mapi/{lang}/api/LASS/getMember?member_id={member_id}"
+)
+
+
+def crawl_member(
+    context: Context,
+    member: Dict[str, Union[str, int]],
+    pages: Dict[str, Dict[str, Union[str, int, List]]],
+):
+    context.log.info(
+        "Adding {name} ({name_tc})".format(
+            name=pages["en"]["name"], name_tc=pages["tc"]["name"]
+        )
+    )
+    person = context.make("Person")
+    person.id = context.make_id(member["member_id"])
+    h.apply_name(person, full=pages["en"]["name"])
+    if member.get("is_president", "N") == "Y":
+        position_name = "President of the Legislative Council"
+    else:
+        position_name = "Member of the Legislative Council"
+    position = h.make_position(
+        context,
+        name=position_name,
+        country="China",
+        subnational_area="Hong Kong Special Administrative Region",
+    )
+    categorisation = categorise(context, position)
+    if not categorisation.is_pep:
+        return
+    occupancy = h.make_occupancy(
+        context, person, position, True, categorisation=categorisation
+    )
+    context.emit(person, target=True)
+    context.emit(position)
+    context.emit(occupancy)
+
+
+def crawl(context: Context):
+    """Retrieve member list and member information from the JSON API
+    and emit entities for council members."""
+    response = context.fetch_json(context.dataset.data.url, cache_days=7)
+    members = response["data"]
+    for member in members:
+        if member.get("is_active", "N") == "N":
+            continue
+        member_id = member["member_id"]
+        # Retrieve member pages in English, traditional and simplified Chinese
+        pages = {}
+        for lang in "en", "tc", "cn":
+            member_url = MEMBER_URL_FORMAT.format(lang=lang, member_id=member_id)
+            response = context.fetch_json(member_url, cache_days=7)
+            pages[lang] = response["data"]
+        crawl_member(context, member, pages)

--- a/datasets/hk/legco/hk_legco.yml
+++ b/datasets/hk/legco/hk_legco.yml
@@ -1,0 +1,22 @@
+name: hk_legco
+title: Members of the Hong Kong Legislative Council
+url: https://www.legco.gov.hk/en/members/legco-members/members-biographies.html
+summary: >-
+  Members of the Hong Kong Legislative Council.
+description: |
+  Members of the Hong Kong Legislative Council, their type of
+  constituency, and which constituency they represent.
+entry_point: crawler.py
+prefix: hk-legco
+publisher:
+  name: >-
+    Hong Kong Legislative Council
+  official: true
+  description: |
+    Legislative Council of the Hong Kong Special Administrative Region
+    of the People's Republic of China
+  url: https://legco.gov.hk/
+data:
+  url: https://app4.legco.gov.hk/mapi/en/api/LASS/getListMember
+  format: JSON
+


### PR DESCRIPTION
Here is a crawler that loads the JSON from the backend for the HK legislative council and emits entities for members.

There is some work to be done to get all the information and fit it into the schema, and the metadata will need to be completed as well.