### PR TITLE
[gleif] Some fixes

### DIFF
--- a/datasets/_global/gleif/crawler.py
+++ b/datasets/_global/gleif/crawler.py
@@ -295,6 +295,8 @@ def parse_rr_file(context: Context, fh: BinaryIO):
             assert start_prop == "asset"
             asset = context.make("Company")
             asset.id = lei_id(start_lei)
+            # Also emit leiCode so that Context.emit doesn't complain about the Entity having no properties
+            asset.add("leiCode", start_lei)
             context.emit(asset)
 
         for period in rel.findall(".//RelationshipPeriod"):


### PR DESCRIPTION
- **[gleif] When re-emitting a company, add a single prop to avoid emit complaining**
  

- **[gleif] Parse EntityStatus properly**
  From the LLM, having been fed the XSD:
  
  > The parser is checking for "DUPLICATE" and "ANNULLED" as EntityStatus values, but according to the schema, these are actually RegistrationStatus values, not EntityStatus values.
  > 2. Missing EntityStatus Validation
  > The parser should validate that EntityStatus is one of: ACTIVE, INACTIVE, or NULL. Currently, it's not validating this field against the schema.
  > 3. RegistrationStatus Field Missing
  > The schema defines a separate RegistrationStatus field with values like DUPLICATE, ANNULLED, ISSUED, etc., but the parser is not extracting this field. This is likely what should be used for filtering out invalid records.
  