### PR TITLE
Remove children and datasets for non-collections

### DIFF
--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -149,10 +149,13 @@ class Dataset(FollowTheMoneyDataset):
         assert self._type in ("collection", "source", "external"), self._type
         data.pop("resources", None)
         data.pop("version", None)
-        # data.pop("children", None)
-        # data.pop("datasets", None)
+
         data["type"] = self._type
         if not self.is_collection:
+            # Should be empty for non-collection datasets, they are dumped from the model as empty lists.
+            data.pop("datasets", None)
+            data.pop("children", None)
+
             collections = [
                 p.name for p in catalog.datasets if self in p.datasets and p != self
             ]

--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -141,6 +141,10 @@ class Dataset(FollowTheMoneyDataset):
             # HACK backwards compatibility
             data["datasets"] = [d.name for d in self.datasets]
             data["datasets"].remove(self.name)
+        else:
+            # Should be empty for non-collection datasets, they are dumped from the model as empty lists.
+            data.pop("datasets", None)
+            data.pop("children", None)
         return data
 
     def to_opensanctions_dict(self, catalog: "ArchiveBackedCatalog") -> Dict[str, Any]:
@@ -152,10 +156,6 @@ class Dataset(FollowTheMoneyDataset):
 
         data["type"] = self._type
         if not self.is_collection:
-            # Should be empty for non-collection datasets, they are dumped from the model as empty lists.
-            data.pop("datasets", None)
-            data.pop("children", None)
-
             collections = [
                 p.name for p in catalog.datasets if self in p.datasets and p != self
             ]

--- a/zavod/zavod/tests/test_dataset.py
+++ b/zavod/zavod/tests/test_dataset.py
@@ -107,6 +107,8 @@ def test_validation_os_dict(testdataset1: Dataset, collection: Dataset):
     assert osa["data"]["format"] == "CSV"
     assert "hidden" in osa
     assert "exports" not in osa
+    assert "children" not in osa
+    assert "datasets" not in osa
     assert "summary" in osa
     assert "description" in osa
     assert osa["entry_point"] == "testentrypoint1"


### PR DESCRIPTION
Keep the public export as lean an non-changing as possible
