### PR TITLE
A way to catch edit inconsistencies and forgetfulness

### DIFF
--- a/contrib/check_children.py
+++ b/contrib/check_children.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+from typing import Dict, List
+from glob import glob
+from pathlib import Path
+
+from zavod.meta.dataset import Dataset
+from zavod.meta import get_catalog
+
+
+ROOTS = {
+    "graph",
+    "all",
+    "securities",
+    "sanctions_unresolved",
+    "work",
+    "incoming",
+    "openownership",
+    "alert_testing",
+}
+
+catalog = get_catalog()
+yamls = glob("datasets/**/*.y*ml", recursive=True)
+for yaml in yamls:
+    catalog.load_yaml(Path(yaml))
+
+dataset_collections: Dict[str, List[str]] = defaultdict(list)
+
+# For each dataset with children, do all of its children exist?
+for dataset in catalog.datasets:
+    # nomenklatura.dataset.Dataset.children will log missing datasets on access.
+    for child in dataset.children:
+        dataset_collections[child.name].append(dataset.name)
+
+# Is each dataset in at least one collection?
+for dataset in catalog.datasets:
+    if dataset.name not in ROOTS and not dataset_collections[dataset.name]:
+        print(f"Dataset {dataset} is not in any collections")


### PR DESCRIPTION
```
-> opensanctions/opensanctions):
 (catch-fail) $ python contrib/check_children.py
Missing child dataset: 'th_amlo' (in 'incoming')
Dataset <Dataset(kz_companies)> is not in any collections
Dataset <Dataset(th_designated_person)> is not in any collections
```

1) Can you see this as part of CI? Perhaps as

```bash
$FAIL=$(python check_children.py)
[[ -z "$1" ]] && { echo $FAIL; exit 1 }
```

2) Is there already something that does this definition-side globbing?