### PR TITLE
us plum book

### DIFF
--- a/datasets/us/plum_book/crawler.py
+++ b/datasets/us/plum_book/crawler.py
@@ -40,7 +40,6 @@ def crawl(context: Context):
             position = h.make_position(
                 context,
                 name=position_name,
-                description=appointment_type,
                 subnational_area=location,
                 country="us",
             )
@@ -51,6 +50,8 @@ def crawl(context: Context):
             occupancy = h.make_occupancy(
                 context, person, position, end_date=expiration_date
             )
+            if occupancy is not None:
+                occupancy.add("description", appointment_type)
             if not occupancy:
                 continue
             context.emit(person, target=True)

--- a/datasets/us/plum_book/crawler.py
+++ b/datasets/us/plum_book/crawler.py
@@ -6,7 +6,6 @@ from zavod.logic.pep import categorise
 IGNORE = [
     "OrganizationName",
     "PositionStatus",
-    "AppointmentTypeDescription",
     "PaymentPlanDescription",
     "LevelGradePay",
     "Tenure",
@@ -21,7 +20,7 @@ def crawl(context: Context):
             agency_name = row.pop("\ufeffAgencyName")
             # org_name = row.pop("OrganizationName")
             position_title = row.pop("PositionTitle", None)
-            # appointment_type = row.pop("AppointmentTypeDescription")
+            appointment_type = row.pop("AppointmentTypeDescription")
             expiration_date = row.pop("ExpirationDate")
             location = row.pop("Location")
             incumbent_first_name = row.pop("IncumbentFirstName")
@@ -39,8 +38,11 @@ def crawl(context: Context):
             position = h.make_position(
                 context,
                 name=f"{position_title}, {agency_name}",
+                description=appointment_type,
                 subnational_area=location,
+                country="us",
             )
+
             categorisation = categorise(context, position, is_pep=True)
             if categorisation.is_pep:
                 occupancy = h.make_occupancy(

--- a/datasets/us/plum_book/crawler.py
+++ b/datasets/us/plum_book/crawler.py
@@ -18,7 +18,6 @@ def crawl(context: Context):
         reader = csv.DictReader(fh)
         for row in reader:
             agency_name = row.pop("\ufeffAgencyName")
-            # org_name = row.pop("OrganizationName")
             position_title = row.pop("PositionTitle", None)
             appointment_type = row.pop("AppointmentTypeDescription")
             expiration_date = row.pop("ExpirationDate")

--- a/datasets/us/plum_book/crawler.py
+++ b/datasets/us/plum_book/crawler.py
@@ -1,0 +1,53 @@
+import csv
+
+from zavod import Context, helpers as h
+from zavod.logic.pep import categorise
+
+IGNORE = [
+    "OrganizationName",
+    "PositionStatus",
+    "AppointmentTypeDescription",
+    "PaymentPlanDescription",
+    "LevelGradePay",
+    "Tenure",
+]
+
+
+def crawl(context: Context):
+    path = context.fetch_resource("source.csv", context.data_url)
+    with open(path, "r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            agency_name = row.pop("\ufeffAgencyName")
+            # org_name = row.pop("OrganizationName")
+            position_title = row.pop("PositionTitle", None)
+            # appointment_type = row.pop("AppointmentTypeDescription")
+            expiration_date = row.pop("ExpirationDate")
+            location = row.pop("Location")
+            incumbent_first_name = row.pop("IncumbentFirstName")
+            incumbent_last_name = row.pop("IncumbentLastName")
+
+            if not incumbent_first_name or not incumbent_last_name:
+                continue
+            person = context.make("Person")
+            person.id = context.make_slug(incumbent_first_name, incumbent_last_name)
+            h.apply_name(
+                person, first_name=incumbent_first_name, last_name=incumbent_last_name
+            )
+            person.add("position", f"{position_title}, {agency_name}")  # for dedupe
+
+            position = h.make_position(
+                context,
+                name=f"{position_title}, {agency_name}",
+                subnational_area=location,
+            )
+            categorisation = categorise(context, position, is_pep=True)
+            if categorisation.is_pep:
+                occupancy = h.make_occupancy(
+                    context, person, position, end_date=expiration_date
+                )
+                if occupancy:
+                    context.emit(person, target=True)
+                    context.emit(position)
+                    context.emit(occupancy)
+            context.audit_data(row, ignore=IGNORE)

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -9,32 +9,30 @@ summary: >
   The Plum Book lists federal positions filled by political appointees, Schedule C 
   employees, and other executives.
 description: |
-  The Plum Book is a listing of over 8,000 civil service leadership and support positions 
-  (filled and vacant) in the Legislative and Executive branches of the Federal Government 
-  that may be subject to noncompetitive appointments. These positions include agency heads 
-  and their immediate subordinates, policy executives and advisors, and aides who report to 
-  these officials. Many positions have duties which support Administration policies and programs.
-# yet to be double-checked
-  The people holding these positions usually have a close and confidential relationship with 
-  the agency head or other key officials.
-
-  Positions in the Plum Book include the following:
-    
-    - **Schedule C (SC)** positions are excepted from the competitive service because of their 
-      confidential or policy-determining character. The decision concerning whether to place a 
-      position in Schedule C is made by the Director, U.S. Office of Personnel Management, upon 
-      agency request.
-
-    - **Senior Executive Service (SES)** is a personnel system covering top level policy, supervisory, 
-      and managerial positions in most Federal agencies. The SES includes most Civil Service positions 
-      above grade 15 of the General Schedule. 
-      There are two types of SES positions:
-      - **Career Reserved**
-      - **General**
+  Published by the Senate Committee on Homeland Security and Governmental Affairs and 
+  House Committee on Government Reform alternately after each Presidential election, 
+  the Plum Book lists over 7,000 Federal civil service leadership and support positions 
+  in the legislative and executive branches of the Federal Government that may be subject 
+  to noncompetitive appointment, nationwide. 
   
-  **Sources:**
-  - [Office of Human Resources Management](https://www.commerce.gov/hr/practitioners/ses-policies/plum-book#:~:text=What%20is%20the%20Plum%20Book,between%20the%20House%20and%20Senate)  
-  - [U.S. Office of Personnel Management - Plum Book Reporting](https://www.opm.gov/about-us/open-government/plum-reporting/position-descriptions/)
+  Data covers positions such as agency heads and their immediate subordinates, policy 
+  executives and advisors, and aides who report to these officials. The duties of many 
+  such positions may involve advocacy of Administration policies and programs and the 
+  incumbents usually have a close and confidential working relationship with the agency 
+  or other key officials.
+
+  The major categories of positions listed in United States Government Policy and Supporting 
+  Positions include:
+
+  * **Executive Schedule** and salary-equivalent positions paid at the rates established for 
+  levels I through V of the Executive Schedule;
+  * **Senior Executive Service** "General" positions and **Senior Foreign Service** positions;
+  * **Schedule C** positions excepted from the competitive service by the President, or by the 
+  Director, Office of Personnel Management, and other positions at the GS-14 and above level 
+  excepted from the competitive civil service by law, because of the confidential or 
+  policy-determining nature of the position duties.
+
+  [Source: GovInfo](https://www.govinfo.gov/collection/plum-book?path=/GPO/United%20States%20Government%20Policy%20and%20Supporting%20Positions%20%2528Plum%20Book%2529)
 publisher:
   name: U.S. Office of Personnel Management
   acronym: OPM

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -14,7 +14,7 @@ description: |
   that may be subject to noncompetitive appointments. These positions include agency heads 
   and their immediate subordinates, policy executives and advisors, and aides who report to 
   these officials. Many positions have duties which support Administration policies and programs.
-
+# yet to be double-checked
   The people holding these positions usually have a close and confidential relationship with 
   the agency head or other key officials.
 

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -18,19 +18,23 @@ description: |
   The people holding these positions usually have a close and confidential relationship with 
   the agency head or other key officials.
 
-  Positions in the Plum Book include the following: 
+  Positions in the Plum Book include the following:
+    
+    - **Schedule C (SC)** positions are excepted from the competitive service because of their 
+      confidential or policy-determining character. The decision concerning whether to place a 
+      position in Schedule C is made by the Director, U.S. Office of Personnel Management, upon 
+      agency request.
 
-  * **Executive Schedule (EX)** and salary-equivalent positions paid at the rates established 
-    for Levels I through V of the Executive Schedule.
-  * **Senior Executive Service (SES)** "General" positions (i.e., those positions which may be 
-    filled by a career, noncareer, or limited appointment).
-  * **Senior Foreign Service (SFS)** positions.
-  * **Schedule C (SC)** positions excepted from the competitive service by the President, or by the 
-    Director, Office of Personnel Management, because of the confidential or policy-determining 
-    nature of the position duties.
-  * **Other** confidential or policy-determining positions.
-
-  [Source: Office of Human Resources Management](https://www.commerce.gov/hr/practitioners/ses-policies/plum-book#:~:text=What%20is%20the%20Plum%20Book,between%20the%20House%20and%20Senate.)
+    - **Senior Executive Service (SES)** is a personnel system covering top level policy, supervisory, 
+      and managerial positions in most Federal agencies. The SES includes most Civil Service positions 
+      above grade 15 of the General Schedule. 
+      There are two types of SES positions:
+      - **Career Reserved**
+      - **General**
+  
+  **Sources:**
+  - [Office of Human Resources Management](https://www.commerce.gov/hr/practitioners/ses-policies/plum-book#:~:text=What%20is%20the%20Plum%20Book,between%20the%20House%20and%20Senate)  
+  - [U.S. Office of Personnel Management - Plum Book Reporting](https://www.opm.gov/about-us/open-government/plum-reporting/position-descriptions/)
 publisher:
   name: U.S. Office of Personnel Management
   acronym: OPM

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -39,7 +39,7 @@ dates:
 assertions:
   min:
     schema_entities:
-      Person: 7700
+      Person: 6700
   max:
     schema_entities:
       Person: 9000

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -1,4 +1,4 @@
-title: U.S. Office of Personnel Management (OPM) Plum Book
+title: United States Government Policy and Supporting Positions (Plum Book)
 entry_point: crawler.py
 prefix: plum
 coverage:

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -1,0 +1,51 @@
+title: U.S. Office of Personnel Management (OPM) Plum Book
+entry_point: crawler.py
+prefix: plum
+coverage:
+  frequency: daily
+  start: 2024-11-06"
+load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
+summary: >
+  The Plum Book data provides details on political appointees, Schedule C 
+  employees, and other federal positions by department, title, and agency.
+description: |
+  The U.S. Office of Personnel Management (OPM) publishes the Plum Book, 
+  listing positions within the federal government filled by presidential 
+  appointment, as well as other executive roles. The data is collected 
+  and verified by the OPM in coordination with the White House Office of 
+  Presidential Personnel. It includes details on job titles, incumbents, 
+  department, position status, type of appointment, and pay plans. Updated 
+  biannually, this resource supports transparency on political and leadership 
+  appointments in federal agencies and departments.
+publisher:
+  name: U.S. Office of Personnel Management
+  acronym: OPM
+  description: >
+    The Office of Personnel Management (OPM) oversees the federal workforce, 
+    including personnel policies, employee benefits, recruitment, and retention 
+    strategies across federal agencies. It also manages the Plum Book, a 
+    biannual report on political appointees and senior government positions.
+  country: us
+  url: https://www.opm.gov/
+  official: true
+url: https://www.treasury.gov/resource-center/sanctions/Pages/default.aspx
+data:
+  url: https://escs.opm.gov/escs-net/api/pbpub/download-data
+  format: CSV
+  lang: eng
+
+dates: 
+  formats: ["%m/%d/%Y 00:00:00"]
+assertions:
+  min:
+    schema_entities:
+      Person: 7700
+  max:
+    schema_entities:
+      Person: 9000
+
+lookups:
+  type.date:
+    options:
+      - match: 0001-01-01
+        value: null

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -3,32 +3,29 @@ entry_point: crawler.py
 prefix: plum
 coverage:
   frequency: daily
-  start: 2024-11-06"
+  start: 2024-11-06
 load_db_uri: ${OPENSANCTIONS_DATABASE_URI}
 summary: >
-  The Plum Book data provides details on political appointees, Schedule C 
-  employees, and other federal positions by department, title, and agency.
+  The Plum Book lists federal positions filled by political appointees, Schedule C 
+  employees, and other executives.
 description: |
-  The U.S. Office of Personnel Management (OPM) publishes the Plum Book, 
-  listing positions within the federal government filled by presidential 
-  appointment, as well as other executive roles. The data is collected 
-  and verified by the OPM in coordination with the White House Office of 
-  Presidential Personnel. It includes details on job titles, incumbents, 
-  department, position status, type of appointment, and pay plans. Updated 
-  biannually, this resource supports transparency on political and leadership 
-  appointments in federal agencies and departments.
+  The Plum Book provides a comprehensive listing of federal positions appointed by the 
+  President, including Schedule C and other key roles within the executive branch. 
+  The data covers job titles, agency affiliations, appointment types, and other relevant 
+  information about these roles. Verified by OPM in coordination with the White House Office 
+  of Presidential Personnel, the Plum Book is updated biennially to support transparency on 
+  political appointments across federal agencies and departments.
 publisher:
   name: U.S. Office of Personnel Management
   acronym: OPM
   description: >
-    The Office of Personnel Management (OPM) oversees the federal workforce, 
-    including personnel policies, employee benefits, recruitment, and retention 
-    strategies across federal agencies. It also manages the Plum Book, a 
-    biannual report on political appointees and senior government positions.
+    The U.S. Office of Personnel Management (OPM) serves as the chief human resources agency 
+    and personnel policy manager for the Federal Government.
+    [Source: Official Website](https://www.opm.gov/about-us/)
   country: us
   url: https://www.opm.gov/
   official: true
-url: https://www.treasury.gov/resource-center/sanctions/Pages/default.aspx
+url: https://www.opm.gov/about-us/open-government/plum-reporting/plum-data/
 data:
   url: https://escs.opm.gov/escs-net/api/pbpub/download-data
   format: CSV

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -9,12 +9,28 @@ summary: >
   The Plum Book lists federal positions filled by political appointees, Schedule C 
   employees, and other executives.
 description: |
-  The Plum Book provides a comprehensive listing of federal positions appointed by the 
-  President, including Schedule C and other key roles within the executive branch. 
-  The data covers job titles, agency affiliations, appointment types, and other relevant 
-  information about these roles. Verified by OPM in coordination with the White House Office 
-  of Presidential Personnel, the Plum Book is updated biennially to support transparency on 
-  political appointments across federal agencies and departments.
+  The Plum Book is a listing of over 8,000 civil service leadership and support positions 
+  (filled and vacant) in the Legislative and Executive branches of the Federal Government 
+  that may be subject to noncompetitive appointments. These positions include agency heads 
+  and their immediate subordinates, policy executives and advisors, and aides who report to 
+  these officials. Many positions have duties which support Administration policies and programs.
+
+  The people holding these positions usually have a close and confidential relationship with 
+  the agency head or other key officials.
+
+  Positions in the Plum Book include the following: 
+
+  * **Executive Schedule (EX)** and salary-equivalent positions paid at the rates established 
+    for Levels I through V of the Executive Schedule.
+  * **Senior Executive Service (SES)** "General" positions (i.e., those positions which may be 
+    filled by a career, noncareer, or limited appointment).
+  * **Senior Foreign Service (SFS)** positions.
+  * **Schedule C (SC)** positions excepted from the competitive service by the President, or by the 
+    Director, Office of Personnel Management, because of the confidential or policy-determining 
+    nature of the position duties.
+  * **Other** confidential or policy-determining positions.
+
+  [Source: Office of Human Resources Management](https://www.commerce.gov/hr/practitioners/ses-policies/plum-book#:~:text=What%20is%20the%20Plum%20Book,between%20the%20House%20and%20Senate.)
 publisher:
   name: U.S. Office of Personnel Management
   acronym: OPM


### PR DESCRIPTION
opensanctions/crawler-planning#273

We've decided to keep both positions for now in order to dedupe based on the `person.add("position")`