### PR TITLE
Add monaco_sanction crawler

### DIFF
--- a/datasets/mc/fund_freezes/crawler.py
+++ b/datasets/mc/fund_freezes/crawler.py
@@ -1,0 +1,84 @@
+from zavod import Context
+from zavod import helpers as h
+import re
+from typing import Dict
+
+
+def crawl_person(context: Context, record):
+    person_details = record.get("mesureDetails")
+    first_name = person_details.pop("prenom")
+    gender = person_details.pop("sexe")
+    dob = person_details.pop("dateNaissance")
+    if dob:
+        dob = h.parse_date(dob, ["%d/%m/%Y"])
+    place_of_birth = person_details.pop("lieuNaissance")
+    nationality = person_details.pop("nationalite")
+    title = person_details.pop("titre")
+    passport = person_details.pop("passeport")
+
+    person = crawl_common(context, record, "Person")
+    person.add("firstName", first_name)
+    person.add("gender", gender)
+    person.add("birthDate", dob)
+    person.add("birthPlace", place_of_birth)
+    person.add("nationality", re.split(r",\s*|/|;", nationality))
+    person.add("title", title)
+    person.add("passportNumber", passport)
+
+    context.emit(person, target=True)
+    context.audit_data(person_details, ignore=["autoriteMesure"])
+
+
+def crawl_common(context: Context, data: Dict[str, str], schema: str):
+    entity_details = data.get("mesureDetails")
+
+    name = data.get("nom")
+    alias = entity_details.pop("alias")
+    address = entity_details.pop("adresse")
+    notes = entity_details.pop("autresInfos")
+    reason = entity_details.pop("motifs")
+    legal_basis = entity_details.pop("fondementJuridique")
+    sanction_regime = entity_details.pop("regimeSanction")
+    expiration_date = entity_details.pop("dateExpiration")
+    if expiration_date:
+        expiration_date = h.parse_date(expiration_date, ["%d/%m/%Y"])
+
+    entity = context.make(schema)
+    entity.id = context.make_id("mc-freezes", data.get("mesureId"))
+    entity.add("name", name)
+    entity.add("alias", alias)
+    entity.add("address", address)
+    entity.add("notes", notes)
+    entity.add("topics", "sanction")
+
+    sanction = h.make_sanction(context, entity)
+    sanction.add("reason", reason)
+    sanction.add("provisions", legal_basis)
+    sanction.add("program", sanction_regime)
+    sanction.add("endDate", expiration_date)
+
+    context.emit(sanction)
+    return entity
+
+
+def crawl_company(context: Context, record):
+    org = crawl_common(context, record, "Organization")
+
+    context.emit(org, target=True)
+
+
+def crawl(context: Context):
+    data = context.fetch_json(context.data_url, cache_days=1)
+    count_person = 0
+    count_company = 0
+    for record in data:
+        record_type = record.get("nature")
+        if record_type == "Personne physique":
+            crawl_person(context, record)
+            count_person += 1
+        elif record_type in ["Personne morale", "Navire"]:
+            crawl_company(context, record)
+            count_company += 1
+        else:
+            context.log.warn(f"Entity type not handled: {record_type}")
+    print(count_person, count_company, sep="\n")

--- a/datasets/mc/fund_freezes/crawler.py
+++ b/datasets/mc/fund_freezes/crawler.py
@@ -81,4 +81,3 @@ def crawl(context: Context):
             count_company += 1
         else:
             context.log.warn(f"Entity type not handled: {record_type}")
-    print(count_person, count_company, sep="\n")

--- a/datasets/mc/fund_freezes/mc_fund_freezes.yml
+++ b/datasets/mc/fund_freezes/mc_fund_freezes.yml
@@ -4,7 +4,7 @@ prefix: mc-freezes
 coverage:
   frequency: daily
   start: 2024-08-09
-# load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
 summary: >
   A list of entities subject to fund and economic resource freezing procedures
 description: |
@@ -33,8 +33,40 @@ lookups:
     options:
       - contains:
           - RPDC
+          - République populaire démocratique de Corée
         value: kp
-
+      - contains:
+          - PAKISTAN
+        value: pk
+      - contains:
+          - JORDANIE
+        value: jo
+      - contains:
+          - CENTRAFRIQUE
+        value: cf
+      - contains:
+          - RUSSIE
+        value: ru
+      - contains:
+          - INDONÉSIE
+        value: id
+      - contains:
+          - RDC
+        value: cg
+      - match:
+          - FRANCE-ALGERIE
+        values:
+          - fr
+          - al
+      - contains:
+          - Tchadienne
+        value: td
+      - contains:
+          - SYRIE
+        value: sy
+      - match:
+          - UKRAINE et
+        value: ua
 assertions:
   min:
     schema_entities:

--- a/datasets/mc/fund_freezes/mc_fund_freezes.yml
+++ b/datasets/mc/fund_freezes/mc_fund_freezes.yml
@@ -1,0 +1,43 @@
+title: Monaco National Fund Freezing List
+entry_point: crawler.py
+prefix: mc-freezes
+coverage:
+  frequency: daily
+  start: 2024-08-09
+# load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+summary: >
+  A list of entities subject to fund and economic resource freezing procedures
+description: |
+  This dataset publishes a national list of individuals and entities subject to the freezing of funds and economic resources 
+  in the Principality as mandated by the Sovereign Ordinance No. 8,664 of May 26, 2021
+  This list is managed and regularly updated by the Budget and Treasury Department. It aligns with those established 
+  by the United Nations, the European Union, France and also includes designations made by the Minister of State under UN 
+  Security Council Resolution 1373 (2001). 
+  Updates to the list are published via ministerial decisions.
+  [Read More](https://geldefonds.gouv.mc/a-propos-de-la-liste-nationale-de-gel-des-fonds)
+publisher:
+  name: la Principauté de Monaco
+  name_en: The Principality of Monaco
+  description: Official Monaco Government
+  url: https://www.gouv.mc/
+  country: mc
+  official: true
+url: https://geldefonds.gouv.mc/
+data:
+  url: https://geldefonds.gouv.mc/directdownload/sanctions.json
+  format: JSON
+lookups:
+  type.country:
+    lowercase: true
+    normalize: true
+    options:
+      - contains:
+          - RPDC
+        value: kp
+
+assertions:
+  min:
+    schema_entities:
+      Person: 3500
+      Organization: 1000
+      Sanction: 4500

--- a/datasets/mc/fund_freezes/mc_fund_freezes.yml
+++ b/datasets/mc/fund_freezes/mc_fund_freezes.yml
@@ -40,4 +40,3 @@ assertions:
     schema_entities:
       Person: 3500
       Organization: 1000
-      Sanction: 4500


### PR DESCRIPTION
close [Monaco sanctions list #121](https://github.com/opensanctions/crawler-planning/issues/121)
Hey @jbothma , I'm getting a weird reaction when I add datapatch lookups for `type.country`.
When I add a lookup for rejected value, I rejects even more values of that patch I applied.
Example, I add a lookup that contains RUSSIE to patch to ru, but the other RUSIE values that were not rejected gets rejected after the patch.
I may be doing something wrongly but what do you think ?
 
