### PR TITLE
Release tw_shtc to sanctions collection

### DIFF
--- a/datasets/_collections/sanctions.yml
+++ b/datasets/_collections/sanctions.yml
@@ -105,6 +105,7 @@ children:
   - sg_terrorists
   - th_designated_person
   - tr_fcib
+  - tw_shtc
   - ua_nsdc_sanctions
   - ua_sfms_blacklist
   - un_1718_vessels


### PR DESCRIPTION
It's technically an export control list, but it's a really quite a
generic baddies list. jp_meti_ru uses the same risk topic and is also in
`sanctions`, so I think this is a good place for it to go.
