### PR TITLE
Re review factor logic

### DIFF
--- a/datasets/us/cftc_enforcement_actions/crawler.py
+++ b/datasets/us/cftc_enforcement_actions/crawler.py
@@ -1,20 +1,21 @@
 from typing import Optional, List, Literal
 from pydantic import BaseModel, Field
 import re
+
+from rigour.mime.types import HTML
 from zavod.entity import Entity
 from zavod.shed import enforcements
 
-from lxml.html import HtmlElement, fromstring, tostring
+from lxml.html import HtmlElement, tostring
 
 from zavod.context import Context
 from zavod import helpers as h
 from zavod.shed.gpt import DEFAULT_MODEL, run_typed_text_prompt
 from zavod.stateful.review import (
-    Review,
     assert_all_accepted,
     request_review,
     get_review,
-    model_hash,
+    source_html_matches,
 )
 
 Schema = Literal["Person", "Company", "LegalEntity"]
@@ -28,13 +29,9 @@ Status = Literal[
     "Other",
 ]
 
-MODEL_VERSION = 1
-MIN_MODEL_VERSION = 1
+CRAWLER_VERSION = 1
 
 REGEX_RELEASE_ID = re.compile(r"(\w{2,8}-\w{2,4}[\w #-]*)$")
-
-something_changed = False
-
 
 # Not extracting relationships for now because the results were inconsistent
 # between GPT queries.
@@ -139,48 +136,6 @@ def fetch_article(context: Context, url: str) -> HtmlElement | None:
     return article_element
 
 
-def source_changed(review: Review, article_element: HtmlElement) -> bool:
-    """
-    The key exists but the current source data looks different from the existing version
-    in spite of heavy normalisation.
-    """
-    seen_element = fromstring(review.source_value)
-    return h.element_text_hash(seen_element) != h.element_text_hash(article_element)
-
-
-def check_something_changed(
-    context: Context,
-    review: Review,
-    article_html: str,
-    article_element: HtmlElement,
-) -> bool:
-    """
-    Returns True if the source content has changed.
-
-    In that case it also reprompts to log whether the extracted data has changed.
-    """
-    if source_changed(review, article_element):
-        prompt_result = run_typed_text_prompt(context, PROMPT, article_html, Defendants)
-        if model_hash(prompt_result) == model_hash(review.orig_extraction_data):
-            context.log.warning(
-                "The source content has changed but the extracted data has not",
-                url=review.source_url,
-                seen_source_value=review.source_value,
-                new_source_value=article_html,
-            )
-        else:
-            # A new extraction result looks different from the known original extraction
-            context.log.warning(
-                "The extracted data has changed",
-                url=review.source_url,
-                orig_extracted_data=review.orig_extraction_data.model_dump(),
-                prompt_result=prompt_result.model_dump(),
-            )
-        return True
-    else:
-        return False
-
-
 def make_related_company(context: Context, name: str) -> Entity:
     entity = context.make("Company")
     entity.id = context.make_id(name)
@@ -212,33 +167,20 @@ def crawl_enforcement_action(context: Context, date: str, url: str) -> None:
         return
     article_html = tostring(article_element, pretty_print=True, encoding="unicode")
     release_id = get_release_id(url)
-    review = get_review(context, Defendants, release_id, MIN_MODEL_VERSION)
-    if review is None:
+
+    review = get_review(context, data_model=Defendants, key_parts=release_id)
+    if review is None or not source_html_matches(review, article_element):
         prompt_result = run_typed_text_prompt(context, PROMPT, article_html, Defendants)
         review = request_review(
             context,
-            release_id,
-            article_html,
-            "text/html",
-            "Enforcement Action Notice",
-            url,
-            prompt_result,
-            MODEL_VERSION,
+            key_parts=release_id,
+            source_value=article_html,
+            source_mime_type=HTML,
+            source_label="Enforcement Action Notice",
+            source_url=url,
+            orig_extraction_data=prompt_result,
+            crawler_version=CRAWLER_VERSION,
         )
-
-    if check_something_changed(context, review, article_html, article_element):
-        # In the first iteration, we're being super conservative and rejecting
-        # export if the source content has changed regardless of whether the
-        # extraction result has changed. If we see this happening and we see that
-        # the extraction result reliably identifies real data changes, we can
-        # relax this to only reject if the extraction result has changed.
-
-        # Similarly if we see that broad markup changes don't trigger massive
-        # re-reviews but legitimate changes are reliably detected, we can allow
-        # it to automatically request re-reviews upon extraction changes.
-        global something_changed
-        something_changed = True
-        return
 
     if not review.accepted:
         return
@@ -325,6 +267,3 @@ def crawl(context: Context) -> None:
             break
 
     assert_all_accepted(context)
-    global something_changed
-    error = "See what changed to determine whether to trigger re-review."
-    assert not something_changed, error

--- a/datasets/us/ofac/enforcement_actions/crawler.py
+++ b/datasets/us/ofac/enforcement_actions/crawler.py
@@ -202,7 +202,7 @@ def crawl(context: Context):
         )
         if not links:
             break
-        search_results = doc.findall(".//div[contains(@class, 'search-result')]")
+        search_results = doc.xpath(".//div[contains(@class, 'search-result')]")
         for result in search_results:
             enforcement_date = result.xpath(
                 ".//div[contains(@class,'margin-top-1') and contains(., 'Enforcement Actions')]/text()[normalize-space()]"

--- a/ui/lib/db.ts
+++ b/ui/lib/db.ts
@@ -100,8 +100,8 @@ async function assertSchemaMatchesExpected(db: Kysely<ReviewDatabase>) {
   for (const column of reviewTable.columns) {
     existingColumnNames.add(column.name);
   }
-  const unexpected = expectedColumns.difference(existingColumnNames);
-  const missing = existingColumnNames.difference(expectedColumns);
+  const missing = expectedColumns.difference(existingColumnNames);
+  const unexpected = existingColumnNames.difference(expectedColumns);
   if (unexpected.size > 0 || missing.size > 0) {
     let msg = `Table ${tableName} doesn't match expected schema. `;
     if (unexpected.size > 0)

--- a/ui/lib/db.ts
+++ b/ui/lib/db.ts
@@ -18,6 +18,7 @@ const expectedColumns = new Set<string>([
   'id',
   'key',
   'dataset',
+  'extraction_checksum',
   'extraction_schema',
   'source_value',
   'source_mime_type',

--- a/ui/lib/db.ts
+++ b/ui/lib/db.ts
@@ -24,7 +24,7 @@ const expectedColumns = new Set<string>([
   'source_label',
   'source_url',
   'accepted',
-  'model_version',
+  'crawler_version',
   'orig_extraction_data',
   'extracted_data',
   'last_seen_version',
@@ -43,7 +43,7 @@ export interface ReviewTable {
   source_label: string
   source_url: string | null
   accepted: boolean
-  model_version: number
+  crawler_version: number
   orig_extraction_data: JSONColumnType<object, object, object>
   extracted_data: JSONColumnType<object, object, object>
   last_seen_version: string

--- a/zavod/migrations/2025-09-19-checksum-and-version.sql
+++ b/zavod/migrations/2025-09-19-checksum-and-version.sql
@@ -1,1 +1,2 @@
 ALTER TABLE review RENAME COLUMN model_version TO crawler_version;
+ALTER TABLE review ADD COLUMN extraction_checksum VARCHAR(255);

--- a/zavod/migrations/2025-09-19-crawler-version.sql
+++ b/zavod/migrations/2025-09-19-crawler-version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE review RENAME COLUMN model_version TO crawler_version;

--- a/zavod/zavod/helpers/__init__.py
+++ b/zavod/zavod/helpers/__init__.py
@@ -66,6 +66,7 @@ from zavod.helpers.change import assert_dom_hash, assert_file_hash
 from zavod.helpers.change import assert_url_hash, assert_html_url_hash
 from zavod.helpers.pdf import make_pdf_page_images, parse_pdf_table
 from zavod.helpers.articles import make_article, make_documentation
+from zavod.helpers.llm import prompt_for_review
 
 __all__ = [
     "clean_note",
@@ -113,4 +114,5 @@ __all__ = [
     "split_comma_names",
     "make_pdf_page_images",
     "parse_pdf_table",
+    "prompt_for_review",
 ]

--- a/zavod/zavod/helpers/llm.py
+++ b/zavod/zavod/helpers/llm.py
@@ -1,0 +1,17 @@
+from zavod.context import Context
+from zavod.shed.gpt import run_typed_text_prompt
+from zavod.stateful.review import LLMExtractionConfig, SourceValue, ModelType
+
+
+def prompt_for_review(
+    context: Context,
+    extraction_config: LLMExtractionConfig[ModelType],
+    source_value: SourceValue,
+) -> ModelType:
+    return run_typed_text_prompt(
+        context,
+        extraction_config.prompt,
+        source_value.value_string,
+        extraction_config.data_model,
+        model=extraction_config.llm_model,
+    )

--- a/zavod/zavod/stateful/model.py
+++ b/zavod/zavod/stateful/model.py
@@ -52,6 +52,7 @@ review_table = Table(
     Column("id", Integer, primary_key=True),
     Column("key", Unicode(KEY_LEN), nullable=False, index=True),
     Column("dataset", Unicode(KEY_LEN), nullable=False, index=True),
+    Column("extraction_checksum", Unicode(KEY_LEN), nullable=False),
     Column("extraction_schema", JSON, nullable=False),
     Column("source_value", Unicode(LARGE_VALUE_LEN), nullable=True),
     Column("source_mime_type", Unicode(VALUE_LEN), nullable=True),

--- a/zavod/zavod/stateful/model.py
+++ b/zavod/zavod/stateful/model.py
@@ -58,7 +58,7 @@ review_table = Table(
     Column("source_label", Unicode(VALUE_LEN), nullable=True),
     Column("source_url", Unicode(VALUE_LEN), nullable=True),
     Column("accepted", Boolean, nullable=False, index=True),
-    Column("model_version", Integer, nullable=False),
+    Column("crawler_version", Integer, nullable=False),
     # only to be edited by the crawler
     Column("orig_extraction_data", JSON, nullable=False),
     # editable by the reviewer

--- a/zavod/zavod/stateful/model.py
+++ b/zavod/zavod/stateful/model.py
@@ -60,11 +60,8 @@ review_table = Table(
     Column("source_url", Unicode(VALUE_LEN), nullable=True),
     Column("accepted", Boolean, nullable=False, index=True),
     Column("crawler_version", Integer, nullable=False),
-    # only to be edited by the crawler
     Column("orig_extraction_data", JSON, nullable=False),
-    # editable by the reviewer
     Column("extracted_data", JSON, nullable=False),
-    # The crawl version that last saw this review key
     Column("last_seen_version", Unicode(KEY_LEN), nullable=False, index=True),
     Column("modified_at", DateTime, nullable=False),
     Column("modified_by", Unicode(KEY_LEN), nullable=False),

--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from datetime import datetime, timezone
 from hashlib import sha1
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
@@ -17,7 +18,7 @@ from lxml.html import HtmlElement, fromstring
 
 from zavod.context import Context
 from zavod.stateful.model import review_table
-from zavod.helpers import html as h
+from zavod import helpers as h
 
 log = getLogger(__name__)
 
@@ -42,6 +43,7 @@ class Review(BaseModel, Generic[ModelType]):
     id: Optional[int] = None
     key: str
     dataset: str
+    extraction_checksum: str
     extraction_schema: JsonValue
     source_value: str
     source_mime_type: str
@@ -124,6 +126,7 @@ class Review(BaseModel, Generic[ModelType]):
         ins = insert(review_table).values(
             key=self.key,
             dataset=self.dataset,
+            extraction_checksum=self.extraction_checksum,
             extraction_schema=self.extraction_schema,
             source_value=self.source_value,
             source_mime_type=self.source_mime_type,
@@ -159,6 +162,84 @@ class Review(BaseModel, Generic[ModelType]):
         return conn.execute(select_stmt).scalar_one()
 
 
+class ExtractionConfig(Generic[ModelType]):
+    checksum: str
+    data_model: Type[ModelType]
+
+
+class BackfillExtractionConfig(ExtractionConfig[ModelType]):
+    def __init__(self, data_model: Type[ModelType]):
+        self.data_model = data_model
+        self.checksum = "backfilled"
+
+
+class LLMExtractionConfig(ExtractionConfig[ModelType]):
+    def __init__(self, data_model: Type[ModelType], llm_model: str, prompt: str):
+        self.data_model = data_model
+        self.llm_model = llm_model
+        self.checksum = text_hash(llm_model + prompt)
+
+
+class SourceValue(ABC):
+    key_parts: str | List[str]
+    mime_type: str
+    label: str
+    url: Optional[str]
+    value_string: str
+
+    def matches(self, review: Review[ModelType]) -> bool:
+        raise NotImplementedError
+
+
+class HtmlSourceValue(SourceValue):
+    html: str
+    element: HtmlElement
+
+    def __init__(
+        self,
+        key_parts: str | List[str],
+        mime_type: str,
+        label: str,
+        url: Optional[str],
+        value_string: str,
+        element: HtmlElement,
+    ):
+        """
+        Args:
+            key_parts: The key parts will be slugified and shorted with a hash of all the
+                parts if the slug would be too long.
+
+                Should be unique within the dataset, and as consistent as possible between runs.
+            source_value: The value of the original text, or a url to an archived original
+                to be used as evidence by the reviewer and for provenance if we're challenged.
+            source_mime_type: The mime type of the source value. Useful to know how to display
+                the source value to the reviewer.
+            source_label: Used to indicate the context of the source value to the reviewer,
+                e.g. "Banking Organization field in CSV" or "Screenshot of PDF page"
+            source_url: The url where source_value was fetched from.
+            value_string: The string value of the source value.
+        """
+        self.key_parts = key_parts
+        self.mime_type = mime_type
+        self.label = label
+        self.url = url
+        self.value_string = value_string
+        self.element = element
+
+    def matches(self, review: Review[ModelType]) -> bool:
+        assert review.source_mime_type == HTML, review.source_mime_type
+        seen_element = fromstring(review.source_value)
+        return h.html.element_text_hash(seen_element) == h.html.element_text_hash(
+            self.element
+        )
+
+
+class SourceObservation(Generic[ModelType]):
+    def __init__(self, review: Optional[Review[ModelType]], should_extract: bool):
+        self.review = review
+        self.should_extract = should_extract
+
+
 def review_key(parts: str | List[str]) -> str:
     """Generates a unique key for a given string of party names.
     If the slug would be longer than 255 chars, we include a truncated hash of the
@@ -174,18 +255,24 @@ def review_key(parts: str | List[str]) -> str:
         return f"{slug[:80]}-{hash[:10]}"
 
 
+def should_review(
+    review: Optional[Review[ModelType]], extraction_result: ModelType
+) -> bool:
+    """
+    Determine if a review should be requested for a given extraction result.
+    """
+    if review is None:
+        return True
+    return model_hash(extraction_result) != model_hash(review.orig_extraction_data)
+
+
 def request_review(
     context: Context,
-    *,
-    key_parts: str | List[str],
-    source_value: str,
-    source_mime_type: str,
-    source_label: str,
-    source_url: Optional[str],
+    source_value: SourceValue,
+    extraction_config: ExtractionConfig[ModelType],
     orig_extraction_data: ModelType,
     crawler_version: int,
     default_accepted: bool = False,
-    keep_if_equal: bool = True,
 ) -> Review[ModelType]:
     """
     Add automatically extracted data for review and
@@ -193,17 +280,8 @@ def request_review(
 
     Args:
         context: The runner context with dataset metadata.
-        key_parts: The key parts will be slugified and shorted with a hash of all the
-            parts if the slug would be too long.
-
-            Should be unique within the dataset, and as consistent as possible between runs.
-        source_value: The value of the original text, or a url to an archived original
-            to be used as evidence by the reviewer and for provenance if we're challenged.
-        source_mime_type: The mime type of the source value. Useful to know how to display
-            the source value to the reviewer.
-        source_label: Used to indicate the context of the source value to the reviewer,
-            e.g. "Banking Organization field in CSV" or "Screenshot of PDF page"
-        source_url: The url where source_value was fetched from.
+        source_value: The source value for the extracted data.
+        extraction_config: The configuration for extracting the data.
         orig_extraction_data: An instance of a pydantic model of data extracted
             from the source. Any reviewer changes to the data will be validated against
             this model.
@@ -211,44 +289,49 @@ def request_review(
             requiring re-extraction and/or re-review.
             Useful e.g. when breaking model changes are made.
         default_accepted: Whether the data should be marked as accepted by default.
-        keep_if_equal: Keep the accepted status and extracted data if the new
-            orig_extraction_data equals existing orig_extraction_data for this key.
     """
-    key_slug = review_key(key_parts)
+    key_slug = review_key(source_value.key_parts)
     assert key_slug is not None
     dataset = context.dataset.name
+
+    review = Review.by_key(context.conn, type(orig_extraction_data), dataset, key_slug)
+
     schema = type(orig_extraction_data).model_json_schema(
         schema_generator=SchemaGenerator
     )
-    now = datetime.now(timezone.utc)
-    review = Review.by_key(context.conn, type(orig_extraction_data), dataset, key_slug)
+    always_fields = {
+        "dataset": dataset,
+        "source_value": source_value.value_string,
+        "source_mime_type": source_value.mime_type,
+        "source_label": source_value.label,
+        "source_url": source_value.url,
+        "source_value": source_value.value_string,
+        "extraction_schema": schema,
+        "extraction_checksum": extraction_config.checksum,
+        "data_model": type(orig_extraction_data),
+        "crawler_version": crawler_version,
+        "orig_extraction_data": orig_extraction_data,
+        "last_seen_version": context.version.id,
+        "modified_at": datetime.now(timezone.utc),
+        "modified_by": "zavod",
+    }
+
     if review is None:
         # First insert
         context.log.debug("Requesting review", key=key_slug)
         review = Review(
             key=key_slug,
-            dataset=dataset,
-            extraction_schema=schema,
-            source_value=source_value,
-            source_mime_type=source_mime_type,
-            source_label=source_label,
-            source_url=source_url,
-            data_model=type(orig_extraction_data),
-            crawler_version=crawler_version,
-            orig_extraction_data=orig_extraction_data,
             extracted_data=orig_extraction_data,
             accepted=default_accepted,
-            last_seen_version=context.version.id,
-            modified_at=now,
-            modified_by="zavod",
+            **always_fields,
         )  # type: ignore
         review.save(context.conn)
     # We're re-requesting review for an existing key for this dataset.
     else:
-        new_result_equals_old = model_hash(orig_extraction_data) == model_hash(
-            review.orig_extraction_data
-        )
-        if keep_if_equal and new_result_equals_old:
+        if model_hash(orig_extraction_data) == model_hash(review.orig_extraction_data):
+            # If the extraction result is the same as the original, we just store
+            # a new version of the review with latest source data but keep the
+            # acceptance status and any edits in extracted_data.
             accepted = review.accepted
             extracted_data = review.extracted_data
         else:
@@ -256,49 +339,62 @@ def request_review(
             extracted_data = orig_extraction_data
 
         context.log.debug("Re-requesting review", key=key_slug)
-        review.extraction_schema = schema
-        review.source_value = source_value
-        review.source_mime_type = source_mime_type
-        review.source_label = source_label
-        review.source_url = source_url
-        review.crawler_version = crawler_version
-        review.orig_extraction_data = orig_extraction_data
         review.extracted_data = extracted_data
         review.accepted = accepted
-        review.last_seen_version = context.version.id
-        review.modified_at = now
-        review.modified_by = "zavod"
+        for key, value in always_fields.items():
+            setattr(review, key, value)
         review.save(context.conn)
     return review
 
 
-def get_review(
+def should_extract(
+    review: Optional[Review[ModelType]],
+    source_value: SourceValue,
+    extraction_config: ExtractionConfig[ModelType],
+) -> bool:
+    if review is None:
+        return True
+
+    if not review.accepted and review.extraction_checksum != extraction_config.checksum:
+        return True
+
+    if not source_value.matches(review):
+        return True
+
+    return False
+
+
+def observe_source_value(
     context: Context,
-    *,
-    data_model: Type[ModelType],
-    key_parts: str | List[str],
-) -> Optional[Review[ModelType]]:
+    source_value: SourceValue,
+    extraction_config: ExtractionConfig[ModelType],
+) -> SourceObservation[ModelType]:
     """
-    Get a review for a given key if it exists and its model is up to date.
-    Returned reviews will have had their last_seen_version updated to the current crawl version.
+    Get a review for a given key if it exists and update its last_seen_version to the current crawl version.
+
+    Determine whether extraction should be performed for the given value and extraction config.
 
     Args:
         context: The runner context with dataset metadata.
+        source_value: The source value for the extracted data.
         data_model: The pydantic data model class used to extract the data.
-        key_parts: The key parts will be slugified and shorted if needed consistently
-            with the key generated by `request_review`.
     """
-    key_slug = review_key(key_parts)
+    key_slug = review_key(source_value.key_parts)
     assert key_slug is not None
     review = Review[ModelType].by_key(
-        context.conn, data_model, context.dataset.name, key_slug
+        context.conn, extraction_config.data_model, context.dataset.name, key_slug
     )
+
     if review is None:
         context.log.debug("Review not found", key=key_slug)
-        return None
-    context.log.debug("Review found, updating last_seen_version", key=key_slug)
-    review.update_version(context.conn, context.version.id)
-    return review
+    else:
+        context.log.debug("Review found, updating last_seen_version", key=key_slug)
+        review.update_version(context.conn, context.version.id)
+
+    return SourceObservation(
+        review=review,
+        should_extract=should_extract(review, source_value, extraction_config),
+    )
 
 
 def assert_all_accepted(context: Context, *, raise_on_unaccepted: bool = True) -> None:
@@ -353,12 +449,3 @@ def model_hash(data: BaseModel) -> str:
     # Sort dictionary keys and convert to orjson
     raw_data_json = orjson.dumps(sorted_data, option=orjson.OPT_SORT_KEYS)
     return text_hash(raw_data_json.decode("utf-8"))
-
-
-def source_html_matches(review: Review[ModelType], element: HtmlElement) -> bool:
-    """
-    True if the source data matches the given element.
-    """
-    assert review.source_mime_type == HTML, review.source_mime_type
-    seen_element = fromstring(review.source_value)
-    return h.element_text_hash(seen_element) == h.element_text_hash(element)

--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -43,7 +43,7 @@ class Review(BaseModel, Generic[ModelType]):
     id: Optional[int] = None
     key: str
     dataset: str
-    extraction_checksum: str
+    extraction_checksum: Optional[str]
     extraction_schema: JsonValue
     source_value: str
     source_mime_type: str
@@ -178,6 +178,7 @@ class LLMExtractionConfig(ExtractionConfig[ModelType]):
         self.data_model = data_model
         self.llm_model = llm_model
         self.checksum = text_hash(llm_model + prompt)
+        self.prompt = prompt
 
 
 class SourceValue(ABC):

--- a/zavod/zavod/tests/stateful/test_review.py
+++ b/zavod/zavod/tests/stateful/test_review.py
@@ -24,16 +24,16 @@ def get_row(conn, key):
 
 def test_new_key_saved_and_accepted_false(testdataset1):
     context = Context(testdataset1)
-    model = DummyModel(foo="bar")
+    data = DummyModel(foo="bar")
     review = request_review(
         context,
-        "key1",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        model,
-        1,
+        key_parts="key1",
+        source_value=SOURCE_VALUE,
+        source_mime_type=SOURCE_MIME_TYPE,
+        source_label=SOURCE_LABEL,
+        source_url=SOURCE_URL,
+        orig_extraction_data=data,
+        crawler_version=1,
     )
     assert review.accepted is False
     row = get_row(context.conn, "key1")
@@ -49,13 +49,13 @@ def test_current_model_version_updates_last_seen_version(testdataset1, monkeypat
     data = DummyModel(foo="bar")
     request_review(
         context1,
-        "key2",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        data,
-        1,
+        key_parts="key2",
+        source_value=SOURCE_VALUE,
+        source_mime_type=SOURCE_MIME_TYPE,
+        source_label=SOURCE_LABEL,
+        source_url=SOURCE_URL,
+        orig_extraction_data=data,
+        crawler_version=1,
     )
     row = get_row(context1.conn, "key2")
     assert row and row["last_seen_version"] == context1_version
@@ -65,9 +65,8 @@ def test_current_model_version_updates_last_seen_version(testdataset1, monkeypat
     context2_version = context2.version.id
     review = get_review(
         context2,
-        DummyModel,
-        "key2",
-        1,
+        data_model=DummyModel,
+        key_parts="key2",
     )
     assert review.last_seen_version == context2_version
     row = get_row(context2.conn, "key2")
@@ -75,48 +74,18 @@ def test_current_model_version_updates_last_seen_version(testdataset1, monkeypat
     assert context1_version != context2_version
 
 
-def test_expired_model_version_returns_none(testdataset1, monkeypatch):
-    context = Context(testdataset1)
-    context.begin(clear=True)
-    data = DummyModel(foo="bar")
-    review = request_review(
-        context,
-        "key3",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        data,
-        1,
-    )
-    review = get_review(
-        context,
-        DummyModel,
-        "key3",
-        1,
-    )
-    assert review is not None
-    review = get_review(
-        context,
-        DummyModel,
-        "key3",
-        2,
-    )
-    assert review is None
-
-
 def test_re_request_deletes_old_and_inserts_new(testdataset1, monkeypatch):
     context1 = Context(testdataset1)
     data = DummyModel(foo="bar")
     review = request_review(
         context1,
-        "key3",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        data,
-        1,
+        key_parts="key3",
+        source_value=SOURCE_VALUE,
+        source_mime_type=SOURCE_MIME_TYPE,
+        source_label=SOURCE_LABEL,
+        source_url=SOURCE_URL,
+        orig_extraction_data=data,
+        crawler_version=1,
         default_accepted=True,
     )
     assert review.accepted is True
@@ -124,13 +93,13 @@ def test_re_request_deletes_old_and_inserts_new(testdataset1, monkeypatch):
     context2 = Context(testdataset1)
     review = request_review(
         context2,
-        "key3",
-        SOURCE_VALUE,
-        SOURCE_MIME_TYPE,
-        SOURCE_LABEL,
-        SOURCE_URL,
-        data2,
-        2,
+        key_parts="key3",
+        source_value=SOURCE_VALUE,
+        source_mime_type=SOURCE_MIME_TYPE,
+        source_label=SOURCE_LABEL,
+        source_url=SOURCE_URL,
+        orig_extraction_data=data2,
+        crawler_version=2,
         default_accepted=False,
     )
     old = (


### PR DESCRIPTION
Based on and takes it a bit further than https://github.com/opensanctions/opensanctions/pull/2848 - see the new stuff used in the CFTC crawler. Tests aren't updated  yet.

Move all the should_extract ~and should_review logic~ into  a function in zavod.stateful.review.

`request_review` still does its own `model_hash(extraction_result) != model_hash(review.orig_extraction_data)` - I think it makes sense not to update source_value until we've decided whether we need to re-review. Even if we're not re-reviewing, we want to update sourve_value.

It's tempting to move 

```python
if observation.should_extract:
        prompt_result = run_typed_text_prompt(
            context,
            extraction_config.prompt,
            source_value.value_string,
            extraction_config.data_model,
            model=extraction_config.llm_model,
        )
        review = request_review(
            context,
            source_value,
            extraction_config,
            orig_extraction_data=prompt_result,
            crawler_version=CRAWLER_VERSION,
        )
```

into observe_source_value - the two kinds of extractions we currently have are once-per-crawler backfilling based on regex/lookups, and LLM. The two options I see for this are:

- logic based on the extraction config type
- passing a callable (extraction_config, source_value_string) -> BaseModel to `observe_source_value`

Should we go that far or is this a good step for now? Is there a better way?