### PR TITLE
Create a new data review version by default if source data changes

### DIFF
--- a/datasets/us/cftc_enforcement_actions/crawler.py
+++ b/datasets/us/cftc_enforcement_actions/crawler.py
@@ -1,20 +1,21 @@
 from typing import Optional, List, Literal
 from pydantic import BaseModel, Field
 import re
+
+from rigour.mime.types import HTML
 from zavod.entity import Entity
 from zavod.shed import enforcements
 
-from lxml.html import HtmlElement, fromstring, tostring
+from lxml.html import HtmlElement, tostring
 
 from zavod.context import Context
 from zavod import helpers as h
 from zavod.shed.gpt import DEFAULT_MODEL, run_typed_text_prompt
 from zavod.stateful.review import (
-    Review,
     assert_all_accepted,
     request_review,
     get_review,
-    model_hash,
+    source_html_matches,
 )
 
 Schema = Literal["Person", "Company", "LegalEntity"]
@@ -28,13 +29,9 @@ Status = Literal[
     "Other",
 ]
 
-MODEL_VERSION = 1
-MIN_MODEL_VERSION = 1
+CRAWLER_VERSION = 1
 
 REGEX_RELEASE_ID = re.compile(r"(\w{2,8}-\w{2,4}[\w #-]*)$")
-
-something_changed = False
-
 
 # Not extracting relationships for now because the results were inconsistent
 # between GPT queries.
@@ -139,48 +136,6 @@ def fetch_article(context: Context, url: str) -> HtmlElement | None:
     return article_element
 
 
-def source_changed(review: Review, article_element: HtmlElement) -> bool:
-    """
-    The key exists but the current source data looks different from the existing version
-    in spite of heavy normalisation.
-    """
-    seen_element = fromstring(review.source_value)
-    return h.element_text_hash(seen_element) != h.element_text_hash(article_element)
-
-
-def check_something_changed(
-    context: Context,
-    review: Review,
-    article_html: str,
-    article_element: HtmlElement,
-) -> bool:
-    """
-    Returns True if the source content has changed.
-
-    In that case it also reprompts to log whether the extracted data has changed.
-    """
-    if source_changed(review, article_element):
-        prompt_result = run_typed_text_prompt(context, PROMPT, article_html, Defendants)
-        if model_hash(prompt_result) == model_hash(review.orig_extraction_data):
-            context.log.warning(
-                "The source content has changed but the extracted data has not",
-                url=review.source_url,
-                seen_source_value=review.source_value,
-                new_source_value=article_html,
-            )
-        else:
-            # A new extraction result looks different from the known original extraction
-            context.log.warning(
-                "The extracted data has changed",
-                url=review.source_url,
-                orig_extracted_data=review.orig_extraction_data.model_dump(),
-                prompt_result=prompt_result.model_dump(),
-            )
-        return True
-    else:
-        return False
-
-
 def make_related_company(context: Context, name: str) -> Entity:
     entity = context.make("Company")
     entity.id = context.make_id(name)
@@ -212,33 +167,20 @@ def crawl_enforcement_action(context: Context, date: str, url: str) -> None:
         return
     article_html = tostring(article_element, pretty_print=True, encoding="unicode")
     release_id = get_release_id(url)
-    review = get_review(context, Defendants, release_id, MIN_MODEL_VERSION)
-    if review is None:
+
+    review = get_review(context, data_model=Defendants, key_parts=release_id)
+    if review is None or not source_html_matches(review, article_element):
         prompt_result = run_typed_text_prompt(context, PROMPT, article_html, Defendants)
         review = request_review(
             context,
-            release_id,
-            article_html,
-            "text/html",
-            "Enforcement Action Notice",
-            url,
-            prompt_result,
-            MODEL_VERSION,
+            key_parts=release_id,
+            source_value=article_html,
+            source_mime_type=HTML,
+            source_label="Enforcement Action Notice",
+            source_url=url,
+            orig_extraction_data=prompt_result,
+            crawler_version=CRAWLER_VERSION,
         )
-
-    if check_something_changed(context, review, article_html, article_element):
-        # In the first iteration, we're being super conservative and rejecting
-        # export if the source content has changed regardless of whether the
-        # extraction result has changed. If we see this happening and we see that
-        # the extraction result reliably identifies real data changes, we can
-        # relax this to only reject if the extraction result has changed.
-
-        # Similarly if we see that broad markup changes don't trigger massive
-        # re-reviews but legitimate changes are reliably detected, we can allow
-        # it to automatically request re-reviews upon extraction changes.
-        global something_changed
-        something_changed = True
-        return
 
     if not review.accepted:
         return
@@ -325,6 +267,3 @@ def crawl(context: Context) -> None:
             break
 
     assert_all_accepted(context)
-    global something_changed
-    error = "See what changed to determine whether to trigger re-review."
-    assert not something_changed, error

--- a/datasets/us/ofac/enforcement_actions/crawler.py
+++ b/datasets/us/ofac/enforcement_actions/crawler.py
@@ -202,7 +202,7 @@ def crawl(context: Context):
         )
         if not links:
             break
-        search_results = doc.findall(".//div[contains(@class, 'search-result')]")
+        search_results = doc.xpath(".//div[contains(@class, 'search-result')]")
         for result in search_results:
             enforcement_date = result.xpath(
                 ".//div[contains(@class,'margin-top-1') and contains(., 'Enforcement Actions')]/text()[normalize-space()]"

--- a/ui/lib/db.ts
+++ b/ui/lib/db.ts
@@ -24,7 +24,7 @@ const expectedColumns = new Set<string>([
   'source_label',
   'source_url',
   'accepted',
-  'model_version',
+  'crawler_version',
   'orig_extraction_data',
   'extracted_data',
   'last_seen_version',
@@ -43,7 +43,7 @@ export interface ReviewTable {
   source_label: string
   source_url: string | null
   accepted: boolean
-  model_version: number
+  crawler_version: number
   orig_extraction_data: JSONColumnType<object, object, object>
   extracted_data: JSONColumnType<object, object, object>
   last_seen_version: string

--- a/zavod/migrations/2025-09-19-crawler-version.sql
+++ b/zavod/migrations/2025-09-19-crawler-version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE review RENAME COLUMN model_version TO crawler_version;

--- a/zavod/zavod/stateful/model.py
+++ b/zavod/zavod/stateful/model.py
@@ -58,7 +58,7 @@ review_table = Table(
     Column("source_label", Unicode(VALUE_LEN), nullable=True),
     Column("source_url", Unicode(VALUE_LEN), nullable=True),
     Column("accepted", Boolean, nullable=False, index=True),
-    Column("model_version", Integer, nullable=False),
+    Column("crawler_version", Integer, nullable=False),
     # only to be edited by the crawler
     Column("orig_extraction_data", JSON, nullable=False),
     # editable by the reviewer

--- a/zavod/zavod/tests/stateful/test_review.py
+++ b/zavod/zavod/tests/stateful/test_review.py
@@ -24,16 +24,16 @@ def get_row(conn, key):
 
 def test_new_key_saved_and_accepted_false(testdataset1):
     context = Context(testdataset1)
-    model = DummyModel(foo="bar")
+    data = DummyModel(foo="bar")
     review = request_review(
         context,
-        "key1",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        model,
-        1,
+        key_parts="key1",
+        source_value=SOURCE_VALUE,
+        source_mime_type=SOURCE_MIME_TYPE,
+        source_label=SOURCE_LABEL,
+        source_url=SOURCE_URL,
+        orig_extraction_data=data,
+        crawler_version=1,
     )
     assert review.accepted is False
     row = get_row(context.conn, "key1")
@@ -49,13 +49,13 @@ def test_current_model_version_updates_last_seen_version(testdataset1, monkeypat
     data = DummyModel(foo="bar")
     request_review(
         context1,
-        "key2",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        data,
-        1,
+        key_parts="key2",
+        source_value=SOURCE_VALUE,
+        source_mime_type=SOURCE_MIME_TYPE,
+        source_label=SOURCE_LABEL,
+        source_url=SOURCE_URL,
+        orig_extraction_data=data,
+        crawler_version=1,
     )
     row = get_row(context1.conn, "key2")
     assert row and row["last_seen_version"] == context1_version
@@ -65,9 +65,8 @@ def test_current_model_version_updates_last_seen_version(testdataset1, monkeypat
     context2_version = context2.version.id
     review = get_review(
         context2,
-        DummyModel,
-        "key2",
-        1,
+        data_model=DummyModel,
+        key_parts="key2",
     )
     assert review.last_seen_version == context2_version
     row = get_row(context2.conn, "key2")
@@ -75,48 +74,18 @@ def test_current_model_version_updates_last_seen_version(testdataset1, monkeypat
     assert context1_version != context2_version
 
 
-def test_expired_model_version_returns_none(testdataset1, monkeypatch):
-    context = Context(testdataset1)
-    context.begin(clear=True)
-    data = DummyModel(foo="bar")
-    review = request_review(
-        context,
-        "key3",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        data,
-        1,
-    )
-    review = get_review(
-        context,
-        DummyModel,
-        "key3",
-        1,
-    )
-    assert review is not None
-    review = get_review(
-        context,
-        DummyModel,
-        "key3",
-        2,
-    )
-    assert review is None
-
-
 def test_re_request_deletes_old_and_inserts_new(testdataset1, monkeypatch):
     context1 = Context(testdataset1)
     data = DummyModel(foo="bar")
     review = request_review(
         context1,
-        "key3",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        data,
-        1,
+        key_parts="key3",
+        source_value=SOURCE_VALUE,
+        source_mime_type=SOURCE_MIME_TYPE,
+        source_label=SOURCE_LABEL,
+        source_url=SOURCE_URL,
+        orig_extraction_data=data,
+        crawler_version=1,
         default_accepted=True,
     )
     assert review.accepted is True
@@ -124,13 +93,13 @@ def test_re_request_deletes_old_and_inserts_new(testdataset1, monkeypatch):
     context2 = Context(testdataset1)
     review = request_review(
         context2,
-        "key3",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        data2,
-        2,
+        key_parts="key3",
+        source_value=SOURCE_VALUE,
+        source_mime_type=SOURCE_MIME_TYPE,
+        source_label=SOURCE_LABEL,
+        source_url=SOURCE_URL,
+        orig_extraction_data=data2,
+        crawler_version=2,
         default_accepted=False,
     )
     old = (


### PR DESCRIPTION
Keeps the current accepted status and extracted_data (potentially modified and accepted by a reviewer) if the old orig_extraction_data matches the new orig_extraction_data unless `keep_if_equals` is set to False.

This also renames the model_version field to crawler_version and moves the responsibility to check if the version has changed to the crawler. This is because building this into `zavod.stateful.review` complicates the notions of whether historical data should be kept, while this is still a hypothetical case.

Only a couple of something_changed crawlers have been updated for discussion, but I'll do the rest in this PR once we settle on a direction.

The cases we want to know we can handle reasonable easily:

- they've made a correction to one page: A relevant name change should appear in the extracted data and trigger a re-review automatically
- [they've changed the article body markup across the board](https://github.com/opensanctions/opensanctions/pull/2849)
- we want to change the crawler in a way that we want to bulk-re-request reviews: bump CRAW:ER_VERSION, compare to get_review().crawler_version, and re-request review with accepted defaulting to true/false as appropriate.