### PR TITLE
[gb_fcdo_sanctions] Selectively treat blank alias strength as weak/ab…

### DIFF
--- a/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
+++ b/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
@@ -180,13 +180,12 @@ lookups:
       - match: "Alias"
         prop: alias
         is_alias: true
-  weak_types:
+  is_weak_alias:
     lowercase: true
     normalize: true
     options:
-      - match:
-          - "good quality a.k.a"
-          - null # ONLY if it's an alias and not a primary name!!
+      # blanks in CSV is handled in crawler because it depends on a number of factors
+      - match: "good quality a.k.a"
         value: False
       - match: "low quality a.k.a"
         value: True


### PR DESCRIPTION
…breviation

Previously we'd treat all blank alias strength rows as weak aliases. Some are indeed not great, but there are real names in there like "Boko Haram".

This changes the behaviour so that some obviously bad aliases move to weakAlias or abbreviation as needed, and the rest remain in `alias`.

```
Delta export complete          [gb_fcdo_sanctions] added=101 dataset=gb_fcdo_sanctions deleted=77 metric=delta_counts modified=638
```

The adds/deletes should be my out of date resolver.

