### PR TITLE
Not even meeting its own previous results against yente at the moment

### DIFF
--- a/datasets/_externals/ext_ee_ariregister.yml
+++ b/datasets/_externals/ext_ee_ariregister.yml
@@ -69,19 +69,3 @@ config:
     # - LegalEntity
     # - Person
   cache_days: 30
-
-assertions:
-  min:
-    schema_entities:
-      Company: 83
-      Person: 22
-      LegalEntity: 10
-    country_entities:
-      ee: 94
-      ua: 7
-      cy: 3
-    countries: 6
-  max:
-    schema_entities:
-      Company: 200
-      Person: 100


### PR DESCRIPTION
maybe because ann_graph_topics didn't emit topics for the ee_ariregister entities we missed in the previous successful build, so it couldn't expand on sanctions-related and RCAs?