### PR TITLE
WIP: Don't publish failed runs `index.json` to `/datasets`

### DIFF
--- a/zavod/zavod/cli.py
+++ b/zavod/zavod/cli.py
@@ -24,7 +24,7 @@ from zavod.logs import (
     set_logging_context_dataset_name,
 )
 from zavod.meta import load_dataset_from_path, get_multi_dataset, Dataset
-from zavod.publish import publish_dataset, publish_failure
+from zavod.publish import publish_dataset, archive_failure
 from zavod.reset import reset_caches
 from zavod.runtime.versions import make_version
 from zavod.stateful.model import create_db
@@ -142,14 +142,14 @@ def run(
         clear_data_path(dataset.name)
     if dataset.model.disabled:
         log.info("Dataset is disabled, skipping: %s" % dataset.name)
-        publish_failure(dataset, latest=latest)
+        archive_failure(dataset, latest=latest)
         sys.exit(0)
     # Crawl
     if dataset.model.entry_point is not None and not dataset.is_collection:
         try:
             crawl_dataset(dataset, dry_run=False)
         except RunFailedException:
-            publish_failure(dataset, latest=latest)
+            archive_failure(dataset, latest=latest)
             sys.exit(1)
     else:
         make_version(dataset, settings.RUN_VERSION, overwrite=True)
@@ -165,7 +165,7 @@ def run(
             validate_dataset(dataset, view)
     except Exception:
         log.exception("Validation failed for %r" % dataset.name)
-        publish_failure(dataset, latest=latest)
+        archive_failure(dataset, latest=latest)
         store.close()
         sys.exit(1)
     # Export and Publish

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -5,9 +5,7 @@ from zavod.logs import get_logger
 from zavod.archive import publish_resource, dataset_resource_path
 from zavod.archive import publish_dataset_version, publish_artifact
 from zavod.archive import INDEX_FILE, CATALOG_FILE
-from zavod.archive import STATEMENTS_FILE, RESOURCES_FILE, STATISTICS_FILE
-from zavod.archive import VERSIONS_FILE, ARTIFACT_FILES
-from zavod.archive import DELTA_EXPORT_FILE, DELTA_INDEX_FILE
+from zavod.archive import ARTIFACT_FILES
 from zavod.runtime.resources import DatasetResources
 from zavod.runtime.versions import get_latest
 from zavod.exporters import write_dataset_index
@@ -15,7 +13,8 @@ from zavod.exporters import write_dataset_index
 log = get_logger(__name__)
 
 
-def _publish_artifacts(dataset: Dataset) -> None:
+def _archive_artifacts(dataset: Dataset) -> None:
+    """Archive artifacts of the run to the data bucket."""
     version = get_latest(dataset.name, backfill=False)
     if version is None:
         raise ValueError(f"No working version found for dataset: {dataset.name}")
@@ -33,7 +32,11 @@ def _publish_artifacts(dataset: Dataset) -> None:
 
 
 def publish_dataset(dataset: Dataset, latest: bool = True) -> None:
-    """Upload a dataset to the archive."""
+    """Publish a dataset to the archive.
+
+    Note that we only publish successful runs to /datasets.
+    Failed runs are only archived to /artifacts.
+    """
     resources = DatasetResources(dataset)
     for resource in resources.all():
         if resource.name in ARTIFACT_FILES:
@@ -63,36 +66,25 @@ def publish_dataset(dataset: Dataset, latest: bool = True) -> None:
             continue
         mime_type = JSON if meta.endswith(".json") else None
         publish_resource(path, dataset.name, meta, latest=latest, mime_type=mime_type)
-    _publish_artifacts(dataset)
+    _archive_artifacts(dataset)
 
 
-def publish_failure(dataset: Dataset, latest: bool = True) -> None:
-    """Upload failure information about a dataset to the archive."""
+def archive_failure(dataset: Dataset, latest: bool = True) -> None:
+    """Archive artifacts about a run to the archive."""
     # Collections currently should never call publish_failure (as that only gets called for crawl and validate).
     # But if they ever did (for example to publish a failure in the export stage), we should think very well about
     # what exactly a failed index.json for default should look like. Currently, it would have empty resources,
     # and our clients likely wouldn't appreciate that.
     assert not dataset.is_collection
-    # Clear out interim artifacts so they cannot pollute the metadata we're
-    # generating.
-    dataset_resource_path(dataset.name, STATEMENTS_FILE).unlink(missing_ok=True)
-    # TODO: The statistics file gets pulled in by write_dataset_index,
-    #  so they get published as part of the artifacts anyway.
-    #  For a brief discussion of our currently broken failure semantics,
-    #  see https://github.com/opensanctions/opensanctions/pull/2483
-    dataset_resource_path(dataset.name, STATISTICS_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, INDEX_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, CATALOG_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, RESOURCES_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, DELTA_EXPORT_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, DELTA_INDEX_FILE).unlink(missing_ok=True)
 
+    # TODO(Leon Handreke): write a status: FAILED field to index
+    # See https://github.com/opensanctions/opensanctions/issues/2541
     write_dataset_index(dataset)
     path = dataset_resource_path(dataset.name, INDEX_FILE)
     if not path.is_file():
         log.error("Metadata file not found: %s" % path, dataset=dataset.name)
         return
-    publish_resource(path, dataset.name, INDEX_FILE, latest=latest, mime_type=JSON)
-    _publish_artifacts(dataset)
-    dataset_resource_path(dataset.name, RESOURCES_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, VERSIONS_FILE).unlink(missing_ok=True)
+
+    # archive to /artifacts, but don't publish_resource anything to /datasets!
+    # This is useful to debug failed runs.
+    _archive_artifacts(dataset)

--- a/zavod/zavod/tests/exporters/test_delta.py
+++ b/zavod/zavod/tests/exporters/test_delta.py
@@ -11,7 +11,7 @@ from zavod.archive import DELTA_EXPORT_FILE, DATASETS, DELTA_INDEX_FILE
 from zavod.entity import Entity
 from zavod.exporters import export_dataset
 from zavod.meta import Dataset
-from zavod.publish import _publish_artifacts
+from zavod.publish import _archive_artifacts
 from zavod.runtime.versions import make_version
 from zavod.store import get_store
 
@@ -81,7 +81,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
         dataset_path / DELTA_INDEX_FILE, expected_versions
     )
 
-    _publish_artifacts(testdataset1)
+    _archive_artifacts(testdataset1)
 
     version2 = Version.new("bbb")
     make_version(testdataset1, version2, overwrite=True)
@@ -113,7 +113,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     )
 
     # Round 3: check that the delta exporter can handle resolver changes
-    _publish_artifacts(testdataset1)
+    _archive_artifacts(testdataset1)
     version3 = Version.new("ccc")
     make_version(testdataset1, version3, overwrite=True)
     canon_id = resolver.decide("EC", "ECX", Judgement.POSITIVE)


### PR DESCRIPTION
This commit tries to establish some new language around publishing: "Archiving" means uploading to `/artifacts`, while "publishing" means pushing the file out to our customers at `/datasets`.

By no longer unlinking `statistics.json` before calling `write_dataset_index`, we will also be archiving the stats not from the last successful run, but from the current one (which may not have any stats at all if things failed very early on. Neither `index.json` nor `statistics.json` will end up in `/latest` for a failed run.

Unanswered questions:

- Does it make sense to archive (not publish!) all artifacts for forensics? Do we want to exclude some?
- Why were we unlinking RESOURCES_FILE and VERSIONS_FILE at the end of `publish_failure`? What purpose did that serve?

I don't think we have to tell our customers that we're no longer serving them bullshit `index.json`s that don't contain any resources but instead stats from the last successful run... do we?

See https://github.com/opensanctions/opensanctions/issues/2541
