### PR TITLE
[cli] Add dataset context to CLI logs, even after Context teardown

### DIFF
--- a/zavod/zavod/cli.py
+++ b/zavod/zavod/cli.py
@@ -1,9 +1,9 @@
+import structlog
 import sys
 import click
 import logging
 from pathlib import Path
 from typing import Optional, List
-
 
 from followthemoney.cli.util import InPath, OutPath
 from nomenklatura.tui import dedupe_ui
@@ -39,6 +39,7 @@ def _load_dataset(path: Path) -> Dataset:
     dataset = load_dataset_from_path(path)
     if dataset is None:
         raise click.BadParameter("Invalid dataset path: %s" % path)
+    structlog.contextvars.bind_contextvars(dataset=dataset.name)
     return dataset
 
 

--- a/zavod/zavod/tests/runtime/test_issues.py
+++ b/zavod/zavod/tests/runtime/test_issues.py
@@ -49,3 +49,4 @@ def test_issue_logger(testdataset1: Dataset):
     context = Context(testdataset1)
     context.begin(clear=True)
     assert len(list(context.issues.all())) == 0
+    context.close()


### PR DESCRIPTION
It doesn't seem awful, but again, I'm using `global`, so not sure if I maybe should feel awful about this...