### PR TITLE
[regulatory] schedule trumps frequency, so delete schedule to match intention

### DIFF
--- a/datasets/_collections/regulatory.yml
+++ b/datasets/_collections/regulatory.yml
@@ -2,8 +2,7 @@ type: collection
 title: Regulatory Watchlists
 coverage:
   start: "2024-07-01"
-  schedule: "0 */8 * * *"
-  frequency: weekly
+  frequency: daily
 deploy:
   memory: "1500Mi"
 summary: >


### PR DESCRIPTION
See https://github.com/opensanctions/opensanctions/commit/3aeefb8f0a, the intention seems to have been to make it run weekly.
