### PR TITLE
Try urllib3 backoff and retry

### DIFF
--- a/datasets/_global/interpol/interpol_api.py
+++ b/datasets/_global/interpol/interpol_api.py
@@ -2,7 +2,8 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Set
 from requests.exceptions import HTTPError
-from time import sleep
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 
 from zavod import Context
 from zavod import helpers as h
@@ -12,7 +13,6 @@ from zavod import helpers as h
 CACHE_VSHORT = 1
 CACHE_SHORT = 7
 CACHE_LONG = 14
-SLEEP_SECONDS = 0
 IGNORE_FIELDS = [
     "languages_spoken_ids",
     "hairs_id",
@@ -23,7 +23,9 @@ IGNORE_FIELDS = [
 MAX_RESULTS = 160
 SEEN_URLS: Set[str] = set()
 SEEN_IDS: Set[str] = set()
-COUNTRIES_URL = "https://www.interpol.int/en/How-we-work/Notices/Red-Notices/View-Red-Notices"
+COUNTRIES_URL = (
+    "https://www.interpol.int/en/How-we-work/Notices/Red-Notices/View-Red-Notices"
+)
 FORMATS = ["%Y/%m/%d", "%Y/%m", "%Y"]
 GENDERS = ["M", "F", "U"]
 AGE_MIN = 20
@@ -36,7 +38,6 @@ STATUSES = defaultdict(int)
 
 def get_countries(context: Context) -> List[Any]:
     doc = context.fetch_html(COUNTRIES_URL, cache_days=CACHE_VSHORT, headers=HEADERS)
-    sleep(SLEEP_SECONDS)
     path = ".//select[@id='arrestWarrantCountryId']/option"
     options: List[Any] = []
     for option in doc.findall(path):
@@ -73,7 +74,6 @@ def crawl_notice(context: Context, notice: Dict[str, Any]) -> None:
         )
         STATUSES[err.response.status_code] += 1
         return
-    sleep(SLEEP_SECONDS)
     notice.pop("_links", {})
     notice.pop("_embedded", {})
     entity_id = notice.pop("entity_id")
@@ -117,10 +117,7 @@ def crawl_query(context: Context, query: Dict[str, Any]) -> int:
     params["resultPerPage"] = MAX_RESULTS
     try:
         data = context.fetch_json(
-            context.data_url,
-            params=params,
-            cache_days=CACHE_SHORT,
-            headers=HEADERS
+            context.data_url, params=params, cache_days=CACHE_SHORT, headers=HEADERS
         )
     except HTTPError as err:
         if err.response.status_code == 404:
@@ -132,7 +129,6 @@ def crawl_query(context: Context, query: Dict[str, Any]) -> int:
         )
         STATUSES[err.response.status_code] += 1
         return 0
-    sleep(SLEEP_SECONDS)
     total: int = data.get("total", 0)
     notices = data.get("_embedded", {}).get("notices", [])
     for notice in notices:
@@ -145,6 +141,10 @@ def crawl(context: Context) -> None:
     # context.log.info("Loading interpol API cache...")
     # context.cache.preload("https://ws-public.interpol.int/notices/%")
     # crawl_query(context, {"sexId": "U"})
+
+    retries = Retry(total=5, backoff_factor=1, status_forcelist=[403])
+    context.http.mount("https://", HTTPAdapter(max_retries=retries))
+
     countries = get_countries(context)
     covered_countries = set()
 


### PR DESCRIPTION
it seems to work well with interpol's setup - some requests require numerous retries, some only one or two

```
2024-03-05 11:56:36 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2024-10721 HTTP/1.1" 200 866 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:36 [debug    ] HTTP GET                       [interpol_red_notices] dataset=interpol_red_notices url=https://ws-public.interpol.int/notices/v1/red/2003-44473
2024-03-05 11:56:36 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2003-44473 HTTP/1.1" 403 315 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:36 [debug    ] Incremented Retry for (url='/notices/v1/red/2003-44473'): Retry(total=4, connect=None, read=None, redirect=None, status=None) [urllib3.util.retry] dataset=interpol_red_notices
2024-03-05 11:56:36 [debug    ] Retry: /notices/v1/red/2003-44473 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:36 [debug    ] Resetting dropped connection: ws-public.interpol.int [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:36 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2003-44473 HTTP/1.1" 403 315 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:36 [debug    ] Incremented Retry for (url='/notices/v1/red/2003-44473'): Retry(total=3, connect=None, read=None, redirect=None, status=None) [urllib3.util.retry] dataset=interpol_red_notices
2024-03-05 11:56:38 [debug    ] Retry: /notices/v1/red/2003-44473 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:38 [debug    ] Resetting dropped connection: ws-public.interpol.int [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:38 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2003-44473 HTTP/1.1" 403 315 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:38 [debug    ] Incremented Retry for (url='/notices/v1/red/2003-44473'): Retry(total=2, connect=None, read=None, redirect=None, status=None) [urllib3.util.retry] dataset=interpol_red_notices
2024-03-05 11:56:42 [debug    ] Retry: /notices/v1/red/2003-44473 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:42 [debug    ] Resetting dropped connection: ws-public.interpol.int [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:42 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2003-44473 HTTP/1.1" 403 315 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:42 [debug    ] Incremented Retry for (url='/notices/v1/red/2003-44473'): Retry(total=1, connect=None, read=None, redirect=None, status=None) [urllib3.util.retry] dataset=interpol_red_notices
2024-03-05 11:56:50 [debug    ] Retry: /notices/v1/red/2003-44473 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:50 [debug    ] Resetting dropped connection: ws-public.interpol.int [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:50 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2003-44473 HTTP/1.1" 200 876 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:50 [debug    ] HTTP GET                       [interpol_red_notices] dataset=interpol_red_notices url=https://ws-public.interpol.int/notices/v1/red/2024-9074
2024-03-05 11:56:51 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2024-9074 HTTP/1.1" 200 789 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:51 [debug    ] HTTP GET                       [interpol_red_notices] dataset=interpol_red_notices url=https://ws-public.interpol.int/notices/v1/red/2024-9454
2024-03-05 11:56:51 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2024-9454 HTTP/1.1" 403 314 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:51 [debug    ] Incremented Retry for (url='/notices/v1/red/2024-9454'): Retry(total=4, connect=None, read=None, redirect=None, status=None) [urllib3.util.retry] dataset=interpol_red_notices
2024-03-05 11:56:51 [debug    ] Retry: /notices/v1/red/2024-9454 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:51 [debug    ] Resetting dropped connection: ws-public.interpol.int [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:51 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2024-9454 HTTP/1.1" 403 314 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:51 [debug    ] Incremented Retry for (url='/notices/v1/red/2024-9454'): Retry(total=3, connect=None, read=None, redirect=None, status=None) [urllib3.util.retry] dataset=interpol_red_notices
2024-03-05 11:56:53 [debug    ] Retry: /notices/v1/red/2024-9454 [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:53 [debug    ] Resetting dropped connection: ws-public.interpol.int [urllib3.connectionpool] dataset=interpol_red_notices
2024-03-05 11:56:53 [debug    ] https://ws-public.interpol.int:443 "GET /notices/v1/red/2024-9454 HTTP/1.1" 200 817 [urllib3.connectionpool] dataset=interpol_red_notices
```