### PR TITLE
[logs] Fix logging to issues

### DIFF
--- a/zavod/zavod/tests/test_logs.py
+++ b/zavod/zavod/tests/test_logs.py
@@ -87,7 +87,10 @@ def test_redacts_issue_logger(testdataset1: Dataset):
     context.begin(clear=True)
     assert not issues_path.exists()
 
-    context.log.warn("This is a warning to correcthorsebatterystaple")
+    context.log.warn(
+        "This is a warning to correcthorsebatterystaple",
+        extra="correcthorsebatterystaple",
+    )
     # Non-structlog logs take a slightly different path
     logging.warning("This is a python logging warning to correcthorsebatterystaple")
     context.close()


### PR DESCRIPTION
The issue was that format_json would move level -> severity in the event dict and subsequently let issues_log error out.

The comment in there about any of these processors performing stringifcation (which made me not touch it previously) is a lie. Non-str objects in the log dict simply won't be redacted. This commit doesn't fix that, but doesn't change it either

I feel this thing is up for a bit of a refactor. Some of the stuff in there (like the database URI redaction) is a bit scary.