### PR TITLE
Dataset Issues and Fixes

### DIFF
--- a/datasets/ar/repet/ar_repet.yml
+++ b/datasets/ar/repet/ar_repet.yml
@@ -70,14 +70,14 @@ lookups:
       - contains: Syrian Arab Republic
         value: Syria
       - match:
-          - LIBANÉS
           - Libyan Arab Jamahiriya
         value: Libya
       - match: Kuwaiti citizenship withdrawn in 2002
         value: null
       - contains: EL LIBANO
         value: Lebanon
-      - match: 
+      - match:
+          - LIBANÉS
           - Libanesa
           - Repùblica Libanesa
         value: Lebanon

--- a/datasets/ca/dfatd/crawler.py
+++ b/datasets/ca/dfatd/crawler.py
@@ -53,7 +53,7 @@ def parse_entry(context: Context, node: _Element):
     sanction.add("authorityId", node.findtext("./Item"))
     h.apply_date(sanction, "listingDate", node.findtext("./DateOfListing"))
 
-    names = node.findtext("./Aliases")
+    names = collapse_spaces(node.findtext("./Aliases"))
     if names is not None:
         for name in h.multi_split(names, ALIAS_SPLITS):
             trim_name = collapse_spaces(name)

--- a/datasets/ph/sec_advisories/ph_sec_advisories.yaml
+++ b/datasets/ph/sec_advisories/ph_sec_advisories.yaml
@@ -345,7 +345,7 @@ lookups:
         name:
           - CRYPTO EXPERT, INC.
           - CRYPTOEXPERT TRADING
-          - CRYPTOEXPERT: MUTUAL FUNDS AND TRADING EXPERT
+          - "CRYPTOEXPERT: MUTUAL FUNDS AND TRADING EXPERT"
           - CRYPTOEXPERT
       - match: "YEHEEY ITRAFFIC SYSTEM INC. (\u201cYEHEEY\u201d)"
         name:

--- a/datasets/us/fed_enforcements/crawler.py
+++ b/datasets/us/fed_enforcements/crawler.py
@@ -77,7 +77,7 @@ def crawl_item(input_dict: Dict[str, str], context: Context):
         sanction.add("provisions", provisions)
         sanction.add("description", sanction_description)
 
-        if url != "DNE":
+        if not url.endswith("DNE"):
             sanction.add("sourceUrl", url)
 
         if termination_date != "":


### PR DESCRIPTION
### Dataset Issues and Fixes

1. `datasets/ph/sec_advisories/ph_sec_advisories.yaml`

- **Issue**: The name field incorrectly appears as a JSON string instead of a standard string.
- **Incorrect**
```
name:  
  - CRYPTOEXPERT: MUTUAL FUNDS AND TRADING EXPERT
```
Example result:
```
{
    "id": "ph-sec-adv-89fe369e1f835f6974dbdb6ec9a026967a32e3d3",
    "caption": "CRYPTOEXPERT TRADING",
    "schema": "LegalEntity",
    "properties": {
        "name": [
            "CRYPTO EXPERT, INC.",
            "CRYPTOEXPERT",
            "{'CRYPTOEXPERT': 'MUTUAL FUNDS AND TRADING EXPERT'}",
            "CRYPTOEXPERT TRADING"
        ]
    },    
    "datasets": [
        "ph_sec_advisories"
    ]
}
```
- **Correct**
```
name:  
  - "CRYPTOEXPERT: MUTUAL FUNDS AND TRADING EXPERT"
```

2. `datasets/ar/repet/ar_repet.yml`

- **Issue**: The term LIBANÉS is incorrectly mapped to Libya instead of Lebanon.

- **Suggested Fix**: Based on the birth place, it should be map to Lebanon.
Entity:
```
{
    "id": "Q181182",
    "caption": "Hasan Nasrallah",
    "schema": "Person",
    "properties": {
        "birthPlace": [
            "Al Basuriyah, Lebanon",
            "Al Basuriyah, Líbano"
        ],        
        "country": [
            "lb"
        ],       
        "nationality": [
            "ly"
        ],
        "gender": [
            "male"
        ]
    },
    "datasets": [
        "ar_repet"
    ]
}
```
```
  - match:
    - LIBANÉS
    - Libanesa
    - Repùblica Libanesa
  value: Lebanon
```

3. `datasets/us/fed_enforcements/crawler.py`
- **Issue**:  The logic to check for the value DNE is outdated and does not align with the current logic for parsing URLs.
```
if url != "DNE":
    sanction.add("sourceUrl", url)
```
- **Suggested Fix**:
```
if not url.endswith("DNE"):
    sanction.add("sourceUrl", url)
```

4. `datasets/ca/dfadt/ca_dfadt.yml`
- **Issue**: Some alias names include line breaks (eg: `Sudokhodnaya Kompaniya Azia LLC,\nAZSCO, Azia Shipping Co`), causing issues when splitting them into separate aliases.
Example result:
```
{
    "id": "NK-g65ALnE6VTe5fk2ugN5khD",
    "caption": "Azia Shipping Company LLC",
    "schema": "LegalEntity",
    "properties": {        
        "alias": [
            "Sudokhodnaya Kompaniya Azia LLC, AZSCO",
            "Azia Shipping Co"
        ]
    },
    "datasets": [
        "ca_dfatd_sema_sanctions"
    ]
}
```
Suggested Fix:
```
names = collapse_spaces(node.findtext("./Aliases"))
```

5. datasets/eg/terrorists/crawler.py
- **Issue**: Additional date formats (yyyy-mm-dd and dd-MM-yyyy) are not yet handled in the crawler.
- **Suggested Fix**:
```
DATES_RE = [
    re.compile(r"(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})"),  # yyyy/MM/dd
    re.compile(r"(?P<day>\d{1,2})/(?P<month>\d{1,2})/(?P<year>\d{4})"),  # dd/MM/yyyy
    re.compile(r"(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})"),  # yyyy-MM-dd
    re.compile(r"(?P<day>\d{1,2})-(?P<month>\d{1,2})-(?P<year>\d{4})"),  # dd-MM-yyyy
]

def parse_date(date_str: str) -> Optional[datetime]:
    if not date_str:
        return None

    latin_date = arabic_to_latin(date_str)

    for date_re in DATES_RE:
        m = date_re.match(latin_date)
        if m:
            year = m.group("year")
            month = m.group("month")
            day = m.group("day")
            return datetime.strptime(f"{year}-{month}-{day}", "%Y-%m-%d")

    return None
```
