### PR TITLE
Cymru am byth and ignore unused prop

### DIFF
--- a/datasets/gb/coh/gb_coh_psc.yml
+++ b/datasets/gb/coh/gb_coh_psc.yml
@@ -70,3 +70,5 @@ lookups:
         value: vc
       - match: YEMEN ARAB REPUBLIC
         value: ye
+      - match: Cymraes
+        value: gb-wls

--- a/datasets/gb/coh/psc_parse.py
+++ b/datasets/gb/coh/psc_parse.py
@@ -275,7 +275,9 @@ def parse_psc_data(context: Context) -> None:
         if data.pop("is_sanctioned", False):
             psc.add("topics", "sanction")
 
-        context.audit_data(data)
+        context.audit_data(
+            data, ignore=["service_address_is_same_as_registered_office_address"]
+        )
         context.emit(psc)
         context.emit(link)
         context.emit(asset)


### PR DESCRIPTION
Based off of these complaints from issues.log:
```
┌──────────────┬──────────────────────────────────────┐
│     prop     │                value                 │
│   varchar    │               varchar                │
├──────────────┼──────────────────────────────────────┤
│ country      │ Republic of North Macedonia          │
│ country      │ United Kindom                        │
│ nationality  │ Cymraes                              │
│ nationality  │ Cymraes                              │
│ jurisdiction │ Luxmebourg                           │
│ nationality  │ Us Dual                              │
│ jurisdiction │ Engalnd And Wales                    │
│ country      │ Gbraltar                             │
│ country      │ United Kingdom ( England )  (Gb-Eng) │
│ jurisdiction │ Minnesota, Usa                       │
├──────────────┴──────────────────────────────────────┤
│ 10 rows                                   2 columns │
└─────────────────────────────────────────────────────┘
```
Anything else here needs fixing?