### PR TITLE
More Sentry-compatible logging when crawl experiences HTTP errors

### DIFF
--- a/zavod/zavod/crawl.py
+++ b/zavod/zavod/crawl.py
@@ -51,14 +51,19 @@ def crawl_dataset(dataset: Dataset, dry_run: bool = False) -> ContextStats:
     except RequestException as rexc:
         url = rexc.request.url if rexc.request else None
         if rexc.response is not None:
-            context.log.error(
-                str(rexc),
+            context.log.exception(
+                f"Runner failed with {type(rexc).__name__} on {url}",
+                error_str=str(rexc),
                 url=url,
                 response_code=rexc.response.status_code,
                 response_text=rexc.response.text,
             )
         else:
-            context.log.error(str(rexc), url=url)
+            context.log.exception(
+                f"Runner failed with {type(rexc).__name__}",
+                error_str=str(rexc),
+                url=url,
+            )
         raise RunFailedException() from rexc
     except Exception as exc:
         context.log.exception("Runner failed: %s" % str(exc))


### PR DESCRIPTION
Using log.exception transmits the exception to Sentry. Only put the type
name (instead of the full object repr, which includes the memory
address) in the log message to get a nicer message in the issues
overview
