### PR TITLE
adding South Carolina medicare exclusions crawler

### DIFF
--- a/datasets/us/sc/med_exclusions/us_sc_med_exclusions.yaml
+++ b/datasets/us/sc/med_exclusions/us_sc_med_exclusions.yaml
@@ -40,6 +40,7 @@ url: https://www.scdhhs.gov/fraud
 data:
   url: https://www.scdhhs.gov/fraud
   format: XLSX
+ci_test: false
 
 dates:
   formats: ["%m/%d/%y"]

--- a/datasets/us/sc/med_exclusions/us_sc_med_exclusions.yaml
+++ b/datasets/us/sc/med_exclusions/us_sc_med_exclusions.yaml
@@ -1,0 +1,53 @@
+title: US South Carolina Excluded Providers
+entry_point: crawler.py
+prefix: us-medsc
+coverage:
+  frequency: daily
+  start: "2024-10-23"
+load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+summary: >
+  Medical providers excluded from South Carolina's Medicaid program.
+description: |
+  According to their [website](https://www.scdhhs.gov/fraud):
+  > The Bureau of Internal Audit and Program Integriy compiles a list of 
+  > individuals and entities that have been excluded by the federal government
+  > and/or the State of South Carolina. Anyone appearing on the following lists 
+  > should not submit claims for Medicaid reimbursement and should not be affiliated
+  > with any organization or facility that participates in the Medicaid program.
+  > In addition, providers cannot bill for any medicines, medical supplies or
+  > medical equipment that is prescribed or authorized by an excluded provider 
+  > on behalf of a Medicaid beneficiary.
+
+  This dataset specifically only includes providers excluded by the State of South Carolina.
+publisher:
+  name: South Carolina Department of Health and Human Services
+  description: >
+    > The Department of Health and Human Services is the administrator of Healthy Connections,
+    > South Carolina's Medicaid Program. Medicaid provides health coverage for eligible
+    > residents of South Carolina, including:
+    > - Children
+    > - Parent and Caretaker Relatives
+    > - Pregnant Women
+    > - People Over the Age of 65
+    > - People with Disabilities
+    > - Children with Developmental Delays
+    > - Breast and Cervical Cancer Patients
+  acronym: SCDHHS
+  url: https://www.scdhhs.gov
+  official: true
+  country: "us"
+url: https://www.scdhhs.gov/fraud
+data:
+  url: https://www.scdhhs.gov/fraud
+  format: XLSX
+
+dates:
+  formats: ["%m/%d/%y"]
+
+assertions:
+  min:
+    schema_entities:
+      LegalEntity: 900
+  max:
+    schema_entities:
+      LegalEntity: 1100


### PR DESCRIPTION
I tried to find a way to identify if it's a company or a person but I don't think it's possible because there are companies with `,` in the name, for example:

<img width="344" alt="Screenshot 2024-10-23 at 17 45 34" src="https://github.com/user-attachments/assets/176ad179-a3f3-4b4d-97c1-57d00298e505">

From what I see it is because of the suffixes `, Inc`, `, LLC` etc. Would it be ok to assume that if there is a `,` and if it's not those suffixes, then it is a person?