### PR TITLE
Warn to avoid duplication between FSF and Journal Sheet

### DIFF
--- a/datasets/eu/journal_sanctions/crawler.py
+++ b/datasets/eu/journal_sanctions/crawler.py
@@ -17,7 +17,7 @@ def crawl_row(
     country = row.pop("Country").strip()
     reg_number = row.pop("registrationNumber").strip()
 
-    context.log.info(f"Processing row ID {row_id}: {name}")
+    context.log.info(f"Processing row #{row_idx}: {name}")
     entity = context.make(entity_type)
     entity.id = context.make_id(row_id, name, country)
     context.log.debug(f"Unique ID {entity.id}")


### PR DESCRIPTION
This is so that we don't end up with lots of duplicate but unmanaged information in the journal sheet. 