### PR TITLE
Pin third-party actions to a SHA as recommended by GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,8 @@ jobs:
     needs: [docker, python]
     steps:
       - name: Dispatch add-on build
-        uses: peter-evans/repository-dispatch@v3
+        # pinned to v3.0.0
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0
         with:
           token: ${{ secrets.OPERATIONS_PAT }}
           repository: opensanctions/operations

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,8 @@ jobs:
           python3 -m build --wheel
       - name: Get any modified dataset files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        # pinned v46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         with:
           files: "datasets/**"
       - name: Crawl modified datasets

--- a/.github/workflows/lint_crawlers.yml
+++ b/.github/workflows/lint_crawlers.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get modified dataset yamls
         id: changed-yamls
-        uses: tj-actions/changed-files@v46
+        # pinned v46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         with:
           files: 'datasets/**/*.y*ml'
       - name: Lint modiied dataset yamls
@@ -21,7 +22,8 @@ jobs:
           yamllint ${{ steps.changed-yamls.outputs.all_changed_files }}
       - name: Get modified dataset python
         id: changed-python
-        uses: tj-actions/changed-files@v46
+        # pinned v46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         with:
           files: 'datasets/**/*.py'
       - uses: actions/setup-python@v5


### PR DESCRIPTION
- **Pin tj-actions/changed-files action to specific SHA**
- **Pin peter-evans/repository-dispatch action to specific SHA**

See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses

> Using the commit SHA of a released action version is the safest for stability and security.

Also https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
