### PR TITLE
Validate prefix for type safety

### DIFF
--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -32,7 +32,9 @@ class Dataset(NKDataset):
                 dataset=self.name,
                 summary=self.summary,
             )
-        self.prefix: str = data.get("prefix", slugify(self.name, sep="-")).strip()
+        prefix = data.get("prefix", slugify(self.name, sep="-"))
+        assert isinstance(prefix, str), "Dataset prefix must be a string"
+        self.prefix: str = prefix.strip()
         assert self.prefix == slugify(self.prefix, sep="-"), (
             "Dataset prefix is invalid: %s" % self.prefix
         )
@@ -79,7 +81,7 @@ class Dataset(NKDataset):
         )
         """
         List of assertions which should be considered warnings if they fail.
-        
+
         Configured as follows:
 
         ```yaml


### PR DESCRIPTION
I think failing loudly here is nicer than massaging probably a mistake in a metadata edit into a string prefix, perhaps rekeying a dataset unintentionally

https://github.com/python/mypy/blob/master/CHANGELOG.md#stricter-type-checking-with-imprecise-types