### PR TITLE
adding Massachusetts medicare exclusions crawler

### DIFF
--- a/datasets/us/ma/med_exclusions/crawler.py
+++ b/datasets/us/ma/med_exclusions/crawler.py
@@ -1,0 +1,49 @@
+from typing import Dict
+from rigour.mime.types import XLSX
+from openpyxl import load_workbook
+import requests
+from lxml import html
+from io import BytesIO
+
+from zavod import Context, helpers as h
+
+def crawl_item(row: Dict[str, str], context: Context):
+
+    name = row.pop("provider_name")
+
+    if not name:
+        return
+
+    entity = context.make("LegalEntity")
+    entity.id = context.make_id(name, row.get("national_provider_identifier_npi"))
+    entity.add("name", name)
+    entity.add("npiCode", row.pop("national_provider_identifier_npi"))
+    entity.add("sector", row.pop("provider_type"))
+
+    entity.add("topics", "debarment")
+
+    sanction = h.make_sanction(context, entity)
+    sanction.add("startDate", row.pop("suspension_exclusion_effective_date"))
+    sanction.add("reason", row.pop("suspension_exclusion_reason"))
+
+    context.emit(entity, target=True)
+    context.emit(sanction)
+
+    context.audit_data(row, ignore=["unique_id"])
+
+
+def crawl_excel_url(context: Context):
+    doc = html.fromstring(requests.get(context.data_url).text)
+    doc.make_links_absolute(context.data_url)
+    return doc.xpath("//*[contains(text(), 'XLSX')]/../@href")[0]
+
+
+def crawl(context: Context) -> None:
+    # First we find the link to the excel file
+    excel_url = crawl_excel_url(context)
+    excel_file = requests.get(excel_url).content
+
+    wb = load_workbook(BytesIO(excel_file), read_only=True)
+
+    for item in h.parse_xlsx_sheet(context, wb.active):
+        crawl_item(item, context)

--- a/datasets/us/ma/med_exclusions/us_ma_med_exclusions.yaml
+++ b/datasets/us/ma/med_exclusions/us_ma_med_exclusions.yaml
@@ -1,0 +1,31 @@
+title: Massachusetts Terminated Provider List
+entry_point: crawler.py
+prefix: us-medma
+coverage:
+  frequency: daily
+  start: "2024-08-15"
+load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+summary: >
+  This dataset contains a list of providers who have been terminated for cause from Massachusetts's Medicaid program.
+description: |
+  The MassHealth program maintains a list of providers who have been suspended or excluded
+  from participating in the MassHealth program. This list is updated monthly and reflects
+  suspensions or exclusions effective on or after March 23, 2010.
+publisher:
+  name: MassHealth
+  acronym: MASS
+  url: https://www.mass.gov
+  official: true
+  country: "us"
+url: "https://www.mass.gov/info-details/learn-about-suspended-or-excluded-masshealth-providers"
+data:
+  url: https://www.mass.gov/info-details/learn-about-suspended-or-excluded-masshealth-providers
+  format: HTML
+
+assertions:
+   min:
+     schema_entities:
+       LegalEntity: 150 
+   max:
+     schema_entities:
+       LegalEntity: 350 


### PR DESCRIPTION
I wasn't able to use the `context.fetch_html` and `context.fetch_resource` to get the data because it was returning with status code = 403.