### PR TITLE
[tr_parliament] add birth date/place to IDs (externally)

### DIFF
--- a/datasets/tr/parliament/crawler.py
+++ b/datasets/tr/parliament/crawler.py
@@ -44,7 +44,9 @@ def crawl_birth_year_place(context: Context, url: str) -> tuple[str | None, str 
         actions=UNBLOCK_ACTIONS,
         javascript=True,
         absolute_links=True,
-        cache_days=1,
+        # Cache disabled because their bot blocking includes regularly-changing UUIDs in the URL
+        # making caching fairly futile.
+        cache_days=None,
     )
 
     # Pick the first element under the span in the profile free text section
@@ -87,8 +89,6 @@ def crawl_item(context: Context, item: etree):
     entity.add("political", party)
 
     birth_year, birth_place = crawl_birth_year_place(context, deputy_url)
-    entity.add("birthDate", birth_year)
-    entity.add("birthPlace", birth_place)
 
     position = h.make_position(
         context, "Member of the Grand National Assembly", country="tr"
@@ -116,8 +116,7 @@ def crawl_item(context: Context, item: etree):
         context.emit(entity)
         context.emit(position)
         context.emit(occupancy)
-        if birth_year is not None and birth_place is not None:
-            context.emit(entity_temp, external=True)
+        context.emit(entity_temp, external=True)
 
 
 def crawl(context: Context):

--- a/datasets/tr/parliament/tr_parliament.yml
+++ b/datasets/tr/parliament/tr_parliament.yml
@@ -39,6 +39,11 @@ assertions:
     country_entities:
       tr: 590
     countries: 1
+    property_fill_rate:
+      Person:
+        # The birth date extraction is prone to failure because it's a regex on free text.
+        # If it breaks, we risk re-keying the dataset unintentionally.
+        birthDate: 0.7
   max:
     schema_entities:
       Person: 605


### PR DESCRIPTION
emit external entities using new id scheme incl birth date/place 

This doesn't modify existing entities. It only emits external entities with matching names to gracefully move over to the new IDs in https://github.com/opensanctions/opensanctions/pull/3686

issue [#596](https://github.com/opensanctions/crawler-planning/issues/596)