### PR TITLE
[default] Allow default more than 25GB of disk space

### DIFF
--- a/datasets/_collections/default.yml
+++ b/datasets/_collections/default.yml
@@ -7,7 +7,7 @@ deploy:
   memory: "2000Mi"
   memory_limit: "2500Mi"
   cpu: "800m"
-  disk: "25Gi"
+  disk: "50Gi"
   command: /etl/scripts/export-default.sh
   premium: true
 exports:


### PR DESCRIPTION
A week ago we were using 24GB max and then we added a big dataset and improved enrichment