### PR TITLE
parse table with rowspan support

### DIFF
--- a/zavod/zavod/shed/parse_rowspan_table.py
+++ b/zavod/zavod/shed/parse_rowspan_table.py
@@ -1,0 +1,58 @@
+from lxml.html import HtmlElement
+from typing import Dict, Generator
+
+from zavod import Context
+
+
+def parse_table_with_rowspan(
+    context: Context,
+    table: HtmlElement,
+) -> Generator[Dict[str, HtmlElement], None, None]:
+    headers = None
+    rowspan_cells = {}  # Dictionary to keep track of cells with rowspan
+
+    for row_index, row in enumerate(table.findall(".//tr")):
+        if headers is None:
+            headers = []
+            for el in row.findall("./th"):
+                # Workaround because lxml-stubs doesn't yet support HtmlElement
+                eltree = el  # If necessary, you can use cast(HtmlElement, el)
+                label = eltree.text_content().strip()
+                headers.append(context.lookup_value("headers", label))
+            continue
+
+        cells = row.findall("./td")
+        row_data = {}
+
+        cell_index = 0  # To track which header corresponds to which cell
+        for idx, cell in enumerate(cells):
+            while cell_index in rowspan_cells and rowspan_cells[cell_index][1] > 0:
+                # If we have data from a rowspan to apply, take it
+                row_data[headers[cell_index]] = rowspan_cells[cell_index][0]
+                rowspan_cells[cell_index] = (
+                    rowspan_cells[cell_index][0],
+                    rowspan_cells[cell_index][1] - 1,
+                )
+                cell_index += 1  # Move to next cell header
+
+            # If current cell has a rowspan
+            rowspan_value = cell.get("rowspan")
+            if rowspan_value:
+                rowspan_length = int(rowspan_value) - 1  # Exclude the current row
+                rowspan_cells[cell_index] = (cell, rowspan_length)
+
+            # Store current row's cell element (not text content)
+            row_data[headers[cell_index]] = cell
+            cell_index += 1  # Move to the next header for each processed cell
+
+        # Apply any remaining rowspan data
+        while cell_index < len(headers):
+            if cell_index in rowspan_cells and rowspan_cells[cell_index][1] > 0:
+                row_data[headers[cell_index]] = rowspan_cells[cell_index][0]
+                rowspan_cells[cell_index] = (
+                    rowspan_cells[cell_index][0],
+                    rowspan_cells[cell_index][1] - 1,
+                )
+            cell_index += 1
+
+        yield row_data


### PR DESCRIPTION
@jbothma's commets and suggestions: 

supporting rowspan is technically cool, but this is a huge load of logic and I'd want to have some tests to be able to touch this code. how about putting this in zavod/shed/html.py and putting tests in zavod/tests/shed/test_html.py` to start with? Putting it in shed means it won't be part of the advertised API in helpers (the other obvious place to put it) so we can think about it still


does this work if

1. there's rowspan on column 0?
2. there's rowspan on column 3?
3. there's rowspan on column 0 and 3 out of 4 columns?
4. rowspan for column 0 ends before rowspan of column 3?
5. rowspan for column 3 ends before column 0?

I think at least test cases like this are needed, unless limited support (e.g. only column 0) is clearly documented


```
  for idx, cell in enumerate(cells):
            while cell_index in rowspan_cells and rowspan_cells[cell_index][1] > 0:
```
I'm not sure I understand this - why two loops? Can you explain how it works in words, perhaps with excel style cell references for the example?

```
for each cell in the row
    for each what?
```

Perhaps the general mechanism could be documented in the function-level docstring?


```
   table: HtmlElement,
) -> Generator[Dict[str, HtmlElement], None, None]:
    headers = None
    rowspan_cells = {}  # Dictionary to keep track of cells with rowspan
```

I think it'd be good to document a data structure underpinning something like this - it looks like keys are column indices and values are tuples where the first element is what? and the second element is the span value?