### PR TITLE
Remove countrynames

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -18,11 +18,10 @@ classifiers = [
 ]
 requires-python = ">= 3.11"
 dependencies = [
-    "followthemoney == 4.1.1",
-    "nomenklatura == 4.1.0",
-    "countrynames >= 1.16.10, < 2.0",
+    "followthemoney == 4.1.2",
+    "nomenklatura == 4.1.1",
     "plyvel == 1.5.1",
-    "rigour == 1.1.1",
+    "rigour == 1.2.2",
     "datapatch >= 1.2.4, < 1.3",
     "certifi",
     "colorama",


### PR DESCRIPTION
This is now implemented via rigour to allow the country name database to be used by the entity name tagger. 