### PR TITLE
[sk_rpvs] Fix some GLEIF codes

### DIFF
--- a/zavod/zavod/shed/bods.py
+++ b/zavod/zavod/shed/bods.py
@@ -47,6 +47,7 @@ SCHEME_PROPS = {
     "OpenOwnership Register": "sourceUrl",
     "OpenCorporates": "opencorporatesUrl",
     "Global Legal Entity Identifier Index": "leiCode",
+    "Global Legal Entity Identifier Index (2)": "leiCode",
     "Companies House": "registrationNumber",
 }
 


### PR DESCRIPTION
I noticed this while going through the KYB datasets with many issues. Currently, this is causing 3346 issues in sk_rpvs. I'm unsure why they introduced this different schema name. The schema type on these records is still XI-LEI, and they're valid LEI codes pointing to the right place in the GLEIF database. There is also no other LEI code on them, so this is not a second LEI code associated with the entity. Not sure what the suffix means :(