### PR TITLE
Strict occupancy dates

### DIFF
--- a/datasets/at/meine_abgeordneten/at_meine_abgeordneten.yml
+++ b/datasets/at/meine_abgeordneten/at_meine_abgeordneten.yml
@@ -78,7 +78,7 @@ lookups:
           - Kandidatin zur EU-Wahl 2024
         name: Kandidat zur EU-Wahl 2024
 dates:
-  formats: ["%d. %m %Y", "%d.%m.%Y", "%m/%Y"]
+  formats: ["%d. %m %Y", "%d.%m.%Y", "%m/%Y", "%Y-%m-%d", "%Y-%m", "%Y"]
   months:
     "01": Januar
     "02": Februar

--- a/datasets/br/pep/br_pep.yaml
+++ b/datasets/br/pep/br_pep.yaml
@@ -33,10 +33,3 @@ ci_test: false
 
 dates: 
   formats: ["%d/%m/%Y"]
-lookups: 
-  type.date: 
-    lowercase: true
-    normalize: true
-    options:
-      - match: Não informada
-        value: null

--- a/datasets/br/pep/crawler.py
+++ b/datasets/br/pep/crawler.py
@@ -66,7 +66,7 @@ def create_entity(raw_entity: Dict[str, Any], context: Context) -> None:
         position,
         False,
         start_date=raw_entity["Data_Início_Exercício"],
-        end_date=raw_entity["Data_Fim_Exercício"],
+        end_date=raw_entity["Data_Fim_Exercício"].replace("Não informada", "") or None,
         categorisation=categorisation,
     )
 

--- a/datasets/lt/magnitsky_amendments/crawler.py
+++ b/datasets/lt/magnitsky_amendments/crawler.py
@@ -29,13 +29,11 @@ def crawl(context: Context):
     # Open the file and process its content within the `with` block
     with open(path, "r", encoding="utf-8") as fh:
         data = json.load(fh)
-        # print(f"Fetched data: {data}")  # Debug statement to confirm data fetch
 
     # Checking data limits
     check_data_limits(data)
 
     for entry in data.get("list", []):
-        # print(f"Processing entry: {entry}")  # Debug statement for each entry
 
         # Create a Person entity
         person = context.make("Person")
@@ -43,7 +41,6 @@ def crawl(context: Context):
         person.id = person_id
         person.add("name", f"{entry.get('vardas')} {entry.get('pavarde')}", lang="lit")
         h.apply_date(person, "birthDate", entry.get("gimimoData"))
-        # person.add("birthDate", h.parse_date(entry.get("gimimoData"), DATE_FORMATS))
         person.add("topics", "sanction")
         gender = map_gender(entry.get("lytis"))
         if gender:
@@ -61,8 +58,10 @@ def crawl(context: Context):
         # Create a Sanction entity
         sanction = h.make_sanction(context, person)
         sanction.add("reason", entry.get("priezastis"), lang="lit")
-        for date in h.multi_split(entry.get("priezastis"), ["galiojanti nuo "]):
-            h.apply_date(sanction, "startDate", date)
+
+        # I'm not sure whether this is the start of the sanction or the legislation.
+        # for date in h.multi_split(entry.get("priezastis"), ["galiojanti nuo "]):
+        #     h.apply_date(sanction, "startDate", date)
         h.apply_date(sanction, "endDate", entry.get("uzdraustaIki"))
 
         # Emit entities

--- a/datasets/ps/local_freezing/crawler.py
+++ b/datasets/ps/local_freezing/crawler.py
@@ -3,8 +3,6 @@ from typing import Generator, Dict
 from normality import collapse_spaces, slugify
 from zavod import Context, helpers as h
 
-# FORMATS = ["%d/%m/%Y"]
-
 
 def parse_table(table) -> Generator[Dict[str, str], None, None]:
     """
@@ -64,7 +62,6 @@ def crawl_item(input_dict: dict, context: Context):
         entity.add("alias", aliases)
 
     sanction = h.make_sanction(context, entity)
-    # sanction.add("startDate", h.parse_date(input_dict.pop("date-of-freezing"), FORMATS))
     h.apply_date(sanction, "startDate", input_dict.pop("date-of-freezing"))
     sanction.add(
         "program",

--- a/datasets/za/pmg_legislators/za_pmg_legislators.yaml
+++ b/datasets/za/pmg_legislators/za_pmg_legislators.yaml
@@ -35,6 +35,8 @@ url: https://pa.org.za/help/api
 data:
   url: https://pa.org.za/media_root/popolo_json/pombola.json
   format: JSON
+dates:
+  formats: ["%Y-%m-%d", "%Y-%m", "%Y"]
 assertions:
   min:
     schema_entities:

--- a/zavod/zavod/helpers/dates.py
+++ b/zavod/zavod/helpers/dates.py
@@ -88,10 +88,18 @@ def replace_months(dataset: Dataset, text: str) -> str:
     return spec.months_re.sub(lambda m: spec.mappings[m.group().lower()], text)
 
 
-def extract_date(dataset: Dataset, text: DateValue) -> List[str]:
+def extract_date(
+    dataset: Dataset, text: DateValue, strict_label: Optional[str] = None
+) -> List[str]:
     """
     Extract a date from the provided text using predefined `formats` in the metadata.
-    If the text doesn't match any format, return the original text.
+    If the text doesn't match any format, returns the original text
+    or raises ValueError if strict_label is provided.
+
+    Args:
+        dataset: The dataset which contains a date format specification.
+        text: The text to extract a date from.
+        strict_label: The label to describe the date if it doesn't parse.
     """
     if text is None:
         return []
@@ -111,6 +119,8 @@ def extract_date(dataset: Dataset, text: DateValue) -> List[str]:
         years = extract_years(text)
         if len(years):
             return years
+    if strict_label is not None:
+        raise ValueError(f"Invalid {strict_label}: {repr(text)}")
     return [text]
 
 

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -131,13 +131,21 @@ def make_occupancy(
         status: Overrides determining PEP occupancy status
     """
 
-    clean_start_dates = h.extract_date(context.dataset, start_date)
+    clean_start_dates = h.extract_date(context.dataset, start_date, "start_date")
     assert len(clean_start_dates) <= 1
     clean_start_date = clean_start_dates[0] if clean_start_dates else None
 
-    clean_end_dates = h.extract_date(context.dataset, end_date)
+    clean_end_dates = h.extract_date(context.dataset, end_date, "end_date")
     assert len(clean_end_dates) <= 1
     clean_end_date = clean_end_dates[0] if clean_end_dates else None
+
+    clean_birth_dates = h.extract_date(context.dataset, birth_date, "birth_date")
+    assert len(clean_birth_dates) <= 1
+    clean_birth_date = clean_birth_dates[0] if clean_birth_dates else None
+
+    clean_death_dates = h.extract_date(context.dataset, death_date, "death_date")
+    assert len(clean_death_dates) <= 1
+    clean_death_date = clean_death_dates[0] if clean_death_dates else None
 
     if categorisation is not None:
         assert categorisation.is_pep, person
@@ -151,8 +159,8 @@ def make_occupancy(
             current_time,
             clean_start_date,
             clean_end_date,
-            birth_date,
-            death_date,
+            clean_birth_date,
+            clean_death_date,
             categorisation,
         )
     if status is None:


### PR DESCRIPTION
Since make_occupancy does date comparisons, it seems worthwhile requiring them to be valid and not just leaving it to datapatches to clean what we store.

This gives errors like

```
2024-10-07 12:39:19 [info     ] Running dataset                [br_pep] data_path=datasets/br_pep data_time=2024-10-07T12:39:17 dataset=br_pep version=20241007123917-eoy
2024-10-07 12:39:23 [info     ] Extracting 202408_PEP.csv      [br_pep] dataset=br_pep
2024-10-07 12:39:23 [error    ] Runner failed: Invalid end_date: Não informada [br_pep] dataset=br_pep
Traceback (most recent call last):
  File "/Users/jdb/projects/opensanctions/opensanctions/zavod/zavod/crawl.py", line 35, in crawl_dataset
    entry_point(context)
  File "/Users/jdb/projects/opensanctions/opensanctions/datasets/br/pep/crawler.py", line 100, in crawl
    create_entity(row, context)
  File "/Users/jdb/projects/opensanctions/opensanctions/datasets/br/pep/crawler.py", line 63, in create_entity
    occupancy = h.make_occupancy(
                ^^^^^^^^^^^^^^^^^
  File "/Users/jdb/projects/opensanctions/opensanctions/zavod/zavod/helpers/positions.py", line 138, in make_occupancy
    clean_end_dates = h.extract_date(context.dataset, end_date, "end_date")
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jdb/projects/opensanctions/opensanctions/zavod/zavod/helpers/dates.py", line 123, in extract_date
    raise ValueError(f"Invalid {strict_label}: {text}")
ValueError: Invalid end_date: Não informada
```

It also requires prefix-date formats to be specified in the metadata.