### PR TITLE
Make `uv sync` just work by switching to dependency-groups and installing deps & docs by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: zavod
         run: |
           python -m pip install --upgrade pip wheel
-          pip install --no-cache-dir -q -e ".[dev,dspy]"
+          pip install --no-cache-dir -q --group dev --group dspy -e "."
           pip freeze
       - name: Test crawlers with tests
         run: pytest datasets

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,8 +33,7 @@ jobs:
         working-directory: zavod
         run: |
           python -m pip install --upgrade pip
-          pip install --no-cache-dir -q -e ".[dev]"
-          pip install --no-cache-dir -q -e ".[docs]"
+          pip install --no-cache-dir -q --group dev --group docs -e "."
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/lint_crawlers.yml
+++ b/.github/workflows/lint_crawlers.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install python linting dependencies
         working-directory: zavod
         run: |
-          pip install -q -e ".[dev]"
+          pip install -q --group dev -e "."
       - name: Lint modified dataset python
         if: ${{ steps.changed-python.outputs.all_changed_files != '' }}
         run: |

--- a/zavod/docs/install.md
+++ b/zavod/docs/install.md
@@ -44,7 +44,7 @@ The application is a fairly stand-alone Python application, albeit with a large 
 
 ```bash
 # Inside the opensanctions repository path:
-$ pushd zavod; uv sync --extra dev; popd
+$ pushd zavod; uv sync; popd
 # Activate the virtualenv
 $ source zavod/.venv/bin/activate
 # You can check if the application has been installed successfully by

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -52,7 +52,7 @@ Documentation = "https://github.com/opensanctions/opensanctions/"
 Repository = "https://github.com/opensanctions/opensanctions.git"
 Issues = "https://github.com/opensanctions/opensanctions/issues"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "isort >= 6.0.1",
     "wheel >= 0.29.0",
@@ -84,6 +84,9 @@ docs = [
 dspy = [
     "dspy == 3.1.2",
 ]
+
+[tool.uv]
+default-groups = ["dev", "docs"]
 
 [project.scripts]
 zavod = "zavod.cli:cli"


### PR DESCRIPTION
See for why this is better: https://peps.python.org/pep-0735/.

Claude:

> Migrate development dependencies from project.optional-dependencies to standardized dependency-groups table (PEP 735). This change properly separates published package extras from local-only development dependencies, ensuring dev tooling (pytest, ruff, etc.) is not included in package metadata when published to PyPI. The migration maintains compatibility with both uv (which has supported dependency-groups since its initial release) and pip 25.1+ (released April 2025), which added --group flag support.

I don't really care that it's better, I just want `uv sync` to do the right thing by default.

PSA: If you're using pip, instead of `pip install ".[dev]"`, you'll have to do `pip install --group dev .` now.
