### PR TITLE
[gb_fcdo_sanctions] Only demote weak types to weakAlias if it's an alias

### DIFF
--- a/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
+++ b/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
@@ -167,6 +167,7 @@ lookups:
       - match: "" # we don't want to warn on empty languages
         value: null
   name_type:
+    # is_alias tells us whether we should pay attention to "Alias strength"
     lowercase: true
     normalize: true
     options:
@@ -174,16 +175,18 @@ lookups:
           - "Primary name"
           - "Primary name variation"
           - "" # if we have no name type, we assume it is a primary name
-        value: name
+        prop: name
+        is_alias: false
       - match: "Alias"
-        value: alias
+        prop: alias
+        is_alias: true
   weak_types:
     lowercase: true
     normalize: true
     options:
       - match:
           - "good quality a.k.a"
-          - null
+          - null # ONLY if it's an alias and not a primary name!!
         value: False
       - match: "low quality a.k.a"
         value: True


### PR DESCRIPTION
We treat blank "alias strength" as "weak", but it's always blank when name type isn't an alias, but rather a primary name. So we were sending primary names from the CSV to weakAlias incorrectly. The name consolidation them moved lots of matching primary names to weakAlias in collections including this dataset. (edit: the name demotion was limited to names shorter than 15 chars and single token names)

Expect deltas of up to 5720

```
Delta export complete          [gb_fcdo_sanctions] added=8 dataset=gb_fcdo_sanctions deleted=0 metric=delta_counts modified=5720 version=20260109134533-jmi
```