### PR TITLE
Set Sentry "Transaction Name" to current dataset name

### DIFF
--- a/zavod/zavod/cli.py
+++ b/zavod/zavod/cli.py
@@ -1,4 +1,3 @@
-import structlog
 import sys
 import click
 import logging
@@ -11,7 +10,12 @@ from nomenklatura.statement import CSV, FORMATS
 from nomenklatura.matching import DefaultAlgorithm
 
 from zavod import settings
-from zavod.logs import configure_logging, get_logger, configure_sentry_integration
+from zavod.logs import (
+    configure_logging,
+    get_logger,
+    configure_sentry_integration,
+    set_sentry_dataset_name,
+)
 from zavod.meta import load_dataset_from_path, get_multi_dataset, Dataset
 from zavod.crawl import crawl_dataset
 from zavod.store import get_store
@@ -39,7 +43,7 @@ def _load_dataset(path: Path) -> Dataset:
     dataset = load_dataset_from_path(path)
     if dataset is None:
         raise click.BadParameter("Invalid dataset path: %s" % path)
-    structlog.contextvars.bind_contextvars(dataset=dataset.name)
+    set_sentry_dataset_name(dataset.name)
     return dataset
 
 

--- a/zavod/zavod/logs.py
+++ b/zavod/zavod/logs.py
@@ -125,6 +125,12 @@ def configure_sentry_integration() -> None:
         )
 
 
+def set_sentry_dataset_name(dataset_name: str) -> None:
+    structlog.contextvars.bind_contextvars(dataset=dataset_name)
+    # A Transaction in Sentry parlance is the "current task being executed"
+    sentry_sdk.get_current_scope().set_transaction_name(dataset_name)
+
+
 def set_sentry_event_level(level: int) -> None:
     """Set the level above which events are sent to Sentry."""
     if _sentry_processor is not None:


### PR DESCRIPTION
https://docs.sentry.io/platforms/python/enriching-events/transaction-name/

> The transaction name can reference the current web app route, or the current task being executed.

Maybe the right thing to do here is actually to set `[dataset_name].crawl` as the transaction? But not sure how much that actually helps our cause, and this is a one-liner that doesn't litter our code everywhere.