### PR TITLE
Rename publish -> archive artifact to reserve publish for /datasets

### DIFF
--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -16,7 +16,8 @@ from zavod.exporters import write_dataset_index
 log = get_logger(__name__)
 
 
-def _publish_artifacts(dataset: Dataset) -> None:
+def _archive_artifacts(dataset: Dataset) -> None:
+    """Archive artifacts to the /artifacts/ path on the data bucket."""
     version = get_latest(dataset.name, backfill=False)
     if version is None:
         raise ValueError(f"No working version found for dataset: {dataset.name}")
@@ -34,7 +35,7 @@ def _publish_artifacts(dataset: Dataset) -> None:
 
 
 def publish_dataset(dataset: Dataset, latest: bool = True) -> None:
-    """Upload a dataset to the archive."""
+    """Publish a dataset to the archive, i.e. to /datasets."""
     resources = DatasetResources(dataset)
     for resource in resources.all():
         if resource.name in ARTIFACT_FILES:
@@ -64,7 +65,7 @@ def publish_dataset(dataset: Dataset, latest: bool = True) -> None:
             continue
         mime_type = JSON if meta.endswith(".json") else None
         publish_resource(path, dataset.name, meta, latest=latest, mime_type=mime_type)
-    _publish_artifacts(dataset)
+    _archive_artifacts(dataset)
 
 
 def publish_failure(dataset: Dataset, latest: bool = True) -> None:
@@ -94,6 +95,6 @@ def publish_failure(dataset: Dataset, latest: bool = True) -> None:
         log.error("Metadata file not found: %s" % path, dataset=dataset.name)
         return
     publish_resource(path, dataset.name, INDEX_FILE, latest=latest, mime_type=JSON)
-    _publish_artifacts(dataset)
+    _archive_artifacts(dataset)
     dataset_resource_path(dataset.name, RESOURCES_FILE).unlink(missing_ok=True)
     dataset_resource_path(dataset.name, VERSIONS_FILE).unlink(missing_ok=True)

--- a/zavod/zavod/tests/exporters/test_delta.py
+++ b/zavod/zavod/tests/exporters/test_delta.py
@@ -11,7 +11,7 @@ from zavod.archive import DELTA_EXPORT_FILE, DATASETS, DELTA_INDEX_FILE
 from zavod.entity import Entity
 from zavod.exporters import export_dataset
 from zavod.meta import Dataset
-from zavod.publish import _publish_artifacts
+from zavod.publish import _archive_artifacts
 from zavod.runtime.versions import make_version
 from zavod.store import get_store
 
@@ -81,7 +81,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
         dataset_path / DELTA_INDEX_FILE, expected_versions
     )
 
-    _publish_artifacts(testdataset1)
+    _archive_artifacts(testdataset1)
 
     version2 = Version.new("bbb")
     make_version(testdataset1, version2, append_new_version_to_history=True)
@@ -113,7 +113,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     )
 
     # Round 3: check that the delta exporter can handle resolver changes
-    _publish_artifacts(testdataset1)
+    _archive_artifacts(testdataset1)
     version3 = Version.new("ccc")
     make_version(testdataset1, version3, append_new_version_to_history=True)
     canon_id = resolver.decide("EC", "ECX", Judgement.POSITIVE)

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -25,10 +25,10 @@ def _read_history(dataset_name: str) -> Optional[VersionHistory]:
 
 def test_publish_dataset(testdataset1: Dataset):
     linker = get_dataset_linker(testdataset1)
-    art_path = settings.ARCHIVE_PATH / ARTIFACTS
-    arch_path = settings.ARCHIVE_PATH / DATASETS
-    release_path = arch_path / settings.RELEASE / testdataset1.name
-    latest_path = arch_path / "latest" / testdataset1.name
+    artifacts_path = settings.ARCHIVE_PATH / ARTIFACTS
+    published_path = settings.ARCHIVE_PATH / DATASETS
+    release_path = published_path / settings.RELEASE / testdataset1.name
+    latest_path = published_path / "latest" / testdataset1.name
     assert not release_path.joinpath(INDEX_FILE).exists()
     assert not latest_path.joinpath(INDEX_FILE).exists()
     history = _read_history(testdataset1.name)
@@ -44,7 +44,7 @@ def test_publish_dataset(testdataset1: Dataset):
     assert history is not None
     assert history.latest is not None
     assert history.latest.id is not None
-    artifact_path = art_path / testdataset1.name / history.latest.id
+    artifact_path = artifacts_path / testdataset1.name / history.latest.id
     assert artifact_path.exists()
     assert artifact_path.joinpath(STATEMENTS_FILE).exists()
     assert artifact_path.joinpath(STATEMENTS_FILE).exists()
@@ -71,9 +71,9 @@ def test_publish_dataset(testdataset1: Dataset):
 
 
 def test_publish_failure(testdataset1: Dataset):
-    arch_path = settings.ARCHIVE_PATH / DATASETS
-    art_path = settings.ARCHIVE_PATH / ARTIFACTS
-    latest_path = arch_path / "latest" / testdataset1.name
+    published_path = settings.ARCHIVE_PATH / DATASETS
+    artifacts_path = settings.ARCHIVE_PATH / ARTIFACTS
+    latest_path = published_path / "latest" / testdataset1.name
     assert testdataset1.data is not None
     testdataset1.data.format = "FAIL"
     try:
@@ -86,7 +86,7 @@ def test_publish_failure(testdataset1: Dataset):
     assert history is not None
     assert history.latest is not None
     assert history.latest.id is not None
-    artifact_path = art_path / testdataset1.name / history.latest.id
+    artifact_path = artifacts_path / testdataset1.name / history.latest.id
 
     assert not latest_path.joinpath("statements.pack").exists()
     assert not latest_path.joinpath("issues.json").exists()


### PR DESCRIPTION
This is part of a general drive to make `/artifacts` the place where (possibly failed) runs go, and `/dataset` the place where we publish stuff fit for public consumption.

https://github.com/opensanctions/opensanctions/issues/2541
