### PR TITLE
[us_tn_med_exclusions] Switch to zyte with geolocation US

### DIFF
--- a/datasets/us/tn/med_exclusions/crawler.py
+++ b/datasets/us/tn/med_exclusions/crawler.py
@@ -1,8 +1,11 @@
 from zavod import Context, helpers as h
+from zavod.shed import zyte_api
 
 
 def crawl(context: Context) -> None:
-    data = context.fetch_json(context.data_url)
+    data = zyte_api.fetch_json(
+        context, context.data_url, expected_charset=None, geolocation="us"
+    )
     for row in data["data"]:
         first_name = row.pop("First Name")
         last_name = row.pop("Last Name")


### PR DESCRIPTION
They're doing DNS-based geofencing, which I haven't seen before. I
haven't fully understood what is happening. When connecting to a VPN in
the US, I can resolve www.tn.gov fine, but I get different opinions:

```
$ dig a www.tn.gov @1.1.1.1 +short
www.extglb.tn.gov.
170.141.165.146

$ dig a www.tn.gov @8.8.8.8 +short
198.18.1.187
```

Doing the same from Europe:

```
$ dig a www.tn.gov @8.8.8.8
[...]
; OPT=15: 00 17 4e 6f 20 72 65 73 70 6f 6e 73 65 20 72 65 63 65 69 76 65 64 20 66 72 6f 6d 20 6e 61 6d 65 20 73 65 72 76 65 72 73 20 66 6f 72 20 65 78 74 67 6c 62 2e 74 6e 2e 67 6f 76 ("..No response received from name servers for extglb.tn.gov")
```

Using a DNS resolver in the US from Europe:

```
$ dig a www.tn.gov @88.198.92.222
[...]
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 61346
[...]
;; QUESTION SECTION:
;www.tn.gov.			IN	A

;; ANSWER SECTION:
www.tn.gov.		270	IN	CNAME	www.extglb.tn.gov.
```

Weirdly enough, using 88.198.92.222, which I think is in the US and not
an Anycast IP, I get differen results looking up www.extglb.tn.gov. from
Europe vs. US, which is... weird? DNS does not have a Referrer header,
right? Or is NordVPN messing with my DNS queries?

Anyway, this fixes it. Happy for any thoughts.
