### PR TITLE
Sketch out nested topic-based export

### DIFF
--- a/datasets/_collections/default.yml
+++ b/datasets/_collections/default.yml
@@ -14,6 +14,7 @@ exports:
   - names.txt
   - senzing.json
   - targets.nested.json
+  - topics.nested.json
   - targets.simple.csv
   - statements.csv
 summary: >

--- a/datasets/_externals/wikidata.yml
+++ b/datasets/_externals/wikidata.yml
@@ -361,6 +361,7 @@ lookups:
           - Later Han dynasty
           - Shang dynasty
           - Mohegan
+          - New Spain
         value: null
       - match:
           - Cherokee Nation

--- a/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
+++ b/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
@@ -58,6 +58,7 @@ lookups:
     options:
       - match:
           - aka
+          - a
           - Original Script
         value: alias
       - match:
@@ -110,6 +111,8 @@ lookups:
         value: Lebanon
       - match: Ukranian
         value: UA
+      - match: Belarussian
+        value: BY
       - match: Tobago
         value: Trinidad
       - match: Herzegovina

--- a/datasets/gb/hmt/gb_hmt_sanctions.yml
+++ b/datasets/gb/hmt/gb_hmt_sanctions.yml
@@ -103,6 +103,8 @@ lookups:
           - Central Bank of Russia
           - Petrostroi-SPB Aktsionernoe Obshchestvo ATTK-NN
           - Moscow Institute of Thermal Technology
+          - PARAMOUNT ENERGY & COMMODITIES DMCC
+          - AKTSIONERNOE OBSHCHESTVO ALYUMINIEVYE PRODUKTY - KHOLDING
         value: SAME
       - match: Subsidiary of the Organisation for Technological Industries (OTI) and therefore the Syrian Ministry of Defence
         values:
@@ -607,6 +609,18 @@ lookups:
           - 20shrhrabota@gmail.com
       - match: info@etemad mobin.com
         value: info@etemad-mobin.com
+      - match: (1) Info@sasta.ru (2) sastalogist@yandex.ru
+        values:
+          - Info@sasta.ru
+          - sastalogist@yandex.ru
+      - match: (1) Info@bpk-spb.ru (2) service@bpk.spb.ru
+        values:
+          - Info@bpk-spb.ru 
+          - service@bpk.spb.ru
+      - match: (1) azia@aziaship.com (2) business@aziaship.com
+        values:
+          - azia@aziaship.com
+          - business@aziaship.com
   type.gender:
     lowercase: true
     normalize: true

--- a/zavod/zavod/exporters/__init__.py
+++ b/zavod/zavod/exporters/__init__.py
@@ -6,7 +6,8 @@ from zavod.context import Context
 from zavod.meta import Dataset
 from zavod.exporters.common import Exporter
 from zavod.exporters.ftm import FtMExporter
-from zavod.exporters.nested import NestedJSONExporter
+from zavod.exporters.nested import NestedTargetsJSONExporter
+from zavod.exporters.nested import NestedTopicsJSONExporter
 from zavod.exporters.names import NamesExporter
 from zavod.exporters.simplecsv import SimpleCSVExporter
 from zavod.exporters.senzing import SenzingExporter
@@ -22,7 +23,7 @@ log = get_logger(__name__)
 DEFAULT_EXPORTERS: Set[str] = {
     StatisticsExporter.FILE_NAME,
     FtMExporter.FILE_NAME,
-    NestedJSONExporter.FILE_NAME,
+    NestedTargetsJSONExporter.FILE_NAME,
     NamesExporter.FILE_NAME,
     SimpleCSVExporter.FILE_NAME,
     SenzingExporter.FILE_NAME,
@@ -30,7 +31,8 @@ DEFAULT_EXPORTERS: Set[str] = {
 EXPORTERS: Dict[str, Type[Exporter]] = {
     StatisticsExporter.FILE_NAME: StatisticsExporter,
     FtMExporter.FILE_NAME: FtMExporter,
-    NestedJSONExporter.FILE_NAME: NestedJSONExporter,
+    NestedTargetsJSONExporter.FILE_NAME: NestedTargetsJSONExporter,
+    NestedTopicsJSONExporter.FILE_NAME: NestedTopicsJSONExporter,
     NamesExporter.FILE_NAME: NamesExporter,
     SimpleCSVExporter.FILE_NAME: SimpleCSVExporter,
     SenzingExporter.FILE_NAME: SenzingExporter,

--- a/zavod/zavod/exporters/nested.py
+++ b/zavod/zavod/exporters/nested.py
@@ -13,9 +13,8 @@ class NestedJSONExporter(Exporter):
 
     def feed(self, entity: Entity) -> None:
         if self.is_root(entity):
-            return
-        data = entity.to_nested_dict(self.view)
-        write_json(data, self.fh)
+            data = entity.to_nested_dict(self.view)
+            write_json(data, self.fh)
 
     def finish(self) -> None:
         self.fh.close()

--- a/zavod/zavod/exporters/nested.py
+++ b/zavod/zavod/exporters/nested.py
@@ -4,16 +4,15 @@ from zavod.entity import Entity
 
 
 class NestedJSONExporter(Exporter):
-    TITLE = "Targets as nested JSON"
-    FILE_NAME = "targets.nested.json"
-    MIME_TYPE = "application/json"
-
     def setup(self) -> None:
         super().setup()
         self.fh = open(self.path, "wb")
 
+    def is_root(self, entity: Entity) -> bool:
+        return False
+
     def feed(self, entity: Entity) -> None:
-        if not entity.target:
+        if self.is_root(entity):
             return
         data = entity.to_nested_dict(self.view)
         write_json(data, self.fh)
@@ -21,3 +20,40 @@ class NestedJSONExporter(Exporter):
     def finish(self) -> None:
         self.fh.close()
         super().finish()
+
+
+class NestedTargetsJSONExporter(NestedJSONExporter):
+    TITLE = "Targets as nested JSON"
+    FILE_NAME = "targets.nested.json"
+    MIME_TYPE = "application/json"
+
+    def is_root(self, entity: Entity) -> bool:
+        return entity.target or False
+
+
+class NestedTopicsJSONExporter(NestedJSONExporter):
+    TITLE = "Relevant topic tagged entities as nested JSON"
+    FILE_NAME = "topics.nested.json"
+    MIME_TYPE = "application/json"
+
+    _TOPICS = set(
+        [
+            "role.pep",
+            "role.rca",
+            "sanction",
+            "sanction.linked",
+            "debarment",
+            "poi",
+            "crime",
+            "crime.theft",
+            "crime.war",
+            "crime.fin",
+            "crime.traffick" "corp.disqual",
+            "export.control",
+            "role.oligarch",
+        ]
+    )
+
+    def is_root(self, entity: Entity) -> bool:
+        topics = entity.get("topics", quiet=True)
+        return len(self._TOPICS.intersection(topics)) > 0

--- a/zavod/zavod/tests/exporters/test_nested.py
+++ b/zavod/zavod/tests/exporters/test_nested.py
@@ -1,0 +1,70 @@
+from json import loads
+from datetime import datetime
+
+from zavod import settings
+from zavod.meta import Dataset
+from zavod.archive import clear_data_path
+from zavod.exporters.nested import NestedTargetsJSONExporter
+from zavod.exporters.nested import NestedTopicsJSONExporter
+from zavod.crawl import crawl_dataset
+from zavod.tests.exporters.util import harnessed_export
+
+
+TIME_SECONDS_FMT = "%Y-%m-%dT%H:%M:%S"
+
+
+
+def test_nested_targets(testdataset1: Dataset):
+    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    clear_data_path(testdataset1.name)
+
+    crawl_dataset(testdataset1)
+    harnessed_export(NestedTargetsJSONExporter, testdataset1)
+
+    with open(dataset_path / "targets.nested.json") as nested_file:
+        entities = [loads(line) for line in nested_file.readlines()]
+
+    for entity in entities:
+        # Fail if incorrect format
+        datetime.strptime(entity["first_seen"], TIME_SECONDS_FMT)
+        datetime.strptime(entity["last_seen"], TIME_SECONDS_FMT)
+        datetime.strptime(entity["last_change"], TIME_SECONDS_FMT)
+        assert entity["datasets"] == ["testdataset1"]
+
+    john = [e for e in entities if e["id"] == "osv-john-doe"][0]
+    assert john['properties']["name"] == ["John Doe"]
+
+    family_id = "osv-eb0a27f226377001807c04a1ca7de8502cf4d0cb"
+    # Family relationship is not included as a root object
+    assert len([e for e in entities if e["id"] == family_id]) == 0
+
+    assert len(john["properties"]["familyPerson"]) == 1
+    fam = john["properties"]["familyPerson"][0]
+    assert fam["id"] == family_id
+    assert fam["properties"]["person"][0] == "osv-john-doe"
+    assert fam["properties"]["relative"][0]["id"] == "osv-jane-doe"
+
+
+def test_nested_topics(testdataset1: Dataset):
+    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    clear_data_path(testdataset1.name)
+
+    crawl_dataset(testdataset1)
+    harnessed_export(NestedTopicsJSONExporter, testdataset1)
+
+    with open(dataset_path / "topics.nested.json") as nested_file:
+        entities = [loads(line) for line in nested_file.readlines()]
+
+    assert len(entities) > 0, entities
+
+    for entity in entities:
+        # Fail if incorrect format
+        datetime.strptime(entity["first_seen"], TIME_SECONDS_FMT)
+        datetime.strptime(entity["last_seen"], TIME_SECONDS_FMT)
+        datetime.strptime(entity["last_change"], TIME_SECONDS_FMT)
+        assert entity["datasets"] == ["testdataset1"]
+        topics = entity['properties']['topics']
+        assert len(NestedTopicsJSONExporter._TOPICS.intersection(topics)) > 0
+
+    john = [e for e in entities if e["id"] == "osv-mierscheid"][0]
+    assert john['properties']["name"] == ["Jakob Maria Mierscheid"]


### PR DESCRIPTION
This implements #594 but not for all topic types, only the ones that can be counted as risk indications. The alternative would be to only export `role.pep` and `role.rca`, which meets the more narrow customer need expressed. 