### PR TITLE
Suggestion get data with pagination for dataset br-tuc-disq

### DIFF
--- a/datasets/br/tcu_disqualified/crawler.py
+++ b/datasets/br/tcu_disqualified/crawler.py
@@ -69,10 +69,21 @@ def crawl(context: Context):
 
     :param context: The context object.
     """
-    response = context.fetch_json(context.data_url)
-    if "items" not in response:
-        context.log.error("Items not found in JSON")
-        return
 
-    for item in response["items"]:
-        crawl_item(item, context)
+    url = context.data_url
+    while True:
+        response = context.fetch_json(url)
+        if "items" not in response:
+            context.log.error("Items not found in JSON")
+            return
+
+        for item in response["items"]:
+            crawl_item(item, context)
+
+        # if hasMore = true -> there is a link for next
+        has_more = response.get("hasMore", False)
+        if not has_more:
+            break
+
+        links = response.get("links", [])
+        url = next((link.get("href") for link in links if link.get("rel") == "next"), "")


### PR DESCRIPTION
### Issue Description

The current implementation in `datasets/br/tcu_disqualified/crawler.py` fetches data only from the first page of the API. However, the API response from `https://contas.tcu.gov.br/ords/condenacao/consulta/inabilitados` contains pagination metadata that indicates more data can be retrieved beyond the first page. Below is an example of the API response:

```
{
  "items": [
    {
      "nome": "ABDALA GOMES SANTOS",
      "cpf": "215.805.453-00",
      "processo": "026.615/2020-7",
      "deliberacao": "AC-000738/2022-PL",
      "data_transito_julgado": "2022-07-16T03:00:00Z",
      "data_final": "2027-07-16T03:00:00Z",
      "data_acordao": "2022-04-06T17:30:00Z",
      "uf": "MA",
      "municipio": "SANTA INES"
    },
    {
      "nome": "ALEXANDRE DE MORAES HISSA",
      "cpf": "034.199.574-67",
      "processo": "042.677/2021-1",
      "deliberacao": "AC-001397/2023-PL",
      "data_transito_julgado": "2023-08-17T03:00:00Z",
      "data_final": "2028-08-17T03:00:00Z",
      "data_acordao": "2023-07-05T17:30:00Z",
      "uf": "PE",
      "municipio": "OLINDA"
    }
  ],
  "hasMore": true,
  "limit": 25,
  "offset": 0,
  "count": 25,
  "links": [
    {
      "rel": "self",
      "href": "http://contas.tcu.gov.br/ords/condenacao/consulta/inabilitados"
    },....
    {
      "rel": "describedby",
      "href": "http://contas.tcu.gov.br/ords/condenacao/metadata-catalog/consulta/item"
    },
    {
      "rel": "first",
      "href": "http://contas.tcu.gov.br/ords/condenacao/consulta/inabilitados"
    },
    {
      "rel": "next",
      "href": "http://contas.tcu.gov.br/ords/condenacao/consulta/inabilitados?offset=25"
    }
  ]
}
```

The `hasMore` property in the response is set to `true`, indicating that additional pages of data are available. Furthermore, the links property contains a "next" URL that can be used to retrieve subsequent pages of data.

### Suggested Fix

To address this issue, I propose enhancing the crawler to:

1. Iterate through all pages: Continue fetching data until the hasMore property is false.
2. Use the links.next URL: Leverage the "next" URL from the links property to navigate to the next page.