### PR TITLE
Minor test cleanup in test_validate to make it a bit nicer to read

### DIFF
--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -2,7 +2,6 @@ from typing import Type
 
 from structlog.testing import capture_logs
 
-from zavod.archive import clear_data_path
 from zavod.context import Context
 from zavod.crawl import crawl_dataset
 from zavod.integration import get_dataset_linker
@@ -32,88 +31,88 @@ def run_validator(clazz: Type[BaseValidator], dataset: Dataset):
 
     store.close()
     context.close()
-    return validator, cap_logs
+
+    cap_logs = [(log["log_level"], log["event"]) for log in cap_logs]
+    return validator, set(cap_logs)
 
 
 def test_dangling_references(testdataset3) -> None:
-    clear_data_path(testdataset3.name)
     crawl_dataset(testdataset3)
-    validator, cap_logs = run_validator(DanglingReferencesValidator, testdataset3)
+    validator, logs = run_validator(DanglingReferencesValidator, testdataset3)
 
-    logs = [f"{entry['log_level']}: {entry['event']}" for entry in cap_logs]
-    assert (
-        "warning: td3-child-of-nonexistent-co property parent references missing id td3-nonexistent-co"
-    ) in logs, logs
-    assert (
-        "warning: td3-asset-of-nonexistent-co-ownership-nonexistent-co property owner references missing id td3-nonexistent-co"
-    ) in logs, logs
-    assert len(logs) == 2, logs
+    assert logs == {
+        (
+            "warning",
+            "td3-child-of-nonexistent-co property parent references missing id td3-nonexistent-co",
+        ),
+        (
+            "warning",
+            "td3-asset-of-nonexistent-co-ownership-nonexistent-co property owner references missing id td3-nonexistent-co",
+        ),
+    }
     assert validator.abort is False
 
 
 def test_self_references(testdataset3) -> None:
-    clear_data_path(testdataset3.name)
     crawl_dataset(testdataset3)
-    validator, cap_logs = run_validator(SelfReferenceValidator, testdataset3)
+    validator, logs = run_validator(SelfReferenceValidator, testdataset3)
 
-    logs = [f"{entry['log_level']}: {entry['event']}" for entry in cap_logs]
-    assert (
-        "info: td3-owner-of-self-co references itself via ownershipOwner"
-        " -> td3-owner-of-self-co-ownership-owner-of-self-co -> asset"
-    ) in logs, logs
-    assert (
-        "info: td3-owner-of-self-co references itself via ownershipAsset"
-        " -> td3-owner-of-self-co-ownership-owner-of-self-co -> owner"
-    ) in logs, logs
-    assert len(logs) == 2, logs
+    assert logs == {
+        (
+            "info",
+            "td3-owner-of-self-co references itself via ownershipOwner -> td3-owner-of-self-co-ownership-owner-of-self-co -> asset",
+        ),
+        (
+            "info",
+            "td3-owner-of-self-co references itself via ownershipAsset -> td3-owner-of-self-co-ownership-owner-of-self-co -> owner",
+        ),
+    }
     assert validator.abort is False
 
 
 def test_assertions(testdataset3) -> None:
-    clear_data_path(testdataset3.name)
     crawl_dataset(testdataset3)
-    validator, cap_logs = run_validator(AssertionsValidator, testdataset3)
-
-    logs = [f"{entry['log_level']}: {entry['event']}" for entry in cap_logs]
+    validator, logs = run_validator(AssertionsValidator, testdataset3)
     assert (
-        "warning: Assertion failed for value 2: "
-        "<Assertion entity_count gte 3 filter: country=de>"
-    ) in logs, logs
+        "warning",
+        "Assertion failed for value 2: <Assertion entity_count gte 3 filter: country=de>",
+    ) in logs
     assert (
-        "warning: Assertion failed for value 2: "
-        "<Assertion entity_count lte 1 filter: country=de>"
-    ) in logs, logs
+        "warning",
+        "Assertion failed for value 2: <Assertion entity_count lte 1 filter: country=de>",
+    ) in logs
     assert (
-        "warning: Assertion failed for value 7: "
-        "<Assertion entity_count gte 10 filter: schema=Company>"
-    ) in logs, logs
+        "warning",
+        "Assertion failed for value 7: <Assertion entity_count gte 10 filter: schema=Company>",
+    ) in logs
     assert (
-        "warning: Assertion failed for value 6: <Assertion country_count gte 7>" in logs
-    ), logs
+        "warning",
+        "Assertion failed for value 6: <Assertion country_count gte 7>",
+    ) in logs
     assert (
-        "warning: Assertion failed for value 7: <Assertion entities_with_prop_count gte 11 filter: entities_with_prop=('Company', 'name')>"
-        in logs
-    ), logs
-    assert "error: One or more assertions failed." in logs, logs
+        "warning",
+        "Assertion failed for value 7: <Assertion entities_with_prop_count gte 11 filter: entities_with_prop=('Company', 'name')>",
+    ) in logs
+    assert ("error", "One or more assertions failed.") in logs
     assert validator.abort is True
 
 
 def test_no_assertions_warning(testdataset3: Dataset) -> None:
     testdataset3.assertions = []
     crawl_dataset(testdataset3)
-    validator, cap_logs = run_validator(AssertionsValidator, testdataset3)
-    assert {"log_level": "warning", "event": "Dataset has no assertions."} in cap_logs
+    validator, logs = run_validator(AssertionsValidator, testdataset3)
+    assert ("warning", "Dataset has no assertions.") in logs
 
 
-def test_empty(testdataset3) -> None:
-    clear_data_path(testdataset3.name)
+def test_not_empty_after_crawl(testdataset3) -> None:
     crawl_dataset(testdataset3)
-    validator, cap_logs = run_validator(EmptyValidator, testdataset3)
-    assert "No entities validated" not in str(cap_logs)
+    validator, logs = run_validator(EmptyValidator, testdataset3)
+    assert "No entities validated" not in str(logs)
     assert validator.abort is False
 
-    clear_data_path(testdataset3.name)
-    validator, cap_logs = run_validator(EmptyValidator, testdataset3)
-    logs = [f"{entry['log_level']}: {entry['event']}" for entry in cap_logs]
-    assert "warning: No entities validated." in logs, logs
+
+def test_no_crawl_is_empty(testdataset3) -> None:
+    # We don't crawl here so that no entities are emitted
+    validator, logs = run_validator(EmptyValidator, testdataset3)
+    assert ("warning", "No entities validated.") in logs
     assert validator.abort is False


### PR DESCRIPTION
We don't need to run clear_data_path every time, the wrapper in conftest.py already does that