### PR TITLE
Skip superfluous (breaking) encoding/decoding

### DIFF
--- a/datasets/us/cftc_enforcement_actions/crawler.py
+++ b/datasets/us/cftc_enforcement_actions/crawler.py
@@ -212,7 +212,7 @@ def crawl_enforcement_action(context: Context, date: str, url: str) -> None:
     article_element = fetch_article(context, url)
     if article_element is None:
         return
-    article_html = tostring(article_element, pretty_print=True).decode("utf-8")
+    article_html = tostring(article_element, pretty_print=True, encoding="unicode")
     release_id = get_release_id(url)
     review = get_review(context, Defendants, release_id, MIN_MODEL_VERSION)
     if review is None:

--- a/datasets/us/ofac/enforcement_actions/crawler.py
+++ b/datasets/us/ofac/enforcement_actions/crawler.py
@@ -180,7 +180,7 @@ def crawl_enforcement_action(context: Context, url: str) -> None:
     assert len(article_content) == 1
     article_element = article_content[0]
     date = article.xpath(DATE_XPATH)[0]
-    article_html = tostring(article_element, pretty_print=True).decode("utf-8")
+    article_html = tostring(article_element, pretty_print=True, encoding="unicode")
     assert all([article_name, article_html, date]), "One or more fields are empty"
 
     review = get_review(context, Defendants, url, MIN_MODEL_VERSION)

--- a/datasets/us/sec/litigation/crawler.py
+++ b/datasets/us/sec/litigation/crawler.py
@@ -191,7 +191,7 @@ def crawl_release(
     article_element = doc.xpath(article_xpath)[0]
     case_numbers = get_case_numbers(article_element)
     strip_non_body_content(article_element)
-    article_html = tostring(article_element, pretty_print=True).decode("utf-8")
+    article_html = tostring(article_element, pretty_print=True, encoding="unicode")
     release_id = get_release_id(url)
     review = get_review(context, Defendants, release_id, MIN_MODEL_VERSION)
     if review is None:


### PR DESCRIPTION
Encoding broken encoding, decoding as utf-8, saving that to db, and reading that back, gives a slightly different flavour of broken encoding than just the first two steps. Funnily enough that's a bit broken.

e.g.

```
-       In December 1, 2020, the Securities and Exchange Commission charged an unregistered investment adviser based in Orlando, Florida for defrauding the Municipality of Mayagƒ¼ez, Puerto Rico and misappropriating $7.1 million of taxpayer funds.

?                                                                                                                                                                                ^

+       In December 1, 2020, the Securities and Exchange Commission charged an unregistered investment adviser based in Orlando, Florida for defrauding the Municipality of Mayag¼ez, Puerto Rico and misappropriating $7.1 million of taxpayer funds.

?
```

Just stay in the safe home of code points and nobody gets hurt.