### PR TITLE
Handle unicode length behaviour in name simplification

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "nomenklatura[leveldb] == 3.17.4",
     "countrynames >= 1.16.10, < 2.0",
     "plyvel == 1.5.1",
-    "rigour == 0.13.0",
+    "rigour == 0.14.1",
     "datapatch >= 1.1,< 1.3",
     "fingerprints == 1.2.*",
     "certifi",

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "nomenklatura[leveldb] == 3.17.4",
     "countrynames >= 1.16.10, < 2.0",
     "plyvel == 1.5.1",
-    "rigour == 0.14.1",
+    "rigour == 0.14.2",
     "datapatch >= 1.1,< 1.3",
     "fingerprints == 1.2.*",
     "certifi",

--- a/zavod/zavod/exporters/fragment.py
+++ b/zavod/zavod/exporters/fragment.py
@@ -58,10 +58,9 @@ class ViewFragment(View[Dataset, Entity]):
                 yield prop, entity
 
             if len(self._inverted[id]) > self.MAX_BUFFER:
-                log.warning(
-                    "Adjacency list for %s is greater than buffer limit (%d entries)",
-                    id,
-                    len(self._inverted[id]),
+                log.debug(
+                    "Adjacency list for %s is greater than buffer limit (%d entries)"
+                    % (id, len(self._inverted[id])),
                 )
 
     def entities(self) -> Generator[Entity, None, None]:


### PR DESCRIPTION
We weren't prepared for the fact that two strings can have different lengths if they are lowercased. This is now being handled as a warning: 

```
2025-07-02 10:35:10 [warning  ] Failed to pick case: Names mismatch: 'AHMET ŞAHİN' vs 'Ahmet Şahi̇n' [rigour.names.pick] dataset=default
2025-07-02 10:35:10 [warning  ] Failed to pick case: Names mismatch: 'ORHAN GEDİK' vs 'Orhan Gedi̇k' [rigour.names.pick] dataset=default
2025-07-02 10:35:10 [warning  ] Failed to pick case: Names mismatch: 'Hamza SEVİNÇ' vs 'Hamza Sevi̇nç' [rigour.names.pick] dataset=default
2025-07-02 10:35:10 [warning  ] Failed to pick case: Names mismatch: 'Özlem CİHAN' vs 'Özlem Ci̇han' [rigour.names.pick] dataset=default
2025-07-02 10:35:10 [warning  ] Failed to pick case: Names mismatch: 'Serdar YEŞİLYURT' vs 'Serdar Yeşi̇lyurt' [rigour.names.pick] dataset=default
2025-07-02 10:35:10 [warning  ] Failed to pick case: Names mismatch: 'NEVZAT GENELİ' vs 'Nevzat Geneli̇' [rigour.names.pick] dataset=default
2025-07-02 10:35:11 [warning  ] Failed to pick case: Names mismatch: 'TANER ERTEKİN' vs 'Taner Erteki̇n' [rigour.names.pick] dataset=default
2025-07-02 10:35:11 [warning  ] Failed to pick case: Names mismatch: 'AYHAN ÇETİN' vs 'Ayhan Çeti̇n' [rigour.names.pick] dataset=default
2025-07-02 10:35:11 [warning  ] Failed to pick case: Names mismatch: 'Neval HAMİTOĞLU' vs 'Neval Hami̇toğlu' [rigour.names.pick] dataset=default
2025-07-02 10:35:11 [warning  ] Failed to pick case: Names mismatch: 'TÜRKAN ÇETİN' vs 'Türkan Çeti̇n' [rigour.names.pick] dataset=default
2025-07-02 10:35:11 [warning  ] Failed to pick case: Names mismatch: 'SUAT YİĞİT' vs 'Suat Yi̇ği̇t' [rigour.names.pick] dataset=default
2025-07-02 10:35:11 [warning  ] Failed to pick case: Names mismatch: 'Nurcan AĞRALİ' vs 'Nurcan Ağrali̇' [rigour.names.pick] dataset=default
2025-07-02 10:35:11 [warning  ] Failed to pick case: Names mismatch: 'DURMUŞ YİĞİT' vs 'Durmuş Yi̇ği̇t' [rigour.names.pick] dataset=default
```