### PR TITLE
Crawl PDF lists with Liechtenstein posting sanctions

### DIFF
--- a/datasets/li/posting_sanctions/li_entsg_debarments.yml
+++ b/datasets/li/posting_sanctions/li_entsg_debarments.yml
@@ -1,0 +1,49 @@
+title: Liechtenstein Posted Workers Act (EntsG) Debarments
+prefix: li-entsgdebar
+entry_point: crawler.py:crawl_debarments
+coverage:
+  frequency: weekly
+  start: 2023-07-10
+load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+summary: >-
+  Companies and persons against whom a legally binding sanction
+  has been imposed for an infraction, in accordance with article 7
+  of the Liechtenstein Posted Workers Act (Entsendegesetz, EntsG)
+description: |
+  The Office of Economic Affairs of the Principality of Liechtenstein
+  publishes a list of companies and persons against whom a legally binding
+  sanction has been imposed in accordance with articles 7 and 9 of the
+  Liechtenstein Posted Workers Act (Entsendegesetz, EntsG).
+
+  The companies and persons on this list have been debarred
+  for major or repeated infractions in accordance with article 7.
+  (Sanctions in accordance with article 9 are published on a different
+  list).
+
+  * [Posted Workers Act (Entsendegesetz, EntsG)](https://www.gesetze.li/konso/2000.88)
+  * [Posted Workers Decree (Entsendeverordnung, EntsV)](https://www.gesetze.li/konso/2019.371)
+
+publisher:
+  name: Office of Economic Affairs
+  acronym: AVW
+  description: |
+    The Office of Economic Affairs is a government agency
+    of the Principality of Liechtenstein. It is part of
+    the Ministry of the Interior, Justice and Economy.
+  country: li
+  url: https://www.llv.li/de/landesverwaltung/amt-fuer-volkswirtschaft
+  official: true
+
+url: https://www.llv.li/de/unternehmen/berichtspflichten-bewilligungen/grenzueberschreitende-dienstleistungen/entsendung-von-arbeitnehmern/sanktionsliste-gemaess-art.-7-abs.-4-entsg
+
+data:
+  url: https://www.llv.li/serviceportal2/amtsstellen/amt-fuer-volkswirtschaft/wirtschaft/entsendegesetz/sperren.pdf
+  format: PDF
+
+lookups:
+  classifications:
+    options:
+      - match: Individual
+        value: Person
+      - match: Firm
+        value: Company

--- a/datasets/li/posting_sanctions/li_entsg_infractions.yml
+++ b/datasets/li/posting_sanctions/li_entsg_infractions.yml
@@ -1,23 +1,24 @@
 title: Liechtenstein Posted Workers Act (EntsG) Sanctions
 prefix: li-entsg
-entry_point: crawler.py
-# disabled: true
+entry_point: crawler.py:crawl_infractions
 coverage:
-  frequency: never
-  start: 2023-08-23
-  end: 2023-10-03
-deploy:
-  schedule: "@monthly"
+  frequency: weekly
+  start: 2023-07-10
 load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
 summary: >-
   Companies and persons against whom a legally binding sanction
-  has been imposed in accordance with articles 7 and 9 of the
-  Liechtenstein Posted Workers Act (Entsendegesetz, EntsG)
+  has been imposed for an infraction, in accordance with article 9
+  of the Liechtenstein Posted Workers Act (Entsendegesetz, EntsG)
 description: |
   The Office of Economic Affairs of the Principality of Liechtenstein
   publishes a list of companies and persons against whom a legally binding
   sanction has been imposed in accordance with articles 7 and 9 of the
   Liechtenstein Posted Workers Act (Entsendegesetz, EntsG).
+
+  The companies and persons on this list have been legally sanctioned
+  for minor first-time infractions in accordance with article 9.
+  (Debarments in accordance with article 7 are published on a different
+  list).
 
   * [Posted Workers Act (Entsendegesetz, EntsG)](https://www.gesetze.li/konso/2000.88)
   * [Posted Workers Decree (Entsendeverordnung, EntsV)](https://www.gesetze.li/konso/2019.371)
@@ -36,8 +37,8 @@ publisher:
 url: https://www.llv.li/de/unternehmen/berichtspflichten-bewilligungen/grenzueberschreitende-dienstleistungen/entsendung-von-arbeitnehmern/sanktionsliste-gemaess-art.-7-abs.-4-entsg
 
 data:
-  url: https://www.llv.li/de/unternehmen/berichtspflichten-bewilligungen/grenzueberschreitende-dienstleistungen/entsendung-von-arbeitnehmern/sanktionsliste-gemaess-art.-7-abs.-4-entsg
-  format: HTML
+  url: https://www.llv.li/serviceportal2/amtsstellen/amt-fuer-volkswirtschaft/wirtschaft/entsendegesetz/uebertretungen.pdf
+  format: PDF
 
 lookups:
   classifications:

--- a/zavod/setup.py
+++ b/zavod/setup.py
@@ -38,6 +38,7 @@ setup(
         "orjson == 3.10.6",
         "ijson > 3.2, < 4.0",
         "pantomime == 0.6.1",
+        "pdfminer.six",
         "prefixdate",
         "psycopg2-binary",
         "pyicu == 2.13.1",


### PR DESCRIPTION
Although the PDF layout analysis is not perfect, its quality appears to be decent. For the debarments list, we can extract 100% of sanctions. However, for the infractions list, we fail extracting 7 sanctions because their names are so long that two table columns get merged together.

https://github.com/opensanctions/opensanctions/issues/430