### PR TITLE
Add slovenia debarment crawler

### DIFF
--- a/datasets/si/br/crawler.py
+++ b/datasets/si/br/crawler.py
@@ -1,0 +1,86 @@
+from zavod import Context
+from typing import Any, Dict
+
+
+HEADERS = {"Cookie": "ORIGIN=KPK1&KPK2.KPK1"}
+
+
+def fetch_data(context: Context, offset, limit):
+    page_url = f"https://erar.si/api/omejitve/?&draw=2&columns%5B0%5D%5Bdata%5D=org_naziv&columns%5B0%5D%5Bname%5D=&columns%5B0%5D%5Bsearchable%5D=true&columns%5B0%5D%5Borderable%5D=true&columns%5B0%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B0%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B1%5D%5Bdata%5D=omejitev_do&columns%5B1%5D%5Bname%5D=&columns%5B1%5D%5Bsearchable%5D=true&columns%5B1%5D%5Borderable%5D=true&columns%5B1%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B1%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B2%5D%5Bdata%5D=subjekt_naziv&columns%5B2%5D%5Bname%5D=&columns%5B2%5D%5Bsearchable%5D=true&columns%5B2%5D%5Borderable%5D=true&columns%5B2%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B2%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B3%5D%5Bdata%5D=od&columns%5B3%5D%5Bname%5D=&columns%5B3%5D%5Bsearchable%5D=true&columns%5B3%5D%5Borderable%5D=true&columns%5B3%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B3%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B4%5D%5Bdata%5D=do&columns%5B4%5D%5Bname%5D=&columns%5B4%5D%5Bsearchable%5D=true&columns%5B4%5D%5Borderable%5D=true&columns%5B4%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B4%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B5%5D%5Bdata%5D=st_transakcij&columns%5B5%5D%5Bname%5D=&columns%5B5%5D%5Bsearchable%5D=true&columns%5B5%5D%5Borderable%5D=true&columns%5B5%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B5%5D%5Bsearch%5D%5Bregex%5D=false&order%5B0%5D%5Bcolumn%5D=0&order%5B0%5D%5Bdir%5D=asc&start={offset}&length={limit}&search%5Bvalue%5D=&search%5Bregex%5D=false&_=1706090961920"
+
+    response = context.fetch_response(page_url, headers=HEADERS)
+    return response.json()
+
+
+def create_entities(context: Context, record: Dict[str, Any]):
+    organization = context.make("Organization")
+
+    organization_name = record.get("org_naziv")
+    organization_number = record.get("org_sifrapu")
+
+    organization.id = context.make_id(organization_number or organization_name)
+    organization.add("name", organization_name)
+    organization.add("idNumber", organization_number)
+
+    legal_entity = context.make("LegalEntity")
+    subject_name = record.get("subjekt_naziv")
+    registration_number = record.get("subjekt_maticna")
+
+    if not (subject_name and registration_number):
+        context.log.error("Subject name and registration number not found")
+        return
+
+    legal_entity.id = context.make_id(registration_number or subject_name)
+    legal_entity.add("name", subject_name)
+    legal_entity.add("registrationNumber", registration_number)
+    legal_entity.add("taxNumber", record.get("subjekt_davcna"))
+
+    if registration_number:
+        legal_entity.add(
+            "sourceUrl",
+            f"https://erar.si/transakcija/placnik/{organization_number}/prejemnik/{registration_number}",
+        )
+
+    validity_link = context.make("UnknownLink")
+    validity_link.id = context.make_id(legal_entity.id)
+    validity_link.add("startDate", record.get("od"))
+
+    if not record.get("do").startswith("9999"):
+        validity_link.add("endDate", record.get("do"))
+
+    validity_link.add(
+        "description",
+        "When the restriction is valid from, and when it ends. No end date implies it is valid until canceled",
+    )
+    validity_link.add("subject", legal_entity)
+    validity_link.add("object", organization)
+
+    context.emit(legal_entity, target=True)
+    context.emit(organization)
+    context.emit(validity_link)
+    context.audit_data(record, ignore=["omejitev_do", "st_transakcij"])
+
+
+def parse_data(context: Context, response: Dict[str, Any]):
+    data = response.get("data")
+
+    for record in data:
+        create_entities(context, record)
+
+
+def crawl(context: Context):
+    offset = 0
+    limit = 100
+    records_total = limit
+    while True:
+        response = fetch_data(context, offset, limit)
+        records_total = (
+            response.get("recordsTotal") if records_total == limit else records_total
+        )
+        parse_data(context, response)
+
+        if offset + limit >= records_total:
+            break
+
+        offset += limit
+        context.log.info(f"Processed entities from page {offset//limit}")

--- a/datasets/si/br/crawler.py
+++ b/datasets/si/br/crawler.py
@@ -35,9 +35,7 @@ def create_entities(context: Context, record: Dict[str, Any]):
 
     legal_entity.add(
         "program",
-        f"""{subject_name} is subject to business restriction, valid from {start_date} and applies {end_date}. 
-         Following the regulations, the entity is prohibited because a public sector, {organization_name}, must avoid awarding contracts 
-         or special rights to entities where an official or their family has significant involvement or ownership exceeding 5% """,
+        f"{organization_name} is restricted from procurement from {subject_name} from {start_date} until {end_date} due to ownership or management role of a public official in {organization_name} or their family member. This is a preventative restriction by Komisija za preprečevanje korupcije and implies no wrongdoing.",
     )
 
     context.emit(legal_entity, target=True)

--- a/datasets/si/br/crawler.py
+++ b/datasets/si/br/crawler.py
@@ -2,25 +2,9 @@ from zavod import Context
 from typing import Any, Dict
 
 
-HEADERS = {"Cookie": "ORIGIN=KPK1&KPK2.KPK1"}
-
-
-def fetch_data(context: Context, offset, limit):
-    page_url = f"https://erar.si/api/omejitve/?&draw=2&columns%5B0%5D%5Bdata%5D=org_naziv&columns%5B0%5D%5Bname%5D=&columns%5B0%5D%5Bsearchable%5D=true&columns%5B0%5D%5Borderable%5D=true&columns%5B0%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B0%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B1%5D%5Bdata%5D=omejitev_do&columns%5B1%5D%5Bname%5D=&columns%5B1%5D%5Bsearchable%5D=true&columns%5B1%5D%5Borderable%5D=true&columns%5B1%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B1%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B2%5D%5Bdata%5D=subjekt_naziv&columns%5B2%5D%5Bname%5D=&columns%5B2%5D%5Bsearchable%5D=true&columns%5B2%5D%5Borderable%5D=true&columns%5B2%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B2%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B3%5D%5Bdata%5D=od&columns%5B3%5D%5Bname%5D=&columns%5B3%5D%5Bsearchable%5D=true&columns%5B3%5D%5Borderable%5D=true&columns%5B3%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B3%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B4%5D%5Bdata%5D=do&columns%5B4%5D%5Bname%5D=&columns%5B4%5D%5Bsearchable%5D=true&columns%5B4%5D%5Borderable%5D=true&columns%5B4%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B4%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B5%5D%5Bdata%5D=st_transakcij&columns%5B5%5D%5Bname%5D=&columns%5B5%5D%5Bsearchable%5D=true&columns%5B5%5D%5Borderable%5D=true&columns%5B5%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B5%5D%5Bsearch%5D%5Bregex%5D=false&order%5B0%5D%5Bcolumn%5D=0&order%5B0%5D%5Bdir%5D=asc&start={offset}&length={limit}&search%5Bvalue%5D=&search%5Bregex%5D=false&_=1706090961920"
-
-    response = context.fetch_json(page_url, headers=HEADERS, cache_days=1)
-    return response
-
-
 def create_entities(context: Context, record: Dict[str, Any]):
-    organization = context.make("Organization")
-
     organization_name = record.pop("org_naziv")
     organization_number = record.pop("org_sifrapu")
-
-    organization.id = context.make_id(organization_number or organization_name)
-    organization.add("name", organization_name)
-    organization.add("idNumber", organization_number)
 
     legal_entity = context.make("LegalEntity")
     subject_name = record.pop("subjekt_naziv")
@@ -42,24 +26,21 @@ def create_entities(context: Context, record: Dict[str, Any]):
             f"https://erar.si/transakcija/placnik/{organization_number}/prejemnik/{registration_number}",
         )
 
-    validity_link = context.make("UnknownLink")
-    validity_link.id = context.make_id(legal_entity.id)
+    start_date = record.pop("od")
     end_date = record.pop("do")
+    if end_date.startswith("9999"):
+        end_date = "until cancelation"
+    else:
+        end_date = f"to {end_date}"
 
-    validity_link.add("startDate", record.pop("od"))
-    if not end_date.startswith("9999"):
-        validity_link.add("endDate", end_date)
-
-    validity_link.add(
-        "description",
-        "When the restriction is valid from, and when it ends. No end date implies it is valid until canceled",
+    legal_entity.add(
+        "program",
+        f"""{subject_name} is subject to business restriction, valid from {start_date} and applies {end_date}. 
+         Following the regulations, the entity is prohibited because a public sector, {organization_name}, must avoid awarding contracts 
+         or special rights to entities where an official or their family has significant involvement or ownership exceeding 5% """,
     )
-    validity_link.add("subject", legal_entity)
-    validity_link.add("object", organization)
 
     context.emit(legal_entity, target=True)
-    context.emit(organization)
-    context.emit(validity_link)
     context.audit_data(record, ignore=["omejitev_do", "st_transakcij"])
 
 
@@ -71,18 +52,5 @@ def parse_data(context: Context, response: Dict[str, Any]):
 
 
 def crawl(context: Context):
-    offset = 0
-    limit = 100
-    records_total = limit
-    while True:
-        response = fetch_data(context, offset, limit)
-        records_total = (
-            response.get("recordsTotal") if records_total == limit else records_total
-        )
-        parse_data(context, response)
-
-        if offset + limit >= records_total:
-            break
-
-        offset += limit
-        context.log.info(f"Processed entities from page {offset//limit}")
+    response = context.fetch_json(context.data_url, cache_days=1)
+    parse_data(context, response)

--- a/datasets/si/br/si_br.yml
+++ b/datasets/si/br/si_br.yml
@@ -11,12 +11,12 @@ description: >
   More detail from the publisher:
   ----------------------------------
   As the public sector conducts business with private-sector entities, certain corruption risks are generated, especially when individuals with personal interests in the business activity are involved. To safeguard public funds from being used for private gain, legal measures, such as restrictions on business activities and prohibitions, are implemented.
-  These measures are outlined in the Integrity and Prevention of Corruption Act (IPCA)and focus on preventing corruption and avoiding conflicts of interest.
+  These measures are outlined in the Integrity and Prevention of Corruption Act (IPCA) and focus on preventing corruption and avoiding conflicts of interest.
   [Translated and edited from https://www.kpk-rs.si/en/restrictions-of-business-activities/](https://www.kpk-rs.si/en/restrictions-of-business-activities/)
 
   Data gathering process
   --------------------------
-  The data is gathered from the app [Erar](https://erar.si). It is a web application developed by the Komisija za preprečevanje korupcije to enhance transparency by allowing the public and state authorities in Slovenia to access detailed information on transactions involving public institutions and state-owned entities.
+  The data is gathered from the app [Erar](https://erar.si/doc/). It is a web application developed by the Komisija za preprečevanje korupcije to enhance transparency by allowing the public and state authorities in Slovenia to access detailed information on transactions involving public institutions and state-owned entities.
   While the Commission emphasizes the accuracy of published data, occasional discrepancies may occur, urging users to check their completeness, accuracy and up-to-dateness with the original administrator of the database before making decisions based on them. Due to such corrections, the published data may change at any time without prior notice.
 
 publisher:
@@ -25,7 +25,6 @@ publisher:
   description: >
     The Commission for the Prevention of Corruption of the Republic of Slovenia is an independent state body in the Republic of Slovenia whose task is detection 
     and prosecution in pre-criminal or criminal proceedings in the field of corruption. [Source: Wikipedia](https://sl.wikipedia.org/wiki/Komisija_za_prepre%C4%8Devanje_korupcije)
-
   url: https://www.kpk-rs.si/
   country: si
 data:

--- a/datasets/si/br/si_br.yml
+++ b/datasets/si/br/si_br.yml
@@ -10,11 +10,11 @@ description: >
   
   **This is a preventative restriction by Komisija za preprečevanje korupcije and implies no wrongdoing.**
 
-  More detail from the publisher:
-  ----------------------------------
-  As the public sector conducts business with private-sector entities, certain corruption risks are generated, especially when individuals with personal interests in the business activity are involved. To safeguard public funds from being used for private gain, legal measures, such as restrictions on business activities and prohibitions, are implemented.
-  These measures are outlined in the Integrity and Prevention of Corruption Act (IPCA) and focus on preventing corruption and avoiding conflicts of interest.
-  [Translated and edited from https://www.kpk-rs.si/en/restrictions-of-business-activities/](https://www.kpk-rs.si/en/restrictions-of-business-activities/)
+  ### More detail from the publisher:
+  
+  > As the public sector conducts business with private-sector entities, certain corruption risks are generated, especially when individuals with personal interests in the business activity are involved. To safeguard public funds from being used for private gain, legal measures, such as restrictions on business activities and prohibitions, are implemented.
+  > These measures are outlined in the Integrity and Prevention of Corruption Act (IPCA) and focus on preventing corruption and avoiding conflicts of interest.
+  [From https://www.kpk-rs.si/en/restrictions-of-business-activities/](https://www.kpk-rs.si/en/restrictions-of-business-activities/)
 
   Data gathering process
   --------------------------

--- a/datasets/si/br/si_br.yml
+++ b/datasets/si/br/si_br.yml
@@ -4,33 +4,37 @@ prefix: si-br
 url: https://erar.si/omejitve/
 summary: List of Business Restrictions in Slovenia
 description: >
-  This dataset provides information on entities subject to business restrictions and applicable to public sector bodies or organizations involved in public procurement processes or the awarding of concessions or public-private partnerships
+  This dataset provides information on entities subject to business restrictions and applicable to public sector bodies or organizations involved in public procurement processes 
+  or the awarding of concessions or public-private partnerships
 
-  According to the regulations, these entities are prohibited from ordering goods, services, or constructions, and from entering into partnerships or granting special rights to entities in which an official, or their family member, holds a managerial, 
-  administrative, or legal role, or has a significant financial stake exceeding five percent of founding rights, management, or capital. This measure is designed to prevent conflicts of interest and ensure transparency in public dealings.
+  According to the regulations, these entities are prohibited from ordering goods, services, or constructions, and from entering into partnerships or granting special rights to entities 
+  in which an official, or their family member, holds a managerial, administrative, or legal role, or has a significant financial stake exceeding five percent of founding rights, management, 
+  or capital. This measure is designed to prevent conflicts of interest and ensure transparency in public dealings.
 
-  This list is compiled using data provided by committed authorities, with officials required to report information about related entities within one month of assuming office and within eight days of any subsequent changes. 
-  Once received, the relevant authority must communicate this data to the Commission within 15 days. Consequently, the process of entering a specific entity onto the list may take up to 45 days from the start of a function, 
-  and changes may take up to 23 days. 
+  This list is compiled using data provided by committed authorities, with officials required to report information about related entities within one month of assuming office and within 
+  eight days of any subsequent changes. Once received, the relevant authority must communicate this data to the Commission within 15 days. Consequently, the process of entering a specific 
+  entity onto the list may take up to 45 days from the start of a function, and changes may take up to 23 days. 
 
   It's crucial to note that business restrictions come into effect by law immediately upon their occurrence, irrespective of whether the entity is officially registered on the list. 
   Therefore, the absence of an entity on the list does not negate the applicability of business restrictions with that entity.
 publisher:
-  name: Erar application
+  name: Komisija za preprečevanje korupcije
+  acronym: KPK
   description: >
-    Erar (Aerarium) is the Latin name of the treasury and literally means public finances. The application shows data on the use of public money in the Republic of Slovenia. 
-    Individual transactions, data on public procurement e-invoices and other bases for payments are shown.
+    The Commission for the Prevention of Corruption of the Republic of Slovenia is an independent state body in the Republic of Slovenia whose task is detection 
+    and prosecution in pre-criminal or criminal proceedings in the field of corruption. [Source: Wikipedia](https://sl.wikipedia.org/wiki/Komisija_za_prepre%C4%8Devanje_korupcije)
 
-    Developed by the Commission for the Prevention of Corruption, the Erar app enhances transparency by allowing the public and state authorities in Slovenia to access detailed information on 
-    transactions involving public institutions and state-owned entities. Covering various financial aspects such as salaries, social benefits, and subsidies, the platform aims to foster accountability, 
-    informed discussions, and mitigate risks associated with corruption and mismanagement. Utilizing data from multiple registers and institutions, the Erar app is a crucial tool in the Commission's mission 
-    to strengthen the rule of law, integrity, and transparency.
+    Erar is an app developed by the commision that enhances transparency by allowing the public and state authorities in Slovenia to access detailed information on 
+    transactions involving public institutions and state-owned entities. Covering various financial aspects such as salaries, social benefits, and subsidies, the platform aims 
+    to foster accountability, informed discussions, and mitigate risks associated with corruption and mismanagement. Utilizing data from multiple registers and institutions, 
+    the Erar app is a crucial tool in the Commission's mission to strengthen the rule of law, integrity, and transparency.
 
     While the Commission emphasizes the accuracy of published data, occasional discrepancies may occur, urging users to check their completeness, accuracy and up-to-dateness with the original 
-    administrator of the database before making decisions based on them. Due to such corrections, the published data may change at any time without prior notice.
+    administrator of the database before making decisions based on them. Due to such corrgotections, the published data may change at any time without prior notice.
+    [Source: Erar app](https://erar.si/doc/)
 
-  url: https://erar.si
+  url: https://www.kpk-rs.si/
   country: si
 data:
-  url: https://erar.si/api/omejitve/?
+  url: https://erar.si/api/omejitve/
   format: JSON

--- a/datasets/si/br/si_br.yml
+++ b/datasets/si/br/si_br.yml
@@ -16,9 +16,9 @@ description: >
   > These measures are outlined in the Integrity and Prevention of Corruption Act (IPCA) and focus on preventing corruption and avoiding conflicts of interest.
   [From https://www.kpk-rs.si/en/restrictions-of-business-activities/](https://www.kpk-rs.si/en/restrictions-of-business-activities/)
 
-  Data gathering process
-  --------------------------
-  The data is gathered from the app [Erar](https://erar.si/doc/). It is a web application developed by the Komisija za preprečevanje korupcije to enhance transparency by allowing the public and state authorities in Slovenia to access detailed information on transactions involving public institutions and state-owned entities.
+  ### Data gathering process
+
+    The data is gathered from the app [Erar](https://erar.si/doc/). It is a web application developed by the Komisija za preprečevanje korupcije to enhance transparency by allowing the public and state authorities in Slovenia to access detailed information on transactions involving public institutions and state-owned entities.
   While the Commission emphasizes the accuracy of published data, occasional discrepancies may occur, urging users to check their completeness, accuracy and up-to-dateness with the original administrator of the database before making decisions based on them. Due to such corrections, the published data may change at any time without prior notice.
 
 publisher:

--- a/datasets/si/br/si_br.yml
+++ b/datasets/si/br/si_br.yml
@@ -2,36 +2,29 @@ title: Slovenia Business Restrictions
 entry_point: crawler.py
 prefix: si-br
 url: https://erar.si/omejitve/
-summary: List of Business Restrictions in Slovenia
+summary: List of Business restrictions preventing conflict of interest in Slovenia
 description: >
-  This dataset provides information on entities subject to business restrictions and applicable to public sector bodies or organizations involved in public procurement processes 
-  or the awarding of concessions or public-private partnerships
+  Slovenian public bodies and organizations may not procure from entities in which an official in that organization or their family member is a manager, legal representative, or has 5% or more ownership.
+  This is a list of entities where such a relationship exists, and the public organization is restricted/prohibited or permitted to engage in business activities in some instances with the entity. The restricted public organization is noted in the program property of each entity. **The restriction is only on the public organization where the public official has a role - it does not apply to the entire public sector.**
+  **This is a preventative restriction by Komisija za preprečevanje korupcije and implies no wrongdoing.**
 
-  According to the regulations, these entities are prohibited from ordering goods, services, or constructions, and from entering into partnerships or granting special rights to entities 
-  in which an official, or their family member, holds a managerial, administrative, or legal role, or has a significant financial stake exceeding five percent of founding rights, management, 
-  or capital. This measure is designed to prevent conflicts of interest and ensure transparency in public dealings.
+  More detail from the publisher:
+  ----------------------------------
+  As the public sector conducts business with private-sector entities, certain corruption risks are generated, especially when individuals with personal interests in the business activity are involved. To safeguard public funds from being used for private gain, legal measures, such as restrictions on business activities and prohibitions, are implemented.
+  These measures are outlined in the Integrity and Prevention of Corruption Act (IPCA)and focus on preventing corruption and avoiding conflicts of interest.
+  [Translated and edited from https://www.kpk-rs.si/en/restrictions-of-business-activities/](https://www.kpk-rs.si/en/restrictions-of-business-activities/)
 
-  This list is compiled using data provided by committed authorities, with officials required to report information about related entities within one month of assuming office and within 
-  eight days of any subsequent changes. Once received, the relevant authority must communicate this data to the Commission within 15 days. Consequently, the process of entering a specific 
-  entity onto the list may take up to 45 days from the start of a function, and changes may take up to 23 days. 
+  Data gathering process
+  --------------------------
+  The data is gathered from the app [Erar](https://erar.si). It is a web application developed by the Komisija za preprečevanje korupcije to enhance transparency by allowing the public and state authorities in Slovenia to access detailed information on transactions involving public institutions and state-owned entities.
+  While the Commission emphasizes the accuracy of published data, occasional discrepancies may occur, urging users to check their completeness, accuracy and up-to-dateness with the original administrator of the database before making decisions based on them. Due to such corrections, the published data may change at any time without prior notice.
 
-  It's crucial to note that business restrictions come into effect by law immediately upon their occurrence, irrespective of whether the entity is officially registered on the list. 
-  Therefore, the absence of an entity on the list does not negate the applicability of business restrictions with that entity.
 publisher:
   name: Komisija za preprečevanje korupcije
   acronym: KPK
   description: >
     The Commission for the Prevention of Corruption of the Republic of Slovenia is an independent state body in the Republic of Slovenia whose task is detection 
     and prosecution in pre-criminal or criminal proceedings in the field of corruption. [Source: Wikipedia](https://sl.wikipedia.org/wiki/Komisija_za_prepre%C4%8Devanje_korupcije)
-
-    Erar is an app developed by the commision that enhances transparency by allowing the public and state authorities in Slovenia to access detailed information on 
-    transactions involving public institutions and state-owned entities. Covering various financial aspects such as salaries, social benefits, and subsidies, the platform aims 
-    to foster accountability, informed discussions, and mitigate risks associated with corruption and mismanagement. Utilizing data from multiple registers and institutions, 
-    the Erar app is a crucial tool in the Commission's mission to strengthen the rule of law, integrity, and transparency.
-
-    While the Commission emphasizes the accuracy of published data, occasional discrepancies may occur, urging users to check their completeness, accuracy and up-to-dateness with the original 
-    administrator of the database before making decisions based on them. Due to such corrgotections, the published data may change at any time without prior notice.
-    [Source: Erar app](https://erar.si/doc/)
 
   url: https://www.kpk-rs.si/
   country: si

--- a/datasets/si/br/si_br.yml
+++ b/datasets/si/br/si_br.yml
@@ -5,7 +5,9 @@ url: https://erar.si/omejitve/
 summary: List of Business restrictions preventing conflict of interest in Slovenia
 description: >
   Slovenian public bodies and organizations may not procure from entities in which an official in that organization or their family member is a manager, legal representative, or has 5% or more ownership.
+  
   This is a list of entities where such a relationship exists, and the public organization is restricted/prohibited or permitted to engage in business activities in some instances with the entity. The restricted public organization is noted in the program property of each entity. **The restriction is only on the public organization where the public official has a role - it does not apply to the entire public sector.**
+  
   **This is a preventative restriction by Komisija za preprečevanje korupcije and implies no wrongdoing.**
 
   More detail from the publisher:

--- a/datasets/si/br/si_br.yml
+++ b/datasets/si/br/si_br.yml
@@ -1,0 +1,32 @@
+title: Slovenia Business Restrictions
+entry_point: crawler.py
+prefix: si-br
+url: https://erar.si/omejitve/
+summary: List of Business Restrictions in Slovenia
+description: >
+  This dataset provides information on entities subject to business restrictions, applicable to public sector bodies or organizations involved in public procurement processes or the awarding of concessions or public-private partnerships
+
+  According to the regulations, these entities are prohibited from ordering goods, services, or constructions, and from entering into partnerships or granting special rights to entities in which an official, or their family member, holds a managerial, administrative, or legal role, or has a significant financial stake exceeding five percent of founding rights, management, or capital. This measure is designed to prevent conflicts of interest and ensure transparency in public dealings.
+
+  The list of entities subject to business restrictions serves as an informative tool managed by the Commission for the Prevention of Corruption. This list is compiled using data provided by committed authorities, with officials required to report information about related entities within one month of assuming office and within eight days of any subsequent changes. Once received, the relevant authority must communicate this data to the Commission within 15 days. Consequently, the process of entering a specific entity onto the list may take up to 45 days from the start of a function, and changes may take up to 23 days. 
+
+  It's crucial to note that business restrictions come into effect by law immediately upon their occurrence, irrespective of whether the entity is officially registered on the list. Therefore, the absence of an entity on the list does not negate the applicability of business restrictions with that entity. This approach ensures timely enforcement and independence from formal registration processes.
+publisher:
+  name: Erar application
+  description: >
+    Erar (Aerarium) is the Latin name of the treasury and literally means public finances. The application shows data on the use of public money in the Republic of Slovenia. 
+    Individual transactions, data on public procurement e-invoices and other bases for payments are shown.
+
+    Developed by the Commission for the Prevention of Corruption, the Erar app enhances transparency by allowing the public and state authorities in Slovenia to access detailed information on 
+    transactions involving public institutions and state-owned entities. Covering various financial aspects such as salaries, social benefits, and subsidies, the platform aims to foster accountability, 
+    informed discussions, and mitigate risks associated with corruption and mismanagement. Utilizing data from multiple registers and institutions, the Erar app is a crucial tool in the Commission's mission 
+    to strengthen the rule of law, integrity, and transparency.
+
+    While the Commission emphasizes the accuracy of published data, occasional discrepancies may occur, urging users to check their completeness, accuracy and up-to-dateness with the original 
+    administrator of the database before making decisions based on them. Due to such corrections, the published data may change at any time without prior notice.
+
+  url: https://erar.si
+  country: si
+data:
+  url: https://erar.si/api/omejitve
+  format: JSON

--- a/datasets/si/br/si_br.yml
+++ b/datasets/si/br/si_br.yml
@@ -4,13 +4,17 @@ prefix: si-br
 url: https://erar.si/omejitve/
 summary: List of Business Restrictions in Slovenia
 description: >
-  This dataset provides information on entities subject to business restrictions, applicable to public sector bodies or organizations involved in public procurement processes or the awarding of concessions or public-private partnerships
+  This dataset provides information on entities subject to business restrictions and applicable to public sector bodies or organizations involved in public procurement processes or the awarding of concessions or public-private partnerships
 
-  According to the regulations, these entities are prohibited from ordering goods, services, or constructions, and from entering into partnerships or granting special rights to entities in which an official, or their family member, holds a managerial, administrative, or legal role, or has a significant financial stake exceeding five percent of founding rights, management, or capital. This measure is designed to prevent conflicts of interest and ensure transparency in public dealings.
+  According to the regulations, these entities are prohibited from ordering goods, services, or constructions, and from entering into partnerships or granting special rights to entities in which an official, or their family member, holds a managerial, 
+  administrative, or legal role, or has a significant financial stake exceeding five percent of founding rights, management, or capital. This measure is designed to prevent conflicts of interest and ensure transparency in public dealings.
 
-  The list of entities subject to business restrictions serves as an informative tool managed by the Commission for the Prevention of Corruption. This list is compiled using data provided by committed authorities, with officials required to report information about related entities within one month of assuming office and within eight days of any subsequent changes. Once received, the relevant authority must communicate this data to the Commission within 15 days. Consequently, the process of entering a specific entity onto the list may take up to 45 days from the start of a function, and changes may take up to 23 days. 
+  This list is compiled using data provided by committed authorities, with officials required to report information about related entities within one month of assuming office and within eight days of any subsequent changes. 
+  Once received, the relevant authority must communicate this data to the Commission within 15 days. Consequently, the process of entering a specific entity onto the list may take up to 45 days from the start of a function, 
+  and changes may take up to 23 days. 
 
-  It's crucial to note that business restrictions come into effect by law immediately upon their occurrence, irrespective of whether the entity is officially registered on the list. Therefore, the absence of an entity on the list does not negate the applicability of business restrictions with that entity. This approach ensures timely enforcement and independence from formal registration processes.
+  It's crucial to note that business restrictions come into effect by law immediately upon their occurrence, irrespective of whether the entity is officially registered on the list. 
+  Therefore, the absence of an entity on the list does not negate the applicability of business restrictions with that entity.
 publisher:
   name: Erar application
   description: >
@@ -28,5 +32,5 @@ publisher:
   url: https://erar.si
   country: si
 data:
-  url: https://erar.si/api/omejitve
+  url: https://erar.si/api/omejitve/?
   format: JSON


### PR DESCRIPTION
Closes #419  

@jbothma I crawled the dataset similar to the entities used in [aleph](https://aleph.occrp.org/datasets/8867) but the `target.nested.json` stays empty.
I was thinking it is could be because the debarment role has not been added to the dataset but the target entity (`LegalEntity`)  does not have th attribute.
can you please take a look and let me know what you think.
