### PR TITLE
leonhandreke/install docs

### DIFF
--- a/zavod/docs/install.md
+++ b/zavod/docs/install.md
@@ -27,7 +27,7 @@ $ zavod --help
 
 If you encounter any errors during the installation, please consider googling errors related to libraries used by `zavod` (e.g.: SQLAlchemy, Python-Levenshtein, click, etc.).
 
-!!! info Installing `plyvel` on macOS
+!!! info "Installing `plyvel` on macOS"
     To make Plyvel install on macOS, set the following environment variables before running `uv sync`.
 
     ```sh


### PR DESCRIPTION
- **docs: Improve install docs**
  - If your pyICU fails to install, you'll notice and start googling. We don't need a box about this
  - Put the thing to make plyvel install front and center
  

- **docs: Remove docker from install instructions**
  There is not really any point to developing zavod using docker, it's just a hassle and if it's not a hassle to you or you're running in prod, you will have no issue figuring out the five commands. I think having this front and center as the "easy option" is just confusing.
  

- **docs: Add database bringup to install docs**
  

- **docs: Fix syntax error**
  