### PR TITLE
use raw strings for regexes to avoid SyntaxErrors

### DIFF
--- a/datasets/_global/everypolitician/crawler.py
+++ b/datasets/_global/everypolitician/crawler.py
@@ -10,7 +10,7 @@ from zavod.logic.pep import categorise
 
 
 PHONE_SPLITS = [",", "/", "(1)", "(2)", "(3)", "(4)", "(5)", "(6)", "(7)", "(8)"]
-PHONE_REMOVE = re.compile("(ex|ext|extension|fax|tel|\:|\-)", re.IGNORECASE)
+PHONE_REMOVE = re.compile(r"(ex|ext|extension|fax|tel|\:|\-)", re.IGNORECASE)
 
 
 def clean_emails(emails):

--- a/datasets/ch/seco_sanctions/crawler.py
+++ b/datasets/ch/seco_sanctions/crawler.py
@@ -34,17 +34,17 @@ NAME_PARTS: Dict[MayStr, MayStr] = {
 }
 # Some metadata is dirty text in <other-information> tags
 # TODO: take in charge multiple values
-REGEX_WEBSITE = re.compile("Website ?: ((https?:|www\.)\S*)")
+REGEX_WEBSITE = re.compile(r"Website ?: ((https?:|www\.)\S*)")
 REGEX_EMAIL = re.compile(
-    "E-?mail( address)? ?: ([A-Za-z0-9._-]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+)"
+    r"E-?mail( address)? ?: ([A-Za-z0-9._-]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+)"
 )
-REGEX_PHONE = re.compile("(Tel\.|Telephone)( number)? ?: (\+?[0-9- ()]+)")
-REGEX_INN = re.compile("Taxpayer [Ii]dentification [Nn]umber ?: (\d+)\.?")
+REGEX_PHONE = re.compile(r"(Tel\.|Telephone)( number)? ?: (\+?[0-9- ()]+)")
+REGEX_INN = re.compile(r"Taxpayer [Ii]dentification [Nn]umber ?: (\d+)\.?")
 REGEX_REGNUM = re.compile(
-    "(ОГРН/main )?([Ss]tate |Business )?[Rr]egistration number ?: (\d+)\.?"
+    r"(ОГРН/main )?([Ss]tate |Business )?[Rr]egistration number ?: (\d+)\.?"
 )
-REGEX_TAX = re.compile("Tax [Rr]egistration [Nn]umber ?: (\d+)\.?")
-REGEX_IMO = re.compile("IMO [Nn]umber ?: (\d+)\.?")
+REGEX_TAX = re.compile(r"Tax [Rr]egistration [Nn]umber ?: (\d+)\.?")
+REGEX_IMO = re.compile(r"IMO [Nn]umber ?: (\d+)\.?")
 FORMATS = ["%d.%m.%Y", "%Y", "%b %Y", "%d %B %Y", "%d %b %Y", "%b, %Y"]
 
 

--- a/datasets/md/interdictie/crawler.py
+++ b/datasets/md/interdictie/crawler.py
@@ -7,9 +7,9 @@ from rigour.mime.types import HTML
 from zavod import Context, Entity
 from zavod import helpers as h
 
-REGEX_DELAY = re.compile(".+(\d{2}[\.\/]\d{2}[\.\/]\d{4})$")
+REGEX_DELAY = re.compile(r".+(\d{2}[\.\/]\d{2}[\.\/]\d{4})$")
 # e.g. 6/23 from "6/23 din 02.05.2023"
-REGEX_SANCTION_NUMBER = re.compile(".*(\d+\/\d+)[\w ]+(\d{2}[\.\/]\d{2}[\.\/]\d{4}).*")
+REGEX_SANCTION_NUMBER = re.compile(r".*(\d+\/\d+)[\w ]+(\d{2}[\.\/]\d{2}[\.\/]\d{4}).*")
 REGEX_MEMBER_GROUPS = (
     "^(?P<unknown>[\w, \(\)%\.]+)?"
     "("

--- a/datasets/ru/rupep/crawler.py
+++ b/datasets/ru/rupep/crawler.py
@@ -42,7 +42,7 @@ OBVIOUSLY_NOT_PEP_ROLES = {
     "Senior Lecturer",
     "shareholder",
 }
-REGEX_SUBNATIONAL = re.compile("(?P<area>\w{4,}) city|regional")
+REGEX_SUBNATIONAL = re.compile(r"(?P<area>\w{4,}) city|regional")
 PUNCTUATION = {
     "Pc": "-",
     "Pd": "-",

--- a/datasets/us/cia_world_factbook/crawler.py
+++ b/datasets/us/cia_world_factbook/crawler.py
@@ -27,7 +27,7 @@ REGEX_SKIP_CATEGORY_HTML = re.compile(
     "|note [1-6]:.+"  # Afghanistan
     ")"
 )
-REGEX_RELEVANT_CATEGORY = re.compile("^(chief of state|head of government): ")
+REGEX_RELEVANT_CATEGORY = re.compile(r"^(chief of state|head of government): ")
 REGEX_HOLDER = re.compile(
     (
         "((New Zealand is )?represented by )?"

--- a/datasets/us/fbi_most_wanted/crawler.py
+++ b/datasets/us/fbi_most_wanted/crawler.py
@@ -25,7 +25,7 @@ IGNORE_FIELDS = (
     "Build",
     "Scars and Marks",
 )
-SPLIT_DATES = re.compile("([^,]+,[^,]+)")
+SPLIT_DATES = re.compile(r"([^,]+,[^,]+)")
 
 
 def index_validator(doc: etree._Element) -> bool:

--- a/datasets/za/wanted/crawler.py
+++ b/datasets/za/wanted/crawler.py
@@ -5,7 +5,7 @@ import re
 
 from zavod import helpers as h
 
-REGEX_PATTERN = re.compile("(.+)\((.+)\)(.+)")
+REGEX_PATTERN = re.compile(r"(.+)\((.+)\)(.+)")
 
 
 def crawl_person(context: Context, cell: html.HtmlElement):


### PR DESCRIPTION
> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)