### PR TITLE
Fix bad json cache

### DIFF
--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -339,7 +339,9 @@ class Context:
                 return orjson.loads(text)
             except Exception:
                 cache_url = build_url(url, params)
-                fingerprint = request_hash(cache_url, auth=auth, method=method, data=data)
+                fingerprint = request_hash(
+                    cache_url, auth=auth, method=method, data=data
+                )
                 self.clear_url(fingerprint)
                 raise
 
@@ -382,7 +384,9 @@ class Context:
                 return html.fromstring(text)
             except Exception:
                 cache_url = build_url(url, params)
-                fingerprint = request_hash(cache_url, auth=auth, method=method, data=data)
+                fingerprint = request_hash(
+                    cache_url, auth=auth, method=method, data=data
+                )
                 self.clear_url(fingerprint)
                 raise
         raise ValueError("Invalid HTML document: %s" % url)

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -338,7 +338,8 @@ class Context:
             try:
                 return orjson.loads(text)
             except Exception:
-                fingerprint = request_hash(url, auth=auth, method=method, data=data)
+                cache_url = build_url(url, params)
+                fingerprint = request_hash(cache_url, auth=auth, method=method, data=data)
                 self.clear_url(fingerprint)
                 raise
 
@@ -380,7 +381,8 @@ class Context:
             try:
                 return html.fromstring(text)
             except Exception:
-                fingerprint = request_hash(url, auth=auth, method=method, data=data)
+                cache_url = build_url(url, params)
+                fingerprint = request_hash(cache_url, auth=auth, method=method, data=data)
                 self.clear_url(fingerprint)
                 raise
         raise ValueError("Invalid HTML document: %s" % url)

--- a/zavod/zavod/tests/test_context.py
+++ b/zavod/zavod/tests/test_context.py
@@ -197,14 +197,23 @@ def test_context_fetchers_exceptions(testdataset1: Dataset):
         context.fetch_text("https://test.com/bla", cache_days=0, method="PLOP")
 
     params = {"query": "test"}
+    data = {"foo": "bar"}
+    auth = ("user", "pass")
     # Test that JSON decode failure clears its cache entry
 
     context.cache.clear()
     with pytest.raises(orjson.JSONDecodeError, match="unexpected.+"):
         with requests_mock.Mocker() as m:
-            m.get("/bla", text='{"msg": "Jason who? The object doesn\'t close."')
+            m.post("/bla", text='{"msg": "Jason who? The object doesn\'t close."')
 
-            context.fetch_json("https://test.com/bla", params=params, cache_days=10)
+            context.fetch_json(
+                "https://test.com/bla",
+                method="POST",
+                auth=auth,
+                params=params,
+                data=data,
+                cache_days=10,
+            )
 
     # Checking that cleanup function wiped the cache properly
     assert list(context.cache.all(None)) == []
@@ -213,8 +222,15 @@ def test_context_fetchers_exceptions(testdataset1: Dataset):
 
     with pytest.raises(etree.ParserError, match="Document is empty"):
         with requests_mock.Mocker() as m:
-            m.get("/bla", text="<")
-            context.fetch_html("https://test.com/bla", params=params, cache_days=10)
+            m.post("/bla", text="<")
+            context.fetch_html(
+                "https://test.com/bla",
+                method="POST",
+                auth=auth,
+                params=params,
+                data=data,
+                cache_days=10,
+            )
 
     # Checking that cleanup function wiped the cache properly
     assert list(context.cache.all(None)) == []


### PR DESCRIPTION
we got some bad JSON from wikidata and cached it. This fixes the cache clearing mechanism when we fail to parse the value.

Maybe a future refactor could be to pass a parsing function to fetch_text which lets it skip caching the response in the first place, a bit like zyte_api unblock_validator does.