### PR TITLE
Don't backfill issues log, take 2

### DIFF
--- a/zavod/zavod/runtime/issues.py
+++ b/zavod/zavod/runtime/issues.py
@@ -77,7 +77,10 @@ class DatasetIssues(object):
     def all(self) -> Generator[Issue, None, None]:
         """Iterate over all issues in the log."""
         self.close()
-        path = get_dataset_artifact(self.dataset.name, ISSUES_LOG)
+        # Don't backfill the issues log, otherwise we'll get issues from a previous run for collections.
+        # For data sources (that run crawl), that's not the case because they run clear() at the beginning
+        # of the crawl stage.
+        path = get_dataset_artifact(self.dataset.name, ISSUES_LOG, backfill=False)
         if not path.is_file():
             return
         with open(path, "rb") as fh:


### PR DESCRIPTION
https://github.com/opensanctions/opensanctions/pull/3362

Recapping the conversation for any future archaeologists:

From @pudo:

> I think the premise back when I built it was that you'd be able to run zavod export without running zavod crawl before, and it would just backfill everything. Since this has never happened, let's just jettison the use case! Would you have one look around the code to see if there's other stuff we can not backfill, like resources.json, index.json etc.? resources probably only after the other successful run stuff is merged?

from @leonhandreke:

> I thought about this some more. I feel like your idea of making the steps independent and always backfill is really nice and maybe we should hold onto it?
>
> I think the core issue may be that we don't have a "lifecycle orchestrator". Context is too short-lived, and cli is... well, at least it should be just a little layer on top of the business logic. We want to reset the issues at the beginning of the "dataset lifecycle", but that beginning is crawl for leaves, and export for collections.
>
> Anyway, I feel like this is an okay fix for now until we figure out a more appropriate strategy, so I'll merge.
