### PR TITLE
Add Otkhozoria–Tatunashvili List

### DIFF
--- a/datasets/_collections/sanctions.yml
+++ b/datasets/_collections/sanctions.yml
@@ -36,6 +36,7 @@ children:
   - fr_tresor_gels_avoir
   - gb_hmt_invbans
   - gb_hmt_sanctions
+  - ge_ot_list
   - il_mod_terrorists
   - in_mha_banned
   - jp_mof_sanctions

--- a/datasets/eu/reg_2878_sanctions/crawler.py
+++ b/datasets/eu/reg_2878_sanctions/crawler.py
@@ -16,7 +16,6 @@ def crawl_row(context: Context, row: Dict[str, str]):
     name = row.pop("Name").strip()
     country = row.pop("Country").strip()
 
-
     context.log.info(f"Processing row ID {row_id}: {name}")
     entity = context.make(entity_type)
     entity.id = context.make_id(row_id, name, country)

--- a/datasets/ge/ot_list/crawler.py
+++ b/datasets/ge/ot_list/crawler.py
@@ -6,7 +6,6 @@ the individuals on the Otkhozoria–Tatunashvili List.
 import re
 from typing import Dict
 
-from transliterate import translit
 from zavod import Context, Entity
 from zavod import helpers as h
 from lxml.html import HtmlElement
@@ -23,7 +22,6 @@ UNUSED_FIELDS = [
 ]
 DATE_FORMATS = ["%d.%m.%Y", "%Y"]
 PATROYNMIC = re.compile(r"\b(\S+)\s+ძე\s+")
-RUSSIANIZE = re.compile(r"([oe]v)i$")
 
 
 def extract_name(context: Context, person: Entity, name: str):
@@ -35,14 +33,6 @@ def extract_name(context: Context, person: Entity, name: str):
         name = name[:m.start()] + name[m.end():]
         context.log.debug(f"Patroynmic: {m.group(1)}")
     h.apply_name(person, full=name, patronymic=patronym, lang="geo")
-    transliterated = translit(name, "ka", reversed=True).title()
-    context.log.debug(f"Transliterated: {transliterated}")
-    h.apply_name(person, transliterated)
-    # Remove Georgian -ი ending from obviously Russian names
-    rname = RUSSIANIZE.sub(r"\1", transliterated)
-    if rname != name:
-        context.log.debug(f"Russified: {rname}")
-        h.apply_name(person, rname)
 
 
 def crawl_row(context: Context, row: Dict[str, str]):

--- a/datasets/ge/ot_list/crawler.py
+++ b/datasets/ge/ot_list/crawler.py
@@ -1,0 +1,94 @@
+"""
+Crawl the website of the Legislative Herald of Georgia and extract
+the individuals on the Otkhozoria–Tatunashvili List.
+"""
+
+import re
+from typing import Dict
+
+from transliterate import translit
+from zavod import Context, Entity
+from zavod import helpers as h
+from lxml.html import HtmlElement
+
+TARGET = "ბრალდებული/ მსჯავრდებული"
+DEMOGRAPHICS = "დემოგრაფიული მონაცემები"
+STATUS = "სტატუსი"
+UNKNOWN = "უცნობია"
+UNUSED_FIELDS = [
+    "საქმის მდგომარეობა",
+    "დანაშაულის ჩადენის ადგილი",
+    "მოკლე ფაბულა",
+    "შენიშვნა",
+]
+DATE_FORMATS = ["%d.%m.%Y", "%Y"]
+PATROYNMIC = re.compile(r"\b(\S+)\s+ძე\s+")
+RUSSIANIZE = re.compile(r"([oe]v)i$")
+
+
+def extract_name(context: Context, person: Entity, name: str):
+    """Parse a Georgian name slightly and transliterate."""
+    patronym = None
+    m = PATROYNMIC.search(name)
+    if m is not None:
+        patronym = m.group(1)
+        name = name[:m.start()] + name[m.end():]
+        context.log.debug(f"Patroynmic: {m.group(1)}")
+    h.apply_name(person, full=name, patronymic=patronym, lang="geo")
+    transliterated = translit(name, "ka", reversed=True).title()
+    context.log.debug(f"Transliterated: {transliterated}")
+    h.apply_name(person, transliterated)
+    # Remove Georgian -ი ending from obviously Russian names
+    rname = RUSSIANIZE.sub(r"\1", transliterated)
+    if rname != name:
+        context.log.debug(f"Russified: {rname}")
+        h.apply_name(person, rname)
+
+
+def crawl_row(context: Context, row: Dict[str, str]):
+    """Process a row of the table in the OT list."""
+    name = row.pop(TARGET)
+    context.log.debug(f"Adding person: {name}")
+    birth_date = row.pop(DEMOGRAPHICS).split(maxsplit=1)[0]
+    status = row.pop(STATUS)
+    person = context.make("Person")
+    person.id = context.make_id(row.pop("index"), name, status)
+    context.log.debug(f"Unique ID {person.id}")
+    if birth_date != UNKNOWN:
+        person.add("birthDate", h.parse_date(birth_date, DATE_FORMATS))
+    person.add("topics", "sanction")
+    person.add("country", "ge")
+    extract_name(context, person, name)
+    context.audit_data(row, UNUSED_FIELDS)
+    sanction = h.make_sanction(context, person)
+    sanction.set("authority", "Georgian Ministry of Justice")
+    sanction.add("sourceUrl", context.data_url)
+    context.emit(person, target=True)
+    context.emit(sanction)
+
+
+def crawl_page(context: Context, page: HtmlElement):
+    """Process the HTML format of the OT list."""
+    maindoc = page.get_element_by_id("maindoc")
+    table = maindoc.get_element_by_id("DOCUMENT:1;ENCLOSURE:1;POINT:1;_Content")
+    # It is a table within a table, but it might not always be
+    t = table.find("tr/td/table")
+    if t is not None:
+        table = t
+    rows = table.iterfind(".//tr")
+    header = next(rows)
+    titles = [c.text_content().strip() for c in header.iterfind("td")]
+    titles[0] = "index"
+    for tr in rows:
+        row = dict(
+            (titles[idx], c.text_content().strip())
+            for idx, c in enumerate(tr.iterfind("td"))
+        )
+        crawl_row(context, row)
+
+
+def crawl(context: Context):
+    """Retrieve the text of the Otkhozoria-Tatunashvili List and
+    extract entities."""
+    page = context.fetch_html(context.data_url, cache_days=1)
+    crawl_page(context, page)

--- a/datasets/ge/ot_list/ge_ot_list.yml
+++ b/datasets/ge/ot_list/ge_ot_list.yml
@@ -31,4 +31,12 @@ publisher:
     state agencies, as well as international agreements, decisions by
     the Constitutional Court, local self-government acts, and public
     statements.
-
+assertions:
+  min:
+    schema_entities:
+      Person: 33
+    country_entities:
+      ge: 1
+  max:
+    schema_entities:
+      Person: 33

--- a/datasets/ge/ot_list/ge_ot_list.yml
+++ b/datasets/ge/ot_list/ge_ot_list.yml
@@ -1,0 +1,34 @@
+title: Otkhozoria–Tatunashvili List
+entry_point: crawler.py
+prefix: ge-ot-list
+coverage:
+  frequency: daily
+  start: 2024-03-01
+summary: >-
+  List of individuals involved in crimes against Georgians in Abkhazia
+  and South Osssetia.
+description: |
+  The Otkhozoria–Tatunashvili List was originally adopted by the
+  parliament of Georgia on June 26, 2018 in response to the killings
+  of Archil Tatunashvili and Giga Otkhozoria by separatist authorities
+  in Russian-occupied regions of Georgia.  It lists a number of
+  individuals who have been found guilty or are awaiting trial for
+  crimes such as murder, kidnapping, torture, and inhumane treatment
+  against ethnic Georgians.
+url: https://matsne.gov.ge/ka/document/view/4234552?publication=0
+data:
+  url: https://matsne.gov.ge/ka/document/view/4234552?publication=0
+  format: HTML
+publisher:
+  name: საქართველოს საკანონმდებლო მაცნე
+  country: ge
+  url: https://matsne.gov.ge/en
+  description: |
+    The Legislative Herald of Georgia, established in 1998 under the
+    authority of the Ministry of Justice, is the official gazette of
+    Georgia.  Since 2011, it maintains a user-friendly, protected, and
+    regularly updated website providing all normative acts adopted by
+    state agencies, as well as international agreements, decisions by
+    the Constitutional Court, local self-government acts, and public
+    statements.
+

--- a/datasets/ge/ot_list/ge_ot_list.yml
+++ b/datasets/ge/ot_list/ge_ot_list.yml
@@ -39,4 +39,4 @@ assertions:
       ge: 1
   max:
     schema_entities:
-      Person: 33
+      Person: 100

--- a/zavod/setup.py
+++ b/zavod/setup.py
@@ -46,7 +46,6 @@ setup(
         "requests_oauthlib",
         "sqlalchemy[mypy]",
         "structlog",
-        "transliterate",
         "xlrd == 2.0.1",
     ],
     tests_require=[],

--- a/zavod/setup.py
+++ b/zavod/setup.py
@@ -46,6 +46,7 @@ setup(
         "requests_oauthlib",
         "sqlalchemy[mypy]",
         "structlog",
+        "transliterate",
         "xlrd == 2.0.1",
     ],
     tests_require=[],


### PR DESCRIPTION
Add sanctioned individuals from the OT list.  Attempt to provide coverage of different versions of their names (please verify this...)

Note that it isn't clear from the "demographic data" column whether the places listed are place of birth or current residence.  For this reason I haven't done anything with them.  The dates are clearly dates of birth though.

Names are not transliterated since the downstream entity matching framework will handle that.  Patronymics, of the sort "დავით **ჯემალის ძე** გურწიევი" (Davit **Jemalis dze** Gurtsievi) are extracted as they are not generally used in Georgian names, but could be useful for disambiguating (presumably they are used equivalently to Russian patronyms here)

See https://github.com/opensanctions/crawler-planning/issues/77