### PR TITLE
Prefer designationDate for sanction start date

### DIFF
--- a/zavod/zavod/shed/fsf.py
+++ b/zavod/zavod/shed/fsf.py
@@ -74,9 +74,21 @@ def parse_sanctions(context: Context, entity: Entity, entry: Element) -> None:
         )
         sanction.set("sourceUrl", url)
         sanction.add("reason", regulation.get("numberTitle"))
-        sanction.add("startDate", regulation.get("entryIntoForceDate"))
+
+        # Sometimes the entity tag doesn't have a designationDate,
+        # and the regulation date is the correct start date.
+        # Sometimes the referenced regulation is an amendment,
+        # not the original regulation introducing the entity.
+        # In case both exist, use the earliest date.
+        start_dates = [
+            entry.get("designationDate"),
+            regulation.get("entryIntoForceDate"),
+        ]
+        start_date = min([d for d in start_dates if d is not None])
+        sanction.add("startDate", start_date)
+
         sanction.add("listingDate", regulation.get("publicationDate"))
-        entity.add("createdAt", regulation.get("publicationDate"))
+        entity.add("modifiedAt", regulation.get("entryIntoForceDate"))
         sanction.add("unscId", entry.get("unitedNationId"))
         sanction.add("authorityId", entry.get("euReferenceNumber"))
         context.emit(sanction)


### PR DESCRIPTION
Also use entryIntoForceDate for sanction modifiedAt replacing entity createdAt.

Fixes #2240 

Sometimes the referenced regulation is an amendment, not the original regulation introducing the entity.

Sometimes the entity tag doesn't have a designationDate, then and the regulation date is the correct start date.

![image](https://github.com/user-attachments/assets/d15c1616-1a42-44eb-bddf-1781e08d292d)
