### PR TITLE
Export statements before consolidation

### DIFF
--- a/zavod/zavod/exporters/common.py
+++ b/zavod/zavod/exporters/common.py
@@ -26,6 +26,9 @@ class Exporter(object):
     def feed(self, entity: Entity, view: ExportView) -> None:
         raise NotImplementedError()
 
+    def feed_unconsolidated(self, entity: Entity) -> None:
+        pass
+
     def finish(self, view: ExportView) -> None:
         try:
             resource = self.context.export_resource(

--- a/zavod/zavod/exporters/statements.py
+++ b/zavod/zavod/exporters/statements.py
@@ -16,6 +16,9 @@ class StatementsCSVExporter(Exporter):
         self.writer = CSVStatementWriter(self.fh)
 
     def feed(self, entity: Entity, view: ExportView) -> None:
+        pass
+
+    def feed_unconsolidated(self, entity: Entity) -> None:
         for stmt in entity.statements:
             self.writer.write(stmt)
 

--- a/zavod/zavod/tests/exporters/util.py
+++ b/zavod/zavod/tests/exporters/util.py
@@ -1,4 +1,5 @@
 from zavod.context import Context
+from zavod.exporters.consolidate import consolidate_entity
 from zavod.store import get_store
 from zavod.exporters.fragment import ViewFragment
 from zavod.integration import get_dataset_linker
@@ -16,7 +17,10 @@ def harnessed_export(exporter_class, dataset, linker=None) -> None:
     exporter = exporter_class(context)
     exporter.setup()
     for entity in view.entities():
+        exporter.feed_unconsolidated(entity)
         fragment = ViewFragment(view, entity)
+        entity = consolidate_entity(view.store.linker, entity)
+        entity = fragment.get_entity(entity.id)
         exporter.feed(entity, fragment)
     exporter.finish(view)
 


### PR DESCRIPTION
Fixes #3593

Consolidation removes statements. Exporting statements.csv based on consolidated entities means that export doesn't match the statements database which is the union of the relevant source datasets' statements.pack outputs.

This fixes that by adding a feed of pre-consolidation entities for exporters like this who need it.