### PR TITLE
warn instead of error for new enrichers without entities

### DIFF
--- a/zavod/zavod/tests/test_cli.py
+++ b/zavod/zavod/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_validate_dataset():
     result = runner.invoke(cli, ["validate", "/dev/null"])
     assert result.exit_code != 0, result.output
     result = runner.invoke(cli, ["validate", DATASET_1_YML.as_posix()])
-    assert result.exit_code != 0, result.output
+    assert result.exit_code == 0, result.output
     assert "No entities validated" in result.output, result.output
     shutil.rmtree(settings.DATA_PATH)
 

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -112,5 +112,5 @@ def test_empty(testdataset3) -> None:
     clear_data_path(testdataset3.name)
     validator, cap_logs = run_validator(EmptyValidator, testdataset3)
     logs = [f"{entry['log_level']}: {entry['event']}" for entry in cap_logs]
-    assert "error: No entities validated." in logs, logs
-    assert validator.abort is True
+    assert "warning: No entities validated." in logs, logs
+    assert validator.abort is False

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -56,18 +56,18 @@ class TopiclessTargetValidator(BaseValidator):
 
 
 class EmptyValidator(BaseValidator):
-    """Aborts if no entities are validated."""
+    """Warn if no entities are validated."""
 
     def __init__(self, context: Context, view: View):
         super().__init__(context, view)
-        self.abort = True
+        self.is_empty = True
 
     def feed(self, entity: Entity) -> None:
-        self.abort = False
+        self.is_empty = False
 
     def finish(self) -> None:
-        if self.abort:
-            self.context.log.error("No entities validated.")
+        if self.is_empty:
+            self.context.log.warning("No entities validated.")
 
 
 VALIDATORS: List[Type[BaseValidator]] = [


### PR DESCRIPTION
New enrichment datasets don't have internal entities, so the EmptyValidator aborts the run and they don't get published to get the opportunity to be xref'd.

Currently we only validate internal entities.

### Options

- make EmptyValidator only warn, not abort <-- **I picked this one for now**
- validate with external entities too
  - maybe not that crazy, just not sure about the implications and I wanna get the kazakh enricher done ASAP
