### PR TITLE
Don't backfill issues log

### DIFF
--- a/zavod/zavod/runtime/issues.py
+++ b/zavod/zavod/runtime/issues.py
@@ -28,7 +28,6 @@ class DatasetIssues(object):
     def __init__(self, dataset: Dataset) -> None:
         self.dataset = dataset
         self.fh: Optional[BinaryIO] = None
-        get_dataset_artifact(self.dataset.name, ISSUES_LOG)
 
     def write(self, event: Dict[str, Any]) -> None:
         if self.fh is None:


### PR DESCRIPTION
I don't know why this was ever a thing, but this breaks the reasonable assumption that the issues log contains the issues from "this run". For collections, this currently means that `issues.log` is append-only and forever. Leaf datasets currently have their issues log cleared by `Context.begin(clear=True)`.

If I understand the mechanics of this correctly, this means that collections will now export and `issues.log` containing issues logged during the export stage, i.e. validation and assembly.
