### PR TITLE
[exporters] Put Thing.programId into targets.simple.csv

### DIFF
--- a/zavod/zavod/exporters/simplecsv.py
+++ b/zavod/zavod/exporters/simplecsv.py
@@ -26,6 +26,7 @@ class SimpleCSVExporter(Exporter):
         "sanctions",
         "phones",
         "emails",
+        "program_ids",
         "dataset",
         "first_seen",
         "last_seen",
@@ -64,8 +65,11 @@ class SimpleCSVExporter(Exporter):
     def feed(self, entity: Entity, view: ExportView) -> None:
         if not entity.target:
             return
+        program_ids = set(entity.get("programId"))
         countries = set(entity.get_type_values(registry.country))
-        identifiers = set(entity.get_type_values(registry.identifier))
+        # Don't include program_ids in identifiers, they are already in program_ids
+        # and they don't really identify the entity, which is the purpose of this field.
+        identifiers = set(entity.get_type_values(registry.identifier)) - program_ids
         names = set(entity.get_type_values(registry.name))
         names.discard(entity.caption)
         sanctions = set()
@@ -98,6 +102,7 @@ class SimpleCSVExporter(Exporter):
             self.concat_values(sanctions),
             self.concat_values(entity.get_type_values(registry.phone)),
             self.concat_values(entity.get_type_values(registry.email)),
+            self.concat_values(program_ids),
             self.concat_values(datasets),
             entity.first_seen,
             entity.last_seen,

--- a/zavod/zavod/tests/exporters/test_exporters.py
+++ b/zavod/zavod/tests/exporters/test_exporters.py
@@ -269,6 +269,7 @@ def test_targets_simple(testdataset1: Dataset):
         "sanctions",
         "phones",
         "emails",
+        "program_ids",
         "dataset",
         "first_seen",
         "last_seen",
@@ -286,6 +287,7 @@ def test_targets_simple(testdataset1: Dataset):
         "sanctions": "",
         "phones": "",
         "emails": "",
+        "program_ids": "ZZ-TEST1;ZZ-TEST2",
         "dataset": "OpenSanctions Validation Dataset",  # Dataset title
         "first_seen": settings.RUN_TIME_ISO,  # Seconds string format
         "last_seen": settings.RUN_TIME_ISO,

--- a/zavod/zavod/tests/fixtures/testdataset1/dataset.csv
+++ b/zavod/zavod/tests/fixtures/testdataset1/dataset.csv
@@ -1,9 +1,9 @@
-id,type,name,alias,notes,dob,country,id_number,rel_type,rel_other,rel_start,rel_end,rel_summary,city,street,postal_code,topics
-mierscheid,Person,Jakob Maria Mierscheid,Jakob Mierscheid,Fictional parliamentarian,1933-03-01,Germany,DE1234,Membership,spd,1979,,MdB,,,,role.pep
-spd,Organization,Sozialdemokratische Partei Deutschlands,,,,Germany,,,,,,,,,,pol.party
-john-doe,Person,John Doe,,,1975,United States,,Family,jane-doe,2003,,Spouse,,,,poi
-jane-doe,Person,Jane Doe,Jane Smith,,1972,Paraguay,,,,,,,,,,poi
-hans-gruber,Person,Hans Gruber,Bill Clay,Freedom fighter,1978-09-25,East Germany,,,,,,,Dresden,Lauensteiner Str. 49,01277,crime.boss
-umbrella-corp,Company,Umbrella Corporation,"Umbrella Pharmaceuticals, Inc. ",,1980,United States,8723-BX,,,,,,,,,reg.warn
-oswell-spencer,Person,Oswell E. Spencer,Ozwell E. Spencer; オズウェル,,1923,Japan,,Ownership,umbrella-corp,1968,2003,Founder,,,,crime.boss
+id,type,name,alias,notes,dob,country,id_number,rel_type,rel_other,rel_start,rel_end,rel_summary,city,street,postal_code,topics,program_ids
+mierscheid,Person,Jakob Maria Mierscheid,Jakob Mierscheid,Fictional parliamentarian,1933-03-01,Germany,DE1234,Membership,spd,1979,,MdB,,,,role.pep,
+spd,Organization,Sozialdemokratische Partei Deutschlands,,,,Germany,,,,,,,,,,pol.party,
+john-doe,Person,John Doe,,,1975,United States,,Family,jane-doe,2003,,Spouse,,,,poi,ZZ-TEST1;ZZ-TEST2
+jane-doe,Person,Jane Doe,Jane Smith,,1972,Paraguay,,,,,,,,,,poi,
+hans-gruber,Person,Hans Gruber,Bill Clay,Freedom fighter,1978-09-25,East Germany,,,,,,,Dresden,Lauensteiner Str. 49,01277,crime.boss,
+umbrella-corp,Company,Umbrella Corporation,"Umbrella Pharmaceuticals, Inc. ",,1980,United States,8723-BX,,,,,,,,,reg.warn,
+oswell-spencer,Person,Oswell E. Spencer,Ozwell E. Spencer; オズウェル,,1923,Japan,,Ownership,umbrella-corp,1968,2003,Founder,,,,crime.boss,
 johnny-does,Person,Johnny Doe,John Ignatius Doe,,1975,Canada,,Family,oswell-spencer,,,,,,,

--- a/zavod/zavod/tests/fixtures/testdataset1/testentrypoint1.py
+++ b/zavod/zavod/tests/fixtures/testdataset1/testentrypoint1.py
@@ -18,6 +18,9 @@ def crawl_row(context: Context, row: Dict[str, str]):
     entity.add("topics", row.pop("topics"))
     entity.add("notes", row.pop("notes"))
 
+    program_ids = (row.pop("program_ids") or "").split(";")
+    entity.add("programId", program_ids)
+
     address = make_address(
         context,
         street=row.pop("street"),

--- a/zavod/zavod/tests/runtime/test_resources.py
+++ b/zavod/zavod/tests/runtime/test_resources.py
@@ -25,9 +25,9 @@ def test_resources(testdataset1: Dataset):
     assert resource.name == "dataset.csv"
     assert resource.size is not None
     assert resource.size > 0
-    assert resource.checksum == "b7ab865f0112bd9d24c19e3f1ccc8124835ed46a", (
-        resource_path
-    )
+    assert (
+        resource.checksum == "2600ca8d5af7ada55818127c204169b388d20707"
+    ), resource_path
 
     resources.save(resource)
     assert len(resources.all()) == 1


### PR DESCRIPTION
One slightly awkward design choice here: The `identifiers` column pulls out all values with type identifier, of which `programId` is one. But the documentation for `identifiers` states:

> Identifiers such as corporate registrations, passport numbers or tax identifiers linked to this sanctions target.

So I decided to exclude `programId` from that column. More complexity on our side, but less surprising for users I feel? Comments welcome.

Fixes https://github.com/opensanctions/opensanctions/issues/2654
