### PR TITLE
Interpol - Format weight as string

### DIFF
--- a/datasets/_global/interpol/interpol_api.py
+++ b/datasets/_global/interpol/interpol_api.py
@@ -105,7 +105,10 @@ def crawl_notice(context: Context, notice: Dict[str, Any]) -> None:
     if isinstance(height, float):
         height = "%.2f" % height
     entity.add("height", height)
-    entity.add("weight", notice.pop("weight", None))
+    weight = notice.pop("weight", None)
+    if isinstance(weight, float):
+        weight = "%.2f" % weight
+    entity.add("weight", weight)
     entity.add("eyeColor", notice.pop("eyes_colors_id", None))
 
     dob_raw = notice.pop("date_of_birth", None)


### PR DESCRIPTION
Hi,
Weight values could also be float therefore should be parsed as string to avoid decimal discrepancies. Same idea as commit 3b903bf0780e2c23de2aa2609f38fd2c4cd0117a

Example of affected entity:
https://www.opensanctions.org/statements/Q5546542
Source url: https://ws-public.interpol.int/notices/v1/red/2005-30989