### PR TITLE
Disable verbose logging for pdfminer

### DIFF
--- a/zavod/zavod/__init__.py
+++ b/zavod/zavod/__init__.py
@@ -15,3 +15,4 @@ __all__ = [
 
 logging.getLogger("prefixdate").setLevel(logging.ERROR)
 logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+logging.getLogger("pdfminer").setLevel(logging.WARNING)


### PR DESCRIPTION
This makes --debug usable again for crawlers that parse PDFs. The logging is far too verbose, something like this:

> 2025-02-03 18:45:10 [debug    ] add_results: ((10444, /b'f'),) [pdfminer.psparser] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] nextobject: (10444, /b'f')     [pdfminer.psparser] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] exec: f                        [pdfminer.pdfinterp] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] nexttoken: (10446, 193.14)     [pdfminer.psparser] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] add_results: ((10446, 193.14),) [pdfminer.psparser] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] nextobject: (10446, 193.14)    [pdfminer.psparser] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] nexttoken: (10453, 50.94)      [pdfminer.psparser] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] add_results: ((10453, 50.94),) [pdfminer.psparser] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] nextobject: (10453, 50.94)     [pdfminer.psparser] dataset=us_ne_med_exclusions
> 2025-02-03 18:45:10 [debug    ] nexttoken: (10459, 0.48)       [pdfminer.psparser] dataset=us_ne_med_exclusions