### PR TITLE
[shed] translit: Cleaner API surface, more logging

### DIFF
--- a/datasets/bg/jud_declarations/crawler.py
+++ b/datasets/bg/jud_declarations/crawler.py
@@ -8,10 +8,14 @@ from typing import Dict, Generator, List, Optional
 
 from zavod import Context, helpers as h
 from zavod.stateful.positions import categorise, OccupancyStatus
-from zavod.shed.trans import apply_translit_full_name, make_position_translation_prompt
+from zavod.shed.trans import (
+    apply_translit_full_name,
+    make_position_translation_prompt,
+    ENGLISH,
+)
 
 
-TRANSLIT_OUTPUT = {"eng": ("Latin", "English")}
+TRANSLIT_OUTPUT = [ENGLISH]
 POSITION_PROMPT = prompt = make_position_translation_prompt("bul")
 # e.g. (name_html, name_pdf)
 # {

--- a/datasets/ge/declarations/crawler.py
+++ b/datasets/ge/declarations/crawler.py
@@ -223,7 +223,14 @@ def crawl_family(
     person = context.make("Person")
     person.id = context.make_id(first_name, last_name, birth_date, birth_place)
     h.apply_name(person, first_name=first_name, last_name=last_name, lang="kat")
-    apply_translit_names(context, person, "kat", first_name, last_name, TRANSLIT_OUTPUT)
+    apply_translit_names(
+        context,
+        person,
+        input_code="kat",
+        first_name=first_name,
+        last_name=last_name,
+        output_spec=TRANSLIT_OUTPUT,
+    )
     person.add("birthDate", birth_date)
     person.add("birthPlace", birth_place, lang="kat")
     person.add("topics", "role.rca")
@@ -251,7 +258,14 @@ def crawl_declaration(context: Context, item: dict, is_current_year) -> None:
     person = context.make("Person")
     person.id = context.make_id(first_name, last_name, birth_date, birth_place)
     h.apply_name(person, first_name=first_name, last_name=last_name, lang="kat")
-    apply_translit_names(context, person, "kat", first_name, last_name, TRANSLIT_OUTPUT)
+    apply_translit_names(
+        context,
+        person,
+        input_code="kat",
+        first_name=first_name,
+        last_name=last_name,
+        output_spec=TRANSLIT_OUTPUT,
+    )
     person.add("birthDate", birth_date)
     person.add("birthPlace", birth_place, lang="kat")
     declaration_url = (

--- a/datasets/ge/declarations/crawler.py
+++ b/datasets/ge/declarations/crawler.py
@@ -13,6 +13,9 @@ from zavod.shed.trans import (
     apply_translit_full_name,
     apply_translit_names,
     make_position_translation_prompt,
+    ENGLISH,
+    RUSSIAN,
+    ARABIC,
 )
 from zavod.stateful.positions import OccupancyStatus, categorise
 
@@ -22,11 +25,7 @@ DECLARATION_LIST_URL = "https://declaration.acb.gov.ge/Home/DeclarationList"
 REGEX_CHANGE_PAGE = re.compile(r"changePage\((\d+), \d+\)")
 REGEX_FORMER = re.compile(r"\(ყოფილი\)", re.IGNORECASE)
 _18_YEARS_AGO = (datetime.now() - timedelta(days=18 * 365)).isoformat()
-TRANSLIT_OUTPUT = {
-    "eng": ("Latin", "English"),
-    "rus": ("Cyrillic", "Russian"),
-    "ara": ("Arabic", "Arabic"),
-}
+TRANSLIT_OUTPUT = [ENGLISH, RUSSIAN, ARABIC]
 POSITION_PROMPT = prompt = make_position_translation_prompt("kat")
 
 

--- a/datasets/iq/aml_list/crawler.py
+++ b/datasets/iq/aml_list/crawler.py
@@ -6,6 +6,7 @@ from openpyxl import load_workbook
 from rigour.mime.types import XLSX
 from zavod.shed.trans import (
     apply_translit_full_name,
+    ENGLISH,
 )
 from zavod.extract.zyte_api import fetch_html, fetch_resource
 from zavod import Context
@@ -28,7 +29,7 @@ YEAR_PATTERN = re.compile(r"\b\d{4}\b")
 # To mediate in the sale and purchase of foreign currencies
 ENTITY_NAME_REASON = re.compile(r"\s*للتوسط ببيع وشراء العملات الاجنبية$")
 
-TRANSLIT_OUTPUT = {"eng": ("Latin", "English")}
+TRANSLIT_OUTPUT = [ENGLISH]
 
 
 def clean_entity_name(entity_name: Optional[str]) -> Optional[str]:

--- a/datasets/sk/public_officials/crawler.py
+++ b/datasets/sk/public_officials/crawler.py
@@ -6,15 +6,14 @@ from typing import Any, Dict, List
 from zavod.shed.trans import (
     apply_translit_full_name,
     make_position_translation_prompt,
+    ENGLISH,
 )
 from zavod.stateful.positions import OccupancyStatus, categorise
 
 from zavod import Context
 from zavod import helpers as h
 
-TRANSLIT_OUTPUT = {
-    "eng": ("Latin", "English"),
-}
+TRANSLIT_OUTPUT = [ENGLISH]
 POSITION_PROMPT = prompt = make_position_translation_prompt("slk")
 
 

--- a/datasets/th/cabinet/crawler.py
+++ b/datasets/th/cabinet/crawler.py
@@ -1,7 +1,11 @@
 import re
 
 from normality import collapse_spaces
-from zavod.shed.trans import apply_translit_full_name, make_position_translation_prompt
+from zavod.shed.trans import (
+    apply_translit_full_name,
+    make_position_translation_prompt,
+    ENGLISH,
+)
 from zavod.extract.zyte_api import fetch_html
 from zavod.stateful.positions import categorise
 
@@ -17,7 +21,7 @@ REGEX_TITLES = re.compile(
     r"^(นางสาว|นาง|นาย|พลตำรวจเอก|พันตำรวจเอก|พลเอก|พลตำรวจตรี|ร้อยเอก|พลโท|จ่าเอก|พลตำรวจโท|-)"
 )
 POSITION_PROMPT = prompt = make_position_translation_prompt("tha")
-TRANSLIT_OUTPUT = {"eng": ("Latin", "English")}
+TRANSLIT_OUTPUT = [ENGLISH]
 # For lack of anything more semantic, we select persons based on sizing of their containers
 # The prime minister section can be slightly bigger than the others
 PRIME_MINISTER_XPATH = ".//div[contains(@style, 'min-height: 480; max-height: 600')]"


### PR DESCRIPTION
- **[shed] trans: Better debug output for when translit fails**
  This will help figure out what's going on in `ge_declarations`
  

- **[shed] translit: More abstraction for callers**
  Instead of supplying a dictionary that is then read and transformed to a prompt, callers now supply a namedtuple that describes a transliteration target language. Actually, all of them only use the predefined constants of standard languages.
  