### PR TITLE
assertions: add property_fill_rate

### DIFF
--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -91,23 +91,13 @@ HTTP requests for GET requests are automatically retried for connection and HTTP
 
 Data assertions are intended to "smoke test" the data. Assertions are checked on export. If assertions aren't met, warnings are emitted.
 
-Data assertions are checked when running `zavod run` (and `zavod validate --clear` is useful when developing a crawler).
+Data assertions are checked when running `zavod run` (and `zavod validate --rebuild-store` is useful when developing a crawler).
 
-Data assertions are useful to communicate our expectations about what's in a dataset, and a soft indication (they don't cause the export to fail) to us that something's wrong in the dataset or crawler and needs attention.
-
-We usually use the minima to set a baseline for what should be in the dataset, and one or more simpler maxima to just identify when the dataset has grown beyond the validity of our earlier baseline, or if something's gone horribly wrong and emitted way more than expected.
+Data assertions are useful to communicate our expectations about what's in a dataset. `min` validations set a baseline for what should be in the dataset and are fatal to the export if they fail. `max` validations emit a warning when the dataset has grown beyond the validity of our earlier baseline (or if something's gone horribly wrong and emitted way more than expected)
 
 It's a good idea to add assertions at the start of writing a crawler, and then see whether those expectations are met when the crawler is complete. A good rule of thumb for datasets that change over time is minima 10% below the expected number to allow normal variation, unless there's a known hard minimum, and a maximum around twice the expected number of entities to leave room to grow.
 
-- `assertions`
-  - `min` violations abort the crawler run.
-  - `max` violations only result in a Warning.
-  - `min` and `max` can each have the following children
-    - `schema_entities` asserts on the number of entities of a given schema
-    - `country_entities` asserts on the number of entities associated with a country in any of its properties. All properties with type `country` are considered (among them the usual suspects such as `country`, `jurisdiction` and `citizenship`). Countries are given as ISO 3166-1 Alpha-2 country codes.
-    - `countries` asserts on number of countries expected to come up in the dataset
-    - `entities_with_prop` asserts on the number of entities of a given schema that have a property set.
-
+A basic assertion block can look like this:
 
 ```yaml
 assertions:
@@ -115,11 +105,6 @@ assertions:
     schema_entities:
       Person: 160  # at least 160 Person entities
       Position: 30  # at least 30 Position entities
-    country_entities:
-      us: 40  # at least 40 entities for the US
-      cn: 30  # at least 30 entities for China
-      bn: 1  # at least one entity for Brunei
-    countries: 6  # at least 6 countries come up
     entities_with_prop:
       Company:
         taxNumber: 10  # at least 10 Companies have a tax number set
@@ -128,3 +113,25 @@ assertions:
       Person: 400  # at most 400 Person entities
       Position: 80  # at most 80 Position entities
 ```
+
+
+#### Assertion types
+
+**`schema_entities`** asserts on the number of entities of a given schema.
+
+**`country_entities`** asserts on the number of entities associated with a country in any of its properties. All properties with type `country` are considered (among them the usual suspects such as `country`, `jurisdiction` and `citizenship`). Countries are given as ISO 3166-1 Alpha-2 country codes.
+
+**`countries`** asserts on the number of distinct countries expected to appear in the dataset.
+
+**`entities_with_prop`** asserts on the number of entities of a given schema that have a given property set.
+
+**`property_fill_rate`** asserts on the proportion of entities of a given schema that have a given property set, expressed as a float between 0 and 1.
+
+```yaml
+assertions:
+  min:
+    property_fill_rate:
+      Person:
+        birthDate: 0.7  # at least 70% of Persons have a birth date
+```
+

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "openai >= 1.33.0, < 3.0.0",
     "requests[security]",
     "requests_oauthlib",
+    "urllib3>=2.0",
     "sqlalchemy[mypy]",
     "structlog",
     "xlrd == 2.0.2",

--- a/zavod/zavod/meta/assertion.py
+++ b/zavod/zavod/meta/assertion.py
@@ -18,6 +18,9 @@ class Metric(Enum):
     ENTITIES_WITH_PROP_COUNT = "entities_with_prop"
     """Number of entities with property values matching the filter in the dataset."""
 
+    PROPERTY_FILL_RATE = "property_fill_rate"
+    """Fill rate of a property for a given schema in the dataset."""
+
     def __str__(self) -> str:
         return self.value
 

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -15,7 +15,6 @@ from zavod.validators import (
     EmptyValidator,
 )
 from zavod.validators.assertions import (
-    PropertyFillRateAssertionsValidator,
     StatisticsAssertionsValidator,
 )
 from zavod.validators.common import BaseValidator
@@ -174,7 +173,7 @@ def test_validate_assertion_property_fill_rate():
     )
     emit_entity(ds, "Company", {"country": ["ru"]})
 
-    validator, logs = run_validator(PropertyFillRateAssertionsValidator, ds)
+    validator, logs = run_validator(StatisticsAssertionsValidator, ds)
     assert (
         "error",
         "Assertion property_fill_rate failed for Company.name: 0.0 is not >= threshold 0.5",
@@ -182,5 +181,5 @@ def test_validate_assertion_property_fill_rate():
     assert validator.abort is True
 
     emit_entity(ds, "Company", {"name": ["Kalashnikov"]})
-    validator, logs = run_validator(PropertyFillRateAssertionsValidator, ds)
+    validator, logs = run_validator(StatisticsAssertionsValidator, ds)
     assert validator.abort is False

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -8,7 +8,6 @@ from zavod.meta.dataset import Dataset
 from zavod.store import View
 from zavod.entity import Entity
 from zavod.validators.assertions import (
-    PropertyFillRateAssertionsValidator,
     StatisticsAssertionsValidator,
 )
 from zavod.validators.common import BaseValidator
@@ -67,7 +66,6 @@ VALIDATORS: List[Type[BaseValidator]] = [
     DanglingReferencesValidator,
     SelfReferenceValidator,
     StatisticsAssertionsValidator,
-    PropertyFillRateAssertionsValidator,
     EmptyValidator,
 ]
 

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -7,7 +7,10 @@ from zavod.exc import RunFailedException
 from zavod.meta.dataset import Dataset
 from zavod.store import View
 from zavod.entity import Entity
-from zavod.validators.assertions import StatisticsAssertionsValidator
+from zavod.validators.assertions import (
+    PropertyFillRateAssertionsValidator,
+    StatisticsAssertionsValidator,
+)
 from zavod.validators.common import BaseValidator
 
 
@@ -64,6 +67,7 @@ VALIDATORS: List[Type[BaseValidator]] = [
     DanglingReferencesValidator,
     SelfReferenceValidator,
     StatisticsAssertionsValidator,
+    PropertyFillRateAssertionsValidator,
     EmptyValidator,
 ]
 

--- a/zavod/zavod/validators/assertions.py
+++ b/zavod/zavod/validators/assertions.py
@@ -98,7 +98,7 @@ def check_assertion(
     elif assertion.metric == Metric.ENTITIES_WITH_PROP_COUNT:
         # stats["things"]["entities_with_prop"] is a list of dictionaries that look like
         # [
-        #   { "schema": "Person", "property": "firstName", "count": 100 },
+        #   { "schema": "Person", "property": "firstName", "count": 6, "total": 10, "fill_rate": 0.6 },
         # ]
         stats_entity_with_prop_to_count = {
             (item["schema"], item["property"]): item["count"]
@@ -117,9 +117,26 @@ def check_assertion(
                 results_valid.append(valid)
 
     elif assertion.metric == Metric.PROPERTY_FILL_RATE:
-        # We handle that in a separate validator below because it's a special cookie
-        # that doesn't just want the Statistics
-        pass
+        # stats["things"]["entities_with_prop"] is a list of dictionaries that look like
+        # [
+        #   { "schema": "Person", "property": "firstName", "total": 10, "filled": 6, "fill_rate": 0.6 },
+        # ]
+        stats_fill_rate_lookup = {
+            (item["schema"], item["property"]): item["fill_rate"]
+            for item in stats["things"]["entities_with_prop"]
+        }
+
+        for schema, properties in assertion.config.items():
+            for property, threshold in properties.items():
+                key = (schema, property)
+                fill_rate = stats_fill_rate_lookup.get(key, 0.0)
+                valid = check_value(fill_rate, assertion.comparison, threshold)
+                if not valid:
+                    log_fn(
+                        f"Assertion {assertion.metric} failed for {schema}.{property}: {fill_rate} is not {assertion.comparison} threshold {threshold}"
+                    )
+                results_valid.append(valid)
+
     else:
         raise ValueError(f"Unknown metric: {assertion.metric}")
 
@@ -146,65 +163,3 @@ class StatisticsAssertionsValidator(BaseValidator):
             # Only min assertions should abort the dataset.
             if not valid and is_assertion_fatal(assertion):
                 self.abort = True
-
-
-class PropertyFillRateAssertionsValidator(BaseValidator):
-    """Warns if the fill rate of a property is below a threshold.
-
-    The reason this is implemented as a separate validator is that it doesn't just want the Statistics,
-    but the actual entities to compute the fill rate. Putting it in the AssertionsValidator would have
-    made it too complex, so instead I chose to spread the assertions functionality across multiple validators.
-    """
-
-    # schema, property -> (total, with_prop_set)
-    # In the end, we do fill_rate = with_prop_set / total
-    _counts_by_filter: dict[tuple[str, str], tuple[int, int]] = {}
-
-    # For convenience, store property_fill_rate assertions in a list.
-    # This should only be up to two (one for min, one for max)
-    _assertions: list[Assertion] = []
-
-    def __init__(self, context: Context, view: View) -> None:
-        super().__init__(context, view)
-
-        self._assertions = [
-            assertion
-            for assertion in self.context.dataset.assertions
-            if assertion.metric == Metric.PROPERTY_FILL_RATE
-        ]
-
-        for assertion in self._assertions:
-            for schema, properties in assertion.config.items():
-                for property, threshold in properties.items():
-                    self._counts_by_filter[(schema, property)] = (0, 0)
-
-    def feed(self, entity: Entity) -> None:
-        for (schema, prop), (total, with_prop_set) in self._counts_by_filter.items():
-            if entity.schema.is_a(schema):
-                self._counts_by_filter[(schema, prop)] = (
-                    total + 1,
-                    with_prop_set + (1 if entity.has(prop) else 0),
-                )
-
-    def finish(self) -> None:
-        for assertion in self._assertions:
-            log_fn = (
-                self.context.log.error
-                if is_assertion_fatal(assertion)
-                else self.context.log.warning
-            )
-
-            for schema, properties in assertion.config.items():
-                for property, threshold in properties.items():
-                    key = (schema, property)
-                    total, with_prop_set = self._counts_by_filter[key]
-                    # Avoid division by zero
-                    fill_rate = with_prop_set / (total or 1)
-                    valid = check_value(fill_rate, assertion.comparison, threshold)
-                    if not valid:
-                        log_fn(
-                            f"Assertion {assertion.metric} failed for {schema}.{property}: {fill_rate} is not {assertion.comparison} threshold {threshold}"
-                        )
-                        # Only fatal assertions should abort the dataset.
-                        if is_assertion_fatal(assertion):
-                            self.abort = True


### PR DESCRIPTION

I made this a separate validator because it works a bit differently to the other assertions, so I didn't want to lump it into the same class.

There is a bit of a caveat here: the property fill rate validator understands schema inheritance, whereas the statistics-based assertions do not.

See https://github.com/opensanctions/opensanctions/issues/3359