### PR TITLE
Allow validating the number of property manifestation for a type

### DIFF
--- a/datasets/br/slavery/br_slavery.yml
+++ b/datasets/br/slavery/br_slavery.yml
@@ -47,6 +47,9 @@ assertions:
     schema_entities:
       Person: 480
       Company: 180
+    property_values:
+      Sanction:
+        endDate: 3
   max:
     schema_entities:
       Person: 700

--- a/datasets/br/slavery/br_slavery.yml
+++ b/datasets/br/slavery/br_slavery.yml
@@ -47,7 +47,7 @@ assertions:
     schema_entities:
       Person: 480
       Company: 180
-    property_values:
+    entities_with_prop:
       Sanction:
         endDate: 3
   max:

--- a/zavod/zavod/exporters/statistics.py
+++ b/zavod/zavod/exporters/statistics.py
@@ -42,7 +42,7 @@ def get_country_facets(countries: Dict[str, int]) -> List[Any]:
 SchemaProperty = namedtuple("SchemaProperty", ["schema", "property"])
 
 
-def get_property_values_facets(properties: Dict[SchemaProperty, int]) -> List[Any]:
+def get_entities_with_prop_facets(properties: Dict[SchemaProperty, int]) -> List[Any]:
     facets: List[Any] = []
     for prop, count in sorted(properties.items()):
         facet = {
@@ -64,7 +64,7 @@ class Statistics(object):
         self.thing_count = 0
         self.thing_countries: Dict[str, int] = defaultdict(int)
         self.thing_schemata: Dict[str, int] = defaultdict(int)
-        self.property_values_count: Dict[SchemaProperty, int] = defaultdict(int)
+        self.entities_with_prop_count: Dict[SchemaProperty, int] = defaultdict(int)
 
         self.target_count = 0
         self.target_countries: Dict[str, int] = defaultdict(int)
@@ -78,7 +78,7 @@ class Statistics(object):
         for prop_name, values in entity.properties.items():
             # We add 1 instead of len(values) here because we want to count the number of entities that have this
             # value set, not the number of values.
-            self.property_values_count[
+            self.entities_with_prop_count[
                 SchemaProperty(entity.schema.name, prop_name)
             ] += 1
 
@@ -116,8 +116,8 @@ class Statistics(object):
                 "total": self.thing_count,
                 "countries": get_country_facets(self.thing_countries),
                 "schemata": get_schema_facets(self.thing_schemata),
-                "property_values": get_property_values_facets(
-                    self.property_values_count
+                "entities_with_prop": get_entities_with_prop_facets(
+                    self.entities_with_prop_count
                 ),
             },
         }

--- a/zavod/zavod/exporters/statistics.py
+++ b/zavod/zavod/exporters/statistics.py
@@ -1,10 +1,10 @@
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from typing import Dict, List, Any, Optional, Set
+
 from followthemoney import model
 from followthemoney.types import registry
-
-from zavod.entity import Entity
 from zavod.archive import STATISTICS_FILE
+from zavod.entity import Entity
 from zavod.exporters.common import Exporter
 from zavod.util import write_json
 
@@ -37,6 +37,23 @@ def get_country_facets(countries: Dict[str, int]) -> List[Any]:
     return facets
 
 
+# We don't use followthemoney.Property because we want to track manifestations of property values on specific
+# schemas, even though the property might be defined somewhere higher in the type hierarchy.
+SchemaProperty = namedtuple("SchemaProperty", ["schema", "property"])
+
+
+def get_property_values_facets(properties: Dict[SchemaProperty, int]) -> List[Any]:
+    facets: List[Any] = []
+    for prop, count in sorted(properties.items()):
+        facet = {
+            "schema": prop.schema,
+            "property": prop.property,
+            "count": count,
+        }
+        facets.append(facet)
+    return facets
+
+
 class Statistics(object):
     def __init__(self) -> None:
         self.entity_count = 0
@@ -47,6 +64,7 @@ class Statistics(object):
         self.thing_count = 0
         self.thing_countries: Dict[str, int] = defaultdict(int)
         self.thing_schemata: Dict[str, int] = defaultdict(int)
+        self.property_values_count: Dict[SchemaProperty, int] = defaultdict(int)
 
         self.target_count = 0
         self.target_countries: Dict[str, int] = defaultdict(int)
@@ -57,6 +75,10 @@ class Statistics(object):
         self.schemata.add(entity.schema.name)
         for prop in entity.iterprops():
             self.qnames.add(prop.qname)
+        for prop_name, values in entity.properties.items():
+            self.property_values_count[
+                SchemaProperty(entity.schema.name, prop_name)
+            ] += len(values)
 
         if entity.schema.is_a("Thing"):
             self.thing_count += 1
@@ -92,6 +114,9 @@ class Statistics(object):
                 "total": self.thing_count,
                 "countries": get_country_facets(self.thing_countries),
                 "schemata": get_schema_facets(self.thing_schemata),
+                "property_values": get_property_values_facets(
+                    self.property_values_count
+                ),
             },
         }
 

--- a/zavod/zavod/exporters/statistics.py
+++ b/zavod/zavod/exporters/statistics.py
@@ -76,9 +76,11 @@ class Statistics(object):
         for prop in entity.iterprops():
             self.qnames.add(prop.qname)
         for prop_name, values in entity.properties.items():
+            # We add 1 instead of len(values) here because we want to count the number of entities that have this
+            # value set, not the number of values.
             self.property_values_count[
                 SchemaProperty(entity.schema.name, prop_name)
-            ] += len(values)
+            ] += 1
 
         if entity.schema.is_a("Thing"):
             self.thing_count += 1

--- a/zavod/zavod/meta/assertion.py
+++ b/zavod/zavod/meta/assertion.py
@@ -13,7 +13,7 @@ class Metric(Enum):
     """Number of entities matching the filter in the dataset."""
     COUNTRY_COUNT = "country_count"
     """Number of distinct countries occurring in the dataset."""
-    PROPERTY_VALUES_COUNT = "property_values_count"
+    ENTITIES_WITH_PROP_COUNT = "entities_with_prop_count"
     """Number of entities with property values matching the filter in the dataset."""
 
 
@@ -76,24 +76,24 @@ def parse_metrics(
                 yield from parse_filters(
                     Metric.ENTITY_COUNT, comparison, "country", value
                 )
-            case "property_values" if isinstance(value, dict) and value != {}:
+            case "entities_with_prop" if isinstance(value, dict) and value != {}:
                 for schema_name, props in value.items():
                     for prop_name, threshold_value in props.items():
                         schema = model.get(schema_name)
                         if schema is None:
                             raise ValueError(
-                                f"Property value count assertion on unknown schema: {schema_name}:{prop_name}"
+                                f"Entities with prop assertion on unknown schema: {schema_name}:{prop_name}"
                             )
                         prop = schema.get(prop_name)
                         if prop is None:
                             raise ValueError(
-                                f"Property value count assertion on unknown property: {schema_name}:{prop_name}"
+                                f"Entities with prop assertion on unknown property: {schema_name}:{prop_name}"
                             )
                         yield Assertion(
-                            Metric.PROPERTY_VALUES_COUNT,
+                            Metric.ENTITIES_WITH_PROP_COUNT,
                             comparison,
                             threshold_value,
-                            "property_values",
+                            "entities_with_prop",
                             # We don't just put a Property.qname in the shape of "Schema:name" here because we want to
                             # assert not on qnames, which are the canonical name of a property (e.g. Thing.country), but
                             # on property values in entities of a specific type, like Company.country.

--- a/zavod/zavod/meta/assertion.py
+++ b/zavod/zavod/meta/assertion.py
@@ -14,7 +14,7 @@ class Metric(Enum):
     COUNTRY_COUNT = "country_count"
     """Number of distinct countries occurring in the dataset."""
     PROPERTY_VALUES_COUNT = "property_values_count"
-    """Number of property values matching the filter in the dataset."""
+    """Number of entities with property values matching the filter in the dataset."""
 
 
 class Comparison(Enum):

--- a/zavod/zavod/meta/assertion.py
+++ b/zavod/zavod/meta/assertion.py
@@ -1,5 +1,9 @@
 from enum import Enum
 from typing import Any, Dict, Generator, Optional
+
+from followthemoney import model
+
+
 from followthemoney.types import registry
 from nomenklatura.dataset.util import type_require
 
@@ -9,6 +13,8 @@ class Metric(Enum):
     """Number of entities matching the filter in the dataset."""
     COUNTRY_COUNT = "country_count"
     """Number of distinct countries occurring in the dataset."""
+    PROPERTY_VALUES_COUNT = "property_values_count"
+    """Number of property values matching the filter in the dataset."""
 
 
 class Comparison(Enum):
@@ -20,7 +26,7 @@ class Assertion(object):
     """Data assertion specification."""
 
     filter_attribute: Optional[str]
-    filter_value: Optional[str]
+    filter_value: Optional[Any]
 
     def __init__(
         self,
@@ -28,7 +34,7 @@ class Assertion(object):
         comparison: Comparison,
         threshold: int,
         filter_attribute: Optional[str],
-        filter_value: Optional[str],
+        filter_value: Optional[Any],
     ) -> None:
         self.metric = metric
         self.comparison = comparison
@@ -70,6 +76,29 @@ def parse_metrics(
                 yield from parse_filters(
                     Metric.ENTITY_COUNT, comparison, "country", value
                 )
+            case "property_values" if isinstance(value, dict) and value != {}:
+                for schema_name, props in value.items():
+                    for prop_name, threshold_value in props.items():
+                        schema = model.get(schema_name)
+                        if schema is None:
+                            raise ValueError(
+                                f"Property value count assertion on unknown schema: {schema_name}:{prop_name}"
+                            )
+                        prop = schema.get(prop_name)
+                        if prop is None:
+                            raise ValueError(
+                                f"Property value count assertion on unknown property: {schema_name}:{prop_name}"
+                            )
+                        yield Assertion(
+                            Metric.PROPERTY_VALUES_COUNT,
+                            comparison,
+                            threshold_value,
+                            "property_values",
+                            # We don't just put a Property.qname in the shape of "Schema:name" here because we want to
+                            # assert not on qnames, which are the canonical name of a property (e.g. Thing.country), but
+                            # on property values in entities of a specific type, like Company.country.
+                            (schema_name, prop_name),
+                        )
             case "countries":
                 threshold = int(type_require(registry.number, value))
                 yield Assertion(Metric.COUNTRY_COUNT, comparison, threshold, None, None)

--- a/zavod/zavod/tests/fixtures/testdataset3/testdataset3.yml
+++ b/zavod/zavod/tests/fixtures/testdataset3/testdataset3.yml
@@ -24,6 +24,9 @@ assertions:
     country_entities:
       de: 3
     countries: 7
+    property_values:
+      Company:
+        name: 11
   max:
     country_entities:
       de: 1

--- a/zavod/zavod/tests/fixtures/testdataset3/testdataset3.yml
+++ b/zavod/zavod/tests/fixtures/testdataset3/testdataset3.yml
@@ -24,7 +24,7 @@ assertions:
     country_entities:
       de: 3
     countries: 7
-    property_values:
+    entities_with_prop:
       Company:
         name: 11
   max:

--- a/zavod/zavod/tests/test_assertions.py
+++ b/zavod/zavod/tests/test_assertions.py
@@ -6,7 +6,7 @@ from zavod.meta.assertion import parse_assertions, Comparison, Metric
 CONFIG = {
     "min": {
         "schema_entities": {"Person": 1},
-        "property_values": {"Person": {"name": 1}},
+        "entities_with_prop": {"Person": {"name": 1}},
     },
     "max": {"countries": 1},
 }
@@ -20,8 +20,8 @@ def test_parse_assertions():
     assert entity_count.comparison == Comparison.GTE
 
     property_values_count = assertions[1]
-    assert property_values_count.metric == Metric.PROPERTY_VALUES_COUNT
-    assert property_values_count.filter_attribute == "property_values"
+    assert property_values_count.metric == Metric.ENTITIES_WITH_PROP_COUNT
+    assert property_values_count.filter_attribute == "entities_with_prop"
     assert property_values_count.filter_value == ("Person", "name")
     assert property_values_count.comparison == Comparison.GTE
 
@@ -51,13 +51,13 @@ def test_parse_assertions():
         list(parse_assertions(config))
 
 
-def test_parse_property_values_count_unknown_property_name_or_schema():
+def test_parse_entities_with_prop_count_unknown_property_name_or_schema():
     config = deepcopy(CONFIG)
 
-    config["min"]["property_values"] = {"Person": {"bogusProperty": 1}}
+    config["min"]["entities_with_prop"] = {"Person": {"bogusProperty": 1}}
     with pytest.raises(ValueError):
         list(parse_assertions(config))
 
-    config["min"]["property_values"] = {"bogusSchema": {"name": 1}}
+    config["min"]["entities_with_prop"] = {"bogusSchema": {"name": 1}}
     with pytest.raises(ValueError):
         list(parse_assertions(config))

--- a/zavod/zavod/tests/test_dataset.py
+++ b/zavod/zavod/tests/test_dataset.py
@@ -92,7 +92,7 @@ def test_validation(testdataset1: Dataset, testdataset3: Dataset):
     assert len(testdataset1.datasets) == 1
     assert len(testdataset1.inputs) == 0
     assert len(testdataset1.assertions) == 0
-    assert len(testdataset3.assertions) == 4
+    assert len(testdataset3.assertions) == 5
     assert isinstance(testdataset3.assertions[0], Assertion)
 
 

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -1,17 +1,18 @@
 from typing import Type
+
 from structlog.testing import capture_logs
 
+from zavod.archive import clear_data_path
 from zavod.context import Context
+from zavod.crawl import crawl_dataset
+from zavod.integration import get_dataset_linker
 from zavod.meta.dataset import Dataset
 from zavod.store import get_store
-from zavod.integration import get_dataset_linker
 from zavod.validators import (
     DanglingReferencesValidator,
     SelfReferenceValidator,
     EmptyValidator,
 )
-from zavod.archive import clear_data_path
-from zavod.crawl import crawl_dataset
 from zavod.validators.assertions import AssertionsValidator
 from zavod.validators.common import BaseValidator
 
@@ -88,6 +89,10 @@ def test_assertions(testdataset3) -> None:
     ) in logs, logs
     assert (
         "warning: Assertion failed for value 6: <Assertion country_count gte 7>" in logs
+    ), logs
+    assert (
+        "warning: Assertion failed for value 7: <Assertion property_values_count gte 11 filter: property_values=('Company', 'name')>"
+        in logs
     ), logs
     assert "error: One or more assertions failed." in logs, logs
     assert validator.abort is True

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -91,7 +91,7 @@ def test_assertions(testdataset3) -> None:
         "warning: Assertion failed for value 6: <Assertion country_count gte 7>" in logs
     ), logs
     assert (
-        "warning: Assertion failed for value 7: <Assertion property_values_count gte 11 filter: property_values=('Company', 'name')>"
+        "warning: Assertion failed for value 7: <Assertion entities_with_prop_count gte 11 filter: entities_with_prop=('Company', 'name')>"
         in logs
     ), logs
     assert "error: One or more assertions failed." in logs, logs

--- a/zavod/zavod/validators/assertions.py
+++ b/zavod/zavod/validators/assertions.py
@@ -1,11 +1,11 @@
 from typing import Dict, Any, Optional, cast
-from zavod.context import Context
 
+from zavod.context import Context
 from zavod.entity import Entity
-from zavod.meta.assertion import Assertion, Comparison, Metric
 from zavod.exporters.statistics import Statistics
-from zavod.validators.common import BaseValidator
+from zavod.meta.assertion import Assertion, Comparison, Metric
 from zavod.store import View
+from zavod.validators.common import BaseValidator
 
 
 def compare_threshold(value: int, comparison: Comparison, threshold: int) -> bool:
@@ -36,8 +36,22 @@ def get_value(stats: Dict[str, Any], assertion: Assertion) -> Optional[int]:
             if len(items) != 1:
                 return None
             return cast(int, items[0]["count"])
+
+        case Metric.PROPERTY_VALUES_COUNT:
+            items = stats["things"]["property_values"]
+            items = [
+                i
+                for i in items
+                # Filter value is a (schema_name, prop_name) tuple
+                if assertion.filter_value
+                and i["schema"] == assertion.filter_value[0]
+                and i["property"] == assertion.filter_value[1]
+            ]
+            return cast(int, items[0]["count"]) if len(items) == 1 else None
+
         case Metric.COUNTRY_COUNT:
             return len(stats["things"]["countries"])
+
         case _:
             raise ValueError(f"Unknown metric: {assertion.metric}")
 

--- a/zavod/zavod/validators/assertions.py
+++ b/zavod/zavod/validators/assertions.py
@@ -37,8 +37,8 @@ def get_value(stats: Dict[str, Any], assertion: Assertion) -> Optional[int]:
                 return None
             return cast(int, items[0]["count"])
 
-        case Metric.PROPERTY_VALUES_COUNT:
-            items = stats["things"]["property_values"]
+        case Metric.ENTITIES_WITH_PROP_COUNT:
+            items = stats["things"]["entities_with_prop"]
             items = [
                 i
                 for i in items


### PR DESCRIPTION
Some docs in the commit messages, the most important discussion item is probably:

> This carries a slight ambiguity with regards to inheritance: Can an
> assertion on LegalEntity.country be satisfied by Person and Company
> entities? At the moment, the implementation does not allow this.

Semantics aside, I also welcome comments regarding naming. schema, properties, values... such overload.

This makes our `statistics.json` quite a bit larger --- do we want that? I guess we could re-work the code to allow the validations to happen on the `Statistics` object, not on its `dict`-ified version. But then we'd lose the ability to do comparisons with the past in the validations, which is something I'd really like to tackle because I think it's actually more useful than specifying thresholds everywhere.