### PR TITLE
[ext_ru_egrul] Use stable nodepool

### DIFF
--- a/datasets/_externals/ext_ru_egrul.yml
+++ b/datasets/_externals/ext_ru_egrul.yml
@@ -11,6 +11,7 @@ exports:
   - statistics.json
   - entities.delta.json
 deploy:
+  premium: true
   cpu: "1000m"
   cpu_limit: "2000m"
   disk: "150Gi"


### PR DESCRIPTION
>12h with 12G of RAM, I think we just want to pay a bit more to avoid it
being evicted.
