### PR TITLE
[experiment] run issues agent every day

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -4,7 +4,7 @@ name: Issues agent
 "on":
   workflow_dispatch: {}
   schedule:
-    - cron: "45 6 * * *"
+    - cron: "45 6 * * 1-5"
 
 permissions:
   contents: write


### PR DESCRIPTION
the goal here is to see:

* is this useful or distracting?
* what extra constraints should be in the prompt?
* what extra recipes should be in the prompt?

tbd: how can we avoid opening a new PR for the same issues every day, especially the weekend