### PR TITLE
disable docker build cache as an experiment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
           pull: true
           push: true
           tags: ghcr.io/opensanctions/opensanctions:latest
-          cache-from: type=gha
+          # cache-from: type=gha
           cache-to: type=gha,mode=max
 
   dispatch:


### PR DESCRIPTION
We're seeing a ton of vulnerability alerts and I'm not sure if we're using an aged docker base image somehow. 