### PR TITLE
Add program and Improve end_date Handling for Sanction Status

### DIFF
--- a/datasets/be/fod_sanctions/be_fod_sanctions.yml
+++ b/datasets/be/fod_sanctions/be_fod_sanctions.yml
@@ -51,9 +51,11 @@ lookups:
       - match: eu-fsf-eu-11935-5
         value: Organization
       - match:
-          - eu-fsf-eu-9442-82  # Unica
-          - eu-fsf-eu-9443-81  # New Konk
+          - eu-fsf-eu-9442-82 # Unica
+          - eu-fsf-eu-9443-81 # New Konk
         value: Vessel
+  sanction.program:
+    options: []
   contact_info:
     options:
       - match: PHONE
@@ -147,7 +149,7 @@ lookups:
         value: male
       - match: F
         value: female
-  type.string: 
+  type.string:
     lowercase: true
     normalize: true
     options:

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -74,19 +74,19 @@ lookups:
     options:
     # Afghanistan
       - match: AFG
-        value: 
+        value: EU-AFG
     # Belarus
       - match: BLR  # implementing Article 8a of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus
-        value: EU-BRUS
+        value: EU-BLR
     # Bosnia & Herzegovina
       - match: 
         value: EU-BOSNIA
     # Burundi
       - match: BDI  # implementing Regulation (EU) 2015/1755 concerning restrictive measures in view of the situation in Burundi
-        value: EU-BURUNDI
+        value: EU-BDI
     # Central African Republic
       - match: CAF  # implementing Article 17(3) of Regulation (EU) No 224/2014 concerning restrictive measures in view of the situation in the Central African Republic
-        value:
+        value: EU-CAF
     # Chemical weapons
       - match: CHEM  # implementing Regulation (EU) 2018/1542 concerning restrictive measures against the proliferation and use of chemical weapons
         value: EU-CHEM
@@ -98,27 +98,27 @@ lookups:
         value: EU-CYB
     # Democratic People's Republic of Korea (DPRK – North Korea)
       - match: PRK
-        value: 
+        value: EU-PRK
     # Democratic Republic of the Congo
       - match: COD  # implementing Article 9(5) of Regulation (EC) No 1183/2005 imposing certain specific restrictive measures directed against persons acting in violation of the arms embargo with regard to the Democratic Republic of the Congo
-        value: EU-DRC
+        value: EU-COD
     # Guatemala
       - match: GTM  # implementing Regulation (EU) 2024/287 concerning restrictive measures in view of the situation in Guatemala
-        value: EU-GUATEMALA
+        value: EU-GTM
     # Guinea
       - match: GIN  # implementing Regulation (EU) No 1284/2009 imposing certain specific restrictive measures in respect of the Republic of Guinea
-        value: EU-GUINEA
+        value: EU-GIN
     # Guinea-Bissau
       - match: GNB  # mplementing Article 11(1) of Regulation (EU) No 377/2012 concerning restrictive measures directed against certain persons, entities and bodies threatening the peace, security or stability of the Republic of Guinea-Bissau
-        value: 
+        value: EU-GNB
     # Haiti
       - match: HTI  # implementing Regulation (EU) 2022/2309 concerning restrictive measures in view of the situation in Haiti
         values: 
-          - EU-HAITI
+          - EU-HTI
           - 
     # Human rights
       - match: HR
-        value: EU-RIGHTS
+        value: EU-HR
     # Iran
       - match: IRN  # implementing Regulation (EU) No 267/2012 concerning restrictive measures against Iran
                     # implementing Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region
@@ -128,7 +128,7 @@ lookups:
           - 
     # Iraq
       - match: IRQ
-        value:
+        value: EU-IRQ
     # Lebanon
       - match: 
         values: 
@@ -138,48 +138,49 @@ lookups:
     # Libya
       - match: LBY  # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
         value: 
-          - EU-LIBYA
+          - EU-LBY
           - 
     # Mali
       - match: MLI  # implementing Article 12(2) of Regulation (EU) 2017/1770 concerning restrictive measures in view of the situation in Mali
-        value: EU-MALI
+        value: EU-MLI
     # Moldova
       - match: MDA  # implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova
         value: 
-          - EU-MOLDOVA
+          - EU-MDA
           -
     # Montenegro
       - match: 
         value: EU-CRNA-UN757
     # Myanmar (Burma)
       - match: MMR  # implementing Regulation (EU) No 401/2013 concerning restrictive measures in respect of Myanmar/Burma
-        value: EU-MYANMAR
+        value: EU-MMR
     # Nicaragua
       - match: NIC  # implementing Regulation (EU) 2019/1716 concerning restrictive measures in view of the situation in Nicaragua
-        value: EU-NICARAGUA
+        value: EU-NIC
     # Niger
       - match: 
-        value:
+        value: EU-NIGER
     # Russia
       - match: RUS  # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
-        values: 
+        values:
           - EU-RUSSIA-REST
           - 
-          - 
+      - match: RUS
+        value: EU-RUS
     # Serbia
       - match: 
         value: EU-SRB-UN757
     # Somalia
       - match: SOM
-        value:
+        value: EU-SOM
     # South Sudan
       - match: SSD  #  Article 20(3) of Regulation (EU) 2015/735 concerning restrictive measures in respect of the situation in South Sudan
-        value: EU-SOUTH-SUDAN
+        value: EU-SSD
     # Sudan
       - match: SDN  # implementing Article 15(3) of Regulation (EU) No 747/2014 concerning restrictive measures in view of the situation in Sudan
-        value: EU-SUDAN
-      - match:      # implementing Regulation (EU) 2023/2147 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan
-        value: EU-SUDAN-REST
+        value: EU-SDN
+      - match: SDNZ  # implementing Regulation (EU) 2023/2147 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan
+        value: EU-SDNZ
     # Syria
       - match: SYR  # implementing Regulation (EU) No 36/2012 concerning restrictive measures in view of the situation in Syria
         values: 
@@ -225,7 +226,6 @@ lookups:
       #   value: 
 
 # unused: 
-# - EU-WMD
 # - EU-PMR
 # - EU-NIGER
 # ...

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -63,8 +63,104 @@ url: https://www.eeas.europa.eu/eeas/european-union-sanctions_en#10710
 data:
   url: https://webgate.ec.europa.eu/fsd/fsf/public/files/xmlFullSanctionsList_1_1/content?token=dG9rZW4tMjAxNw
   format: XML
+# 'LBY', 'HAM', 'YEM', 'SYR', 'BDI', 'ZWE', 'EUAQ', 'NIC', 'UNLI', 'SDNZ', 
+# 'COD', 'SSD', 'GNB', 'TUR', 'HR', 'TERR', 'SDN', 'VEN', 'MDA', 'BLR', 'TAQA', 
+# 'UKR', 'MMR', 'MLI', 'GTM', 'PRK', 'AFG', 'IRN', 'CYB', 'SOM', 'IRQ', 'HTI', 'GIN', 
+# 'RUS', 'TUN', 'CAF', 'CHEM'
 
 lookups:
+  sanction.program:
+    options:
+      - match: UKR  # implementing Regulation (EU) No 208/2014 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Ukraine
+                    # implementing Regulation (EU) No 269/2014 concerning restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine
+        values: 
+          - EU-UKRAINE-INTEG
+          - EU-CRIMEA
+          - EU-UKRAINE-OCC
+          - EU-UKRAINE-MSF
+      - match: TAQA  # Council Regulation (EC) No 881/2002 imposing certain specific restrictive measures directed against certain persons and entities associated with the Al Qaida network
+        value: EU-ISIS
+      - match: TERR  # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism
+        value: EU-TERROR
+      - match: LBY  # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
+        value: EU-LIBYA
+      - match: HAM  # COUNCIL REGULATION (EU) 2024/386 of 19 January 2024 establishing restrictive measures against those who support, facilitate or enable violent actions by Hamas and the Palestinian Islamic Jihad
+        value: EU-HAMAS
+      # - match: YEM
+      #   value: EU-YEMEN
+      - match: SYR  # implementing Regulation (EU) No 36/2012 concerning restrictive measures in view of the situation in Syria
+        value: EU-SYRIA
+      - match: BDI  # implementing Regulation (EU) 2015/1755 concerning restrictive measures in view of the situation in Burundi
+        value: EU-BURUNDI
+      # - match: ZWE
+      #   value: EU-ZIMBABWE
+      # - match: EUAQ
+      #   value: EU-EUROPEAN-ACT
+      - match: NIC  # implementing Regulation (EU) 2019/1716 concerning restrictive measures in view of the situation in Nicaragua
+        value: EU-NICARAGUA
+      # - match: UNLI
+      #   value: 
+      - match: SDNZ  # implementing Regulation (EU) 2023/2147 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan
+        value: EU-SUDAN-REST
+      - match: COD
+        value: EU-DRC
+      - match: SSD  #  Article 20(3) of Regulation (EU) 2015/735 concerning restrictive measures in respect of the situation in South Sudan
+        value: EU-SOUTH-SUDAN
+      - match: GNB
+        value: EU-GUINEA
+      - match: TUR  # implementing Regulation (EU) 2019/1890 concerning restrictive measures in view of Turkey’s unauthorised drilling activities in the Eastern Mediterranean
+        value: EU-TURKEY-MED
+      # - match: HR
+      #   value: EU-HR
+      - match: SDN  # implementing Article 15(3) of Regulation (EU) No 747/2014 concerning restrictive measures in view of the situation in Sudan
+        value: EU-SUDAN
+      - match: VEN  # implementing Regulation (EU) 2017/2063 concerning restrictive measures in view of the situation in Venezuela
+        value: EU-VEN-REST
+      - match: MDA  # implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova
+        value: EU-MOLDOVA
+      - match: BLR  # implementing Article 8a of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus
+        value: EU-BRUS
+      - match: MMR  # implementing Regulation (EU) No 401/2013 concerning restrictive measures in respect of Myanmar/Burma
+        value: EU-MYANMAR
+      - match: MLI  # implementing Article 12(2) of Regulation (EU) 2017/1770 concerning restrictive measures in view of the situation in Mali
+        value: EU-MALI
+      - match: GTM  # implementing Regulation (EU) 2024/287 concerning restrictive measures in view of the situation in Guatemala
+        value: EU-GUATEMALA
+      # - match: PRK  # implementing Regulation (EU) 2017/1509 concerning restrictive measures against the Democratic People's Republic of Korea
+      #   value: 
+      # - match: AFG
+      #   value: 
+      - match: IRN  # implementing Regulation (EU) No 267/2012 concerning restrictive measures against Iran
+                    # implementing Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region
+        value: 
+          - EU-IRAN-HR
+          - EU-IRAN-RUSSIA
+      - match: CYB
+        value: EU-CYB
+      # - match: SOM
+      #   value: 
+      # - match: IRQ
+      #   value: 
+      - match: HTI  # implementing Regulation (EU) 2022/2309 concerning restrictive measures in view of the situation in Haiti
+        value: EU-HAITI  
+      - match: GIN  # implementing Regulation (EU) No 1284/2009 imposing certain specific restrictive measures in respect of the Republic of Guinea
+        value: EU-GUINEA
+      - match: RUS  # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
+        value: EEU-RUSSIA-REST
+      - match: TUN  # implementing Regulation (EU) No 101/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Tunisia
+        value: EU-TUNISIA
+      # - match: CAF  # implementing Article 17(3) of Regulation (EU) No 224/2014 concerning restrictive measures in view of the situation in the Central African Republic
+      #   value: EU-CENTRAL-AFRICA
+      - match: CHEM  # implementing Regulation (EU) 2018/1542 concerning restrictive measures against the proliferation and use of chemical weapons
+        value: EU-CHEM
+# unused: 
+# - EU-BOSNIA
+# - EU-WMD
+# - EU-PMR
+# - EU-SRB-UN757
+# - EU-CRNA-UN757
+# ...
+
   subject_type:
     options:
       - match: person

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -150,7 +150,7 @@ lookups:
         value: EU-NIGER
     # Russia
       - match: RUS  # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
-        values: EU-RUS
+        value: EU-RUS
     # Serbia
       - match: 
         value: EU-SRB-UN757
@@ -167,7 +167,7 @@ lookups:
         value: EU-SDNZ
     # Syria
       - match: SYR  # Council Regulation concerning restrictive measures in view of the situation in Syria and repealing Regulation (EU) No 442/2011
-        values: EU-SYR
+        value: EU-SYR
     # Terrorism
       - match: TERR
         value: EU-TERR  # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism
@@ -183,7 +183,7 @@ lookups:
         value: EU-TUR
     # Ukraine
       - match: UKR
-        values: EU-UKR
+        value: EU-UKR
     # United States
       - match: 
         value: EU-US-LEG

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -147,7 +147,7 @@ lookups:
       - match: MDA  # implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova
         value: 
           - EU-MDA
-          -
+          - EU-PMR
     # Montenegro
       - match: 
         value: EU-CRNA-UN757
@@ -184,20 +184,21 @@ lookups:
     # Syria
       - match: SYR  # implementing Regulation (EU) No 36/2012 concerning restrictive measures in view of the situation in Syria
         values: 
-          - EU-SYRIA
+          - EU-SYR
           - 
     # Terrorism
       - match: TERR
-        value: 
-          - EU-TERROR  # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism
-          - EU-ISIS  # Council Regulation (EC) No 881/2002 imposing certain specific restrictive measures directed against certain persons and entities associated with the Al Qaida network
-          - EU-HAMAS # COUNCIL REGULATION (EU) 2024/386 of 19 January 2024 establishing restrictive measures against those who support, facilitate or enable violent actions by Hamas and the Palestinian Islamic Jihad
+        value: EU-TERR  # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism
+      - match: TAQA
+        value: EU-TAQA  # Council Regulation (EC) No 881/2002 imposing certain specific restrictive measures directed against certain persons and entities associated with the Al Qaida network
+      - match: HAM  
+        value: EU-HAM # COUNCIL REGULATION (EU) 2024/386 of 19 January 2024 establishing restrictive measures against those who support, facilitate or enable violent actions by Hamas and the Palestinian Islamic Jihad
     # Tunisia
       - match: TUN  # implementing Regulation (EU) No 101/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Tunisia
-        value: EU-TUNISIA
+        value: EU-TUN
     # Türkiye
       - match: TUR  # implementing Regulation (EU) 2019/1890 concerning restrictive measures in view of Turkey’s unauthorised drilling activities in the Eastern Mediterranean
-        value: EU-TURKEY-MED
+        value: EU-TUR
     # Ukraine
       - match: UKR  # implementing Regulation (EU) No 208/2014 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Ukraine
                     # implementing Regulation (EU) No 269/2014 concerning restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine
@@ -211,13 +212,13 @@ lookups:
         value: EU-US-LEG
     # Venezuela
       - match: VEN  # implementing Regulation (EU) 2017/2063 concerning restrictive measures in view of the situation in Venezuela
-        value: EU-VEN-REST
+        value: EU-VEN
     # Yemen
       - match: YEM
-        value: EU-YEMEN
+        value: EU-YEM
     # Zimbabwe
       - match: ZWE
-        value: EU-ZIMBABWE
+        value: EU-ZWE
 
 
       # - match: EUAQ
@@ -227,7 +228,6 @@ lookups:
 
 # unused: 
 # - EU-PMR
-# - EU-NIGER
 # ...
 
   subject_type:

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -115,7 +115,6 @@ lookups:
       - match: HTI  # implementing Regulation (EU) 2022/2309 concerning restrictive measures in view of the situation in Haiti
         values: 
           - EU-HTI
-          - 
     # Human rights
       - match: HR
         value: EU-HR
@@ -133,13 +132,10 @@ lookups:
       - match: 
         values: 
           - EU-LEBANON
-          - 
-          - 
     # Libya
       - match: LBY  # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
         value: 
           - EU-LBY
-          - 
     # Mali
       - match: MLI  # implementing Article 12(2) of Regulation (EU) 2017/1770 concerning restrictive measures in view of the situation in Mali
         value: EU-MLI
@@ -185,7 +181,6 @@ lookups:
       - match: SYR  # implementing Regulation (EU) No 36/2012 concerning restrictive measures in view of the situation in Syria
         values: 
           - EU-SYR
-          - 
     # Terrorism
       - match: TERR
         value: EU-TERR  # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -102,12 +102,12 @@ lookups:
       #   value: 
       - match: SDNZ  # implementing Regulation (EU) 2023/2147 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan
         value: EU-SUDAN-REST
-      - match: COD
+      - match: COD  # implementing Article 9(5) of Regulation (EC) No 1183/2005 imposing certain specific restrictive measures directed against persons acting in violation of the arms embargo with regard to the Democratic Republic of the Congo
         value: EU-DRC
       - match: SSD  #  Article 20(3) of Regulation (EU) 2015/735 concerning restrictive measures in respect of the situation in South Sudan
         value: EU-SOUTH-SUDAN
-      - match: GNB
-        value: EU-GUINEA
+      - match: GNB  # mplementing Article 11(1) of Regulation (EU) No 377/2012 concerning restrictive measures directed against certain persons, entities and bodies threatening the peace, security or stability of the Republic of Guinea-Bissau
+        value: 
       - match: TUR  # implementing Regulation (EU) 2019/1890 concerning restrictive measures in view of Turkey’s unauthorised drilling activities in the Eastern Mediterranean
         value: EU-TURKEY-MED
       # - match: HR
@@ -146,7 +146,7 @@ lookups:
       - match: GIN  # implementing Regulation (EU) No 1284/2009 imposing certain specific restrictive measures in respect of the Republic of Guinea
         value: EU-GUINEA
       - match: RUS  # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
-        value: EEU-RUSSIA-REST
+        value: EU-RUSSIA-REST
       - match: TUN  # implementing Regulation (EU) No 101/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Tunisia
         value: EU-TUNISIA
       # - match: CAF  # implementing Article 17(3) of Regulation (EU) No 224/2014 concerning restrictive measures in view of the situation in the Central African Republic
@@ -159,6 +159,11 @@ lookups:
 # - EU-PMR
 # - EU-SRB-UN757
 # - EU-CRNA-UN757
+# - EU-US-LEG
+# - EU-RIGHTS
+# - EU-LEBANON
+# - EU-NIGER
+# - EU-TIANANMEN
 # ...
 
   subject_type:

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -63,10 +63,6 @@ url: https://www.eeas.europa.eu/eeas/european-union-sanctions_en#10710
 data:
   url: https://webgate.ec.europa.eu/fsd/fsf/public/files/xmlFullSanctionsList_1_1/content?token=dG9rZW4tMjAxNw
   format: XML
-# 'LBY', 'HAM', 'YEM', 'SYR', 'BDI', 'ZWE', 'EUAQ', 'NIC', 'UNLI', 'SDNZ', 
-# 'COD', 'SSD', 'GNB', 'TUR', 'HR', 'TERR', 'SDN', 'VEN', 'MDA', 'BLR', 'TAQA', 
-# 'UKR', 'MMR', 'MLI', 'GTM', 'PRK', 'AFG', 'IRN', 'CYB', 'SOM', 'IRQ', 'HTI', 'GIN', 
-# 'RUS', 'TUN', 'CAF', 'CHEM'
 
 lookups:
   sanction.program:

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -220,15 +220,11 @@ lookups:
       - match: ZWE
         value: EU-ZWE
 
+# - match: EUAQ
+#   value: EU-EUROPEAN-ACT
+# - match: UNLI
+#   value: 
 
-      # - match: EUAQ
-      #   value: EU-EUROPEAN-ACT
-      # - match: UNLI
-      #   value: 
-
-# unused: 
-# - EU-PMR
-# ...
 
   subject_type:
     options:

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -113,37 +113,29 @@ lookups:
         value: EU-GNB
     # Haiti
       - match: HTI  # implementing Regulation (EU) 2022/2309 concerning restrictive measures in view of the situation in Haiti
-        values: 
-          - EU-HTI
+        value: EU-HTI
     # Human rights
       - match: HR
         value: EU-HR
     # Iran
       - match: IRN  # implementing Regulation (EU) No 267/2012 concerning restrictive measures against Iran
                     # implementing Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region
-        value:
-          - EU-IRAN-HR
-          - EU-IRAN-RUSSIA
-          - 
+        value: EU-IRN
     # Iraq
       - match: IRQ
         value: EU-IRQ
     # Lebanon
       - match: 
-        values: 
-          - EU-LEBANON
+        value: EU-LEBANON
     # Libya
       - match: LBY  # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
-        value: 
-          - EU-LBY
+        value: EU-LBY
     # Mali
       - match: MLI  # implementing Article 12(2) of Regulation (EU) 2017/1770 concerning restrictive measures in view of the situation in Mali
         value: EU-MLI
     # Moldova
       - match: MDA  # implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova
-        value: 
-          - EU-MDA
-          - EU-PMR
+        value: EU-MDA     
     # Montenegro
       - match: 
         value: EU-CRNA-UN757
@@ -158,11 +150,7 @@ lookups:
         value: EU-NIGER
     # Russia
       - match: RUS  # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
-        values:
-          - EU-RUSSIA-REST
-          - 
-      - match: RUS
-        value: EU-RUS
+        values: EU-RUS
     # Serbia
       - match: 
         value: EU-SRB-UN757
@@ -178,9 +166,8 @@ lookups:
       - match: SDNZ  # implementing Regulation (EU) 2023/2147 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan
         value: EU-SDNZ
     # Syria
-      - match: SYR  # implementing Regulation (EU) No 36/2012 concerning restrictive measures in view of the situation in Syria
-        values: 
-          - EU-SYR
+      - match: SYR  # Council Regulation concerning restrictive measures in view of the situation in Syria and repealing Regulation (EU) No 442/2011
+        values: EU-SYR
     # Terrorism
       - match: TERR
         value: EU-TERR  # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism
@@ -195,13 +182,8 @@ lookups:
       - match: TUR  # implementing Regulation (EU) 2019/1890 concerning restrictive measures in view of Turkey’s unauthorised drilling activities in the Eastern Mediterranean
         value: EU-TUR
     # Ukraine
-      - match: UKR  # implementing Regulation (EU) No 208/2014 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Ukraine
-                    # implementing Regulation (EU) No 269/2014 concerning restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine
-        values: 
-          - EU-UKRAINE-INTEG
-          - EU-CRIMEA
-          - EU-UKRAINE-OCC
-          - EU-UKRAINE-MSF
+      - match: UKR
+        values: EU-UKR
     # United States
       - match: 
         value: EU-US-LEG
@@ -214,12 +196,6 @@ lookups:
     # Zimbabwe
       - match: ZWE
         value: EU-ZWE
-
-# - match: EUAQ
-#   value: EU-EUROPEAN-ACT
-# - match: UNLI
-#   value: 
-
 
   subject_type:
     options:

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -70,7 +70,134 @@ data:
 
 lookups:
   sanction.program:
+    # in accordance with https://sanctionsmap.eu/#/main?search=%7B%22value%22:%22%22,%22searchType%22:%7B%7D%7D
     options:
+    # Afghanistan
+      - match: AFG
+        value: 
+    # Belarus
+      - match: BLR  # implementing Article 8a of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus
+        value: EU-BRUS
+    # Bosnia & Herzegovina
+      - match: 
+        value: EU-BOSNIA
+    # Burundi
+      - match: BDI  # implementing Regulation (EU) 2015/1755 concerning restrictive measures in view of the situation in Burundi
+        value: EU-BURUNDI
+    # Central African Republic
+      - match: CAF  # implementing Article 17(3) of Regulation (EU) No 224/2014 concerning restrictive measures in view of the situation in the Central African Republic
+        value:
+    # Chemical weapons
+      - match: CHEM  # implementing Regulation (EU) 2018/1542 concerning restrictive measures against the proliferation and use of chemical weapons
+        value: EU-CHEM
+    # China
+      - match: 
+        value: EU-TIANANMEN
+    # Cyber-attacks
+      - match: CYB
+        value: EU-CYB
+    # Democratic People's Republic of Korea (DPRK – North Korea)
+      - match: PRK
+        value: 
+    # Democratic Republic of the Congo
+      - match: COD  # implementing Article 9(5) of Regulation (EC) No 1183/2005 imposing certain specific restrictive measures directed against persons acting in violation of the arms embargo with regard to the Democratic Republic of the Congo
+        value: EU-DRC
+    # Guatemala
+      - match: GTM  # implementing Regulation (EU) 2024/287 concerning restrictive measures in view of the situation in Guatemala
+        value: EU-GUATEMALA
+    # Guinea
+      - match: GIN  # implementing Regulation (EU) No 1284/2009 imposing certain specific restrictive measures in respect of the Republic of Guinea
+        value: EU-GUINEA
+    # Guinea-Bissau
+      - match: GNB  # mplementing Article 11(1) of Regulation (EU) No 377/2012 concerning restrictive measures directed against certain persons, entities and bodies threatening the peace, security or stability of the Republic of Guinea-Bissau
+        value: 
+    # Haiti
+      - match: HTI  # implementing Regulation (EU) 2022/2309 concerning restrictive measures in view of the situation in Haiti
+        values: 
+          - EU-HAITI
+          - 
+    # Human rights
+      - match: HR
+        value: EU-RIGHTS
+    # Iran
+      - match: IRN  # implementing Regulation (EU) No 267/2012 concerning restrictive measures against Iran
+                    # implementing Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region
+        value:
+          - EU-IRAN-HR
+          - EU-IRAN-RUSSIA
+          - 
+    # Iraq
+      - match: IRQ
+        value:
+    # Lebanon
+      - match: 
+        values: 
+          - EU-LEBANON
+          - 
+          - 
+    # Libya
+      - match: LBY  # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
+        value: 
+          - EU-LIBYA
+          - 
+    # Mali
+      - match: MLI  # implementing Article 12(2) of Regulation (EU) 2017/1770 concerning restrictive measures in view of the situation in Mali
+        value: EU-MALI
+    # Moldova
+      - match: MDA  # implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova
+        value: 
+          - EU-MOLDOVA
+          -
+    # Montenegro
+      - match: 
+        value: EU-CRNA-UN757
+    # Myanmar (Burma)
+      - match: MMR  # implementing Regulation (EU) No 401/2013 concerning restrictive measures in respect of Myanmar/Burma
+        value: EU-MYANMAR
+    # Nicaragua
+      - match: NIC  # implementing Regulation (EU) 2019/1716 concerning restrictive measures in view of the situation in Nicaragua
+        value: EU-NICARAGUA
+    # Niger
+      - match: 
+        value:
+    # Russia
+      - match: RUS  # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
+        values: 
+          - EU-RUSSIA-REST
+          - 
+          - 
+    # Serbia
+      - match: 
+        value: EU-SRB-UN757
+    # Somalia
+      - match: SOM
+        value:
+    # South Sudan
+      - match: SSD  #  Article 20(3) of Regulation (EU) 2015/735 concerning restrictive measures in respect of the situation in South Sudan
+        value: EU-SOUTH-SUDAN
+    # Sudan
+      - match: SDN  # implementing Article 15(3) of Regulation (EU) No 747/2014 concerning restrictive measures in view of the situation in Sudan
+        value: EU-SUDAN
+      - match:      # implementing Regulation (EU) 2023/2147 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan
+        value: EU-SUDAN-REST
+    # Syria
+      - match: SYR  # implementing Regulation (EU) No 36/2012 concerning restrictive measures in view of the situation in Syria
+        values: 
+          - EU-SYRIA
+          - 
+    # Terrorism
+      - match: TERR
+        value: 
+          - EU-TERROR  # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism
+          - EU-ISIS  # Council Regulation (EC) No 881/2002 imposing certain specific restrictive measures directed against certain persons and entities associated with the Al Qaida network
+          - EU-HAMAS # COUNCIL REGULATION (EU) 2024/386 of 19 January 2024 establishing restrictive measures against those who support, facilitate or enable violent actions by Hamas and the Palestinian Islamic Jihad
+    # Tunisia
+      - match: TUN  # implementing Regulation (EU) No 101/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Tunisia
+        value: EU-TUNISIA
+    # Türkiye
+      - match: TUR  # implementing Regulation (EU) 2019/1890 concerning restrictive measures in view of Turkey’s unauthorised drilling activities in the Eastern Mediterranean
+        value: EU-TURKEY-MED
+    # Ukraine
       - match: UKR  # implementing Regulation (EU) No 208/2014 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Ukraine
                     # implementing Regulation (EU) No 269/2014 concerning restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine
         values: 
@@ -78,92 +205,29 @@ lookups:
           - EU-CRIMEA
           - EU-UKRAINE-OCC
           - EU-UKRAINE-MSF
-      - match: TAQA  # Council Regulation (EC) No 881/2002 imposing certain specific restrictive measures directed against certain persons and entities associated with the Al Qaida network
-        value: EU-ISIS
-      - match: TERR  # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism
-        value: EU-TERROR
-      - match: LBY  # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
-        value: EU-LIBYA
-      - match: HAM  # COUNCIL REGULATION (EU) 2024/386 of 19 January 2024 establishing restrictive measures against those who support, facilitate or enable violent actions by Hamas and the Palestinian Islamic Jihad
-        value: EU-HAMAS
-      # - match: YEM
-      #   value: EU-YEMEN
-      - match: SYR  # implementing Regulation (EU) No 36/2012 concerning restrictive measures in view of the situation in Syria
-        value: EU-SYRIA
-      - match: BDI  # implementing Regulation (EU) 2015/1755 concerning restrictive measures in view of the situation in Burundi
-        value: EU-BURUNDI
-      # - match: ZWE
-      #   value: EU-ZIMBABWE
-      # - match: EUAQ
-      #   value: EU-EUROPEAN-ACT
-      - match: NIC  # implementing Regulation (EU) 2019/1716 concerning restrictive measures in view of the situation in Nicaragua
-        value: EU-NICARAGUA
-      # - match: UNLI
-      #   value: 
-      - match: SDNZ  # implementing Regulation (EU) 2023/2147 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan
-        value: EU-SUDAN-REST
-      - match: COD  # implementing Article 9(5) of Regulation (EC) No 1183/2005 imposing certain specific restrictive measures directed against persons acting in violation of the arms embargo with regard to the Democratic Republic of the Congo
-        value: EU-DRC
-      - match: SSD  #  Article 20(3) of Regulation (EU) 2015/735 concerning restrictive measures in respect of the situation in South Sudan
-        value: EU-SOUTH-SUDAN
-      - match: GNB  # mplementing Article 11(1) of Regulation (EU) No 377/2012 concerning restrictive measures directed against certain persons, entities and bodies threatening the peace, security or stability of the Republic of Guinea-Bissau
-        value: 
-      - match: TUR  # implementing Regulation (EU) 2019/1890 concerning restrictive measures in view of Turkey’s unauthorised drilling activities in the Eastern Mediterranean
-        value: EU-TURKEY-MED
-      # - match: HR
-      #   value: EU-HR
-      - match: SDN  # implementing Article 15(3) of Regulation (EU) No 747/2014 concerning restrictive measures in view of the situation in Sudan
-        value: EU-SUDAN
+    # United States
+      - match: 
+        value: EU-US-LEG
+    # Venezuela
       - match: VEN  # implementing Regulation (EU) 2017/2063 concerning restrictive measures in view of the situation in Venezuela
         value: EU-VEN-REST
-      - match: MDA  # implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova
-        value: EU-MOLDOVA
-      - match: BLR  # implementing Article 8a of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus
-        value: EU-BRUS
-      - match: MMR  # implementing Regulation (EU) No 401/2013 concerning restrictive measures in respect of Myanmar/Burma
-        value: EU-MYANMAR
-      - match: MLI  # implementing Article 12(2) of Regulation (EU) 2017/1770 concerning restrictive measures in view of the situation in Mali
-        value: EU-MALI
-      - match: GTM  # implementing Regulation (EU) 2024/287 concerning restrictive measures in view of the situation in Guatemala
-        value: EU-GUATEMALA
-      # - match: PRK  # implementing Regulation (EU) 2017/1509 concerning restrictive measures against the Democratic People's Republic of Korea
+    # Yemen
+      - match: YEM
+        value: EU-YEMEN
+    # Zimbabwe
+      - match: ZWE
+        value: EU-ZIMBABWE
+
+
+      # - match: EUAQ
+      #   value: EU-EUROPEAN-ACT
+      # - match: UNLI
       #   value: 
-      # - match: AFG
-      #   value: 
-      - match: IRN  # implementing Regulation (EU) No 267/2012 concerning restrictive measures against Iran
-                    # implementing Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region
-        value: 
-          - EU-IRAN-HR
-          - EU-IRAN-RUSSIA
-      - match: CYB
-        value: EU-CYB
-      # - match: SOM
-      #   value: 
-      # - match: IRQ
-      #   value: 
-      - match: HTI  # implementing Regulation (EU) 2022/2309 concerning restrictive measures in view of the situation in Haiti
-        value: EU-HAITI  
-      - match: GIN  # implementing Regulation (EU) No 1284/2009 imposing certain specific restrictive measures in respect of the Republic of Guinea
-        value: EU-GUINEA
-      - match: RUS  # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
-        value: EU-RUSSIA-REST
-      - match: TUN  # implementing Regulation (EU) No 101/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Tunisia
-        value: EU-TUNISIA
-      # - match: CAF  # implementing Article 17(3) of Regulation (EU) No 224/2014 concerning restrictive measures in view of the situation in the Central African Republic
-      #   value: EU-CENTRAL-AFRICA
-      - match: CHEM  # implementing Regulation (EU) 2018/1542 concerning restrictive measures against the proliferation and use of chemical weapons
-        value: EU-CHEM
+
 # unused: 
-# - EU-BOSNIA
 # - EU-WMD
 # - EU-PMR
-# - EU-SRB-UN757
-# - EU-CRNA-UN757
-# - EU-US-LEG
-# - EU-RIGHTS
-# - EU-LEBANON
 # - EU-NIGER
-# - EU-TIANANMEN
 # ...
 
   subject_type:

--- a/datasets/eu/travel_bans/eu_travel_bans.yml
+++ b/datasets/eu/travel_bans/eu_travel_bans.yml
@@ -52,6 +52,8 @@ lookups:
         value: Organization
   schema_override:
     options: []
+  sanction.program:
+    options: []
   contact_info:
     options:
       - match: PHONE

--- a/datasets/gb/hmt/crawler.py
+++ b/datasets/gb/hmt/crawler.py
@@ -103,11 +103,8 @@ def parse_row(context: Context, row: Dict[str, Any]):
         return
     entity = context.make(schema)
     entity.id = context.make_slug(row.pop("GroupID"))
-    sanction = h.make_sanction(context, entity)
+    sanction = h.make_sanction(context, entity, program=regime_name)
     sanction.add("program", regime_name)
-    sanction.add(
-        "programCode", context.lookup_value("program", regime_name, regime_name)
-    )
     sanction.add("authority", row.pop("ListingType", None))
     h.apply_date(sanction, "listingDate", listing_date)
     h.apply_date(sanction, "startDate", designated_date)

--- a/datasets/gb/hmt/crawler.py
+++ b/datasets/gb/hmt/crawler.py
@@ -327,31 +327,10 @@ def make_row(el):
     return row
 
 
-# def crawl(context: Context):
-#     path = context.fetch_resource("source.xml", context.data_url)
-#     context.export_resource(path, XML, title=context.SOURCE_TITLE)
-#     doc = context.parse_resource_xml(path)
-#     el = h.remove_namespace(doc)
-#     for row_el in el.findall(".//FinancialSanctionsTarget"):
-#         parse_row(context, make_row(row_el))
-
-
-# testing with a limit
 def crawl(context: Context):
     path = context.fetch_resource("source.xml", context.data_url)
     context.export_resource(path, XML, title=context.SOURCE_TITLE)
     doc = context.parse_resource_xml(path)
     el = h.remove_namespace(doc)
-
-    # Initialize a counter
-    row_count = 0
-    max_rows = 100  # Limit to 100 rows
-
     for row_el in el.findall(".//FinancialSanctionsTarget"):
         parse_row(context, make_row(row_el))
-
-        # Increment the counter and check if the limit is reached
-        row_count += 1
-        if row_count >= max_rows:
-            context.log.info(f"Processed {max_rows} rows. Stopping.")
-            break

--- a/datasets/gb/hmt/crawler.py
+++ b/datasets/gb/hmt/crawler.py
@@ -104,7 +104,11 @@ def parse_row(context: Context, row: Dict[str, Any]):
     entity = context.make(schema)
     entity.id = context.make_slug(row.pop("GroupID"))
     sanction = h.make_sanction(
-        context, entity, program_key=regime_name, start_date=designated_date
+        context,
+        entity,
+        program=regime_name,
+        program_key=regime_name,
+        start_date=designated_date,
     )
     sanction.add("authority", row.pop("ListingType", None))
     h.apply_date(sanction, "listingDate", listing_date)

--- a/datasets/gb/hmt/crawler.py
+++ b/datasets/gb/hmt/crawler.py
@@ -332,6 +332,7 @@ def make_row(el):
 #         parse_row(context, make_row(row_el))
 
 
+# testing with a limit
 def crawl(context: Context):
     path = context.fetch_resource("source.xml", context.data_url)
     context.export_resource(path, XML, title=context.SOURCE_TITLE)

--- a/datasets/gb/hmt/crawler.py
+++ b/datasets/gb/hmt/crawler.py
@@ -104,7 +104,7 @@ def parse_row(context: Context, row: Dict[str, Any]):
     entity = context.make(schema)
     entity.id = context.make_slug(row.pop("GroupID"))
     sanction = h.make_sanction(
-        context, entity, program=regime_name, start_date=designated_date
+        context, entity, program_key=regime_name, start_date=designated_date
     )
     sanction.add("authority", row.pop("ListingType", None))
     h.apply_date(sanction, "listingDate", listing_date)

--- a/datasets/gb/hmt/gb_hmt_invbans.yml
+++ b/datasets/gb/hmt/gb_hmt_invbans.yml
@@ -33,3 +33,9 @@ data:
   url: https://ofsistorage.blob.core.windows.net/publishlive/2022format/InvBan.xml
   format: XML
   lang: eng
+
+lookups:
+  sanction.program:
+    options:
+      - match: Russia
+        value: UK-RUS

--- a/datasets/gb/hmt/gb_hmt_sanctions.yml
+++ b/datasets/gb/hmt/gb_hmt_sanctions.yml
@@ -40,7 +40,7 @@ data:
 dates: 
   formats: ["%d/%m/%Y", "00/%m/%Y", "%m/%Y", "00/00/%Y", "%Y"]
 lookups:
-  sanction:
+  sanction.program:
     options:
       - match: Democratic Republic of the Congo
         value: UK-DRC

--- a/datasets/gb/hmt/gb_hmt_sanctions.yml
+++ b/datasets/gb/hmt/gb_hmt_sanctions.yml
@@ -40,71 +40,71 @@ data:
 dates: 
   formats: ["%d/%m/%Y", "00/%m/%Y", "%m/%Y", "00/00/%Y", "%Y"]
 lookups:
-  sanction: 
-    options: 
-      - program: Democratic Republic of the Congo
+  sanction:
+    options:
+      - match: Democratic Republic of the Congo
         value: UK-DRC
-      - program: Afganistan
+      - match: Afganistan
         value: UK-AFG
-      - program: Iraq
+      - match: Iraq
         value: UK-IRQ
-      - program: Nicaragua
+      - match: Nicaragua
         value: UK-NIC
-      - program: Bosnia and Herzegovina
+      - match: Bosnia and Herzegovina
         value: UK-BH
-      - program: Chemical Weapons
+      - match: Chemical Weapons
         value: UK-CW
-      - program: Belarus
+      - match: Belarus
         value: UK-BLR
-      - program: Haiti
+      - match: Haiti
         value: UK-HT
-      - program: Myanmar
+      - match: Myanmar
         value: UK-MMR
-      - program: Mali
+      - match: Mali
         value: UK-MLI
-      - program: Guinea
+      - match: Guinea
         value: UK-GU
-      - program: Sudan
+      - match: Sudan
         value: UK-SDN
-      - program: Global Human Rights
+      - match: Global Human Rights
         value: UK-HR
-      - program: Somalia
+      - match: Somalia
         value: UK-SOM
-      - program: Counter-Terrorism (International)
+      - match: Counter-Terrorism (International)
         value: UK-ICT
-      - program: South Sudan
+      - match: South Sudan
         value: UK-SSD
-      - program: Iran (Nuclear)
+      - match: Iran (Nuclear)
         value: UK-IRAN-NW
-      - program: ISIL (Da'esh) and Al-Qaida
+      - match: ISIL (Da'esh) and Al-Qaida
         value: UK-ISIL
-      - program: Counter-Terrorism (Domestic)
+      - match: Counter-Terrorism (Domestic)
         value: UK-CT
-      - program: Global Anti-Corruption
+      - match: Global Anti-Corruption
         value: UK-AC
-      - program: Central African Republic
+      - match: Central African Republic
         value: UK-CAR
-      - program: Syria
+      - match: Syria
         value: UK-SYR
-      - program: Yemen
+      - match: Yemen
         value: UK-YEM
-      - program: Zimbabwe
+      - match: Zimbabwe
         value: UK-ZIM
-      - program: Iran
+      - match: Iran
         value: UK-IRAN
-      - program: Guinea-Bissau
+      - match: Guinea-Bissau
         value: UK-GNB
-      - program: Afghanistan
+      - match: Afghanistan
         value: UK-AFG
-      - program: Libya
+      - match: Libya
         value: UK-LBY
-      - program: Russia
+      - match: Russia
         value: UK-RUS
-      - program: Cyber
+      - match: Cyber
         value: UK-CYB
-      - program: Venezuela
+      - match: Venezuela
         value: UK-VEN
-      - program: Democratic People's Republic of Korea
+      - match: Democratic People's Republic of Korea
         value: UK-DPRK
   type.identifier:
     options:

--- a/datasets/gb/hmt/gb_hmt_sanctions.yml
+++ b/datasets/gb/hmt/gb_hmt_sanctions.yml
@@ -40,71 +40,71 @@ data:
 dates: 
   formats: ["%d/%m/%Y", "00/%m/%Y", "%m/%Y", "00/00/%Y", "%Y"]
 lookups:
-  program: 
+  sanction: 
     options: 
-      - match: Democratic Republic of the Congo
+      - program: Democratic Republic of the Congo
         value: UK-DRC
-      - match: Afganistan
+      - program: Afganistan
         value: UK-AFG
-      - match: Iraq
+      - program: Iraq
         value: UK-IRQ
-      - match: Nicaragua
+      - program: Nicaragua
         value: UK-NIC
-      - match: Bosnia and Herzegovina
+      - program: Bosnia and Herzegovina
         value: UK-BH
-      - match: Chemical Weapons
+      - program: Chemical Weapons
         value: UK-CW
-      - match: Belarus
+      - program: Belarus
         value: UK-BLR
-      - match: Haiti
+      - program: Haiti
         value: UK-HT
-      - match: Myanmar
+      - program: Myanmar
         value: UK-MMR
-      - match: Mali
+      - program: Mali
         value: UK-MLI
-      - match: Guinea
+      - program: Guinea
         value: UK-GU
-      - match: Sudan
+      - program: Sudan
         value: UK-SDN
-      - match: Global Human Rights
+      - program: Global Human Rights
         value: UK-HR
-      - match: Somalia
+      - program: Somalia
         value: UK-SOM
-      - match: Counter-Terrorism (International)
+      - program: Counter-Terrorism (International)
         value: UK-ICT
-      - match: South Sudan
+      - program: South Sudan
         value: UK-SSD
-      - match: Iran (Nuclear)
+      - program: Iran (Nuclear)
         value: UK-IRAN-NW
-      - match: ISIL (Da'esh) and Al-Qaida
+      - program: ISIL (Da'esh) and Al-Qaida
         value: UK-ISIL
-      - match: Counter-Terrorism (Domestic)
+      - program: Counter-Terrorism (Domestic)
         value: UK-CT
-      - match: Global Anti-Corruption
+      - program: Global Anti-Corruption
         value: UK-AC
-      - match: Central African Republic
+      - program: Central African Republic
         value: UK-CAR
-      - match: Syria
+      - program: Syria
         value: UK-SYR
-      - match: Yemen
+      - program: Yemen
         value: UK-YEM
-      - match: Zimbabwe
+      - program: Zimbabwe
         value: UK-ZIM
-      - match: Iran
+      - program: Iran
         value: UK-IRAN
-      - match: Guinea-Bissau
+      - program: Guinea-Bissau
         value: UK-GNB
-      - match: Afghanistan
+      - program: Afghanistan
         value: UK-AFG
-      - match: Libya
+      - program: Libya
         value: UK-LBY
-      - match: Russia
+      - program: Russia
         value: UK-RUS
-      - match: Cyber
+      - program: Cyber
         value: UK-CYB
-      - match: Venezuela
+      - program: Venezuela
         value: UK-VEN
-      - match: Democratic People's Republic of Korea
+      - program: Democratic People's Republic of Korea
         value: UK-DPRK
   type.identifier:
     options:

--- a/datasets/gb/hmt/gb_hmt_sanctions.yml
+++ b/datasets/gb/hmt/gb_hmt_sanctions.yml
@@ -40,6 +40,11 @@ data:
 dates: 
   formats: ["%d/%m/%Y", "00/%m/%Y", "%m/%Y", "00/00/%Y", "%Y"]
 lookups:
+  program: 
+    options: 
+      - match: "Democratic Republic of the Congo"
+        value: UK-DRC
+      - match: 
   type.identifier:
     options:
       - match: Legal Entity Number 2534006SJ05GGKETEY75 (Russia)  Registration Number 1027739179160 (Russia)

--- a/datasets/gb/hmt/gb_hmt_sanctions.yml
+++ b/datasets/gb/hmt/gb_hmt_sanctions.yml
@@ -42,9 +42,70 @@ dates:
 lookups:
   program: 
     options: 
-      - match: "Democratic Republic of the Congo"
+      - match: Democratic Republic of the Congo
         value: UK-DRC
-      - match: 
+      - match: Afganistan
+        value: UK-AFG
+      - match: Iraq
+        value: UK-IRQ
+      - match: Nicaragua
+        value: UK-NIC
+      - match: Bosnia and Herzegovina
+        value: UK-BH
+      - match: Chemical Weapons
+        value: UK-CW
+      - match: Belarus
+        value: UK-BLR
+      - match: Haiti
+        value: UK-HT
+      - match: Myanmar
+        value: UK-MMR
+      - match: Mali
+        value: UK-MLI
+      - match: Guinea
+        value: UK-GU
+      - match: Sudan
+        value: UK-SDN
+      - match: Global Human Rights
+        value: UK-HR
+      - match: Somalia
+        value: UK-SOM
+      - match: Counter-Terrorism (International)
+        value: UK-ICT
+      - match: South Sudan
+        value: UK-SSD
+      - match: Iran (Nuclear)
+        value: UK-IRAN-NW
+      - match: ISIL (Da'esh) and Al-Qaida
+        value: UK-ISIL
+      - match: Counter-Terrorism (Domestic)
+        value: UK-CT
+      - match: Global Anti-Corruption
+        value: UK-AC
+      - match: Central African Republic
+        value: UK-CAR
+      - match: Syria
+        value: UK-SYR
+      - match: Yemen
+        value: UK-YEM
+      - match: Zimbabwe
+        value: UK-ZIM
+      - match: Iran
+        value: UK-IRAN
+      - match: Guinea-Bissau
+        value: UK-GNB
+      - match: Afghanistan
+        value: UK-AFG
+      - match: Libya
+        value: UK-LBY
+      - match: Russia
+        value: UK-RUS
+      - match: Cyber
+        value: UK-CYB
+      - match: Venezuela
+        value: UK-VEN
+      - match: Democratic People's Republic of Korea
+        value: UK-DPRK
   type.identifier:
     options:
       - match: Legal Entity Number 2534006SJ05GGKETEY75 (Russia)  Registration Number 1027739179160 (Russia)

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -48,20 +48,20 @@ def make_sanction(
     sanction.add("sourceUrl", dataset.url)
     if program is not None:
         sanction.set("program", program)
-    program_id = context.lookup_value("sanction.program", program_key)
-    if program_id is not None:
-        program_url = f"https://www.opensanctions.org/programs/{program_id}"
-        sanction.add("programUrl", program_url)
-        sanction.add("programId", program_id)
-    else:
-        context.log.warn(f"Program key '{program_key}' not found.", program=program)
+    if program_key is not None:
+        program_id = context.lookup_value("sanction.program", program_key)
+        if program_id is not None:
+            program_url = f"https://www.opensanctions.org/programs/{program_id}"
+            sanction.add("programUrl", program_url)
+            sanction.add("programId", program_id)
+        else:
+            context.log.warn(f"Program key {program_key!r} not found.", program=program)
     if start_date is not None:
         h.apply_date(sanction, "startDate", start_date)
     if end_date is not None:
         h.apply_date(sanction, "endDate", end_date)
         iso_end_date = max(sanction.get("endDate"))
-        end_date_obj = datetime.strptime(iso_end_date, "%Y-%m-%d")
-        is_active = end_date_obj >= settings.RUN_TIME
+        is_active = iso_end_date >= settings.RUN_TIME_ISO
         sanction.add("status", "active" if is_active else "inactive")
 
     return sanction

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from zavod.context import Context
 from zavod.entity import Entity
 from zavod import helpers as h
+from zavod import settings
 
 ALWAYS_FORMATS = ["%Y-%m-%d", "%Y-%m", "%Y"]
 
@@ -53,9 +54,9 @@ def make_sanction(
         h.apply_date(sanction, "startDate", start_date)
     if end_date is not None:
         h.apply_date(sanction, "endDate", end_date)
-        iso_end_date = h.extract_date(context.dataset, end_date)[0]
-        end_date_obj = datetime.strptime(iso_end_date[:10], "%Y-%m-%d")
-        is_active = end_date_obj >= datetime.today()
+        iso_end_date = max(sanction.get("endDate"))
+        end_date_obj = datetime.strptime(iso_end_date, "%Y-%m-%d")
+        is_active = end_date_obj >= settings.RUN_TIME
         sanction.add("status", "active" if is_active else "inactive")
 
     return sanction

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -34,9 +34,9 @@ def make_sanction(
         sanction.add("country", dataset.publisher.country)
     sanction.add("authority", dataset.publisher.name)
     sanction.add("sourceUrl", dataset.url)
-    sanction.add("program", program)
 
     if program is not None:
+        sanction.set("program", program)
         program_id = context.lookup_value("sanction", program)
         if program_id is None:
             context.log.warn(f"Program key '{program}' not found.")

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -4,7 +4,10 @@ from zavod.entity import Entity
 
 
 def make_sanction(
-    context: Context, entity: Entity, key: Optional[str] = None
+    context: Context,
+    entity: Entity,
+    key: Optional[str] = None,
+    program: Optional[str] = None,
 ) -> Entity:
     """Create and return a sanctions object derived from the dataset metadata.
 
@@ -15,6 +18,7 @@ def make_sanction(
         context: The runner context with dataset metadata.
         entity: The entity to which the sanctions object will be linked.
         key: An optional key to be included in the ID of the sanction.
+        program: An optional key for looking up the program ID in the YAML configuration.
 
     Returns:
         A new entity of type Sanction.
@@ -30,4 +34,8 @@ def make_sanction(
         sanction.add("country", dataset.publisher.country)
     sanction.add("authority", dataset.publisher.name)
     sanction.add("sourceUrl", dataset.url)
+
+    program_id = context.lookup_value("sanction", program)
+    if program_id is None:
+        context.log.warn(f"Program key '{program}' not found.")
     return sanction

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -46,15 +46,15 @@ def make_sanction(
         sanction.add("country", dataset.publisher.country)
     sanction.add("authority", dataset.publisher.name)
     sanction.add("sourceUrl", dataset.url)
-
     if program is not None:
         sanction.set("program", program)
-    if program_key is not None:
-        program_id = context.lookup_value("sanction.program", program_key)
+    program_id = context.lookup_value("sanction.program", program_key)
+    if program_id is not None:
         program_url = f"https://www.opensanctions.org/programs/{program_id}"
         sanction.add("programUrl", program_url)
-        if program_id is None:
-            context.log.warn(f"Program key '{program_key}' not found.")
+        sanction.add("programId", program_id)
+    else:
+        context.log.warn(f"Program key '{program_key}' not found.", program=program)
     if start_date is not None:
         h.apply_date(sanction, "startDate", start_date)
     if end_date is not None:

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -14,6 +14,7 @@ def make_sanction(
     entity: Entity,
     key: Optional[str] = None,
     program: Optional[str] = None,
+    program_key: Optional[str] = None,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
 ) -> Entity:
@@ -26,7 +27,8 @@ def make_sanction(
         context: The runner context with dataset metadata.
         entity: The entity to which the sanctions object will be linked.
         key: An optional key to be included in the ID of the sanction.
-        program: An optional key for looking up the program ID in the YAML configuration.
+        program: An optional program name.
+        program_key: An optional key for looking up the program ID in the YAML configuration.
         start_date: An optional start date for the sanction.
         end_date: An optional end date for the sanction.
 
@@ -47,9 +49,10 @@ def make_sanction(
 
     if program is not None:
         sanction.set("program", program)
-        program_id = context.lookup_value("sanction", program)
+    if program_key is not None:
+        program_id = context.lookup_value("sanction.program", program_key)
         if program_id is None:
-            context.log.warn(f"Program key '{program}' not found.")
+            context.log.warn(f"Program key '{program_key}' not found.")
     if start_date is not None:
         h.apply_date(sanction, "startDate", start_date)
     if end_date is not None:

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from datetime import datetime
 
 from zavod.context import Context
 from zavod.entity import Entity

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -51,6 +51,8 @@ def make_sanction(
         sanction.set("program", program)
     if program_key is not None:
         program_id = context.lookup_value("sanction.program", program_key)
+        program_url = f"https://www.opensanctions.org/programs/{program_id}"
+        sanction.add("programUrl", program_url)
         if program_id is None:
             context.log.warn(f"Program key '{program_key}' not found.")
     if start_date is not None:

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -34,8 +34,10 @@ def make_sanction(
         sanction.add("country", dataset.publisher.country)
     sanction.add("authority", dataset.publisher.name)
     sanction.add("sourceUrl", dataset.url)
+    sanction.add("program", program)
 
-    program_id = context.lookup_value("sanction", program)
-    if program_id is None:
-        context.log.warn(f"Program key '{program}' not found.")
+    if program is not None:
+        program_id = context.lookup_value("sanction", program)
+        if program_id is None:
+            context.log.warn(f"Program key '{program}' not found.")
     return sanction

--- a/zavod/zavod/shed/fsf.py
+++ b/zavod/zavod/shed/fsf.py
@@ -58,9 +58,15 @@ def parse_sanctions(context: Context, entity: Entity, entry: Element) -> None:
     for regulation in regulations:
         url = regulation.findtext("./publicationUrl")
         assert url is not None, etree.tostring(regulation)
-        sanction = h.make_sanction(context, entity, key=url)
+        program = regulation.get("programme")
+        sanction = h.make_sanction(
+            context,
+            entity,
+            program=program,
+            program_key=program,
+            key=url,
+        )
         sanction.set("sourceUrl", url)
-        sanction.add("program", regulation.get("programme"))
         sanction.add("reason", regulation.get("numberTitle"))
         sanction.add("startDate", regulation.get("entryIntoForceDate"))
         sanction.add("listingDate", regulation.get("publicationDate"))


### PR DESCRIPTION
Enhancements to h.make_sanction:
Add `program` as an optional argument to `h.make_sanction`

Then lookup based on the `program` to get `programId`  from `sanction.program` in the YAML configuration.

```
If `program` wasn't looked up: 
     context.log.warn("")

```

Sanction Status Handling:
Refines the logic for determining the active status of a sanction based on its `end_date`.
If `end_date` exists and is earlier than the current date, the sanction is marked **inactive**; otherwise, it remains **active**.

EU regimes: 

- https://data.europa.eu/apps/eusanctionstracker/
- https://sanctionsmap.eu/#/main?search=%7B%22value%22:%22%22,%22searchType%22:%7B%7D%7D
- https://data.europa.eu/apps/eusanctionstracker/individuals/
