### PR TITLE
Do not move names/aliases from key lists to weakAlias in consolidation

### DIFF
--- a/zavod/zavod/exporters/consolidate.py
+++ b/zavod/zavod/exporters/consolidate.py
@@ -26,9 +26,13 @@ FULL_NAME_PROPS = {"name", "alias"}
 NEVER_REMOVE_NAMES_DATASETS = {
     "us_ofac_sdn",
     "us_ofac_cons",
-    "us_trade_csl",
-    "eu_journal_sanctions",
-    "eu_fsf",
+    # Has every name from us_ofac IN ALL UPPER CASE JUST TO MAKE SURE
+    # so even though it's somewhat important, we don't want to make it holy for now.
+    # "us_trade_csl",
+    # The names suck sometimes and customer's don't have as high expectations for
+    # these to be reproduced verbatim.
+    # "eu_journal_sanctions",
+    # "eu_fsf",
     "eu_sanctions_map",
     "gb_fcdo_sanctions",
     "ca_dfatd_sema_sanctions",

--- a/zavod/zavod/tests/exporters/test_exporters.py
+++ b/zavod/zavod/tests/exporters/test_exporters.py
@@ -2,7 +2,7 @@ from csv import DictReader
 from typing import Optional
 import uuid
 from followthemoney.cli.util import path_entities
-from followthemoney import EntityProxy, Statement
+from followthemoney import Statement, ValueEntity
 from followthemoney.statement import CSV, read_path_statements
 from json import load, loads
 from nomenklatura import Resolver
@@ -64,9 +64,9 @@ def export(dataset: Dataset) -> None:
     export_dataset(dataset, view)
 
 
-def read_exported_entities(dataset: Dataset) -> list[EntityProxy]:
+def read_exported_entities(dataset: Dataset) -> list[ValueEntity]:
     dataset_path = settings.DATA_PATH / DATASETS / dataset.name
-    return list(path_entities(dataset_path / "entities.ftm.json", EntityProxy))
+    return list(path_entities(dataset_path / "entities.ftm.json", ValueEntity))
 
 
 def test_export(testdataset1: Dataset):


### PR DESCRIPTION
Fixes #3383. This is to avoid the `weakAlias` picking up names that are marked as strong in one of the main global sanctions lists. 

@leonhandreke this is not tested, just wanted to drop a sketch. Definitely a bit more mysterious than I'd like my ETL to be: I feel we need to do more work on name cleaning in the messy crawlers and then get rid of this. 