### PR TITLE
Use pdfplumber to extract tabular data

### DIFF
--- a/datasets/jp/meti_eul/crawler.py
+++ b/datasets/jp/meti_eul/crawler.py
@@ -105,3 +105,5 @@ def crawl(context: Context):
         sanction.add("reason", h.multi_split(holder.pop("type_of_wmd"), ",、\n"))
         context.emit(entity, target=True)
         context.emit(sanction)
+
+        context.audit_data(holder)

--- a/datasets/jp/meti_eul/crawler.py
+++ b/datasets/jp/meti_eul/crawler.py
@@ -1,21 +1,23 @@
+from pathlib import Path
+from normality import collapse_spaces, slugify
 from rigour.mime.types import PDF
 from urllib.parse import urljoin
+import pdfplumber
+import re
 
 from zavod import Context
 from zavod import helpers as h
-from zavod.shed.gpt import run_image_prompt
 from zavod.shed.zyte_api import fetch_html, fetch_resource
 
-prompt = """
-Extract structured data from the following page of a PDF document. Return 
-a JSON list (`rows`) in which each object represents a row in the table.
-Each object should have the following fields: `no` (string), `country`
-(latin script version only), `name` (company or organization name in latin
-script), `name_jpn` (company or organization name in japanese script, or
-empty), `also_known_as` (an array with a string for each bullet point)
-`type_of_wmd` (an array with the letters indicated).
-Return an empty string for undefined fields.
-"""
+
+REGEX_NON_ASCII_PARENS = re.compile(r"([\(（]\w*[^a-zA-Z\)）]{3,}[\)）])")
+REGEX_NON_ASCII = re.compile(r"[^ a-zA-Z'-]+")
+NAME_REPLACEMENTS = [
+    ("（", "("),
+    ("）", ")"),
+    ("，", ","),
+    ("・", ""),
+]
 
 
 def unblock_validator(el) -> bool:
@@ -36,35 +38,70 @@ def crawl_pdf_url(context: Context) -> str:
     raise ValueError("No PDF found")
 
 
+def parse_pdf_table(context: Context, path: Path):
+    headers = None
+    pdf = pdfplumber.open(path.as_posix())
+    for page in pdf.pages:
+        for row in page.extract_table():
+            if headers is None:
+                headers = []
+                for cell in row:
+                    parts = cell.split("\n")
+                    if len(parts) == 1:
+                        header = parts[0]
+                    elif len(parts) == 2:
+                        header = parts[1]
+                    else:
+                        context.log.error("Unexpected header", header=cell)
+                        return
+                    headers.append(slugify(header, sep="_"))
+                continue
+            assert len(headers) == len(row), (headers, row)
+            yield dict(zip(headers, row))
+
+
 def crawl(context: Context):
     pdf_url = crawl_pdf_url(context)
     cached, path, media_type, charset = fetch_resource(context, "source.pdf", pdf_url)
     if not cached:
         assert media_type == PDF, media_type
+
     context.export_resource(path, PDF, title=context.SOURCE_TITLE)
     last_no = 0
-    for page_path in h.make_pdf_page_images(path):
-        data = run_image_prompt(context, prompt, page_path)
-        assert "rows" in data, data
-        for holder in data.get("rows", []):
-            no = int(holder.get("no"))
-            if no != last_no + 1:
-                context.log.warn(
-                    "Row number is not continuous",
-                    no=no,
-                    last_no=last_no,
-                )
-            last_no = no
-            name = holder.get("name")
-            entity = context.make("LegalEntity")
-            entity.id = context.make_id(str(no), name)
-            entity.add("name", name, lang="eng")
-            entity.add("name", holder.get("name_jpn"), lang="jpn")
-            entity.add("alias", holder.get("also_known_as"))
-            entity.add("country", holder.get("country"))
-            entity.add("topics", "sanction")
+    for holder in parse_pdf_table(context, path):
+        no = int(holder.pop("no"))
+        if no != last_no + 1:
+            context.log.warn(
+                "Row number is not continuous",
+                no=no,
+                last_no=last_no,
+            )
+        last_no = no
+        name = collapse_spaces(holder.pop("company_or_organization")).strip()
+        non_ascii_match = REGEX_NON_ASCII_PARENS.search(name)
+        if non_ascii_match:
+            name_jpn = non_ascii_match.group(1)
+            name = name.replace(name_jpn, "").strip()
+            name_jpn = name_jpn.strip("()（）")
+        else:
+            name_jpn = None
+        for orig, repl in NAME_REPLACEMENTS:
+            name = name.replace(orig, repl)
 
-            sanction = h.make_sanction(context, entity)
-            sanction.add("reason", holder.get("type_of_wmd"))
-            context.emit(entity, target=True)
-            context.emit(sanction)
+        aliases = [collapse_spaces(a) for a in holder.pop("also_known_as").split("・")]
+
+        country = collapse_spaces(holder.pop("country_or_region"))
+        country = REGEX_NON_ASCII.sub("", country).strip()
+
+        entity = context.make("LegalEntity")
+        entity.id = context.make_id(str(no), name)
+        entity.add("name", name, lang="eng")
+        entity.add("name", name_jpn, lang="jpn")
+        entity.add("alias", aliases)
+        entity.add("country", country)
+        entity.add("topics", "sanction")
+
+        sanction = h.make_sanction(context, entity)
+        sanction.add("reason", h.multi_split(holder.pop("type_of_wmd"), ",、\n"))
+        context.emit(entity, target=True)
+        context.emit(sanction)

--- a/datasets/jp/meti_eul/jp_meti_eul.yml
+++ b/datasets/jp/meti_eul/jp_meti_eul.yml
@@ -15,10 +15,6 @@ description: |
   > the development of weapons of mass destruction (WMDs) and missiles, for
   > the purpose of enhancing the effectiveness of the catch-all control on
   > cargos and other loads relating to WMDs and missiles.
-
-  **Note:** This crawler uses an LLM-based approach to extract the data from
-  the PDF file. We are still working on improving the quality of that process
-  in order to ensure the highest possible accuracy.
 publisher:
   name: "Ministry of Economy, Trade and Industry"
   acronym: METI

--- a/zavod/setup.py
+++ b/zavod/setup.py
@@ -38,6 +38,7 @@ setup(
         "orjson == 3.10.7",
         "ijson > 3.2, < 4.0",
         "pantomime == 0.6.1",
+        "pdfplumber == 0.11.4",
         "prefixdate",
         "psycopg2-binary",
         "pyicu == 2.13.1",


### PR DESCRIPTION
delta

```
added=234 dataset=jp_meti_eul deleted=232 metric=delta_counts modified=772
```
- adds some imperfect name splitting
- removes some spelling mistakes from gpt
- modifications are often removing a hallucinated/erroneously translated japanese name version

pdfplumber
```
$pip freeze

cffi==1.17.1.               <- new
charset-normalizer==3.3.2
cryptography==43.0.1
pdfminer.six==20231228.     <- new
pdfplumber==0.11.4.         <- new
pillow==10.4.0.             <- new
pycparser==2.22.            <- new
pypdfium2==4.30.0.          <- new
```
