### PR TITLE
Export a useful issues log for collections

### DIFF
--- a/zavod/zavod/exporters/__init__.py
+++ b/zavod/zavod/exporters/__init__.py
@@ -18,7 +18,7 @@ from zavod.exporters.maritime import MaritimeExporter
 from zavod.exporters.delta import DeltaExporter
 
 from zavod.exporters.fragment import ViewFragment
-from zavod.exporters.metadata import write_dataset_index, write_issues
+from zavod.exporters.metadata import write_dataset_index
 from zavod.exporters.metadata import write_catalog, write_delta_index
 
 log = get_logger(__name__)
@@ -45,7 +45,7 @@ EXPORTERS: Dict[str, Type[Exporter]] = {
     DeltaExporter.FILE_NAME: DeltaExporter,
 }
 
-__all__ = ["export_dataset", "write_dataset_index", "write_issues"]
+__all__ = ["export_dataset", "write_dataset_index"]
 
 
 def export_data(context: Context, view: View) -> None:
@@ -90,7 +90,6 @@ def export_dataset(dataset: Dataset, view: View) -> None:
         export_data(context, view)
 
         # Export full metadata
-        write_issues(dataset)
         write_delta_index(dataset)
         write_dataset_index(dataset)
         write_catalog(dataset)

--- a/zavod/zavod/exporters/metadata.py
+++ b/zavod/zavod/exporters/metadata.py
@@ -12,7 +12,7 @@ from zavod.archive import get_dataset_artifact, get_artifact_object
 from zavod.archive import iter_dataset_versions, dataset_resource_path
 from zavod.runtime.urls import make_published_url, make_artifact_url
 from zavod.runtime.resources import DatasetResources
-from zavod.runtime.issues import DatasetIssues, Issue
+from zavod.runtime.issues import DatasetIssues
 from zavod.runtime.versions import get_latest
 from zavod.util import write_json
 
@@ -140,27 +140,6 @@ def get_catalog_datasets(scope: Dataset) -> List[Dict[str, Any]]:
     for dataset in scope.datasets:
         datasets.append(get_catalog_dataset(dataset))
     return datasets
-
-
-def write_issues(dataset: Dataset, max_export: int = 1_000) -> None:
-    """Export list of data issues from crawl stage."""
-    if dataset.is_collection:
-        return
-    issues = DatasetIssues(dataset)
-    export_issues: List[Issue] = []
-    for issue in issues.all():
-        if len(export_issues) >= max_export:
-            log.warning(
-                "Maximum issue count for export exceeded, check the issue log instead.",
-                max_export=max_export,
-            )
-            break
-        export_issues.append(issue)
-    issues_path = dataset_resource_path(dataset.name, ISSUES_FILE)
-    log.info("Writing dataset issues list...", path=issues_path.as_posix())
-    with open(issues_path, "wb") as fh:
-        data = {"issues": export_issues}
-        write_json(data, fh)
 
 
 def write_delta_index(

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -10,7 +10,7 @@ from zavod.archive import VERSIONS_FILE, ARTIFACT_FILES
 from zavod.archive import DELTA_EXPORT_FILE, DELTA_INDEX_FILE
 from zavod.runtime.resources import DatasetResources
 from zavod.runtime.versions import get_latest
-from zavod.exporters import write_dataset_index, write_issues
+from zavod.exporters import write_dataset_index
 
 log = get_logger(__name__)
 
@@ -78,7 +78,7 @@ def publish_failure(dataset: Dataset, latest: bool = True) -> None:
     dataset_resource_path(dataset.name, RESOURCES_FILE).unlink(missing_ok=True)
     dataset_resource_path(dataset.name, DELTA_EXPORT_FILE).unlink(missing_ok=True)
     dataset_resource_path(dataset.name, DELTA_INDEX_FILE).unlink(missing_ok=True)
-    write_issues(dataset)
+
     write_dataset_index(dataset)
     path = dataset_resource_path(dataset.name, INDEX_FILE)
     if not path.is_file():

--- a/zavod/zavod/runtime/issues.py
+++ b/zavod/zavod/runtime/issues.py
@@ -88,13 +88,12 @@ class DatasetIssues(object):
     def all(self) -> Generator[Issue, None, None]:
         """Iterate over all issues in the log."""
         self.close()
-        for scope in self.dataset.leaves:
-            path = get_dataset_artifact(scope.name, ISSUES_LOG)
-            if not path.is_file():
-                continue
-            with open(path, "rb") as fh:
-                for line in fh:
-                    yield cast(Issue, orjson.loads(line))
+        path = get_dataset_artifact(self.dataset.name, ISSUES_LOG)
+        if not path.is_file():
+            return
+        with open(path, "rb") as fh:
+            for line in fh:
+                yield cast(Issue, orjson.loads(line))
 
     def by_level(self) -> Dict[str, int]:
         """Count the number of issues by severity level."""


### PR DESCRIPTION
Issues are currently one of the main ways of observability into our ETL
pipeline. As more logic moves into the export stage, it makes sense to
export issues from there. This commit bundles the following changes:

- As a general pattern: catch exceptions in the
  {crawl,validate,export}_dataset functions, write to issues
  (because we have a Context there) and raise
  RunFailedException from there to catch that in CLI. Publish doesn't
  have the Context, so no issues logging from there. But if the
  publishing is broken, the issues file would never see the light of day
  anyway (If a log falls in a forest and no one is there to hear it,
  does it make a sound?)
- Write issue_levels and issue_count in collections metadata. So far,
  they would always just be empty for collections. This will make the
  issues show up in our site.
- When writing the issues for collections, don't aggregate issues from
  sub-datasets. Yeah, this didn't make sense, we always showed 0 issues
  for collections but the issues file would be filled with all the
  issues in the world...
- Reset the issues log in export_dataset if it's a collection. I know
  this is a weird place to do it, but for non-collections this is done
  in crawl_dataset. There isn't really a good place that covers the
  whole "scope lifecycle" (which is different for collections, since
  they don't have a crawl/validate stage), and the CLI seemed like a bad
  place to do it.

Please review: Why did publish_failure `assert not
dataset.is_collection`?

I guess there is the larger question here of is our issues log really
the right place to catch programming errors deep in our application
code. One could argue that job failures are something different from
data/data source issues and they should be dealt with at a different
level and with a different system. But this is it for now.