### PR TITLE
[eu_sanctions_map] map sanction programs

### DIFF
--- a/datasets/eu/journal_sanctions/crawler.py
+++ b/datasets/eu/journal_sanctions/crawler.py
@@ -38,7 +38,7 @@ def extract_program_code(context, source_url):
             f"No EU codes found in program name: {title}",
             source_url=source_url,
         )
-        return None
+        return
     return match.group(1)
 
 

--- a/datasets/eu/journal_sanctions/crawler.py
+++ b/datasets/eu/journal_sanctions/crawler.py
@@ -2,11 +2,12 @@ import csv
 import re
 from typing import Dict
 from normality import squash_spaces
+from functools import cache
+from nomenklatura.resolver import Linker
 
 from zavod import Context, Entity
-import zavod.helpers as h
-from nomenklatura.resolver import Linker
 from zavod.integration import get_dataset_linker
+import zavod.helpers as h
 
 # Some entities come from the full text of the consolidated COUNCIL REGULATION (EU) No 833/2014.
 #  This consolidated document is treated differently from standard EUR-Lex lookups.
@@ -19,6 +20,7 @@ FIRST_CODE_RE = re.compile(
 )
 
 
+@cache
 def extract_program_code(context, source_url):
     """Fetch EU act code from a EUR-Lex page."""
     if SPECIAL_CASE_URL in source_url:

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -85,32 +85,48 @@ lookups:
         value: "mss@korund-m.ru"
   programs:
     options:
-      - match: 
+      - match:
           - "amending Decision 2014/145/CFSP concerning restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine"
+          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
           - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia's actions destabilising the situation in Ukraine"
           - "amending Decision 2014/512/CFSP concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
-          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
-          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia's actions destabilising the situation in Ukraine"
         value: EU-UKR
-      - match: 
-          - "implementing Decision 2013/255/CFSP concerning restrictive measures in view of the situation in Syria"
-        value: EU-SYR
-      - match: "implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia"
-        value: EU-RUS
-      - match: 
+      - match:
           - "implementing Regulation (EU) 2024/2642 concerning restrictive measures in view of Russia’s destabilising activities"
           - "amending Decision (CFSP) 2024/2643 concerning restrictive measures in view of Russia’s destabilising activities"
         value: EU-RUSDA
-      - match: "amending Decision (CFSP) 2024/254 concerning restrictive measures in view of the situation in Guatemala"
-        value: EU-GTM
-      - match: 
+      - match:
           - "amending Decision (CFSP) 2020/1999 concerning restrictive measures against serious human rights violations and abuses"
           - "implementing Regulation (EU) 2020/1998 concerning restrictive measures against serious human rights violations and abuses"
         value: EU-HR
-      - match: 
+      - match:
           - "amending Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region"
+          - "implementing Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region"
           - "amending Decision 2011/235/CFSP concerning restrictive measures directed against certain persons and entities in view of the situation in Iran"
-          - "implementing Regulation (EU) No\xa0359/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Iran"
+          - "implementing Regulation (EU) No 359/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Iran"
+          - "implementing Regulation (EU) No 267/2012 concerning restrictive measures against Iran"
         value: EU-IRN
+      - match:
+          - "implementing Article 8a(1) of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus and the involvement of Belarus in the Russian aggression against Ukraine"
+          - "amending Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus and the involvement of Belarus in the Russian aggression against Ukraine"
+        value: EU-BLR
       - match: "implementing Regulation (EU) 2018/1542 concerning restrictive measures against the proliferation and use of chemical weapons"
         value: EU-CHEM
+      - match: "amending for the 348th time Council Regulation (EC) No 881/2002 imposing certain specific restrictive measures directed against certain persons and entities associated with the ISIL (Da’esh) and Al-Qaida organisations"
+        value: EU-TAQA-EUAQ
+      - match: "amending Decision (CFSP) 2022/2319 concerning restrictive measures in view of the situation in Haiti"
+        value: EU-HTI
+      - match: "implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova"
+        value: EU-MDA
+      - match: "amending Decision (CFSP) 2023/2135 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan"
+        value: EU-SDNZ
+      - match: "updating the list of persons, groups and entities covered by Common Position 2001/931/CFSP on the application of specific measures to combat terrorism, and repealing Decision (CFSP) 2025/207"
+        value: EU-TERR
+      - match: "amending Council Regulation (EC) No 1210/2003 concerning certain specific restrictions on economic and financial relations with Iraq"
+        value: EU-IRQ
+      - match: "implementing Decision 2013/255/CFSP concerning restrictive measures in view of the situation in Syria"
+        value: EU-SYR
+      - match: "implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia"
+        value: EU-RUS
+      - match: "amending Decision (CFSP) 2024/254 concerning restrictive measures in view of the situation in Guatemala"
+        value: EU-GTM

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -86,49 +86,43 @@ lookups:
   sanction.program:
     options:
       - match:
-          - "amending Decision 2014/145/CFSP concerning restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine"
-        value: EU-UKR
-      - match:
-          - "implementing Regulation (EU) 2024/2642 concerning restrictive measures in view of Russia’s destabilising activities"
-          - "amending Decision (CFSP) 2024/2643 concerning restrictive measures in view of Russia’s destabilising activities"
+          - 2024/2642
+          - 2024/2643
         value: EU-RUSDA
       - match: 
-          - "implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia"
-          - "amending Decision 2014/512/CFSP concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
-          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
-          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia's actions destabilising the situation in Ukraine"
-          - "Regulation (EU) No 833/2014"
+          - 2024/1485
+          - 2014/512
+          - 833/2014
         value: EU-RUS
       - match:
-          - "amending Decision (CFSP) 2020/1999 concerning restrictive measures against serious human rights violations and abuses"
-          - "implementing Regulation (EU) 2020/1998 concerning restrictive measures against serious human rights violations and abuses"
+          - 2020/1999
+          - 2020/1998
         value: EU-HR
       - match:
-          - "amending Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region"
-          - "implementing Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region"
-          - "amending Decision 2011/235/CFSP concerning restrictive measures directed against certain persons and entities in view of the situation in Iran"
-          - "implementing Regulation (EU) No 359/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Iran"
-          - "implementing Regulation (EU) No 267/2012 concerning restrictive measures against Iran"
+          - 2023/1529
+          - 2011/235
+          - 359/2011
+          - 267/2012
         value: EU-IRN
-      - match:
-          - "implementing Article 8a(1) of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus and the involvement of Belarus in the Russian aggression against Ukraine"
-          - "amending Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus and the involvement of Belarus in the Russian aggression against Ukraine"
+      - match: 2014/145
+        value: EU-UKR
+      - match: 765/2006
         value: EU-BLR
-      - match: "implementing Regulation (EU) 2018/1542 concerning restrictive measures against the proliferation and use of chemical weapons"
+      - match: 2018/1542
         value: EU-CHEM
-      - match: "amending for the 348th time Council Regulation (EC) No 881/2002 imposing certain specific restrictive measures directed against certain persons and entities associated with the ISIL (Da’esh) and Al-Qaida organisations"
+      - match: 881/2002
         value: EU-TAQA-EUAQ
-      - match: "amending Decision (CFSP) 2022/2319 concerning restrictive measures in view of the situation in Haiti"
+      - match: 2022/2319
         value: EU-HTI
-      - match: "implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova"
+      - match: 2023/888
         value: EU-MDA
-      - match: "amending Decision (CFSP) 2023/2135 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan"
+      - match: 2023/2135
         value: EU-SDNZ
-      - match: "updating the list of persons, groups and entities covered by Common Position 2001/931/CFSP on the application of specific measures to combat terrorism, and repealing Decision (CFSP) 2025/207"
+      - match: 2001/931
         value: EU-TERR
-      - match: "amending Council Regulation (EC) No 1210/2003 concerning certain specific restrictions on economic and financial relations with Iraq"
+      - match: 1210/2003
         value: EU-IRQ
-      - match: "implementing Decision 2013/255/CFSP concerning restrictive measures in view of the situation in Syria"
+      - match: 2013/255
         value: EU-SYR
-      - match: "amending Decision (CFSP) 2024/254 concerning restrictive measures in view of the situation in Guatemala"
+      - match: 2024/254
         value: EU-GTM

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -83,3 +83,34 @@ lookups:
         value: "general@angstrem.ru"
       - match: "mss@korund_m.ru"
         value: "mss@korund-m.ru"
+  programs:
+    options:
+      - match: 
+          - "amending Decision 2014/145/CFSP concerning restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine"
+          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia's actions destabilising the situation in Ukraine"
+          - "amending Decision 2014/512/CFSP concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
+          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
+          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia's actions destabilising the situation in Ukraine"
+        value: EU-UKR
+      - match: 
+          - "implementing Decision 2013/255/CFSP concerning restrictive measures in view of the situation in Syria"
+        value: EU-SYR
+      - match: "implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia"
+        value: EU-RUS
+      - match: 
+          - "implementing Regulation (EU) 2024/2642 concerning restrictive measures in view of Russia’s destabilising activities"
+          - "amending Decision (CFSP) 2024/2643 concerning restrictive measures in view of Russia’s destabilising activities"
+        value: EU-RUSDA
+      - match: "amending Decision (CFSP) 2024/254 concerning restrictive measures in view of the situation in Guatemala"
+        value: EU-GTM
+      - match: 
+          - "amending Decision (CFSP) 2020/1999 concerning restrictive measures against serious human rights violations and abuses"
+          - "implementing Regulation (EU) 2020/1998 concerning restrictive measures against serious human rights violations and abuses"
+        value: EU-HR
+      - match: 
+          - "amending Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region"
+          - "amending Decision 2011/235/CFSP concerning restrictive measures directed against certain persons and entities in view of the situation in Iran"
+          - "implementing Regulation (EU) No\xa0359/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Iran"
+        value: EU-IRN
+      - match: "implementing Regulation (EU) 2018/1542 concerning restrictive measures against the proliferation and use of chemical weapons"
+        value: EU-CHEM

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -83,18 +83,22 @@ lookups:
         value: "general@angstrem.ru"
       - match: "mss@korund_m.ru"
         value: "mss@korund-m.ru"
-  programs:
+  sanction.program:
     options:
       - match:
           - "amending Decision 2014/145/CFSP concerning restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine"
-          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
-          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia's actions destabilising the situation in Ukraine"
-          - "amending Decision 2014/512/CFSP concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
         value: EU-UKR
       - match:
           - "implementing Regulation (EU) 2024/2642 concerning restrictive measures in view of Russia’s destabilising activities"
           - "amending Decision (CFSP) 2024/2643 concerning restrictive measures in view of Russia’s destabilising activities"
         value: EU-RUSDA
+      - match: 
+          - "implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia"
+          - "amending Decision 2014/512/CFSP concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
+          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia’s actions destabilising the situation in Ukraine"
+          - "amending Regulation (EU) No 833/2014 concerning restrictive measures in view of Russia's actions destabilising the situation in Ukraine"
+          - "Regulation (EU) No 833/2014"
+        value: EU-RUS
       - match:
           - "amending Decision (CFSP) 2020/1999 concerning restrictive measures against serious human rights violations and abuses"
           - "implementing Regulation (EU) 2020/1998 concerning restrictive measures against serious human rights violations and abuses"
@@ -126,7 +130,5 @@ lookups:
         value: EU-IRQ
       - match: "implementing Decision 2013/255/CFSP concerning restrictive measures in view of the situation in Syria"
         value: EU-SYR
-      - match: "implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia"
-        value: EU-RUS
       - match: "amending Decision (CFSP) 2024/254 concerning restrictive measures in view of the situation in Guatemala"
         value: EU-GTM

--- a/datasets/eu/sanctions_map/crawler.py
+++ b/datasets/eu/sanctions_map/crawler.py
@@ -16,6 +16,7 @@ def crawl(context: Context):
         regime_data.pop("legal_acts", None)
         regime_data.pop("general_guidances", None)
         regime_data.pop("guidances", None)
+        programme = regime_data.pop("programme")
         authority = regime_data["adopted_by"]["data"]["title"]
 
         for measure in measures["data"]:
@@ -58,8 +59,15 @@ def crawl(context: Context):
                                 entity.add("imoNumber", value)
                             if "MMSI" in type_:
                                 entity.add("mmsi", value)
-
-                    sanction = h.make_sanction(context, entity, key=regime_data["id"])
+                    for prog in programme:
+                        sanction = h.make_sanction(
+                            context,
+                            entity,
+                            key=regime_data["id"],
+                            source_program_key=prog,
+                            program_name=prog,
+                            program_key=h.lookup_sanction_program_key(context, prog),
+                        )
                     sanction.set("authority", authority)
                     sanction.set("reason", member["reason"])
                     sanction.add("summary", regime_data["specification"])

--- a/datasets/eu/sanctions_map/eu_sanctions_map.yml
+++ b/datasets/eu/sanctions_map/eu_sanctions_map.yml
@@ -66,3 +66,117 @@ lookups:
       - match:
           - 09346732 # Invalid IMO
         prop: registrationNumber
+  sanction.program:
+    # in accordance with https://sanctionsmap.eu/#/main?search=%7B%22value%22:%22%22,%22searchType%22:%7B%7D%7D
+    options:
+      # Afghanistan
+      - match: AFG
+        value: EU-AFG
+      # Belarus
+      - match: BLR # implementing Article 8a of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus
+        value: EU-BLR
+      # Burundi
+      - match: BDI # implementing Regulation (EU) 2015/1755 concerning restrictive measures in view of the situation in Burundi
+        value: EU-BDI
+      # Central African Republic
+      - match: CAF # implementing Article 17(3) of Regulation (EU) No 224/2014 concerning restrictive measures in view of the situation in the Central African Republic
+        value: EU-CAF
+      # Chemical weapons
+      - match: CHEM # implementing Regulation (EU) 2018/1542 concerning restrictive measures against the proliferation and use of chemical weapons
+        value: EU-CHEM
+      # Cyber-attacks
+      - match: CYB
+        value: EU-CYB
+      # Democratic People's Republic of Korea (DPRK – North Korea)
+      - match: PRK
+        value: EU-PRK
+      # Democratic Republic of the Congo
+      - match: COD # implementing Article 9(5) of Regulation (EC) No 1183/2005 imposing certain specific restrictive measures directed against persons acting in violation of the arms embargo with regard to the Democratic Republic of the Congo
+        value: EU-COD
+      # Guatemala
+      - match: GTM # implementing Regulation (EU) 2024/287 concerning restrictive measures in view of the situation in Guatemala
+        value: EU-GTM
+      # Guinea
+      - match: GIN # implementing Regulation (EU) No 1284/2009 imposing certain specific restrictive measures in respect of the Republic of Guinea
+        value: EU-GIN
+      # Guinea-Bissau
+      - match: GNB # mplementing Article 11(1) of Regulation (EU) No 377/2012 concerning restrictive measures directed against certain persons, entities and bodies threatening the peace, security or stability of the Republic of Guinea-Bissau
+        value: EU-GNB
+      # Haiti
+      - match: HTI # implementing Regulation (EU) 2022/2309 concerning restrictive measures in view of the situation in Haiti
+        value: EU-HTI
+      # Human rights
+      - match: HR
+        value: EU-HR
+      # Iran
+      - match:
+          IRN # implementing Regulation (EU) No 267/2012 concerning restrictive measures against Iran
+          # implementing Regulation (EU) 2023/1529 concerning restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region
+        value: EU-IRN
+      # Iraq
+      - match: IRQ
+        value: EU-IRQ
+      # Libya
+      - match: LBY # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
+        value: EU-LBY
+      # Mali
+      - match: MLI # implementing Article 12(2) of Regulation (EU) 2017/1770 concerning restrictive measures in view of the situation in Mali
+        value: EU-MLI
+      # Moldova
+      - match: MDA # implementing Regulation (EU) 2023/888 concerning restrictive measures in view of actions destabilising the Republic of Moldova
+        value: EU-MDA
+      # Myanmar (Burma)
+      - match: MMR # implementing Regulation (EU) No 401/2013 concerning restrictive measures in respect of Myanmar/Burma
+        value: EU-MMR
+      # Nicaragua
+      - match: NIC # implementing Regulation (EU) 2019/1716 concerning restrictive measures in view of the situation in Nicaragua
+        value: EU-NIC
+      # Russia
+      - match: RUS # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
+        value: EU-RUS
+      - match: RUSDA
+        value: EU-RUSDA
+      # Somalia
+      - match: SOM
+        value: EU-SOM
+      # South Sudan
+      - match: SSD #  Article 20(3) of Regulation (EU) 2015/735 concerning restrictive measures in respect of the situation in South Sudan
+        value: EU-SSD
+      # Sudan
+      - match: SDN # implementing Article 15(3) of Regulation (EU) No 747/2014 concerning restrictive measures in view of the situation in Sudan
+        value: EU-SDN
+      - match: SDNZ # implementing Regulation (EU) 2023/2147 concerning restrictive measures in view of activities undermining the stability and political transition of Sudan
+        value: EU-SDNZ
+      # Syria
+      - match: SYR # Council Regulation concerning restrictive measures in view of the situation in Syria and repealing Regulation (EU) No 442/2011
+        value: EU-SYR
+      # Terrorism
+      - match: TERR
+        value: EU-TERR # implementing Article 2(3) of Regulation (EC) No 2580/2001 on specific restrictive measures directed against certain persons and entities with a view to combating terrorism
+      - match:
+          - TAQA
+          - EUAQ
+        value: EU-TAQA-EUAQ # Council Regulation (EC) No 881/2002 imposing certain specific restrictive measures directed against certain persons and entities associated with the Al Qaida network
+      - match: HAM
+        value: EU-HAM # COUNCIL REGULATION (EU) 2024/386 of 19 January 2024 establishing restrictive measures against those who support, facilitate or enable violent actions by Hamas and the Palestinian Islamic Jihad
+      # Tunisia
+      - match: TUN # implementing Regulation (EU) No 101/2011 concerning restrictive measures directed against certain persons, entities and bodies in view of the situation in Tunisia
+        value: EU-TUN
+      # Türkiye
+      - match: TUR # implementing Regulation (EU) 2019/1890 concerning restrictive measures in view of Turkey’s unauthorised drilling activities in the Eastern Mediterranean
+        value: EU-TUR
+      # Ukraine
+      - match: UKR
+        value: EU-UKR
+      # Venezuela
+      - match: VEN # implementing Regulation (EU) 2017/2063 concerning restrictive measures in view of the situation in Venezuela
+        value: EU-VEN
+      # According to DG FISMA, this is an initial value used until an EU act is adopted corrsponding to the UN program
+      - match: UNLI
+        value: EU-UNLI
+      # Yemen
+      - match: YEM
+        value: EU-YEM
+      # Zimbabwe
+      - match: ZWE
+        value: EU-ZWE


### PR DESCRIPTION
[eu_journal_sanctions]

- fetch sanctions program titles directly from EUR-Lex pages.
- extract the first EU act code from program titles (e.g., 2024/254, 833/2014) using regex.
- consistently map programs via the `sanction.program` lookup.

[eu_sanctions_map]

- extract and map the regimes reusing the lookups from `eu_fsf`.