### PR TITLE
Close context before writing delta/index/catalog

### DIFF
--- a/zavod/zavod/exporters/__init__.py
+++ b/zavod/zavod/exporters/__init__.py
@@ -88,11 +88,11 @@ def export_dataset(dataset: Dataset, view: View) -> None:
     try:
         context.begin(clear=False)
         export_data(context, view)
-
-        # Export full metadata
-        write_delta_index(dataset)
-        write_dataset_index(dataset)
-        write_catalog(dataset)
-        log.info("Exported dataset: %s" % dataset.name, dataset=dataset.name)
     finally:
         context.close()
+
+    # Export metadata and issues (after the context is closed & flushed)
+    write_delta_index(dataset)
+    write_dataset_index(dataset)
+    write_catalog(dataset)
+    log.info("Exported dataset: %s" % dataset.name, dataset=dataset.name)


### PR DESCRIPTION
I think this may fix the issue where issues in the index are 0 even
though the exporter logged some and they're in the issues.json. My guess
is that they're still in the write buffer of Context at the time that
`write_dataset_index` is called

See https://github.com/opensanctions/opensanctions/issues/2459

`eu_fsf` is a good candidate to verify this, currently two issues but
doesn't show up in our overview, only on the actual issues page.
