### PR TITLE
Adapt dataset names in senzing exports

### DIFF
--- a/zavod/zavod/exporters/senzing.py
+++ b/zavod/zavod/exporters/senzing.py
@@ -29,7 +29,7 @@ STMT_PROPS_TO_MAP = {
 }
 NORM_TEXT = re.compile(r"[^\w\d]", re.U)
 SOURCE_NAME_OVERRIDES = {
-    "OS-OPENOWNERSHIP": "OPENOWNERSHIP",
+    "OS-OPENOWNERSHIP": "OPEN_OWNERSHIP",
     "OS-GLEIF": "GLEIF",
 }
 
@@ -70,8 +70,8 @@ class SenzingExporter(Exporter):
     def setup(self) -> None:
         super().setup()
         self.fh = open(self.path, "wb")
-        self.domain_name = "OPENSANCTIONS"
-        source_name = f"OS-{self.dataset.name.upper().replace('_', '-')}"
+        self.domain_name = "OPEN_SANCTIONS"
+        source_name = f"OS_{self.dataset.name.upper()}"
         self.source_name = SOURCE_NAME_OVERRIDES.get(source_name, source_name)
         if self.dataset.is_collection and self.dataset.name != "openownership":
             self.source_name = self.domain_name

--- a/zavod/zavod/tests/exporters/test_senzing.py
+++ b/zavod/zavod/tests/exporters/test_senzing.py
@@ -36,7 +36,7 @@ def test_senzing(testdataset1: Dataset):
     assert {"REGISTRATION_COUNTRY": "us"} in company_countries
     company_identifiers = company.pop("IDENTIFIERS")
     assert {"NATIONAL_ID_NUMBER": "8723-BX"} in company_identifiers
-    assert company["DATA_SOURCE"] == "OS-TESTDATASET1"
+    assert company["DATA_SOURCE"] == "OS_TESTDATASET1"
     assert company["RECORD_ID"] == "osv-umbrella-corp"
     assert company["RECORD_TYPE"] == "ORGANIZATION"
     assert "/entities/osv-umbrella-corp" in company["URL"]
@@ -52,6 +52,6 @@ def test_senzing(testdataset1: Dataset):
     assert {"DATE_OF_BIRTH": "1978-09-25"} in person_dates
     person_countries = person.pop("COUNTRIES")
     assert {"NATIONALITY": "dd"} in person_countries
-    assert person["DATA_SOURCE"] == "OS-TESTDATASET1"
+    assert person["DATA_SOURCE"] == "OS_TESTDATASET1"
     assert person["RECORD_ID"] == "osv-hans-gruber"
     assert person["RECORD_TYPE"] == "PERSON"


### PR DESCRIPTION
Request by Ant from Senzing, they're apparently steering for a different convention now. 