### PR TITLE
Add a manual_check field to the yml

### DIFF
--- a/datasets/_global/gem_energy_ownership/gem_energy_ownership.yml
+++ b/datasets/_global/gem_energy_ownership/gem_energy_ownership.yml
@@ -6,8 +6,9 @@ coverage:
   start: 2024-09-23
   end: 2024-06-30
 manual_check:
-  last_checked: "2024-09-23"
-  interval: 30
+  last_checked: "2025-04-01"
+  interval: 90
+  message: Please inquire with Global Energy Monitor to check whether any new data has been added to the Global Energy Ownership Tracker.
 deploy:
   schedule: "@monthly"
 exports:

--- a/datasets/cn/sanctions/cn_sanctions.yml
+++ b/datasets/cn/sanctions/cn_sanctions.yml
@@ -4,6 +4,10 @@ prefix: cn-sanc
 coverage:
   frequency: never
   start: 2024-03-08
+manual_check:
+  last_checked: "2025-06-20"
+  interval: 45
+  message: Please do a quick research to find out whether the Chinese government has introduced any new sanctions.
 deploy:
   schedule: "30 6 * * *"
 load_statements: true

--- a/datasets/ir/sanctions/ir_sanctions.yml
+++ b/datasets/ir/sanctions/ir_sanctions.yml
@@ -5,6 +5,10 @@ coverage:
   frequency: never
   start: "2024-05-02"
   end: "2025-05-23"
+manual_check:
+  last_checked: "2025-06-20"
+  interval: 30
+  message: Please check the website for any updates to the sanctions list.
 deploy:
   schedule: "@monthly"
 load_statements: true

--- a/datasets/us/special_leg/us_special_leg.yml
+++ b/datasets/us/special_leg/us_special_leg.yml
@@ -1,6 +1,10 @@
 title: "US Special Legislative Exclusions"
 entry_point: crawler.py
 prefix: us-leg
+manual_check:
+  last_check: 2025-06-20
+  interval: 90
+  message: Please check whether any amendments have been made to the legislation listed in this dataset.
 coverage:
   frequency: never
   schedule: "@monthly"
@@ -36,9 +40,9 @@ description: |
   Processes or Institutions, Significant Corruption, or Obstruction of Investigations Into 
   Such Acts of Corruption in El Salvador, Guatemala, Honduras, and Nicaragua. 
 
-  Since the December 2023 expiration of the Section 353 sanctions authority, individuals 
-  designated under the act have been eligible to apply for new visas.
-  [Source: Congressional Research Service](https://crsreports.congress.gov/product/pdf/IF/IF12486#:~:text=117%2D54)%2C%20requires%20the,into%20such%20acts%20of%20corruption%2C%20requires%20the,into%20such%20acts%20of%20corruption))
+  Since the December 2023 expiration of the Section 353 sanctions authority, individuals
+  designated under the [act](https://www.state.gov/reports/section-353-corrupt-and-undemocratic-actors-report/) have been eligible to apply for new visas.
+  [Source: Congressional Research Service](https://www.congress.gov/crs-product/IF12486)
 
   Section 154 of the [National Defense Authorization Act for Fiscal Year 2024 (Public Law 118-31)](https://www.congress.gov/118/plaws/publ31/PLAW-118publ31.pdf)
   prohibits the Department of Defense, beginning October 1, 2027, from obligating or expending 

--- a/datasets/us/special_leg/us_special_leg.yml
+++ b/datasets/us/special_leg/us_special_leg.yml
@@ -2,7 +2,7 @@ title: "US Special Legislative Exclusions"
 entry_point: crawler.py
 prefix: us-leg
 manual_check:
-  last_check: 2025-06-20
+  last_check: "2025-06-20"
   interval: 90
   message: Please check whether any amendments have been made to the legislation listed in this dataset.
 coverage:


### PR DESCRIPTION
we might still want to cover `iadb_sanctions` (if[ 2413 ](https://github.com/opensanctions/opensanctions/pull/2413) is not robust enough) and `ph_most_wanted` (we need to check if we can implement the hash check there (in progress)) 


UPD: 
- `iadb_sanctions` crawler was covered in a separate PR ([ 2413 ](https://github.com/opensanctions/opensanctions/pull/2413))
- `ph_most_wanted` was updated in  [2416](https://github.com/opensanctions/opensanctions/pull/2414)