### PR TITLE
log.error for assertions that should abort

### DIFF
--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -74,7 +74,7 @@ def test_assertions(testdataset3) -> None:
     crawl_dataset(testdataset3)
     validator, logs = run_validator(AssertionsValidator, testdataset3)
     assert (
-        "warning",
+        "error",
         "Assertion failed for value 2: <Assertion entity_count gte 3 filter: country=de>",
     ) in logs
     assert (
@@ -82,18 +82,17 @@ def test_assertions(testdataset3) -> None:
         "Assertion failed for value 2: <Assertion entity_count lte 1 filter: country=de>",
     ) in logs
     assert (
-        "warning",
+        "error",
         "Assertion failed for value 7: <Assertion entity_count gte 10 filter: schema=Company>",
     ) in logs
     assert (
-        "warning",
+        "error",
         "Assertion failed for value 6: <Assertion country_count gte 7>",
     ) in logs
     assert (
-        "warning",
+        "error",
         "Assertion failed for value 7: <Assertion entities_with_prop_count gte 11 filter: entities_with_prop=('Company', 'name')>",
     ) in logs
-    assert ("error", "One or more assertions failed.") in logs
     assert validator.abort is True
 
 
@@ -121,7 +120,7 @@ def test_no_crawl_is_empty(testdataset3) -> None:
 def test_default_assertion_not_empty(testdataset2):
     validator, logs = run_validator(AssertionsValidator, testdataset2)
     assert (
-        "warning",
+        "error",
         "Assertion failed for value 0: <Assertion entity_count gte 1>",
     ) in logs
     assert validator.abort is True

--- a/zavod/zavod/validators/assertions.py
+++ b/zavod/zavod/validators/assertions.py
@@ -64,11 +64,12 @@ def check_assertion(
 ) -> bool:
     """Returns true if the assertion is valid, false otherwise."""
     value = get_value(stats, assertion)
+    log_fn = context.log.error if assertion.abort else context.log.warning
     if value is None:
-        context.log.warning(f"Value not found for assertion {assertion}")
+        log_fn(f"Value not found for assertion {assertion}")
         return False
     if not compare_threshold(value, assertion.comparison, assertion.threshold):
-        context.log.warning(f"Assertion failed for value {value}: {assertion}")
+        log_fn(f"Assertion failed for value {value}: {assertion}")
         return False
     return True
 
@@ -91,6 +92,3 @@ class AssertionsValidator(BaseValidator):
         for assertion in self.context.dataset.assertions:
             if not check_assertion(self.context, self.stats.as_dict(), assertion):
                 self.abort = self.abort or assertion.abort
-
-        if self.abort:
-            self.context.log.error("One or more assertions failed.")


### PR DESCRIPTION
Also, get rid of "At least one assertion failed", it's just another item in Sentry.

Also consider this a test case for [d0e603a0](https://github.com/opensanctions/opensanctions/commit/d0e603a0c7b2525ad4cb8c71424fd25511018fba) :)