### PR TITLE
Chill ext_gb_coh_psc, chill foreign role warning for lithuanian PEPs

### DIFF
--- a/datasets/_externals/ext_gb_coh_psc.yml
+++ b/datasets/_externals/ext_gb_coh_psc.yml
@@ -11,7 +11,6 @@ exports:
   - statistics.json
   - entities.delta.json
 deploy:
-  schedule: "1 8 * * *"
   memory: "800Mi"
   memory_limit: "3000Mi"
   disk: "20Gi"

--- a/datasets/lt/pep_declarations/crawler.py
+++ b/datasets/lt/pep_declarations/crawler.py
@@ -104,8 +104,13 @@ def parse_affiliations(
             position_name: Optional[str] = role.pop("pareigos")
             assert position_name, (person, position_name)
             if not entity_is_lithuanian:
-                context.log.warning(
-                    "Foreign declared role", name=person.get("name"), entity=entity_name
+                context.log.info(
+                    "Foreign declared role",
+                    name=person.get("name"),
+                    entity=entity_name,
+                    role=role,
+                    affiliation=affiliation,
+                    position=position_name,
                 )
                 continue
             main_duty = role.pop("pareiguTipasPavadinimas")


### PR DESCRIPTION
All the positions I sampled appear to be mistakenly not checking the Lithuanian box.

Most of them aren't significant positions. Most of them have other positions that are sufficient for the categorisation of the person.