### PR TITLE
Some Entity.emit(target=) cleanups

### DIFF
--- a/contrib/peppercat/wd_peppercat.py
+++ b/contrib/peppercat/wd_peppercat.py
@@ -24,4 +24,4 @@ def crawl(context: Context):
             entity.add("name", row.get("person"))
             entity.add("topics", "role.pep")
             entity.add("country", country)
-            context.emit(entity, target=True)
+            context.emit(entity)

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -174,7 +174,7 @@ for role in person_data.pop("roles"):
 
 if pep_entities:
     person.add("topics", "role.pep")
-    context.emit(person, target=True)
+    context.emit(person)
 for entity in pep_entities:
     context.emit(entity)
 ```

--- a/zavod/docs/tutorial.md
+++ b/zavod/docs/tutorial.md
@@ -186,7 +186,7 @@ def crawl(context):
     entity.add('deathDate', 'never')
     
     # Store or update the entity in the database:
-    context.emit(entity, target=True)
+    context.emit(entity)
 ```
 
 The [entity object][zavod.entity.Entity] is based on the [entity proxy in FollowTheMoney](https://followthemoney.tech/reference/python/followthemoney/proxy.html#EntityProxy), so we suggest you also check out the [FtM documentation](https://followthemoney.tech/docs/api/) on entity construction. Some additional utility methods are added in the [`Entity`][zavod.entity.Entity] class in `zavod`.

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -539,8 +539,6 @@ class Context:
             self.log.error("Entity has no properties", entity=entity)
             return
         self.stats.entities += 1
-        if target:
-            self.stats.targets += 1
         if self.stats.entities % 10000 == 0:
             self.log.info(
                 "Emitted %s entities" % self.stats.entities,

--- a/zavod/zavod/runtime/stats.py
+++ b/zavod/zavod/runtime/stats.py
@@ -12,4 +12,3 @@ class ContextStats(object):
         self.statements = 0
         self.changed = 0
         self.entities = 0
-        self.targets = 0

--- a/zavod/zavod/tests/fixtures/testdataset1/dataset.csv
+++ b/zavod/zavod/tests/fixtures/testdataset1/dataset.csv
@@ -1,9 +1,9 @@
-id,type,name,alias,notes,dob,country,id_number,rel_type,rel_other,rel_start,rel_end,rel_summary,city,street,postal_code,topics,target
-mierscheid,Person,Jakob Maria Mierscheid,Jakob Mierscheid,Fictional parliamentarian,1933-03-01,Germany,DE1234,Membership,spd,1979,,MdB,,,,role.pep,true
-spd,Organization,Sozialdemokratische Partei Deutschlands,,,,Germany,,,,,,,,,,pol.party,false
-john-doe,Person,John Doe,,,1975,United States,,Family,jane-doe,2003,,Spouse,,,,poi,true
-jane-doe,Person,Jane Doe,Jane Smith,,1972,Paraguay,,,,,,,,,,poi,true
-hans-gruber,Person,Hans Gruber,Bill Clay,Freedom fighter,1978-09-25,East Germany,,,,,,,Dresden,Lauensteiner Str. 49,01277,crime.boss,true
-umbrella-corp,Company,Umbrella Corporation,"Umbrella Pharmaceuticals, Inc. ",,1980,United States,8723-BX,,,,,,,,,reg.warn,true
-oswell-spencer,Person,Oswell E. Spencer,Ozwell E. Spencer; オズウェル,,1923,Japan,,Ownership,umbrella-corp,1968,2003,Founder,,,,crime.boss,true
-johnny-does,Person,Johnny Doe,John Ignatius Doe,,1975,Canada,,Family,oswell-spencer,,,,,,,,false
+id,type,name,alias,notes,dob,country,id_number,rel_type,rel_other,rel_start,rel_end,rel_summary,city,street,postal_code,topics
+mierscheid,Person,Jakob Maria Mierscheid,Jakob Mierscheid,Fictional parliamentarian,1933-03-01,Germany,DE1234,Membership,spd,1979,,MdB,,,,role.pep
+spd,Organization,Sozialdemokratische Partei Deutschlands,,,,Germany,,,,,,,,,,pol.party
+john-doe,Person,John Doe,,,1975,United States,,Family,jane-doe,2003,,Spouse,,,,poi
+jane-doe,Person,Jane Doe,Jane Smith,,1972,Paraguay,,,,,,,,,,poi
+hans-gruber,Person,Hans Gruber,Bill Clay,Freedom fighter,1978-09-25,East Germany,,,,,,,Dresden,Lauensteiner Str. 49,01277,crime.boss
+umbrella-corp,Company,Umbrella Corporation,"Umbrella Pharmaceuticals, Inc. ",,1980,United States,8723-BX,,,,,,,,,reg.warn
+oswell-spencer,Person,Oswell E. Spencer,Ozwell E. Spencer; オズウェル,,1923,Japan,,Ownership,umbrella-corp,1968,2003,Founder,,,,crime.boss
+johnny-does,Person,Johnny Doe,John Ignatius Doe,,1975,Canada,,Family,oswell-spencer,,,,,,,

--- a/zavod/zavod/tests/fixtures/testdataset1/testentrypoint1.py
+++ b/zavod/zavod/tests/fixtures/testdataset1/testentrypoint1.py
@@ -48,9 +48,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
         rel.add(rel.schema.target_prop, other_id)
         context.emit(rel)
 
-    is_target = row.pop("target") == "true"
-
-    context.emit(entity, target=is_target)
+    context.emit(entity)
     context.audit_data(row)
 
 

--- a/zavod/zavod/tests/fixtures/testdataset2/testentrypoint2.py
+++ b/zavod/zavod/tests/fixtures/testdataset2/testentrypoint2.py
@@ -14,7 +14,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
     name = row.pop("name")
     person.id = context.make_slug(name)
     person.add("name", name)
-    context.emit(person, target=True)
+    context.emit(person)
 
     position = h.make_position(
         context, name=row.pop("position"), country=row.pop("country").split(",")

--- a/zavod/zavod/tests/fixtures/testdataset3/dataset.csv
+++ b/zavod/zavod/tests/fixtures/testdataset3/dataset.csv
@@ -1,8 +1,8 @@
-id,country,name,parent_id,owner_id,topics,is_target
-parent-of-another-co,de,Parent of another co,,,,false
-owner-of-self-co,de,Owner of self co,,owner-of-self-co,sanction,true
-owner-of-another-co,hu,Owner of another co,,,,false
-asset-of-another-co,gb,Asset of another co,,owner-of-another-co,sanction,true
-child-of-nonexistent-co,fr,Child of nonexistent co,nonexistent-co,,sanction,true
-asset-of-nonexistent-co,cn,Asset of nonexistent co,,nonexistent-co,sanction,true
-target-no-topic-co,ls,Target no topic co,,,,true
+id,country,name,parent_id,owner_id,topics
+parent-of-another-co,de,Parent of another co,,,
+owner-of-self-co,de,Owner of self co,,owner-of-self-co,sanction
+owner-of-another-co,hu,Owner of another co,,,
+asset-of-another-co,gb,Asset of another co,,owner-of-another-co,sanction
+child-of-nonexistent-co,fr,Child of nonexistent co,nonexistent-co,,sanction
+asset-of-nonexistent-co,cn,Asset of nonexistent co,,nonexistent-co,sanction
+target-no-topic-co,ls,Target no topic co,,,

--- a/zavod/zavod/tests/fixtures/testdataset3/testentrypoint3.py
+++ b/zavod/zavod/tests/fixtures/testdataset3/testentrypoint3.py
@@ -24,7 +24,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
         ownership.add("asset", entity)
         ownership.add("owner", context.make_slug(owner_id))
         context.emit(ownership)
-    context.emit(entity, target=row.pop("is_target") == "true")
+    context.emit(entity)
     context.audit_data(row)
 
 

--- a/zavod/zavod/tests/fixtures/testdataset_securities/testentrypoint_securities.py
+++ b/zavod/zavod/tests/fixtures/testdataset_securities/testentrypoint_securities.py
@@ -17,7 +17,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
     if issuer := row.pop("issuer"):
         entity.add("issuer", issuer)
 
-    context.emit(entity, target=row.pop("is_target"))
+    context.emit(entity)
     context.audit_data(row)
 
 

--- a/zavod/zavod/tests/runtime/test_resources.py
+++ b/zavod/zavod/tests/runtime/test_resources.py
@@ -26,7 +26,7 @@ def test_resources(testdataset1: Dataset):
     assert resource.size is not None
     assert resource.size > 0
     assert (
-        resource.checksum == "9c429ffa8588f5a98a0104ead60d5c87b98a777a"
+        resource.checksum == "b7ab865f0112bd9d24c19e3f1ccc8124835ed46a"
     ), resource_path
 
     resources.save(resource)

--- a/zavod/zavod/tests/runtime/test_sink.py
+++ b/zavod/zavod/tests/runtime/test_sink.py
@@ -12,7 +12,7 @@ def test_dataset_sink(testdataset1: Dataset):
     entity = context.make("Person")
     entity.id = "foo"
     entity.add("name", "Foo")
-    context.emit(entity, target=True)
+    context.emit(entity)
     context.sink.close()
     assert context.sink.path.is_file()
     with open(context.sink.path, "rb") as fh:


### PR DESCRIPTION
I'm done for the day and this is a braindead activity that I started last week while in a similar state :)

- **Remove use of target arg in Context.emit() in docs**
- **Remove use of target arg in Context.emit in various other places**
- **Remove use of target arg in Context.emit in tests**
- **[rupep] Remove use of target in context.emit**
- **Remove ContextStats.targets, which seems to be unused**
