### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint_crawlers.yml
+++ b/.github/workflows/lint_crawlers.yml
@@ -1,4 +1,6 @@
 name: lint_crawlers
+permissions:
+  contents: read
 
 on:
   - push


### PR DESCRIPTION
Potential fix for [https://github.com/opensanctions/opensanctions/security/code-scanning/18](https://github.com/opensanctions/opensanctions/security/code-scanning/18)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Since this workflow only performs linting operations, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read repository contents without granting unnecessary write access.

The `permissions` block should be added at the top level of the workflow file, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
