### PR TITLE
[us_bis_denied] Handle whatever format they feel like sending on the …

### DIFF
--- a/datasets/us/bis_denied_new/crawler.py
+++ b/datasets/us/bis_denied_new/crawler.py
@@ -1,0 +1,109 @@
+import csv
+
+import openpyxl
+import xlrd
+from followthemoney.types import registry
+from rigour.mime.types import XLS
+
+from zavod import Context
+from zavod import helpers as h
+
+# Program key reused from 'us_trade_csl' for consistency
+# Refers to the same BIS Denied Persons List program
+PROGRAM_KEY = "US-BIS-DPL"
+
+
+def parse_row(context: Context, row):
+    entity = context.make("LegalEntity")
+    effective_date = row.pop("effective_date")
+    name = row.pop("name")
+    country = row.pop("country")
+    city = row.pop("city")
+
+    entity.id = context.make_id(name, city, country)
+    entity.add("name", name)
+    entity.add("notes", row.pop("action"))
+    entity.add("country", country)
+    h.apply_date(entity, "modifiedAt", row.pop("last_update"))
+
+    country_code = registry.country.clean(country)
+    address = h.make_address(
+        context,
+        street=row.pop("street_address"),
+        postal_code=row.pop("postal_code"),
+        city=city,
+        region=row.pop("state"),
+        country_code=country_code,
+    )
+    h.copy_address(entity, address)
+
+    citation = row.pop("fr_citation")
+    # We don't link it to the website here, since it's included in the us_trade_csl
+    # programs, which is linked to the website.
+    sanction = h.make_sanction(context, entity, key=citation, program_key=PROGRAM_KEY)
+    sanction.add("program", citation)
+    h.apply_date(sanction, "startDate", effective_date)
+    h.apply_date(sanction, "endDate", row.pop("expiration_date"))
+
+    if h.is_active(sanction):
+        entity.add("topics", "sanction")
+
+    context.emit(entity)
+    context.emit(sanction)
+
+    context.audit_data(
+        row,
+        [
+            "counter",
+            "standard_order",
+            "type_of_denial",
+            "name_and_address",
+        ],
+    )
+
+
+def crawl(context: Context):
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    urls = doc.xpath(".//a[contains(normalize-space(.), 'Export as CSV')]/@href")
+    assert len(urls) == 1, "Expected exactly one URL"
+    url = urls[0]
+    path = context.fetch_resource("source.whoknows", url)
+
+    rows = None
+    if ".xls" in url:
+        context.log.info("Reading as XLS", url=url)
+        wb = xlrd.open_workbook(path)
+        assert wb.sheet_names() == ["dpl", "Sheet2", "Sheet3"]
+        path = path.rename(path.with_suffix(".xls"))
+        context.export_resource(path, XLS, title=context.SOURCE_TITLE)
+        rows = h.parse_xls_sheet(context, wb["dpl"])
+    elif ".xlsx" in url:
+        context.log.info("Reading as XLSX", url=url)
+        workbook: openpyxl.Workbook = openpyxl.load_workbook(path, read_only=True)
+        assert set(workbook.sheetnames) == ["dpl", "Sheet2", "Sheet3"]
+        path = path.rename(path.with_suffix(".xlsx"))
+        rows = h.parse_xlsx_sheet(path, context.get_lookup("columns"))
+    elif ".csv" in url:
+        context.log.info("Reading as CSV", url=url)
+        path = path.rename(path.with_suffix(".csv"))
+        with open(path, "rt", encoding="utf-8-sig") as infh:
+            reader = csv.DictReader(infh)
+            fieldnames = reader.fieldnames
+        norm_fieldnames = []
+        for field in fieldnames:
+            res = context.lookup("columns", field)
+            if res is None:
+                context.log.warning("Unknown column", column=field)
+                norm_fieldnames.append(field.lower().replace(" ", "_"))
+            norm_fieldnames.append(res.value)
+        with open(path, "rt", encoding="utf-8-sig") as infh:
+            reader = csv.DictReader(infh, fieldnames=norm_fieldnames)
+            next(reader)  # Skip header row
+            rows = list(reader)
+    else:
+        raise Exception(f"No known extension for {path}")
+
+    context.export_resource(path, XLS, title=context.SOURCE_TITLE)
+
+    for row in rows:
+        parse_row(context, row)

--- a/datasets/us/bis_denied_new/us_bis_denied_new.yml
+++ b/datasets/us/bis_denied_new/us_bis_denied_new.yml
@@ -1,0 +1,94 @@
+title: Temporary Denied Persons List crawler to bring in new scheme
+entry_point: crawler.py
+prefix: us-bis
+coverage:
+  schedule: "0 */8 * * *"
+  frequency: daily
+  start: "2015-12-05"
+load_statements: true
+summary: >
+  The Bureau of Industry and Security publishes this list of entities which
+  are relevant with regards to export controls.
+description: |
+  The Denied Persons List is a list of people and companies whose export
+  privileges have been denied by the Department of Commerce's Bureau of
+  Industry and Security (BIS). An American company or individual may not
+  participate in an export transaction with an individual or company on the
+  Denied Persons List.
+
+  The Denied Persons List is also included in the [US Trade Consolidated List](/datasets/us_trade_csl/),
+  so we may want to remove this crawler at some point.
+publisher:
+  name: Bureau of Industry and Security
+  acronym: BIS
+  description: |
+    BIS is part of the U.S. Department of Commerce, where it manages the intersection between
+    business and the foreign policy and security interests of the U.S.
+  url: https://www.bis.gov
+  country: us
+  official: true
+tags:
+  - list.sanction
+  - list.export
+  - juris.us
+  - issuer.west
+url: https://www.bis.gov/licensing/end-user-guidance/denied-persons-list-dpl
+data:
+  url: https://www.bis.gov/licensing/end-user-guidance/denied-persons-list-dpl
+  format: HTML
+  lang: eng
+dates:
+  formats: ["%m/%d/%Y"]
+
+assertions:
+  min:
+    schema_entities:
+      LegalEntity: 1200
+  max:
+    schema_entities:
+      LegalEntity: 2000
+
+lookups:
+  type.country:
+    lowercase: true
+    normalize: true
+    options:
+      - match: NM
+        value: US
+  type.date:
+    options:
+      - match: "3035-04-07"
+        value: 2025-04-07 # since it's a 'modifiedAt' date
+  columns:
+    lowercase: true
+    options:
+      - match: Name_and_Address
+        value: name_and_address
+      - match: Name
+        value: name
+      - match: Street_Address
+        value: street_address
+      - match: City
+        value: city
+      - match: State
+        value: state
+      - match: Country
+        value: country
+      - match: Postal_Code
+        value: postal_code
+      - match: beginning_date
+        value: effective_date
+      - match: Effective_Date
+        value: effective_date
+      - match: ending_date
+        value: expiration_date
+      - match: Expiration_Date
+        value: expiration_date
+      - match: Standard_Order
+        value: standard_order
+      - match: Last_Update
+        value: last_update
+      - match: Action
+        value: action
+      - match: FR_Citation
+        value: fr_citation


### PR DESCRIPTION
…day.

So much more exciting than just a CSV each time

---

`added=1951 dataset=us_bis_denied deleted=1888 metric=delta_counts modified=431`

the rekey is because the start date is part of the id and they've dropped leading zeros. More fun.

Maybe a good time to replace the start date with something more stable, or to drop the dataset entirely.