### PR TITLE
[regulatory] Make frequency metadata match reality (weekly -> daily)

### DIFF
--- a/datasets/_collections/regulatory.yml
+++ b/datasets/_collections/regulatory.yml
@@ -3,7 +3,8 @@ title: Regulatory Watchlists
 coverage:
   start: "2024-07-01"
   schedule: "0 */8 * * *"
-  frequency: weekly
+  # schedule trumps frequency, but we should frequency on the website collections overview table
+  frequency: daily
 deploy:
   memory: "1500Mi"
 summary: >


### PR DESCRIPTION
schedule trumps frequency anyway, but we show frequency in the overview
table
