### PR TITLE
Iran business registry parse facts

### DIFF
--- a/zavod/zavod/helpers/html.py
+++ b/zavod/zavod/helpers/html.py
@@ -14,7 +14,7 @@ def parse_html_table(
     Returns:
         Generator of dict per row, where the keys are the _-slugified table headings
             and the values are the HtmlElement of the cell.
-    
+
     See also:
       - `zavod.helpers.cells_to_str`
       - `zavod.helpers.links_to_dict`

--- a/zavod/zavod/logs.py
+++ b/zavod/zavod/logs.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 from typing import Callable, Optional
 from lxml.etree import _Element, tostring
+from lxml.html import HtmlElement
 from followthemoney.schema import Schema
 
 from typing import Dict, List, Any, MutableMapping
@@ -166,20 +167,29 @@ def format_json(_: Any, __: str, ed: Event) -> Event:
     return ed
 
 
+def stringify(value: Any) -> Any:
+    """Stringify the types that aren't already JSON serializable."""
+
+    if isinstance(value, (_Element, HtmlElement)):
+        return tostring(value, pretty_print=False, encoding=str).strip()
+    if isinstance(value, Path):
+        try:
+            value = value.relative_to(settings.DATA_PATH)
+        except ValueError:
+            pass
+        return str(value)
+    if isinstance(value, Schema):
+        return value.name
+    if isinstance(value, list):
+        return [stringify(v) for v in value]
+    if isinstance(value, dict):
+        for key, value_ in value.items():
+            value[key] = stringify(value_)
+    return value
+
+
 def log_issue(_: Any, __: str, ed: Event) -> Event:
-    data: Dict[str, Any] = dict(ed)
-    for key, value in data.items():
-        if isinstance(value, _Element):
-            value = tostring(value, pretty_print=False, encoding=str)
-        if isinstance(value, Path):
-            try:
-                value = value.relative_to(settings.DATA_PATH)
-            except ValueError:
-                pass
-            value = str(value)
-        if isinstance(value, Schema):
-            value = value.name
-        data[key] = value
+    data: Dict[str, Any] = stringify(dict(ed))
 
     context = data.pop("context", None)
     level: Optional[str] = data.get("level")


### PR DESCRIPTION
I tried to make a helper for this kind of table orientation but none of the other examples I could remember like this have a row container (e.g. https://www.policia.es/_es/colabora_masbucados_detalle.php?id=143) and this is anyway a bit special.

as I was imlementing this I noticed most of the time a row only contains one root span, but affiliats can contain more than one root span, so we really need to handle that - then we'll also get multiple affiliates when more than one is available. e.g. https://www.unitedagainstnucleariran.com/company/airbus

The audit currently emits dicts with lists of HtmlElement values so I've had to expand the enstringificationism in the log handler