### PR TITLE
versions: rename parameter to make_version to make it more clear what's going on

### DIFF
--- a/zavod/zavod/cli.py
+++ b/zavod/zavod/cli.py
@@ -118,7 +118,7 @@ def export(dataset_path: Path, clear: bool = False) -> None:
 @click.option("-l", "--latest", is_flag=True, default=False)
 def publish(dataset_path: Path, latest: bool = False) -> None:
     dataset = _load_dataset(dataset_path)
-    make_version(dataset, settings.RUN_VERSION, overwrite=False)
+    make_version(dataset, settings.RUN_VERSION, append_new_version_to_history=False)
     try:
         publish_dataset(dataset, latest=latest)
     except Exception:
@@ -142,7 +142,7 @@ def run(
         log.info("Dataset is disabled, skipping: %s" % dataset.name)
         publish_failure(dataset, latest=latest)
         sys.exit(0)
-    # Crawl
+    # crawl if it's a dataset, just create a new version if it's a collection
     if dataset.model.entry_point is not None and not dataset.is_collection:
         try:
             crawl_dataset(dataset, dry_run=False)
@@ -150,7 +150,8 @@ def run(
             publish_failure(dataset, latest=latest)
             sys.exit(1)
     else:
-        make_version(dataset, settings.RUN_VERSION, overwrite=True)
+        # crawl_dataset -> Context.begin does this in the case above
+        make_version(dataset, settings.RUN_VERSION, append_new_version_to_history=True)
 
     linker = get_dataset_linker(dataset)
     store = get_store(dataset, linker)

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -114,7 +114,9 @@ class Context:
             dataset=self.dataset.name,
             context=self,
         )
-        make_version(self.dataset, settings.RUN_VERSION, overwrite=clear)
+        make_version(
+            self.dataset, settings.RUN_VERSION, append_new_version_to_history=clear
+        )
         if clear and not self.dry_run:
             self.resources.clear()
             self.issues.clear()

--- a/zavod/zavod/runtime/versions.py
+++ b/zavod/zavod/runtime/versions.py
@@ -12,10 +12,17 @@ def _versions_path(dataset_name: str) -> Path:
     return dataset_resource_path(dataset_name, VERSIONS_FILE)
 
 
-def make_version(dataset: Dataset, version: Version, overwrite: bool = False) -> None:
-    """Add a new version to the dataset history."""
+def make_version(
+    dataset: Dataset, version: Version, append_new_version_to_history: bool = False
+) -> None:
+    """Add a new version to the dataset history.
+
+    Args:
+        append_new_version_to_history: If True, a new version will be appended to the existing version history.
+            If False, a new version will only be created if no versions exist yet.
+    """
     path = _versions_path(dataset.name)
-    if path.exists() and not overwrite:
+    if path.exists() and not append_new_version_to_history:
         return
     data = get_versions_data(dataset.name)
     history = VersionHistory.from_json(data or "{}")

--- a/zavod/zavod/tests/exporters/test_delta.py
+++ b/zavod/zavod/tests/exporters/test_delta.py
@@ -57,7 +57,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
         return resolver.apply(Entity.from_data(testdataset1, data))
 
     version = Version.new("aaa")
-    make_version(testdataset1, version, overwrite=True)
+    make_version(testdataset1, version, append_new_version_to_history=True)
     store.clear()
     writer = store.writer()
     writer.add_entity(e(ENTITY_B))
@@ -84,7 +84,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     _publish_artifacts(testdataset1)
 
     version2 = Version.new("bbb")
-    make_version(testdataset1, version2, overwrite=True)
+    make_version(testdataset1, version2, append_new_version_to_history=True)
     store.clear()
     writer = store.writer()
     writer.add_entity(e(ENTITY_A))
@@ -115,7 +115,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     # Round 3: check that the delta exporter can handle resolver changes
     _publish_artifacts(testdataset1)
     version3 = Version.new("ccc")
-    make_version(testdataset1, version3, overwrite=True)
+    make_version(testdataset1, version3, append_new_version_to_history=True)
     canon_id = resolver.decide("EC", "ECX", Judgement.POSITIVE)
     store.clear()
     writer = store.writer()


### PR DESCRIPTION
This makes it more obvious how overloaded `clear` really is as a term. This will be remedied in following commits.
