### PR TITLE
Enhancement: fixed typos and cleaning value

### DIFF
--- a/datasets/br/tcu_debarred/crawler.py
+++ b/datasets/br/tcu_debarred/crawler.py
@@ -68,7 +68,7 @@ def crawl_item(input_dict: dict, context: Context):
     sanction.add(
         "program",
         (
-            "TCU Debarred entities based on Article 46 of Law 8.443/92 that"
+            "TCU Debarred entities based on Article 46 of Law 8.443/92 that "
             "restricts entities from participating in public biddings"
         ),
     )
@@ -78,7 +78,6 @@ def crawl_item(input_dict: dict, context: Context):
 
 
 def crawl(context: Context):
-    response = context.fetch_json(context.data_url)
     url = context.data_url
     while True:
         response = context.fetch_json(url)

--- a/datasets/il/mod_crypto/crawler.py
+++ b/datasets/il/mod_crypto/crawler.py
@@ -75,8 +75,8 @@ def crawl(context: Context):
                     wallet.id = context.make_id(wallet_id)
                     wallet.set("publicKey", wallet_id)
                     wallets.append(wallet)
-                    if wallet in d:
-                        wallet.set("currency", d[wallet])
+                    if wallet_id in d:
+                        wallet.set("currency", d[wallet_id])
             aso_id = row.pop("Administrative Seizure Order")
             # Create a sanction for each Crypto account
             for wallet in wallets:

--- a/datasets/jp/mof_sanctions/crawler.py
+++ b/datasets/jp/mof_sanctions/crawler.py
@@ -14,7 +14,7 @@ from followthemoney.types.identifier import IdentifierType
 from zavod import Context, Entity
 from zavod import helpers as h
 
-BRACKETED = re.compile(r"(\([^\(\)]*\)|\[[^\[\]]*\])")
+BRACKETED = re.compile(r"([(（][^\(\)]*[)）]|\[[^\[\]]*\])")
 
 SPLITS = ["(%s)" % char for char in string.ascii_lowercase]
 SPLITS = SPLITS + ["（%s）" % char for char in string.ascii_lowercase]
@@ -42,9 +42,10 @@ DATE_SPLITS = SPLITS + [
 DATE_CLEAN = re.compile(r"(\(|\)|（|）| |改訂日|改訂|まれ)")
 
 
-def keep_long_ids(entity, identifier):
-    if len(identifier) > IdentifierType.max_length:
-        entity.add("notes", identifier)
+def keep_long_ids(entity, identifiers):
+    for identifier in identifiers:
+        if len(identifier) > IdentifierType.max_length:
+            entity.add("notes", identifier)
 
 
 def str_cell(cell: Cell) -> Optional[str]:
@@ -79,15 +80,22 @@ def parse_names(names: List[str]) -> List[str]:
         # (a.k.a.:
         # Full width colon. Yes really.
         name = re.sub(r"[(（]a\.k\.a\.?[:：]? ?", "", name)
-        name = name.replace("(original script:", "")
-        name = name.replace("(previously listed as", "")
+        name = re.sub(r"[（(]original script[:：]\s*(.*?)[）)]", r"\1", name)
+        name = re.sub(r"[（(]f.k.a.:\s*(.*?)[）)]", r"\1", name)
+        # in Excel, it has this value as (previously listed as), (Previously listed as some name)
+        name = name.replace("(previously listed as)", "")
         name = name.replace("(formerly listed as", "")
         name = name.replace("a.k.a., the following three aliases:", "")
         # name = name.replace(")", "")
+        if name.count("(") == 0 and name.endswith(")"):
+            name = name.rstrip(")")
+        # e.g: Al Qaïda au Maghreb islamique (AQMI))
+        name = name.replace("))", ")")
+        name = name.strip(" 、")
         cleaned.append(name)
         no_brackets = BRACKETED.sub(" ", name).strip()
         if no_brackets != name and len(no_brackets):
-            cleaned.append(name)
+            cleaned.append(no_brackets)
     return cleaned
 
 

--- a/datasets/si/conflicts/crawler.py
+++ b/datasets/si/conflicts/crawler.py
@@ -23,7 +23,7 @@ def create_entities(context: Context, record: Dict[str, Any]):
     organization_name = record.pop("org_naziv")
     organization_number = record.pop("org_sifrapu")
 
-    if registration_number:
+    if registration_number and organization_number:
         legal_entity.add(
             "sourceUrl",
             f"https://erar.si/transakcija/placnik/{organization_number}/prejemnik/{registration_number}",

--- a/datasets/ua/sfms_blacklist/crawler.py
+++ b/datasets/ua/sfms_blacklist/crawler.py
@@ -8,6 +8,8 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.helpers.xml import ElementOrTree
 from zavod.shed.zyte_api import fetch_resource
+from normality import collapse_spaces
+
 
 REGEX_ID_NUMBER = re.compile(r"\w?[\d-]*\d{6,}[\d-]*")
 SPLITS = [";", "i)", "ii)", "iii)", "iv)", "v)", "vi)", "vii)", "viii)", "ix)", "x)"]
@@ -30,7 +32,7 @@ def clean_id(entity: Entity, text: Optional[str]) -> Generator[str, None, None]:
     for substring in text.split(";"):
         if len(substring) > IdentifierType.max_length:
             entity.add("notes", substring)
-            yield from REGEX_ID_NUMBER.findall(substring)
+        yield from REGEX_ID_NUMBER.findall(substring)
 
 
 def parse_entry(context: Context, entry: ElementOrTree) -> None:
@@ -86,7 +88,8 @@ def parse_entry(context: Context, entry: ElementOrTree) -> None:
         entity.add("address", h.multi_split(node.findtext("./address"), SPLITS))
 
     for pob in entry.findall("./place-of-birth-list"):
-        entity.add_cast("Person", "birthPlace", pob.text)
+        for p in h.multi_split(pob.text, ";"):
+            entity.add_cast("Person", "birthPlace", collapse_spaces(p))
 
     for dob in entry.findall("./date-of-birth-list"):
         if dob.text is not None:

--- a/datasets/ua/sfms_blacklist/ua_sfms_blacklist.yml
+++ b/datasets/ua/sfms_blacklist/ua_sfms_blacklist.yml
@@ -80,6 +80,18 @@ lookups:
         value: Ethiopia
       - match: former Soviet Union
         value: SUHH
+      - match: United Kingdom of Great Britain and Northern Irela
+        value: GB
+      - match: Baghdad, Iraq
+        value: IQ
+      - match: Sanaa, Yemen
+        value: YE
+      - match: South Sudan number
+        value: SS
+      - match: Alexandria, Egypt
+        value: EG
+      - match: "682"
+        value: SA
   type.date:
     options:
       - match: 11 November 1960, 11 November 1967, 11 November 1969, 1 January 1969

--- a/datasets/us/az/med_exclusions/crawler.py
+++ b/datasets/us/az/med_exclusions/crawler.py
@@ -66,6 +66,7 @@ def crawl(context: Context) -> None:
         manual_strings.append(slugify(stringify(items[0])))
 
     # concatenate contiguous manual-extraction rows
+    rows.append(items[0])
     for i, item in enumerate(items[1:], 1):
         if manual_extraction[i]:
             string = slugify(stringify(item))

--- a/datasets/us/cbp_forced_labor/crawler.py
+++ b/datasets/us/cbp_forced_labor/crawler.py
@@ -10,9 +10,6 @@ REGEX_VESSEL = re.compile(r"\bFishing\s+Vessels\b")
 
 
 def crawl_item(context: Context, row: Dict[str, Any]):
-    # Map the special case headers to expected names
-    if "#" in row:
-        row["id"] = row.pop("#")
     # Extract required keys and handle them
     country = row.pop("main_header")
     if REGEX_VESSEL.search(country, re.IGNORECASE):
@@ -23,11 +20,8 @@ def crawl_item(context: Context, row: Dict[str, Any]):
 
 def crawl_vessel(context: Context, row: Dict[str, Any]):
     # if REGEX_VESSEL.search(country, re.IGNORECASE):
-    if "#" in row:
-        row["id"] = row.pop("#")
     internal_id = row.pop("id")
     name = row.pop("entities")
-    name_result = context.lookup("name", name)
     listing_date = row.pop("date")
     status = row.pop("status")
     status_notes = row.pop("status-notes")
@@ -60,7 +54,6 @@ def crawl_vessel(context: Context, row: Dict[str, Any]):
 def crawl_company(context: Context, row: Dict[str, Any], country: str):
     internal_id = row.pop("id")
     name = row.pop("entities")
-    name_result = context.lookup("name", name)
     listing_date = row.pop("date")
     merchandise = row.pop("merchandise")
     status = row.pop("status")
@@ -136,14 +129,14 @@ def parse_table(
 
         # Look for link near status-notes
         for cell in cells:
-            link = cell.find(".//a")
-            if link is not None:
-                link_url = link.get("href")
+            links = cell.findall(".//a")
+            if links:
+                link_urls = [link.get("href") for link in links]
                 if (
                     "status-notes" in row_data
                     and cell.text_content().strip() == row_data["status-notes"]
                 ):
-                    row_data["status_notes_link"] = link_url
+                    row_data["status_notes_link"] = link_urls
         yield row_data
 
 

--- a/datasets/us/co/med_exclusions/crawler.py
+++ b/datasets/us/co/med_exclusions/crawler.py
@@ -13,7 +13,7 @@ def crawl_item(row: Dict[str, str], context: Context):
         return
 
     entity = context.make("LegalEntity")
-    entity.id = context.make_id(name, row.get("npi"))
+    entity.id = context.make_id(name, npi)
     entity.add("name", name)
     entity.add("country", "us")
     entity.add("npiCode", h.multi_split(npi, ["; ", "&", " and "]))

--- a/datasets/us/de/med_exclusions/crawler.py
+++ b/datasets/us/de/med_exclusions/crawler.py
@@ -4,6 +4,7 @@ import re
 
 from zavod import Context, helpers as h
 from zavod.shed.zyte_api import fetch_resource
+from normality import collapse_spaces
 
 REGEX_AKA = re.compile(r"\baka\b|a\.k\.a\.?", re.IGNORECASE)
 # Ruth Diane Jones, DO
@@ -13,7 +14,7 @@ REGEX_JOB_ROLE = re.compile(r"^(?P<name>.+)[,\s]+(?P<role>([A-Z\.,/-]+|\([^\)]+\
 
 
 def crawl_item(row: Dict[str, str], context: Context):
-    raw_name = row.pop("sanctioned_provider_name")
+    raw_name = collapse_spaces(row.pop("sanctioned_provider_name"))
     npi = row.pop("npi")
     # Skip empty rows
     if raw_name == "" and npi == "":
@@ -41,15 +42,18 @@ def crawl_item(row: Dict[str, str], context: Context):
     entity.add("alias", alias)
     entity.add("country", "us")
     entity.add("sector", row.pop("taxonomy"))
-    entity.add("idNumber", row.pop("dea"))
+    dea = row.pop("dea")
+    if dea != "-":
+        entity.add("idNumber", dea)
     entity.add("npiCode", h.multi_split(npi, [";", ",", "&"]))
     license_number = row.pop("license")
     if license_number != "N/A":
-        entity.add("idNumber", license_number.split(","))
+        for license_num in h.multi_split(license_number, [",", ";"]):
+            entity.add("idNumber", collapse_spaces(license_num.replace("\n", "")))
 
     sanction = h.make_sanction(context, entity)
-    sanction.add("description", row.pop("comments"))
-    sanction.set("authority", row.pop("oig_medicaid_sanction"))
+    sanction.add("description", collapse_spaces(row.pop("comments")))
+    sanction.set("authority", collapse_spaces(row.pop("oig_medicaid_sanction")))
     h.apply_date(sanction, "startDate", row.pop("effective_date"))
     reinstated_date = row.pop("reinstated_date")
     h.apply_date(sanction, "endDate", reinstated_date)

--- a/datasets/us/de/med_exclusions/us_de_med_exclusions.yaml
+++ b/datasets/us/de/med_exclusions/us_de_med_exclusions.yaml
@@ -135,3 +135,12 @@ lookups:
         value: 1073778361
       - match: 3336C0003X
         prop: sector
+      - match: "LG0000537 L1-0036672 AN-0007759"
+        values:
+          - LG0000537
+          - L1-0036672
+          - AN-0007759
+      - match: "LG-0000732 L1-0036411"
+        values:
+          - LG-0000732
+          - L1-0036411

--- a/datasets/us/fincen_special_measures/crawler.py
+++ b/datasets/us/fincen_special_measures/crawler.py
@@ -4,6 +4,7 @@ from zavod import Context, helpers as h
 from normality import slugify
 from typing import Dict, Generator, cast
 from typing import List
+from normality import collapse_spaces
 
 
 REGEX_DATE = re.compile(r"(\d{1,2}/\d{1,2}/\d{4})")
@@ -25,8 +26,8 @@ def crawl_item(context: Context, row: Dict[str, str]):
     entity.id = context.make_id(name)
     entity.add("name", name)
     # Adjust the topic based on the presence of "final rule"
-    final_rule = row.get("final_rule", "").strip().lower()
-    rescinded_date = row.get("rescinded").text_content()
+    final_rule = collapse_spaces(row.get("final-rule", "").text_content().strip().lower())
+    rescinded_date = collapse_spaces(row.get("rescinded").text_content())
     if (
         final_rule
         and final_rule != "---"

--- a/datasets/us/mi/med_exclusions/crawler.py
+++ b/datasets/us/mi/med_exclusions/crawler.py
@@ -23,7 +23,7 @@ def crawl_item(row: Dict[str, str], context: Context):
     person = None
     if entity_name := row.pop("entity_name"):
         entity = context.make("Company")
-        entity.id = context.make_id(entity_name, row.get("npi"))
+        entity.id = context.make_id(entity_name, npi)
         entity.add("name", entity_name)
         entity.add("npiCode", npi)
         entity.add("topics", "debarment")


### PR DESCRIPTION
## Summary
This PR fixes multiple issues and enhances data extraction in various dataset crawlers.

---

### 1. `datasets/ua/sfms_blacklist/crawler.py`
#### **Issue:**
- The `clean_id(...)` function should:
  - Extract the ID number from a given text.
  - Add the extracted text as a `notes` field if it exceeds the identifier length limit.
- Currently, the function only returns the ID number when the text is too long, causing some ID number to be missed.

#### **Fix:**

```python
 def clean_id(entity: Entity, text: Optional[str]) -> Generator[str, None, None]:
     if text is None:
         return []
     for substring in text.split(";"):
         if len(substring) > IdentifierType.max_length:
             entity.add("notes", substring)
         yield from REGEX_ID_NUMBER.findall(substring)
```

#### **Enhancement:**
- Handle multiple values in the `place of birth` field, which may be separated by `;`.

```python
for pob in entry.findall("./place-of-birth-list"):
    for p in h.multi_split(pob.text, ";"):
        entity.add_cast("Person", "birthPlace", collapse_spaces(p))
```

---

### 2. `datasets/jp/mof_sanctions/crawler.py`
#### **Issue:**
- The `keep_long_ids(...)` function does not work correctly because `identifier` is a list rather than a string.

#### **Fix:**
Ensure the function iterates over each identifier separately.

```python
 def keep_long_ids(entity, identifiers):
     for identifier in identifiers:
         if len(identifier) > IdentifierType.max_length:
             entity.add("notes", identifier)
```

#### **Enhancement:**
- Improve name cleaning by removing unnecessary text such as:
  - `（original script: سالم أحمد سالم حمدان）` → `سالم أحمد سالم حمدان`
  - `Julkipli Salim)` → `Julkipli Salim`
  - `(f.k.a.: Al-Qaida in Yemen (AQY))` → `Al-Qaida in Yemen (AQY)`

```python
BRACKETED = re.compile(r"([(（][^\(\)]*[)）]|\[[^\[\]]*\])")

def parse_names(names: List[str]) -> List[str]:
    cleaned = []
    for name in names:
        name = re.sub(r"[(（]a\.k\.a\.?[:：]? ?", "", name)
        name = re.sub(r"[（(]original script[:：]\s*(.*?)[）)]", r"\1", name)
        name = re.sub(r"[（(]f.k.a.:\s*(.*?)[）)]", r"\1", name)
        name = name.replace("(previously listed as)", "").replace("(formerly listed as", "")
        name = name.replace("a.k.a., the following three aliases:", "")
        if name.count("(") == 0 and name.endswith(")"):
            name = name.rstrip(")")
        name = name.replace("))", ")").strip(" 、")
        cleaned.append(name)
        no_brackets = BRACKETED.sub(" ", name).strip()
        if no_brackets != name and len(no_brackets):
            cleaned.append(no_brackets)
    return cleaned
```

---

### 3. `datasets/si/conflicts/crawler.py`
#### **Enhancement:**
- Prevent adding an invalid source URL when `organization_number` is `None`.

```python
if registration_number and organization_number:
    legal_entity.add(
        "sourceUrl",
        f"https://erar.si/transakcija/placnik/{organization_number}/prejemnik/{registration_number}",
    )
```

---

### 4. `datasets/il/mod_crypto/crawler.py`
#### **Issue:**
- The condition `if wallet in d:` mistakenly checks for the `wallet` entity as a key instead of `wallet_id`.

#### **Fix:**
```python
if wallet_id in d:
    wallet.set("currency", d[wallet_id])
```

---

### 5. `datasets/us/cbp_forced_labor/crawler.py`
#### **Enhancement:**
- Remove unnecessary code.
- Handle cases where status note url contains multiple URLs in a vessel entity.

```python
for cell in cells:
    links = cell.findall(".//a")
    if links:
        link_urls = [link.get("href") for link in links]
        if (
            "status-notes" in row_data
            and cell.text_content().strip() == row_data["status-notes"]
        ):
            row_data["status_notes_link"] = link_urls
```

---

### 6. `datasets/us/de/med_exclusions/crawler.py`
#### **Enhancements:**
- Prevent adding `idNumber` from the `dea` field with value `-`.
- Handle `license number` fields containing multiple values separated by `,` or `;`.
- Manually map license numbers with uncommon formats (e.g., `LG0000537 L1-0036672 AN-0007759`).

---

### 7. `datasets/us/fincen_special_measures/crawler.py`
#### **Issue:**
- The incorrect key `final_rule` prevents the topic `sanction` from being added.

#### **Fix:**
```python
final_rule = collapse_spaces(row.get("final-rule", "").text_content().strip().lower())
rescinded_date = collapse_spaces(row.get("rescinded").text_content())
```

---

### 8. `datasets/us/az/med_exclusions/crawler.py`
#### **Enhancement:**
- The first row was previously missing from processing.

#### **Fix:**
```python
# concatenate contiguous manual-extraction rows
rows.append(items[0])
for i, item in enumerate(items[1:], 1):
    ...
```
