### PR TITLE
Temporarily disable pip isolation and pin setuptools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,12 @@ jobs:
       - name: Install zavod dependencies
         working-directory: zavod
         run: |
-          python -m pip install --upgrade setuptools==77.0.3
-          python -m pip install --upgrade pip wheel pyicu==2.14
-          pip install --no-cache-dir -q -e ".[dev]"
+          # --no-build-isolation needed to control setuptools version while figuring out
+          # what's incompatible with setuptools 78 (no more hyphen setup.cfg keys)
+          # That means we're responsible for build dependencies.
+          python -m pip install pip "setuptools<78" wheel hatchling editables
+          python -m pip install --no-build-isolation --upgrade wheel pyicu==2.14
+          pip install --no-build-isolation --no-cache-dir -q -e ".[dev]"
       - name: Check zavod type annotations (strict)
         working-directory: zavod
         run: |

--- a/.github/workflows/check_eu_journal.yml
+++ b/.github/workflows/check_eu_journal.yml
@@ -17,8 +17,11 @@ jobs:
           cache: "pip"
       - name: Install zavod
         run: |
-          pip install setuptools==77.0.3 wheel
-          pip install --no-cache-dir -q -e "zavod[dev]"
+          # --no-build-isolation needed to control setuptools version while figuring out
+          # what's incompatible with setuptools 78 (no more hyphen setup.cfg keys)
+          # That means we're responsible for build dependencies.
+          python -m pip install "setuptools<78" wheel hatchling editables
+          pip install --no-build-isolation --no-cache-dir -q -e "zavod[dev]"
           pip install zeep==4.2.1
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,9 +32,12 @@ jobs:
       - name: Install requirements
         working-directory: zavod
         run: |
-          python -m pip install --upgrade pip setuptools==77.0.3
-          pip install --no-cache-dir -q -e ".[dev]"
-          pip install --no-cache-dir -q -e ".[docs]"
+          # --no-build-isolation needed to control setuptools version while figuring out
+          # what's incompatible with setuptools 78 (no more hyphen setup.cfg keys)
+          # That means we're responsible for build dependencies.
+          python -m pip install "setuptools<78" wheel hatchling editables
+          pip install --no-build-isolation --no-cache-dir -q -e ".[dev]"
+          pip install --no-build-isolation --no-cache-dir -q -e ".[docs]"
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ RUN pip3 install --no-cache-dir -U pip
 RUN pip3 install --no-cache-dir -U "pyicu==2.14"
 
 COPY zavod /opensanctions/zavod
-RUN pip install --no-cache-dir -e /opensanctions/zavod
+# --no-build-isolation needed to control setuptools version while figuring out
+# what's incompatible with setuptools 78 (no more hyphen setup.cfg keys)
+# That means we're responsible for build dependencies.
+RUN pip install "setuptools<78" wheel hatchling editables
+RUN pip install --no-build-isolation --no-cache-dir -e /opensanctions/zavod
 WORKDIR /opensanctions
 
 # ----------------------------------------------------------------------------------------
@@ -55,7 +59,11 @@ RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 COPY --from=build /venv /venv
 ENV PATH="/venv/bin:$PATH"
 COPY . /opensanctions
-RUN pip install --no-cache-dir -e /opensanctions/zavod
+# --no-build-isolation needed to control setuptools version while figuring out
+# what's incompatible with setuptools 78 (no more hyphen setup.cfg keys)
+# That means we're responsible for build dependencies.
+RUN pip install "setuptools<78" wheel hatchling editables
+RUN pip install --no-build-isolation --no-cache-dir -e /opensanctions/zavod
 WORKDIR /opensanctions
 
 CMD ["zavod"]


### PR DESCRIPTION
This should get us building again, but let's see if we can pin (haha) down the culprit and fix before merging this)