### PR TITLE
Don't merge reviews for different transliterations

### DIFF
--- a/zavod/zavod/tests/stateful/test_review.py
+++ b/zavod/zavod/tests/stateful/test_review.py
@@ -318,3 +318,9 @@ def test_review_key():
         review_key(["key1"] * 100)
         == "key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1--5611368bed"
     )
+    # All punctuation incl / becomes dash (backward compatibility with normality slugify)
+    assert review_key("STEPHEN D/B/A S CONTRACTING") == "stephen-d-b-a-s-contracting"
+    # Non-ascii printable characters are kept
+    assert review_key("Север Мухамадмухтар Крот") == "север-мухамадмухтар-крот"
+    # Zero-width and other non-printable are removed
+    assert review_key("name\u200bwith\u200cweird\u200dchars") == "namewithweirdchars"


### PR DESCRIPTION
Fixes the following, which especially with the name cleaner, could result in different transliterations getting the same review instance and ending up with the same value.

<img width="986" height="546" alt="image" src="https://github.com/user-attachments/assets/11ca7ed0-2e14-482f-aba3-13a6efdecf47" />
