### PR TITLE
LocalEnricher always matches entities with same ID

### DIFF
--- a/datasets/_externals/ext_ee_ariregister.yml
+++ b/datasets/_externals/ext_ee_ariregister.yml
@@ -46,12 +46,10 @@ inputs:
   - sanctions
 
 config:
-  type: nomenklatura.enrich.yente:YenteEnricher
-  api: https://api.graph.opensanctions.org/
+  type: zavod.runner.local_enricher:LocalEnricher
   dataset: ee_ariregister
   api_key: ${OPENSANCTIONS_GRAPH_API_KEY}
   strip_namespace: true
-  fuzzy: false
   threshold: 0.7
   algorithm: regression-v1
   topics:
@@ -68,7 +66,6 @@ config:
     - Organization
     # - LegalEntity
     # - Person
-  cache_days: 30
 
 assertions:
   min:

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -11,7 +11,6 @@ from nomenklatura.enrich.common import Enricher, EnricherConfig
 from nomenklatura.enrich.common import EnrichmentException
 from nomenklatura.index.tantivy_index import TantivyIndex
 from nomenklatura.matching import get_algorithm, LogicV1
-from nomenklatura.resolver import Identifier
 
 from zavod.archive import dataset_state_path
 from zavod.dedupe import get_resolver
@@ -84,9 +83,10 @@ class LocalEnricher(Enricher):
         )
 
         # The index won't provide an entity with the same ID so get it directly
-        same_id_match = self._view.get_entity(entity.id)
-        if same_id_match is not None:
-            yield same_id_match
+        if entity.id is not None:
+            same_id_match = self._view.get_entity(entity.id)
+            if same_id_match is not None:
+                yield self.entity_from_statements(type(entity), same_id_match)
 
         for match_id, index_score in self._index.match(store_type_entity):
             match = self._view.get_entity(match_id.id)

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -85,7 +85,8 @@ class LocalEnricher(Enricher):
             self._view.store.entity_class, entity
         )
 
-        # The index won't provide an entity with the same ID so get it directly
+        # Make sure an entity with the same ID is yielded. E.g. a QID or ID scheme
+        # intentionally consistent between datasets.
         if entity.id is not None:
             same_id_match = self._view.get_entity(entity.id)
             if same_id_match is not None:


### PR DESCRIPTION
This yields an entity with the same id as the example whether the index would have returned it, and whether `algorithm` would have scored it sufficiently highly, or not.

This is good e.g. if a company name changes and old names aren't included, so positive matches aren't lost.
What's less good is that it's not consistent with the expectation that results match based on score.