### PR TITLE
Skip cleaning namespace from comments

### DIFF
--- a/datasets/ca/listed_terrorists/ca_listed_terrorists.yml
+++ b/datasets/ca/listed_terrorists/ca_listed_terrorists.yml
@@ -39,6 +39,14 @@ data:
   url: "https://www.publicsafety.gc.ca/cnt/_xml/lstd-ntts-eng.xml"
   format: XML
 
+assertions:
+  min:
+    schema_entities:
+      Organization: 65
+  max:
+    schema_entities:
+      Organization: 100
+
 lookups:
   type.date:
     options:

--- a/zavod/zavod/helpers/xml.py
+++ b/zavod/zavod/helpers/xml.py
@@ -17,6 +17,10 @@ def remove_namespace(el: ElementOrTree) -> ElementOrTree:
         An updated element tree with the namespaces removed.
     """
     for elem in el.iter():
+        # https://stackoverflow.com/a/47233934
+        if elem.tag is etree.Comment:  # type: ignore
+            # Can't make a QName from a comment
+            continue
         elem.tag = etree.QName(elem).localname
         for key, value in list(elem.attrib.items()):
             local_key = etree.QName(key).localname

--- a/zavod/zavod/tests/fixtures/doc.xml
+++ b/zavod/zavod/tests/fixtures/doc.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
+<!-- This is a comment in the root -->
 <x:MyAddress xmlns:x="http://www.ibm.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ibm.com x.xsd">
+    <!-- This is a nested comment -->
     <x:name>Peter Smith</x:name>
 </x:MyAddress>


### PR DESCRIPTION
for 

```
Traceback (most recent call last): 
File "/opensanctions/zavod/zavod/crawl.py", line 35, in crawl_dataset entry_point(context) 
File "/opensanctions/datasets/ca/listed_terrorists/crawler.py", line 11, in crawl doc = h.remove_namespace(doc) ^^^^^^^^^^^^^^^^^^^^^^^ 
File "/opensanctions/zavod/zavod/helpers/xml.py", line 20, in remove_namespace elem.tag = etree.QName(elem).localname ^^^^^^^^^^^^^^^^^ 
File "src/lxml/etree.pyx", line 1855, in lxml.etree.QName.__init__ ValueError: Invalid input tag of type <class '_cython_3_0_10.cython_function_or_method'>
--
```