### PR TITLE
Exclude irrelevant categories and debugging function

### DIFF
--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -259,6 +259,9 @@ config:
     - category: Government_of_Turkey
       topic: role.pep
       country: tr
+      negcats: |
+        Turkish_criminals
+        Naturalized_citizens_of_Turkey
     - category: 21st-century_Turkish_politicians
       country: tr
     - category: Members_of_the_28th_Parliament_of_Turkey

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -256,12 +256,6 @@ config:
     - category: Political_office-holders_in_Turkey
       topic: role.pep
       country: tr
-    - category: Government_of_Turkey
-      topic: role.pep
-      country: tr
-      negcats: |
-        Turkish_criminals
-        Naturalized_citizens_of_Turkey
     - category: 21st-century_Turkish_politicians
       country: tr
     - category: Members_of_the_28th_Parliament_of_Turkey
@@ -276,6 +270,34 @@ config:
     - category: Members_of_the_66th_government_of_Turkey
       topic: role.pep
       country: tr
+    - category: Cabinets_of_Turkey
+      topic: role.pep
+      country: tr
+    - category: Constituent_Assembly_of_Turkey
+      topic: role.pep
+      country: tr
+    - category: Grand_National_Assembly_of_Turkey
+      topic: role.pep
+      country: tr
+    - category: Heads_of_government_of_Turkey
+      topic: role.pep
+      country: tr
+    - category: Heads_of_state_of_Turkey
+      topic: role.pep
+      country: tr
+    - category: Turkish_judges
+      topic: role.pep
+      country: tr
+    - category: Military_of_Turkey
+      topic: role.pep
+      country: tr
+    - category: Government_ministers_of_Turkey
+      topic: role.pep
+      country: tr
+    - category: Government_ministries_of_Turkey
+      topic: role.pep
+      country: tr
+    - category: Presidents_of_Turkey
 
     # NK
     - category: Leaders_of_the_Workers'_Party_of_Korea_and_its_predecessors


### PR DESCRIPTION
Criminal included as PEP due to two categories.

I think using negcats excludes all the people in any of those categories even if they are included in a different subcategory, because only one of these categories is needed to exclude this person. This means someone listed in a real PEP category would be excluded if they occur in some category listed in negcats.

```
Q118477652 Government_of_Turkey {'number': '6070', 'title': 'Rawa_Majid', 'pageid': '74837126', 'namespace': '', 'length': '13802', 'touched': '20241102142351', 'Wikidata': 'Q118477652'}

{
    ('Category:Naturalized citizens of Turkey', 'Category:Turkish nationality law', 'Category:Law of Turkey', 'Category:Government of Turkey'), 
    ('Category:Turkish criminals', 'Category:Crime in Turkey', 'Category:Law enforcement in Turkey', 'Category:Law of Turkey', 'Category:Government of Turkey')
}
```