### PR TITLE
docs: improve install instructions

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -18,18 +18,11 @@ See [Data Reviews](../zavod/docs/data_reviews.md)
 
 ## Getting Started
 
-For local development, start a postgres db, and configure the site for local development. E.g.
-
-Run
-
-```bash
-docker compose -f ../docker-compose.yml up -d db # Bring up a dev database
-```
+See [the documentation on how to install `zavod`](../zavod/docs/install.md) to bring up a local database.
 
 Set environment variables, e.g. via .env.local file
 
 ```
-ZAVOD_DATABASE_URI=postgresql://postgres:password@localhost:5432/dev
 ZAVOD_ALLOW_UNAUTHENTICATED=true  # Unsafe if an untrusted network can reach this
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 ```

--- a/zavod/docs/install.md
+++ b/zavod/docs/install.md
@@ -11,7 +11,6 @@ $ cd opensanctions
 
 The steps below assume you're working within a checkout of that repository.
 
-
 ## Python virtual environment
 
 The application is a fairly stand-alone Python application, albeit with a large number of library dependencies. To set up a local development environment using `uv`:
@@ -37,6 +36,18 @@ If you encounter any errors during the installation, please consider googling er
 
 
   For more information on this painpoint, see the related GitHub [issue](https://github.com/wbolster/plyvel/issues/114)
+
+## Running a database
+
+Some (actually, most) crawlers in zavod use the cache and some other things that get read from the database.
+
+To bring a database up for local development:
+
+```bash
+docker compose -f ../docker-compose.yml up -d db # Bring up a dev database
+# Your probably want to put this in your .envrc
+export ZAVOD_DATABASE_URI=postgresql://postgres:password@localhost:5432/dev
+```
 
 ## pre-commit checks
 


### PR DESCRIPTION
- **docs: Improve install docs**
  - If your pyICU fails to install, you'll notice and start googling. We don't need a box about this
  - Put the thing to make plyvel install front and center
  

- **docs: Remove docker from install instructions**
  There is not really any point to developing zavod using docker, it's just a hassle and if it's not a hassle to you or you're running in prod, you will have no issue figuring out the five commands. I think having this front and center as the "easy option" is just confusing.
  

- **docs: Add database bringup to install docs**
  