### PR TITLE
Script loading resolver backup locally

### DIFF
--- a/contrib/load_resolver.sh
+++ b/contrib/load_resolver.sh
@@ -1,0 +1,14 @@
+set -euo pipefail
+
+JSON_PATH=data/resolve.ijson
+SQLITE_PATH=data/resolver.sqlite3
+
+echo "Deleting old resolver data ($JSON_PATH, $SQLITE_PATH)"
+rm -f $JSON_PATH $SQLITE_PATH
+gcloud storage cp gs://resolver-backups.opensanctions.org/resolve.ijson $JSON_PATH
+
+echo "Loading resolver data from $JSON_PATH"
+export NOMENKLATURA_DB_URL=sqlite:///$SQLITE_PATH
+nomenklatura load-resolver $JSON_PATH
+
+echo "Resolver loaded to $NOMENKLATURA_DB_URL"

--- a/zavod/zavod/integration/dedupe.py
+++ b/zavod/zavod/integration/dedupe.py
@@ -22,7 +22,7 @@ AUTO_USER = "zavod/xref"
 WARNED_EPHEMERAL = False
 EPHEMERAL_WARNING = (
     "No database URI configured."
-    " If you want deduplication to be persistent, set DATABASE_URI."
+    " If you want deduplication to be persistent, set ZAVOD_DATABASE_URI."
 )
 
 


### PR DESCRIPTION
I hate writing the env var in the app code away from where it's read and saved to a shortened form. But. Meh. I also don't love adding a ton of logic to ensure it stays in sync.