### PR TITLE
Add and use is_active helper testing if a Sanction is temporally active

### DIFF
--- a/datasets/_global/iadb_sanctions/crawler.py
+++ b/datasets/_global/iadb_sanctions/crawler.py
@@ -82,7 +82,7 @@ def crawl(context: Context):
         # Sometimes row.to is "Ongoing", which will be datapatched to null end_date
         h.apply_date(sanction, "endDate", row.pop("to", None))
 
-        is_debarred = not h.has_ended(sanction)
+        is_debarred = h.is_active(sanction)
         if is_debarred:
             entity.add("topics", "debarment")
 

--- a/datasets/_global/iadb_sanctions/crawler.py
+++ b/datasets/_global/iadb_sanctions/crawler.py
@@ -72,15 +72,6 @@ def crawl(context: Context):
             prop = "nationality" if schema == "Person" else "jurisdiction"
             entity.add(prop, country)
 
-        end_dates = h.extract_date(context.dataset, row.pop("to", None))
-        is_active = False
-        if end_dates:
-            end_date = end_dates[0]
-            today = datetime.now().isoformat()[:10]
-            is_active = today < end_date or end_date == "Ongoing"
-        if is_active:
-            entity.add("topics", "debarment")
-
         sanction = h.make_sanction(context, entity)
         # sanction.add("status", row.pop("statusName"))
         sanction.add("reason", row.pop("grounds", None))
@@ -88,8 +79,13 @@ def crawl(context: Context):
         sanction.add("authority", row.pop("idb_sanction_source", None))
         sanction.add("program", row.pop("idb_sanction_type", None))
         h.apply_date(sanction, "startDate", row.pop("from", None))
-        h.apply_date(sanction, "endDate", end_dates[0])
+        # Sometimes row.to is "Ongoing", which will be datapatched to null end_date
+        h.apply_date(sanction, "endDate", row.pop("to", None))
+
+        is_debarred = not h.has_ended(sanction)
+        if is_debarred:
+            entity.add("topics", "debarment")
 
         context.emit(sanction)
-        context.emit(entity, target=is_active)
+        context.emit(entity, target=is_debarred)
         context.audit_data(row)

--- a/datasets/gg/disqualified_directors/crawler.py
+++ b/datasets/gg/disqualified_directors/crawler.py
@@ -101,6 +101,8 @@ def crawl_item(item: Dict[str, str | None], context: Context):
     )
 
     sanction = h.make_sanction(context, person)
+    sanction.add("authority", item.pop("applicant_for_disqualification"))
+    sanction.add("duration", item.pop("period_of_disqualification"))
     h.apply_date(sanction, "startDate", item.pop("date_of_disqualification"))
     h.apply_date(sanction, "endDate", item.pop("end_of_disqualification_period"))
 

--- a/datasets/gg/disqualified_directors/crawler.py
+++ b/datasets/gg/disqualified_directors/crawler.py
@@ -1,6 +1,5 @@
 from typing import Dict
 from normality import collapse_spaces
-from datetime import datetime
 from lxml import etree
 import re
 from zavod import Context, helpers as h
@@ -101,23 +100,15 @@ def crawl_item(item: Dict[str, str | None], context: Context):
         "Disqualified Directors by the Guernsey Financial Services Commission",
     )
 
-    end_date = h.extract_date(
-        context.dataset, item.pop("end_of_disqualification_period")
-    )
-
-    if end_date and end_date[0] < datetime.now().isoformat():
-        ended = True
-    else:
-        ended = False
-        person.add("topics", "corp.disqual")
-
     sanction = h.make_sanction(context, person)
     h.apply_date(sanction, "startDate", item.pop("date_of_disqualification"))
-    sanction.add("authority", item.pop("applicant_for_disqualification"))
-    sanction.add("duration", item.pop("period_of_disqualification"))
-    sanction.add("endDate", end_date)
+    h.apply_date(sanction, "endDate", item.pop("end_of_disqualification_period"))
 
-    context.emit(person, target=not ended)
+    is_disqualified = not h.has_ended(sanction)
+    if is_disqualified:
+        person.add("topics", "corp.disqual")
+
+    context.emit(person, target=is_disqualified)
     context.emit(sanction)
 
     context.audit_data(item)

--- a/datasets/gg/disqualified_directors/crawler.py
+++ b/datasets/gg/disqualified_directors/crawler.py
@@ -104,7 +104,7 @@ def crawl_item(item: Dict[str, str | None], context: Context):
     h.apply_date(sanction, "startDate", item.pop("date_of_disqualification"))
     h.apply_date(sanction, "endDate", item.pop("end_of_disqualification_period"))
 
-    is_disqualified = not h.has_ended(sanction)
+    is_disqualified = h.is_active(sanction)
     if is_disqualified:
         person.add("topics", "corp.disqual")
 

--- a/datasets/li/posting_sanctions/crawler.py
+++ b/datasets/li/posting_sanctions/crawler.py
@@ -136,7 +136,7 @@ def crawl_debarments(context: Context) -> None:
         sanction.add("reason", violation)
         sanction.add("sourceUrl", DEBARMENT_URL)
 
-        is_debarred = not h.has_ended(sanction)
+        is_debarred = h.is_active(sanction)
         if is_debarred:
             entity.add("topics", "debarment")
 

--- a/datasets/li/posting_sanctions/crawler.py
+++ b/datasets/li/posting_sanctions/crawler.py
@@ -136,15 +136,12 @@ def crawl_debarments(context: Context) -> None:
         sanction.add("reason", violation)
         sanction.add("sourceUrl", DEBARMENT_URL)
 
-        end_date = max(sanction.get("endDate"), default=None)
-        if end_date is None or end_date > context.data_time_iso:
+        is_debarred = not h.has_ended(sanction)
+        if is_debarred:
             entity.add("topics", "debarment")
-            ended = False
-        else:
-            ended = True
 
         context.emit(sanction)
-        context.emit(entity, target=not ended)
+        context.emit(entity, target=is_debarred)
 
 
 def crawl_infractions(context: Context) -> None:

--- a/datasets/us/de/med_exclusions/crawler.py
+++ b/datasets/us/de/med_exclusions/crawler.py
@@ -55,7 +55,7 @@ def crawl_item(row: Dict[str, str], context: Context):
     h.apply_date(sanction, "endDate", reinstated_date)
 
     if sanction.get("endDate"):
-        is_debarred = not h.has_ended(sanction)
+        is_debarred = h.is_active(sanction)
     else:
         res = context.lookup("type.date", reinstated_date)
         if res and res.is_debarred is not None:

--- a/datasets/us/de/med_exclusions/crawler.py
+++ b/datasets/us/de/med_exclusions/crawler.py
@@ -2,7 +2,7 @@ from typing import Dict
 from rigour.mime.types import PDF
 import re
 
-from zavod import Context, helpers as h, settings
+from zavod import Context, helpers as h
 from zavod.shed.zyte_api import fetch_resource
 
 REGEX_AKA = re.compile(r"\baka\b|a\.k\.a\.?", re.IGNORECASE)
@@ -54,9 +54,8 @@ def crawl_item(row: Dict[str, str], context: Context):
     reinstated_date = row.pop("reinstated_date")
     h.apply_date(sanction, "endDate", reinstated_date)
 
-    end_date = sanction.get("endDate")
-    if end_date:
-        is_debarred = max(end_date) >= settings.RUN_TIME_ISO
+    if sanction.get("endDate"):
+        is_debarred = not h.has_ended(sanction)
     else:
         res = context.lookup("type.date", reinstated_date)
         if res and res.is_debarred is not None:

--- a/datasets/us/fed_enforcements/crawler.py
+++ b/datasets/us/fed_enforcements/crawler.py
@@ -80,18 +80,12 @@ def crawl_item(input_dict: Dict[str, str], context: Context):
         if url != "DNE":
             sanction.add("sourceUrl", url)
 
-        if termination_date != "":
-            # if the termination date, is in the future, we assume the entity is still in the crime.fin topic
-            if termination_date > settings.RUN_TIME_ISO:
-                entity.add("topics", "reg.action")
-            h.apply_date(sanction, "endDate", termination_date)
-            is_target = False
-        # if it doesn't have a termination date, we assume the entity is still in the crime.fin topic
-        else:
+        h.apply_date(sanction, "endDate", termination_date)
+        is_active = h.is_active(sanction)
+        if is_active:
             entity.add("topics", "reg.action")
-            is_target = True
 
-        context.emit(entity, target=is_target)
+        context.emit(entity, target=is_active)
         context.emit(sanction)
 
     # Name = the string that appears in the url column

--- a/datasets/us/fed_enforcements/crawler.py
+++ b/datasets/us/fed_enforcements/crawler.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 from rigour.mime.types import CSV
 
-from zavod import Context, settings
+from zavod import Context
 from zavod import helpers as h
 from zavod.shed.gpt import run_text_prompt
 

--- a/datasets/us/hi/med_exclusions/crawler.py
+++ b/datasets/us/hi/med_exclusions/crawler.py
@@ -51,12 +51,12 @@ def crawl_item(row: Dict[str, str], context: Context):
     sanction = h.make_sanction(context, entity)
     h.apply_date(sanction, "startDate", row.pop("exclusion_date"))
     h.apply_date(sanction, "endDate", row.pop("reinstatement_date"))
-    end_date = sanction.get("endDate")
-    ended = end_date != [] and end_date[0] < context.data_time_iso
-    if not ended:
+
+    is_debarred = not h.has_ended(sanction)
+    if is_debarred:
         entity.add("topics", "debarment")
 
-    context.emit(entity, target=not ended)
+    context.emit(entity, target=is_debarred)
     context.emit(sanction)
 
     context.audit_data(row)

--- a/datasets/us/hi/med_exclusions/crawler.py
+++ b/datasets/us/hi/med_exclusions/crawler.py
@@ -52,7 +52,7 @@ def crawl_item(row: Dict[str, str], context: Context):
     h.apply_date(sanction, "startDate", row.pop("exclusion_date"))
     h.apply_date(sanction, "endDate", row.pop("reinstatement_date"))
 
-    is_debarred = not h.has_ended(sanction)
+    is_debarred = h.is_active(sanction)
     if is_debarred:
         entity.add("topics", "debarment")
 

--- a/datasets/us/ia/med_exclusions/crawler.py
+++ b/datasets/us/ia/med_exclusions/crawler.py
@@ -1,8 +1,9 @@
-from typing import Dict
-from normality import slugify
-from rigour.mime.types import XLSX
-from openpyxl import load_workbook
 from datetime import datetime, timedelta
+from typing import Dict
+
+from normality import slugify
+from openpyxl import load_workbook
+from rigour.mime.types import XLSX
 
 from zavod import Context, helpers as h
 
@@ -57,17 +58,15 @@ def crawl_item(row: Dict[str, str], context: Context):
         "Federal Authority",
     ]:
         if sanction_end_date == "2 Years":
-            sanction_end_date = str(
-                datetime.strptime(sanction_start_date, "%Y-%m-%d")
-                + timedelta(days=2 * 365)
-            )[:10]
-        is_debarred = (
-            datetime.strptime(sanction_end_date, "%Y-%m-%d") >= datetime.today()
-        )
+            # TODO(Leon Handreke): Maybe use date.replace(year=start_date.year + 2)
+            # to more accurately represent the semantics intended by the publisher?
+            sanction_end_datetime = datetime.strptime(
+                sanction_start_date, "%Y-%m-%d"
+            ) + timedelta(days=2 * 365)
+            sanction_end_date = sanction_end_datetime.date().isoformat()
         h.apply_date(sanction, "endDate", sanction_end_date)
-    else:
-        is_debarred = True
 
+    is_debarred = h.has_ended(sanction)
     if is_debarred:
         entity.add("topics", "debarment")
 

--- a/datasets/us/ia/med_exclusions/crawler.py
+++ b/datasets/us/ia/med_exclusions/crawler.py
@@ -66,7 +66,7 @@ def crawl_item(row: Dict[str, str], context: Context):
             sanction_end_date = sanction_end_datetime.date().isoformat()
         h.apply_date(sanction, "endDate", sanction_end_date)
 
-    is_debarred = h.has_ended(sanction)
+    is_debarred = h.is_active(sanction)
     if is_debarred:
         entity.add("topics", "debarment")
 

--- a/datasets/us/la/med_exclusions/crawler.py
+++ b/datasets/us/la/med_exclusions/crawler.py
@@ -83,8 +83,7 @@ def crawl_item(row: Dict[str, str], context: Context):
     if (reinstate := row.pop(" Reinstate")) and ("9999" not in reinstate):
         h.apply_date(sanction, "endDate", reinstate)
 
-    is_debarred = not h.has_ended(sanction)
-
+    is_debarred = h.is_active(sanction)
     if is_debarred:
         entity.add("topics", "debarment")
 

--- a/datasets/us/la/med_exclusions/crawler.py
+++ b/datasets/us/la/med_exclusions/crawler.py
@@ -5,6 +5,7 @@ from normality import slugify
 from rigour.mime.types import CSV
 import csv
 
+
 from zavod import Context, helpers as h
 from zavod.shed.zyte_api import fetch_html, fetch_resource
 
@@ -81,11 +82,8 @@ def crawl_item(row: Dict[str, str], context: Context):
 
     if (reinstate := row.pop(" Reinstate")) and ("9999" not in reinstate):
         h.apply_date(sanction, "endDate", reinstate)
-    end_date = max(sanction.get("endDate"), default=None)
-    if end_date is None or end_date > context.data_time_iso:
-        is_debarred = True
-    else:
-        is_debarred = False
+
+    is_debarred = not h.has_ended(sanction)
 
     if is_debarred:
         entity.add("topics", "debarment")

--- a/datasets/us/nj/med_exclusions/crawler.py
+++ b/datasets/us/nj/med_exclusions/crawler.py
@@ -31,13 +31,12 @@ def crawl_item(row: Dict[str, str], context: Context):
 
     h.apply_date(sanction, "startDate", row.pop("effective_date"))
     h.apply_date(sanction, "endDate", row.pop("expiration_date"))
-    end_date = sanction.get("endDate")
-    ended = end_date != [] and end_date[0] < context.data_time_iso
 
-    if not ended:
+    is_debarred = not h.has_ended(sanction)
+    if is_debarred:
         entity.add("topics", "debarment")
 
-    context.emit(entity, target=not ended)
+    context.emit(entity, target=is_debarred)
     context.emit(sanction)
     context.emit(address)
 

--- a/datasets/us/nj/med_exclusions/crawler.py
+++ b/datasets/us/nj/med_exclusions/crawler.py
@@ -32,7 +32,7 @@ def crawl_item(row: Dict[str, str], context: Context):
     h.apply_date(sanction, "startDate", row.pop("effective_date"))
     h.apply_date(sanction, "endDate", row.pop("expiration_date"))
 
-    is_debarred = not h.has_ended(sanction)
+    is_debarred = h.is_active(sanction)
     if is_debarred:
         entity.add("topics", "debarment")
 

--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -61,7 +61,7 @@ def crawl_item(row: Dict[str, str], context: Context):
         sanction, "endDate", row.pop("nevada_medicaid_sanction_period_end_date")
     )
 
-    is_debarred = not h.has_ended(sanction)
+    is_debarred = h.is_active(sanction)
     if is_debarred:
         entity.add("topics", "debarment")
 

--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -57,16 +57,15 @@ def crawl_item(row: Dict[str, str], context: Context):
     h.apply_dates(
         sanction, "startDate", row.pop("contract_termination_date").split("\n")
     )
-    ended = False
     h.apply_date(
         sanction, "endDate", row.pop("nevada_medicaid_sanction_period_end_date")
     )
-    end_date = sanction.get("endDate")
-    ended = end_date != [] and end_date[0] < context.data_time_iso
-    if not ended:
+
+    is_debarred = not h.has_ended(sanction)
+    if is_debarred:
         entity.add("topics", "debarment")
 
-    context.emit(entity, target=not ended)
+    context.emit(entity, target=is_debarred)
     context.emit(sanction)
 
     context.audit_data(

--- a/zavod/zavod/helpers/__init__.py
+++ b/zavod/zavod/helpers/__init__.py
@@ -39,7 +39,7 @@ from zavod.helpers.names import make_name, apply_name, split_comma_names
 from zavod.helpers.positions import make_position, make_occupancy
 from zavod.helpers.text import clean_note, is_empty, remove_bracketed
 from zavod.helpers.text import multi_split
-from zavod.helpers.sanctions import make_sanction
+from zavod.helpers.sanctions import make_sanction, has_ended
 from zavod.helpers.addresses import make_address, format_address
 from zavod.helpers.addresses import copy_address, apply_address, postcode_pobox
 from zavod.helpers.dates import extract_years, parse_date, check_no_year
@@ -65,6 +65,7 @@ __all__ = [
     "copy_address",
     "postcode_pobox",
     "make_sanction",
+    "has_ended",
     "make_identification",
     "extract_years",
     "parse_date",

--- a/zavod/zavod/helpers/__init__.py
+++ b/zavod/zavod/helpers/__init__.py
@@ -39,7 +39,7 @@ from zavod.helpers.names import make_name, apply_name, split_comma_names
 from zavod.helpers.positions import make_position, make_occupancy
 from zavod.helpers.text import clean_note, is_empty, remove_bracketed
 from zavod.helpers.text import multi_split
-from zavod.helpers.sanctions import make_sanction, has_ended
+from zavod.helpers.sanctions import make_sanction, is_active
 from zavod.helpers.addresses import make_address, format_address
 from zavod.helpers.addresses import copy_address, apply_address, postcode_pobox
 from zavod.helpers.dates import extract_years, parse_date, check_no_year
@@ -65,7 +65,7 @@ __all__ = [
     "copy_address",
     "postcode_pobox",
     "make_sanction",
-    "has_ended",
+    "is_active",
     "make_identification",
     "extract_years",
     "parse_date",

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -66,12 +66,17 @@ def make_sanction(
     return sanction
 
 
-def has_ended(sanction: Entity) -> bool:
-    """Check if a sanction is currently active
+def is_active(sanction: Entity) -> bool:
+    """Check if a sanction is currently active.
+
+    A sanction is active if the current time is between its earliest start date and latest end date.
 
     Args:
         sanction: The sanction entity to check.
     """
+    iso_start_date = min(sanction.get("startDate"), default=None)
     iso_end_date = max(sanction.get("endDate"), default=None)
-    is_active = iso_end_date is None or iso_end_date >= settings.RUN_TIME_ISO
-    return not is_active
+    is_active = (
+        iso_start_date is None or iso_start_date <= settings.RUN_TIME_ISO
+    ) and (iso_end_date is None or iso_end_date >= settings.RUN_TIME_ISO)
+    return is_active

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -64,3 +64,14 @@ def make_sanction(
         sanction.add("status", "active" if is_active else "inactive")
 
     return sanction
+
+
+def has_ended(sanction: Entity) -> bool:
+    """Check if a sanction is currently active
+
+    Args:
+        sanction: The sanction entity to check.
+    """
+    iso_end_date = max(sanction.get("endDate"), default=None)
+    is_active = iso_end_date is None or iso_end_date >= settings.RUN_TIME_ISO
+    return not is_active

--- a/zavod/zavod/tests/helpers/test_sanctions.py
+++ b/zavod/zavod/tests/helpers/test_sanctions.py
@@ -1,6 +1,10 @@
+from datetime import timedelta
+
 import pytest
+
+from zavod import Entity, settings
 from zavod.context import Context
-from zavod.helpers.sanctions import make_sanction
+from zavod.helpers.sanctions import make_sanction, has_ended
 
 
 def test_sanctions_helper(vcontext: Context):
@@ -18,3 +22,39 @@ def test_sanctions_helper(vcontext: Context):
 
     sanction3 = make_sanction(vcontext, person, key="other")
     assert sanction.id != sanction3.id
+
+
+@pytest.fixture
+def person(vcontext: Context):
+    person = vcontext.make("Person")
+    person.id = "jeff"
+    return person
+
+
+@pytest.fixture
+def sanction(vcontext: Context, person: Entity):
+    return make_sanction(vcontext, person)
+
+
+def test_sanctions_has_ended_no_end_date(sanction: Entity):
+    sanction.set("endDate", None)
+    assert not has_ended(sanction)
+
+
+def test_sanctions_has_ended_with_end_date_tomorrow(sanction: Entity):
+    tomorrow = (settings.RUN_TIME + timedelta(days=1)).date().isoformat()
+    sanction.set("endDate", tomorrow)
+    assert not has_ended(sanction)
+
+
+def test_sanctions_has_ended_with_end_date_yesterday(sanction: Entity):
+    yesterday = (settings.RUN_TIME - timedelta(days=1)).date().isoformat()
+    sanction.set("endDate", yesterday)
+    assert has_ended(sanction)
+
+
+def test_sanctions_has_ended_with_multiple_end_dates(sanction: Entity):
+    past_date = (settings.RUN_TIME - timedelta(days=20)).date().isoformat()
+    future_date = (settings.RUN_TIME + timedelta(days=20)).date().isoformat()
+    sanction.set("endDate", [past_date, future_date])
+    assert not has_ended(sanction)


### PR DESCRIPTION
This helper is mostly used in places where we infer a topic assignment (is this entity currently sanctioned or debarred?) from the end date.

In a few places, this commit also changes what "now" date is used as a comparison. In the helper, we use settings.RUN_TIME. This is more consistent than using datetime.now() (used in a couple places), which changes throughout the run. It is more semantically correct than using context.data_time, as our topic assignments should reflect whether an entity is debarred *now* (for some definition of now) rather than at the time when the data was published.

Diverging from what we discussed, I built an `is_active` instead of a `has_ended` helper. I feel this is better for two reasons: a) easier to reason about when reading because one fewer negation b) also cover the edgecase of a sanction that begins in the future. Looking forward to your feedback on this semantic nitpick :)