### PR TITLE
Reduce eu journal jobs to manage quota

### DIFF
--- a/.github/workflows/check_eu_journal.yml
+++ b/.github/workflows/check_eu_journal.yml
@@ -3,7 +3,7 @@ name: eu-journal
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "15 6,8,9,10,12,14,16,18,20 * * *"
+    - cron: "15 6,8,9,10,12,14,16,18 * * *"
 
 jobs:
   check_eu_journal:


### PR DESCRIPTION
As the amount of legislation has increased, we're now making more requests than our quota allows, so I'm dropping the 'late night' job - it's erroring out and just noise at the moment.