### PR TITLE
assertions: refactor to dumb down a bit

### DIFF
--- a/zavod/zavod/tests/test_assertions.py
+++ b/zavod/zavod/tests/test_assertions.py
@@ -13,51 +13,26 @@ CONFIG = {
 
 
 def test_parse_assertions():
+    """Test assertions parsing. This doesn't actually test whether they work, that happens in test_validate."""
+
     assertions = list(parse_assertions(CONFIG))
     entity_count = assertions[0]
-    assert entity_count.metric == Metric.ENTITY_COUNT
-    assert entity_count.filter_attribute == "schema"
+    assert entity_count.metric == Metric.SCHEMA_ENTITIES
+    assert entity_count.config == {"Person": 1}
     assert entity_count.comparison == Comparison.GTE
 
     property_values_count = assertions[1]
     assert property_values_count.metric == Metric.ENTITIES_WITH_PROP_COUNT
-    assert property_values_count.filter_attribute == "entities_with_prop"
-    assert property_values_count.filter_value == ("Person", "name")
+    assert property_values_count.config == {"Person": {"name": 1}}
     assert property_values_count.comparison == Comparison.GTE
 
     country_count = assertions[2]
     assert country_count.metric == Metric.COUNTRY_COUNT
-    assert country_count.filter_attribute is None
+    assert country_count.config == 1
     assert country_count.comparison == Comparison.LTE
 
     config = deepcopy(CONFIG)
+    # Should fail because "foo" is not a valid metric
     config["min"]["foo"] = config["min"].pop("schema_entities")
-    with pytest.raises(ValueError):
-        list(parse_assertions(config))
-
-    config = deepcopy(CONFIG)
-    config["min"]["schema_entities"] = 1
-    with pytest.raises(Exception):
-        list(parse_assertions(config))
-
-    config = deepcopy(CONFIG)
-    config["min"]["schema_entities"]["Person"] = "foo"
-    with pytest.raises(Exception):
-        list(parse_assertions(config))
-
-    config = deepcopy(CONFIG)
-    config["whatever"] = config.pop("min")
-    with pytest.raises(ValueError):
-        list(parse_assertions(config))
-
-
-def test_parse_entities_with_prop_count_unknown_property_name_or_schema():
-    config = deepcopy(CONFIG)
-
-    config["min"]["entities_with_prop"] = {"Person": {"bogusProperty": 1}}
-    with pytest.raises(ValueError):
-        list(parse_assertions(config))
-
-    config["min"]["entities_with_prop"] = {"bogusSchema": {"name": 1}}
     with pytest.raises(ValueError):
         list(parse_assertions(config))

--- a/zavod/zavod/tests/test_cli.py
+++ b/zavod/zavod/tests/test_cli.py
@@ -109,9 +109,9 @@ def test_run_validation_failed(testdataset3: Dataset):
     result = runner.invoke(cli, ["run", "--latest", DATASET_3_YML.as_posix()])
     assert result.exit_code != 0, result.output
     # Validation issues in an aborted run are published
-    assert "Assertion failed for value" in result.output, result.output
+    assert "Assertion countries failed" in result.output, result.output
     with open(artifacts_path / "issues.json", "r") as f:
-        assert "Assertion failed for value" in f.read()
+        assert "Assertion countries failed" in f.read()
     shutil.rmtree(settings.DATA_PATH)
 
 

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -1,7 +1,9 @@
 from typing import Type
+import uuid
 
 from structlog.testing import capture_logs
 
+from zavod import Entity
 from zavod.context import Context
 from zavod.crawl import crawl_dataset
 from zavod.integration import get_dataset_linker
@@ -12,15 +14,22 @@ from zavod.validators import (
     SelfReferenceValidator,
     EmptyValidator,
 )
-from zavod.validators.assertions import AssertionsValidator
+from zavod.validators.assertions import (
+    StatisticsAssertionsValidator,
+)
 from zavod.validators.common import BaseValidator
+
+BASE_DATASET_CONFIG = {
+    "name": "test",
+}
 
 
 def run_validator(clazz: Type[BaseValidator], dataset: Dataset):
     context = Context(dataset)
     linker = get_dataset_linker(dataset)
     store = get_store(dataset, linker)
-    store.sync()
+    # Pass clear so that if the test emits statements and re-validates, we pick that up.
+    store.sync(clear=True)
     view = store.view(dataset)
 
     with capture_logs() as cap_logs:
@@ -34,6 +43,20 @@ def run_validator(clazz: Type[BaseValidator], dataset: Dataset):
 
     cap_logs = [(log["log_level"], log["event"]) for log in cap_logs]
     return validator, set(cap_logs)
+
+
+def e(ds: Dataset, schema: str, properties: dict[str, list[str]]) -> Entity:
+    context = Context(ds)
+    context.begin()
+
+    entity = Entity.from_data(
+        context.dataset,
+        {"schema": schema, "id": uuid.uuid4(), "properties": properties},
+    )
+    context.emit(entity)
+
+    context.close()
+    return entity
 
 
 def test_dangling_references(testdataset3) -> None:
@@ -72,46 +95,64 @@ def test_self_references(testdataset3) -> None:
 
 def test_assertions(testdataset3) -> None:
     crawl_dataset(testdataset3)
-    validator, logs = run_validator(AssertionsValidator, testdataset3)
+    validator, logs = run_validator(StatisticsAssertionsValidator, testdataset3)
     assert (
         "error",
-        "Assertion failed for value 2: <Assertion entity_count gte 3 filter: country=de>",
+        "Assertion country_entities failed for de: 2 is not >= threshold 3",
     ) in logs
     assert (
         "warning",
-        "Assertion failed for value 2: <Assertion entity_count lte 1 filter: country=de>",
+        "Assertion country_entities failed for de: 2 is not <= threshold 1",
     ) in logs
     assert (
         "error",
-        "Assertion failed for value 7: <Assertion entity_count gte 10 filter: schema=Company>",
+        "Assertion schema_entities failed for Company: 7 is not >= threshold 10",
     ) in logs
     assert (
         "error",
-        "Assertion failed for value 6: <Assertion country_count gte 7>",
+        "Assertion countries failed: 6 is not >= threshold 7",
     ) in logs
     assert (
         "error",
-        "Assertion failed for value 7: <Assertion entities_with_prop_count gte 11 filter: entities_with_prop=('Company', 'name')>",
+        "Assertion entities_with_prop failed for Company.name: 7 is not >= threshold 11",
     ) in logs
     assert validator.abort is True
 
 
-def test_no_assertions_warning(testdataset3: Dataset) -> None:
-    testdataset3.assertions = []
-    crawl_dataset(testdataset3)
-    validator, logs = run_validator(AssertionsValidator, testdataset3)
-    assert ("error", "Dataset has no assertions.") in logs
+def test_countries_count_assertion(testdataset3) -> None:
+    ds = Dataset(
+        {
+            **BASE_DATASET_CONFIG,
+            "assertions": {
+                "min": {
+                    "countries": 1,
+                }
+            },
+        }
+    )
+    validator, _ = run_validator(StatisticsAssertionsValidator, ds)
+    assert validator.abort is True
 
+    e(ds, "Person", {"name": ["Vladimir Putin"], "country": ["ru"]})
 
-def test_not_empty_after_crawl(testdataset3) -> None:
-    crawl_dataset(testdataset3)
-    validator, logs = run_validator(EmptyValidator, testdataset3)
-    assert "No entities validated" not in str(logs)
+    validator, _ = run_validator(StatisticsAssertionsValidator, ds)
     assert validator.abort is False
 
 
-def test_no_crawl_is_empty(testdataset3) -> None:
-    # We don't crawl here so that no entities are emitted
-    validator, logs = run_validator(EmptyValidator, testdataset3)
-    assert ("warning", "No entities validated.") in logs
+def test_no_assertions_error() -> None:
+    ds = Dataset({**BASE_DATASET_CONFIG, "assertions": {}})
+    validator, logs = run_validator(StatisticsAssertionsValidator, ds)
+    assert ("error", "Dataset has no assertions.") in logs
+
+
+def test_no_entities_warning() -> None:
+    ds = Dataset(BASE_DATASET_CONFIG)
+
+    validator, logs = run_validator(EmptyValidator, ds)
+    assert "No entities validated" in str(logs)
+    assert validator.abort is False
+
+    e(ds, "Person", {"name": ["Vladimir Putin"]})
+    validator, logs = run_validator(EmptyValidator, ds)
+    assert "No entities validated" not in str(logs)
     assert validator.abort is False

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -45,7 +45,7 @@ def run_validator(clazz: Type[BaseValidator], dataset: Dataset):
     return validator, set(cap_logs)
 
 
-def e(ds: Dataset, schema: str, properties: dict[str, list[str]]) -> Entity:
+def emit_entity(ds: Dataset, schema: str, properties: dict[str, list[str]]) -> Entity:
     context = Context(ds)
     context.begin()
 
@@ -133,7 +133,7 @@ def test_countries_count_assertion(testdataset3) -> None:
     validator, _ = run_validator(StatisticsAssertionsValidator, ds)
     assert validator.abort is True
 
-    e(ds, "Person", {"name": ["Vladimir Putin"], "country": ["ru"]})
+    emit_entity(ds, "Person", {"name": ["Vladimir Putin"], "country": ["ru"]})
 
     validator, _ = run_validator(StatisticsAssertionsValidator, ds)
     assert validator.abort is False
@@ -152,7 +152,7 @@ def test_no_entities_warning() -> None:
     assert "No entities validated" in str(logs)
     assert validator.abort is False
 
-    e(ds, "Person", {"name": ["Vladimir Putin"]})
+    emit_entity(ds, "Person", {"name": ["Vladimir Putin"]})
     validator, logs = run_validator(EmptyValidator, ds)
     assert "No entities validated" not in str(logs)
     assert validator.abort is False

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -7,7 +7,7 @@ from zavod.exc import RunFailedException
 from zavod.meta.dataset import Dataset
 from zavod.store import View
 from zavod.entity import Entity
-from zavod.validators.assertions import AssertionsValidator
+from zavod.validators.assertions import StatisticsAssertionsValidator
 from zavod.validators.common import BaseValidator
 
 
@@ -63,7 +63,7 @@ class EmptyValidator(BaseValidator):
 VALIDATORS: List[Type[BaseValidator]] = [
     DanglingReferencesValidator,
     SelfReferenceValidator,
-    AssertionsValidator,
+    StatisticsAssertionsValidator,
     EmptyValidator,
 ]
 

--- a/zavod/zavod/validators/assertions.py
+++ b/zavod/zavod/validators/assertions.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, cast
+from typing import Dict, Any
 
 from zavod.context import Context
 from zavod.entity import Entity
@@ -8,7 +8,9 @@ from zavod.store import View
 from zavod.validators.common import BaseValidator
 
 
-def compare_threshold(value: int, comparison: Comparison, threshold: int) -> bool:
+def check_value(
+    value: int | float, comparison: Comparison, threshold: int | float
+) -> bool:
     match comparison:
         case Comparison.GTE:
             return value >= threshold
@@ -18,64 +20,107 @@ def compare_threshold(value: int, comparison: Comparison, threshold: int) -> boo
             raise ValueError(f"Unknown comparison: {comparison}")
 
 
-def get_value(stats: Dict[str, Any], assertion: Assertion) -> Optional[int]:
-    match assertion.metric:
-        case Metric.ENTITY_COUNT:
-            match assertion.filter_attribute:
-                case "schema":
-                    items = stats["things"]["schemata"]
-                    filter_key = "name"
-                case "country":
-                    items = stats["things"]["countries"]
-                    filter_key = "code"
-                case None:
-                    assert assertion.filter_value is None
-                    return cast(int, stats["things"]["total"])
-                case _:
-                    raise ValueError(
-                        f"Unknown filter attribute: {assertion.filter_attribute}"
-                    )
-            items = [i for i in items if i[filter_key] == assertion.filter_value]
-            if len(items) != 1:
-                return None
-            return cast(int, items[0]["count"])
-
-        case Metric.ENTITIES_WITH_PROP_COUNT:
-            items = stats["things"]["entities_with_prop"]
-            items = [
-                i
-                for i in items
-                # Filter value is a (schema_name, prop_name) tuple
-                if assertion.filter_value
-                and i["schema"] == assertion.filter_value[0]
-                and i["property"] == assertion.filter_value[1]
-            ]
-            return cast(int, items[0]["count"]) if len(items) == 1 else None
-
-        case Metric.COUNTRY_COUNT:
-            return len(stats["things"]["countries"])
-
-        case _:
-            raise ValueError(f"Unknown metric: {assertion.metric}")
-
-
 def check_assertion(
-    context: Context, stats: Dict[str, Any], assertion: Assertion
+    context: Context,
+    stats: Dict[str, Any],
+    assertion: Assertion,
+    log_error: bool = True,
 ) -> bool:
     """Returns true if the assertion is valid, false otherwise."""
-    value = get_value(stats, assertion)
-    log_fn = context.log.error if assertion.abort else context.log.warning
-    if value is None:
-        log_fn(f"Value not found for assertion {assertion}")
-        return False
-    if not compare_threshold(value, assertion.comparison, assertion.threshold):
-        log_fn(f"Assertion failed for value {value}: {assertion}")
-        return False
-    return True
+
+    log_fn = context.log.error if log_error else context.log.warning
+    results_valid: list[bool] = []
+
+    if assertion.metric == Metric.ENTITY_COUNT:
+        threshold = int(assertion.config)
+        value = stats["things"]["total"]
+        valid = check_value(value, assertion.comparison, threshold)
+        if not valid:
+            log_fn(
+                f"Assertion {assertion.metric} failed: {value} is not {assertion.comparison} threshold {threshold}"
+            )
+        results_valid.append(valid)
+
+    elif assertion.metric == Metric.COUNTRY_COUNT:
+        threshold = int(assertion.config)
+        # stats["things"]["countries"] is a list of dictionaries that look like
+        # [
+        #   { "code": "us", "count": 100, label: "United States"},
+        # ]
+        # Here, we only care about the total count
+        value = len(stats["things"]["countries"])
+        valid = check_value(value, assertion.comparison, threshold)
+        if not valid:
+            log_fn(
+                f"Assertion {assertion.metric} failed: {value} is not {assertion.comparison} threshold {threshold}"
+            )
+        results_valid.append(valid)
+
+    elif assertion.metric == Metric.SCHEMA_ENTITIES:
+        # stats["things"]["schemata"] is a list of dictionaries that look like
+        # [
+        #   { "name": "Person", "count": 100 },
+        # ]
+        stats_schema_to_count = {
+            item["name"]: item["count"] for item in stats["things"]["schemata"]
+        }
+
+        for schema, threshold in assertion.config.items():
+            value = stats_schema_to_count.get(schema, 0)
+            valid = check_value(value, assertion.comparison, threshold)
+            if not valid:
+                log_fn(
+                    f"Assertion {assertion.metric} failed for {schema}: {value} is not {assertion.comparison} threshold {threshold}"
+                )
+            results_valid.append(valid)
+
+    elif assertion.metric == Metric.COUNTRY_ENTITIES:
+        # stats["things"]["countries"] is a list of dictionaries that look like
+        # [
+        #   { "code": "us", "count": 100, label: "United States"},
+        # ]
+        stats_country_to_count = {
+            item["code"]: item["count"] for item in stats["things"]["countries"]
+        }
+
+        for country, threshold in assertion.config.items():
+            value = stats_country_to_count.get(country, 0)
+            valid = check_value(value, assertion.comparison, threshold)
+            if not valid:
+                log_fn(
+                    f"Assertion {assertion.metric} failed for {country}: {value} is not {assertion.comparison} threshold {threshold}"
+                )
+            results_valid.append(valid)
+
+    elif assertion.metric == Metric.ENTITIES_WITH_PROP_COUNT:
+        # stats["things"]["entities_with_prop"] is a list of dictionaries that look like
+        # [
+        #   { "schema": "Person", "property": "firstName", "count": 100 },
+        # ]
+        stats_entity_with_prop_to_count = {
+            (item["schema"], item["property"]): item["count"]
+            for item in stats["things"]["entities_with_prop"]
+        }
+
+        for schema, properties in assertion.config.items():
+            for property, threshold in properties.items():
+                key = (schema, property)
+                value = stats_entity_with_prop_to_count.get(key, 0)
+                valid = check_value(value, assertion.comparison, threshold)
+                if not valid:
+                    log_fn(
+                        f"Assertion {assertion.metric} failed for {schema}.{property}: {value} is not {assertion.comparison} threshold {threshold}"
+                    )
+                results_valid.append(valid)
+
+    else:
+        raise ValueError(f"Unknown metric: {assertion.metric}")
+
+    return all(results_valid)
 
 
-class AssertionsValidator(BaseValidator):
-    """Aborts if any dataset assertion fails."""
+class StatisticsAssertionsValidator(BaseValidator):
+    """Validator that checks various asssertions that are based on dataset statistics."""
 
     def __init__(self, context: Context, view: View) -> None:
         super().__init__(context, view)
@@ -90,5 +135,10 @@ class AssertionsValidator(BaseValidator):
             self.context.log.error("Dataset has no assertions.")
 
         for assertion in self.context.dataset.assertions:
-            if not check_assertion(self.context, self.stats.as_dict(), assertion):
-                self.abort = self.abort or assertion.abort
+            is_fatal = assertion.comparison == Comparison.GTE
+            valid = check_assertion(
+                self.context, self.stats.as_dict(), assertion, log_error=is_fatal
+            )
+            # Only min assertions should abort the dataset.
+            if not valid and is_fatal:
+                self.abort = True


### PR DESCRIPTION
Refactor to dumb the whole thing down a bit. Disadvantage is we no longer get Dataset parse level validation for whether the format of the assertions is correct - we'll only know when the validator runs. But now assertions can have quite different config formats (some take just a value, some a value per country, some a value per schema/prop combo) and it won't be two layers of indirection anymore. That also made the error messages a bit better.

Also, make the assertions unit tests a bit mroe unit-testy. Previously, they relied on fat fixtures (`testdatasetN` that made it intransparent what was actually going on and hard to change these fixtures without breaking tests.

See https://github.com/opensanctions/opensanctions/issues/3359
