### PR TITLE
Use entity status for sanction topic

### DIFF
--- a/datasets/ua/nsdc_sanctions/ua_nsdc_sanctions.yml
+++ b/datasets/ua/nsdc_sanctions/ua_nsdc_sanctions.yml
@@ -28,6 +28,14 @@ data:
   format: JSON
 
 lookups:
+  sanctioned_status:
+    options:
+      - match: active
+        value: true
+      - match: expired
+        value: false
+      - match: excluded
+        value: false
   type.country:
     normalize: true
     options:


### PR DESCRIPTION
This removes the sanction topic from 1427 entities. Spot checks match the CSV at https://drs.nsdc.gov.ua/export/subjects