### PR TITLE
Add debug configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__/
 *.sql
 .env
 .envrc
-.vscode
+.vscode/launch.json
 .idea/
 balkhashdb
 

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // This is the main debug configuration for the Zavod project
+            // to use it you can copy it over to your own launch.json file
+            // and then select it from the debug menu while viewing a
+            // crawlers .YAML file.
+            "name": "Debug: Crawl of current .YAML",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/zavod/zavod/debug_cli.py",
+            "console": "integratedTerminal",
+            "args": ["crawl", "-c", "${file}"]
+        },
+    ]
+}

--- a/zavod/docs/usage.md
+++ b/zavod/docs/usage.md
@@ -39,5 +39,5 @@ $ zavod export --clear ...
 ```
 
 # Debugging Crawlers in VSCode
-It is possible to debug crawlers through the Python debugger that comes with the standard VSCode install. To enable it either rename `.vscode/launch.json.example` to `launch.json` or copy over the launch configuration you find in it to your own `launch.json` file. 
+It is possible to debug crawlers through the Python debugger that comes with the standard VSCode install. To enable it either rename `.vscode/launch.json.example` to `.vscode/launch.json` or copy over the launch configuration you find in it to your own `launch.json` file. 
 You should now be able to run crawlers by navigating to their `.yaml` file and running the "Debug: Crawl of current .YAML" launch configuration.

--- a/zavod/docs/usage.md
+++ b/zavod/docs/usage.md
@@ -35,4 +35,9 @@ $ zavod crawl ...
 Then run the exporter with `--clear` to ensure the latest statements are included in the output:
 
 ```bash
-$ zavod export --clear ...```
+$ zavod export --clear ...
+```
+
+# Debugging Crawlers in VSCode
+It is possible to debug crawlers through the Python debugger that comes with the standard VSCode install. To enable it either rename `.vscode/launch.json.example` to `launch.json` or copy over the launch configuration you find in it to your own `launch.json` file. 
+You should now be able to run crawlers by navigating to their `.yaml` file and running the "Debug: Crawl of current .YAML" launch configuration.


### PR DESCRIPTION
Added a debug configuration for the ones of us working in VSCode. To enable it either rename `.vscode/launch.json.example` to `launch.json` or copy over the launch configuration you find in it to your own `launch.json` file. 
You should now be able to run crawlers by navigating to their `.yaml` file and running the "Debug: Crawl of current .YAML" launch configuration.