### PR TITLE
Skip local enricher search results below the average for that search

### DIFF
--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -89,7 +89,16 @@ class LocalEnricher(Enricher):
             if same_id_match is not None:
                 yield self.entity_from_statements(type(entity), same_id_match)
 
-        for match_id, index_score in self._index.match(store_type_entity):
+        search_results = self._index.match(store_type_entity)
+        if len(search_results) == 0:
+            return
+        total_search_score = sum(r[1] for r in search_results)
+        mean_search_score = total_search_score / len(search_results)
+
+        for match_id, search_score in search_results:
+            if search_score < mean_search_score:
+                break
+
             match = self._view.get_entity(match_id.id)
             if match is None:
                 continue

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -37,12 +37,6 @@ class LocalEnricher(Enricher):
           `algorithm`: `str` (default logic-v1) - the name of the algorithm
               to use for matching.
           `index_options`: `dict` - options to pass to the index.
-            `max_candidates`: `int` - (default 100) the maximum number of search
-              results to score.
-            `memory_budget`: `int` - (default 100) the amount of memory to use for
-              indexing in MB
-            `threshold`: `float` - (default 1.0) the minimum tantivy score required
-              to be scored by `algorithm`.
     """
 
     def __init__(self, dataset: DS, cache: Cache, config: EnricherConfig):

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -20,6 +20,11 @@ UMBRELLA_CORP = {
     "id": "xxx",
     "properties": {"name": ["Umbrella Corp."]},
 }
+JOHN_DOE = {
+    "schema": "Person",
+    "id": "abc-john-doe",
+    "properties": {"name": ["John Doe"]},
+}
 JON_DOVER = {
     "schema": "Person",
     "id": "abc-jona-dova",  # Initially different from dataset
@@ -46,6 +51,19 @@ def load_enricher(context: Context, dataset_data, target_dataset: str):
     assert issubclass(enricher_cls, Enricher)
     dataset = Dataset.make(dataset_data_copy)
     return enricher_cls(dataset, context.cache, dataset.config)
+
+
+def test_match(vcontext: Context):
+    """We match multiple values similar enough to the entity"""
+    crawl_dataset(vcontext.dataset)
+    enricher = load_enricher(vcontext, DATASET_DATA, "testdataset1")
+    entity = CompositeEntity.from_data(vcontext.dataset, JOHN_DOE)
+
+    # Match
+    results = list(enricher.match(entity))
+    assert len(results) == 2, results
+    assert str(results[0].id) == "osv-john-doe", results[0]
+    assert str(results[1].id) == "osv-johnny-does", results[1]
 
 
 def test_enrich(vcontext: Context):
@@ -101,7 +119,7 @@ def test_expand_securities(vcontext: Context, testdataset_securities: Dataset):
 
     # Match
     results = list(enricher.match(entity))
-    assert len(results) == 2, results  # USD EUR is also a match
+    assert len(results) == 1, results
     assert str(results[0].id) == "osv-isin-a", results[0]
 
     # Expand


### PR DESCRIPTION
We want to speed up the local enricher. We're currently spending most of the time in regression-v1, and also a significant portion of time fetching matches from the store.

For each entity, we fetch up to 50 results from the tantivy search index and score them. By only scoring the results who scored better than the mean of the tantivy scores for that search, we reduce the number by roughly half.

If the scores are a descending curve, we'll score a bit more, and ascending, we'll score a bit less. We haven't tested whether that really has an impact.

What we've seen is that this doesn't reduce the matches with positive decisions for the current enrichers using LocalEnricher, nor for ext_cz_business_register.