### PR TITLE
Try fixing doc build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y -qq libicu-dev
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.10
           cache: 'pip'
       - name: Install requirements
         working-directory: zavod

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,6 @@ jobs:
           sudo apt-get install -y -qq libicu-dev
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
           cache: 'pip'
       - name: Install requirements
         working-directory: zavod
@@ -51,6 +50,8 @@ jobs:
 
   # Deployment job
   deploy:
+    # just to test without deploying
+    if: ${{ github.ref == 'refs/heads/main' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,11 @@
 name: docs
 
-on:
-  push:
-    branches: ["main"]
-  workflow_dispatch:
+
+on: [push, workflow_dispatch]
+# on:
+#   push:
+#     branches: ["main"]
+#   workflow_dispatch:
 
 permissions:
   contents: read
@@ -27,6 +29,7 @@ jobs:
           sudo apt-get install -y -qq libicu-dev
       - uses: actions/setup-python@v5
         with:
+          python-version: 3.11
           cache: 'pip'
       - name: Install requirements
         working-directory: zavod
@@ -40,6 +43,8 @@ jobs:
         working-directory: zavod
         run: mkdocs build -c -d site
       - name: Upload artifact
+        # just to test without deploying
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./zavod/site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y -qq libicu-dev
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: 'pip'
       - name: Install requirements
         working-directory: zavod

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,9 @@
 name: docs
 
-
-on: [push, workflow_dispatch]
-# on:
-#   push:
-#     branches: ["main"]
-#   workflow_dispatch:
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -43,16 +41,12 @@ jobs:
         working-directory: zavod
         run: mkdocs build -c -d site
       - name: Upload artifact
-        # just to test without deploying
-        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./zavod/site
 
   # Deployment job
   deploy:
-    # just to test without deploying
-    if: ${{ github.ref == 'refs/heads/main' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
           sudo apt-get install -y -qq libicu-dev
       - uses: actions/setup-python@v5
         with:
+          python-version: "3.11"
           cache: 'pip'
       - name: Install requirements
         working-directory: zavod


### PR DESCRIPTION
The docs workflow is failing when we don't pin the python version.

It looks like https://github.com/pypa/pip/issues/10851 but I don't see new mentions of this and I didn't try different pip versions. The latest release of pip was in Feb, and the latest release of the ubuntu-latest runner last week doesn't seem to have touched these things, so I don't understand.

The default version of python on ubuntu-latest seems to be 3.10 but it works when pinning to 3.10. Maybe pinning with setup-python uses a different installation with different pip?

Anyway, pinning to 3.11 works, so whatever.