### PR TITLE
Introduce XSS scanning via regex

### DIFF
--- a/zavod/zavod/runtime/cleaning.py
+++ b/zavod/zavod/runtime/cleaning.py
@@ -8,8 +8,8 @@ from followthemoney import registry, Property, model
 from followthemoney.statement.util import NON_LANG_TYPE_NAMES
 
 from zavod.logs import get_logger
-from zavod.runtime.lookups import is_lookup_value, prop_lookup
-from zavod.runtime.safety import check_xss
+from zavod.runtime.lookups import is_type_lookup_value, prop_lookup
+from zavod.runtime.safety import check_xss_html_smell
 
 
 if TYPE_CHECKING:
@@ -93,7 +93,7 @@ def value_clean(
 
         # Do not check non-text properties
         if clean is not None and prop.type not in NON_LANG_TYPE_NAMES:
-            clean = check_xss(entity, prop_, clean)
+            clean = check_xss_html_smell(entity, prop_, clean)
 
         # We validate Person:*Name properties as names cause they're strings
         # in the FtM model.
@@ -114,7 +114,7 @@ def value_clean(
                 # Allow abbreviations that are not valid names
 
             elif entity.schema.is_a("LegalEntity") and not is_name(clean):
-                if not is_lookup_value(entity, registry.name, item):
+                if not is_type_lookup_value(entity, registry.name, item):
                     log.warning(
                         f"Property value {value!r} is not a valid name.",
                         entity_id=entity.id,

--- a/zavod/zavod/runtime/lookups.py
+++ b/zavod/zavod/runtime/lookups.py
@@ -17,6 +17,16 @@ def get_type_lookup(dataset: Dataset, type_: PropertyType) -> Optional[Lookup]:
     return dataset.lookups.get(f"type.{type_.name}")
 
 
+def is_lookup_value(entity: "Entity", type_: PropertyType, value: str) -> bool:
+    """Check if a given value for a certain property type was obtained from
+    a lookup. This is used to skip validation for looked-up values."""
+    lookup = get_type_lookup(entity.dataset, type_)
+    if lookup is None:
+        return False
+    result = lookup.match(value)
+    return result is not None
+
+
 def type_lookup(
     dataset: Dataset, type_: PropertyType, value: Optional[str]
 ) -> List[str]:

--- a/zavod/zavod/runtime/lookups.py
+++ b/zavod/zavod/runtime/lookups.py
@@ -17,14 +17,17 @@ def get_type_lookup(dataset: Dataset, type_: PropertyType) -> Optional[Lookup]:
     return dataset.lookups.get(f"type.{type_.name}")
 
 
-def is_lookup_value(entity: "Entity", type_: PropertyType, value: str) -> bool:
-    """Check if a given value for a certain property type was obtained from
-    a lookup. This is used to skip validation for looked-up values."""
+def is_type_lookup_value(entity: "Entity", type_: PropertyType, value: str) -> bool:
+    """Check if a given value is the result of a type-based lookup.
+
+    Used to skip validation for looked-up values, because we've added them manually
+    we deem them to be safe.
+    """
     lookup = get_type_lookup(entity.dataset, type_)
     if lookup is None:
         return False
-    result = lookup.match(value)
-    return result is not None
+    # True if the value is the result of any of the lookup's options.
+    return any(option.result.value == value for option in lookup.options)
 
 
 def type_lookup(

--- a/zavod/zavod/runtime/safety.py
+++ b/zavod/zavod/runtime/safety.py
@@ -1,0 +1,49 @@
+import re
+
+from followthemoney import Property
+
+from zavod.logs import get_logger
+from zavod.entity import Entity
+from zavod.runtime.lookups import is_lookup_value
+
+log = get_logger(__name__)
+
+HTML_ENTITY_PATTERN = re.compile(
+    r"&(?:"
+    r"#[0-9]{1,7};|"  # Decimal: &#65;
+    r"#[xX][0-9a-fA-F]{1,6};|"  # Hex: &#x41; &#X41;
+    r"[a-zA-Z][a-zA-Z0-9]*;?"  # Named: &amp; &lt (HTML5 allows no semicolon for some)
+    r")"
+)
+
+XSS_SUSPECT_PATTERN = re.compile(
+    r"<[^>]*>|"  # Tags
+    r"javascript:|data:|vbscript:|"  # URI schemes
+    r"on\w+\s*=|"  # Event handlers
+    r"&#|&[a-zA-Z]",  # Entity references
+    re.IGNORECASE,
+)
+
+
+def check_xss(entity: Entity, prop: Property, value: str) -> str | None:
+    """A very basic HTML entity and XSS check to prevent script injections."""
+    # This is very .... rustic. The reason for that design is that there's a lot of things
+    # here we do not want to do, which normal XSS filters would do, like stripping tags
+    # or escaping entities. Both of these would render our data useless for matching purposes.
+    # So we only want to identify the most egregious cases and log them for manual review.
+    has_xss = XSS_SUSPECT_PATTERN.search(value)
+    has_entities = HTML_ENTITY_PATTERN.search(value)
+    if not has_xss and not has_entities:
+        return value
+    if is_lookup_value(entity, prop.type, value):
+        return value
+    log.warning(
+        f"HTML/XSS suspicion in property value: {value}",
+        prop=prop.name,
+        value=value,
+    )
+    # FIXME: I want to run this in warning mode first, later we need to enable this:
+    # Remove for safety unless it's set
+    # return None
+
+    return value

--- a/zavod/zavod/runtime/safety.py
+++ b/zavod/zavod/runtime/safety.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from followthemoney import Property
 
 from zavod.logs import get_logger
-from zavod.runtime.lookups import is_lookup_value
+from zavod.runtime.lookups import is_type_lookup_value
 
 if TYPE_CHECKING:
     from zavod.entity import Entity
@@ -29,18 +29,28 @@ XSS_SUSPECT_PATTERN = re.compile(
 )
 
 
-def check_xss(entity: "Entity", prop: Property, value: str) -> str | None:
-    """A very basic HTML entity and XSS check to prevent script injections."""
-    # This is very .... rustic. The reason for that design is that there's a lot of things
-    # here we do not want to do, which normal XSS filters would do, like stripping tags
-    # or escaping entities. Both of these would render our data useless for matching purposes.
-    # So we only want to identify the most egregious cases and log them for manual review.
-    has_xss = XSS_SUSPECT_PATTERN.search(value)
-    has_entities = HTML_ENTITY_PATTERN.search(value)
-    if not has_xss and not has_entities:
+def check_xss_html_smell(entity: "Entity", prop: Property, value: str) -> str | None:
+    """A very basic HTML entity and XSS check.
+
+    This validator does not guarantee that the value is "safe" to render in any context,
+    but is more of a smell detector to find values where we screwed up on data extraction
+    or that are crude attempts at planting something malicious in our data.
+
+    Things that are results of lookups (i.e. that we manually reviewed) are exempt from this check.
+    To make a string exempt, just add a lookup from "value" -> "value" to the dataset metadata.
+
+    A full-blown XSS filter (that guarantees that a value is safe to render in a certain HTML context)
+    would also escape things that we require to remain intact for matching purposes.
+    """
+    has_xss_smell = XSS_SUSPECT_PATTERN.search(value)
+    has_html_entities = HTML_ENTITY_PATTERN.search(value)
+    if not has_xss_smell and not has_html_entities:
         return value
-    if is_lookup_value(entity, prop.type, value):
+
+    # Values that came out of a lookup (i.e. that we manually reviewed) are exempt from this check.
+    if is_type_lookup_value(entity, prop.type, value):
         return value
+
     log.warning(
         f"HTML/XSS suspicion in property value: {value}",
         prop=prop.name,

--- a/zavod/zavod/runtime/safety.py
+++ b/zavod/zavod/runtime/safety.py
@@ -1,10 +1,14 @@
 import re
+from typing import TYPE_CHECKING
 
 from followthemoney import Property
 
 from zavod.logs import get_logger
-from zavod.entity import Entity
 from zavod.runtime.lookups import is_lookup_value
+
+if TYPE_CHECKING:
+    from zavod.entity import Entity
+
 
 log = get_logger(__name__)
 

--- a/zavod/zavod/runtime/safety.py
+++ b/zavod/zavod/runtime/safety.py
@@ -29,7 +29,7 @@ XSS_SUSPECT_PATTERN = re.compile(
 )
 
 
-def check_xss(entity: Entity, prop: Property, value: str) -> str | None:
+def check_xss(entity: "Entity", prop: Property, value: str) -> str | None:
     """A very basic HTML entity and XSS check to prevent script injections."""
     # This is very .... rustic. The reason for that design is that there's a lot of things
     # here we do not want to do, which normal XSS filters would do, like stripping tags


### PR DESCRIPTION
Fixes https://github.com/opensanctions/opensanctions/issues/1539 

This is a bit scary in that it uses some custom regex (from the machines), but the issue with using existing frameworks like `nh3` was that they are much more strict than we can tolerate: `&`, `"` and `<` are valid values in our output data, they just become a risk if they meet very specific conditions. `nh3.clean` and `nh3.is_html` don't quite do the right thing here. 