### PR TITLE
Fix name parsing in a few UN-list impersonators

### DIFF
--- a/datasets/ar/repet/crawler.py
+++ b/datasets/ar/repet/crawler.py
@@ -4,6 +4,7 @@ from rigour.mime.types import JSON
 
 from zavod import Context, Entity
 from zavod import helpers as h
+from zavod.shed.un_sc import apply_un_name_list
 
 
 URL = "https://repet.jus.gob.ar/xml/%s.json"
@@ -75,14 +76,18 @@ def crawl_common(context: Context, data: Dict[str, str], part: str, schema: str)
     entity.add("notes", h.clean_note(data.pop("NOTE", None)))
     entity.add("alias", h.multi_split(data.pop("NAME_ORIGINAL_SCRIPT"), ALIAS_SPLITS))
 
-    h.apply_name(
-        entity,
-        name1=data.pop("FIRST_NAME", None),
-        name2=data.pop("SECOND_NAME", None),
-        name3=data.pop("THIRD_NAME", None),
-        name4=data.pop("FOURTH_NAME", None),
-        quiet=True,
-    )
+    names = [
+        name
+        for name in [
+            data.pop("FIRST_NAME", None),
+            data.pop("SECOND_NAME", None),
+            data.pop("THIRD_NAME", None),
+            data.pop("FOURTH_NAME", None),
+        ]
+        if name is not None and name != ""
+    ]
+    # The names are copied from the UN list, so use the same semantics
+    apply_un_name_list(context, entity, names)
 
     sanction = h.make_sanction(context, entity)
     submitted_on = parse_date(data.pop("SUBMITTED_ON", None))

--- a/datasets/qa/nctc_sanctions/crawler.py
+++ b/datasets/qa/nctc_sanctions/crawler.py
@@ -3,6 +3,7 @@ from rigour.mime.types import JSON
 
 from zavod import Context
 from zavod import helpers as h
+from zavod.shed.un_sc import apply_un_name_list
 
 TYPES = {"1": "Person", "2": "Organization"}
 ALIAS_SPLITS = [";", "original script", "(", ")", "previously listed as"]
@@ -22,38 +23,53 @@ def crawl(context: Context):
         entity = context.make(TYPES[typ])
         entity.id = context.make_slug(data_id, full_name_en)
         sanction = h.make_sanction(context, entity)
-        entity.add("name", full_name_en, lang="eng")
-        entity.add("name", item.pop("fullNameAr"), lang="ara")
         entity.add("alias", h.multi_split(item.pop("aliases", ""), ALIAS_SPLITS))
         entity.add("topics", "sanction")
 
-        first_name_ar = item.pop("firstNameAR")
-        first_name_en = item.pop("firstNameEN")
-        second_name_ar = item.pop("secondNameAR")
-        second_name_en = item.pop("secondNameEN")
-        third_name_ar = item.pop("thirdNameAR")
-        third_name_en = item.pop("thirdNameEN")
-        fourth_name_ar = item.pop("fourthNameAR")
-        fourth_name_en = item.pop("fourthNameEN")
+        names_en = [
+            name
+            for name in [
+                item.pop("firstNameEN"),
+                item.pop("secondNameEN"),
+                item.pop("thirdNameEN"),
+                item.pop("fourthNameEN"),
+            ]
+            if name is not None and name != ""
+        ]
+        names_ar = [
+            name
+            for name in [
+                item.pop("firstNameAR"),
+                item.pop("secondNameAR"),
+                item.pop("thirdNameAR"),
+                item.pop("fourthNameAR"),
+            ]
+            if name is not None and name != ""
+        ]
+
         dob_format = item.pop("dobFormat")
         if entity.schema.is_a("Person"):
             entity.add("passportNumber", item.pop("passportNo"))
             entity.add("idNumber", item.pop("qid"))
             entity.add("nationality", item.pop("nationality"))
             h.apply_date(entity, "birthDate", dob_format)
-            entity.add("firstName", first_name_ar, lang="ara")
-            entity.add("firstName", first_name_en, lang="eng")
-            entity.add("secondName", second_name_ar, lang="ara")
-            entity.add("secondName", second_name_en, lang="eng")
-            entity.add("middleName", third_name_ar, lang="ara")
-            entity.add("middleName", third_name_en, lang="eng")
-            entity.add("middleName", fourth_name_ar, lang="ara")
-            entity.add("middleName", fourth_name_en, lang="eng")
+
+            # Because this is mostly a copy of the UN list, names follow the same semantics
+            apply_un_name_list(context, entity, names_en, lang="eng")
+            apply_un_name_list(context, entity, names_ar, lang="ara")
+
+            # For Person, fullNameAR/EN are concatenations of the names, but it doesn't hurt to add them twice
+            # because they get deduped at the statement level.
+            entity.add("name", full_name_en, lang="eng")
+            entity.add("name", item.pop("fullNameAr"), lang="ara")
         elif entity.schema.is_a("Organization"):
-            entity.add("alias", first_name_ar, lang="ara")
-            entity.add("alias", first_name_en, lang="eng")
-            entity.add("alias", second_name_ar, lang="ara")
-            entity.add("alias", second_name_en, lang="eng")
+            # For Organization, fullNameAR/EN are concatenations of the names, but that's dumb for organizations
+            # because we end up with names like
+            # "Al-Khalidi Exchange Al-Khalidi Jewelry Company  Al-Khalidi Money Transfer Office "
+            # so we just don't add them.
+            entity.add("name", names_ar, lang="ara")
+            entity.add("name", names_en, lang="eng")
+
             entity.add("registrationNumber", item.pop("passportNo"))
             entity.add("registrationNumber", item.pop("qid"))
             entity.add("jurisdiction", item.pop("nationality"))

--- a/datasets/ua/sfms_blacklist/crawler.py
+++ b/datasets/ua/sfms_blacklist/crawler.py
@@ -40,8 +40,6 @@ def parse_entry(context: Context, entry: ElementOrTree) -> None:
     if entry.findtext("./type-entry") == "2":
         entity = context.make("Person")
     entry_id = entry.findtext("number-entry")
-    if entry_id == "1460":
-        entity = context.make("LegalEntity")
     entity.id = context.make_slug(entry_id)
 
     sanction = h.make_sanction(context, entity)

--- a/zavod/zavod/shed/un_sc.py
+++ b/zavod/zavod/shed/un_sc.py
@@ -89,7 +89,9 @@ def make_entity(context: Context, prefix: str, schema: str, node: Element) -> En
     return entity
 
 
-def apply_un_name_list(context: Context, entity: Entity, names: List[str]) -> None:
+def apply_un_name_list(
+    context: Context, entity: Entity, names: List[str], lang: Optional[str] = None
+) -> None:
     """Apply the list of names given by the UN to an entity.
 
     The first name in the list is the first name, the last name is the family
@@ -109,7 +111,7 @@ def apply_un_name_list(context: Context, entity: Entity, names: List[str]) -> No
         entity.add("lastName", names[-1])
         # make_name (which is just a fancy wrapper around " ".join) to generate the full name.
         name_args = {f"name{i+1}": name for i, name in enumerate(names)}
-        entity.add("name", h.make_name(**name_args))
+        entity.add("name", h.make_name(**name_args), lang=lang)
 
 
 def load_un_sc(context: Context) -> Tuple[Dataset, ElementOrTree]:

--- a/zavod/zavod/shed/un_sc.py
+++ b/zavod/zavod/shed/un_sc.py
@@ -83,23 +83,33 @@ def make_entity(context: Context, prefix: str, schema: str, node: Element) -> En
         ]
         if name is not None and name != ""
     ]
+    apply_un_name_list(context, entity, names)
+
+    entity.add("topics", "sanction")
+    return entity
+
+
+def apply_un_name_list(context: Context, entity: Entity, names: List[str]) -> None:
+    """Apply the list of names given by the UN to an entity.
+
+    The first name in the list is the first name, the last name is the family
+    name, but unfortunately the rest is murky.  Sometimes, people have multiple
+    last names, sometimes multiple first names, often the names in the middle
+    are patronymic... So don't do anything fancy with the murky ones.
+
+    Some other datasets reproduce the UN list in full and use the same
+    semantics, so it's useful to have this as a helper.
+    """
     if len(names) == 0:
         context.log.warn("No names found for entity %s", entity.id)
     elif len(names) == 1:
         entity.add("name", names[0])
     else:
-        # The first name in the list is the first name, the last name is the family name,
-        # but unfortunately the rest is murky.
-        # Sometimes, people have multiple last names, sometimes multiple first names, often the
-        # names in the middle are patronymic... So don't do anything fancy with the murky ones.
         entity.add("firstName", names[0])
         entity.add("lastName", names[-1])
         # make_name (which is just a fancy wrapper around " ".join) to generate the full name.
         name_args = {f"name{i+1}": name for i, name in enumerate(names)}
         entity.add("name", h.make_name(**name_args))
-
-    entity.add("topics", "sanction")
-    return entity
 
 
 def load_un_sc(context: Context) -> Tuple[Dataset, ElementOrTree]:


### PR DESCRIPTION
- **[ua_sfms_blacklist] Remove the special case, they seem to have fixed it**
  

- **[ua_fsms_blacklist] Use the name list parser from un_sc**
  

- **[ar_repet] Use UN name list parser helper**
  This list is pretty much a copy of the UN list, so it uses the same
  semantics. Otherwise, names end up in weird places - see the
  documentation of the helper for more details.
  

- **[qa_nctc_sanctions] Improve UN-style name list parsing**
  

Fixes https://github.com/opensanctions/opensanctions/issues/2728