### PR TITLE
Don't publish failed runs `index.json` to `/datasets`

### DIFF
--- a/zavod/zavod/cli.py
+++ b/zavod/zavod/cli.py
@@ -25,7 +25,7 @@ from zavod.logs import (
     set_logging_context_dataset_name,
 )
 from zavod.meta import load_dataset_from_path, get_multi_dataset, Dataset
-from zavod.publish import publish_dataset, publish_failure
+from zavod.publish import publish_dataset, archive_failure
 from zavod.runtime.versions import make_version, set_last_successful_version
 from zavod.stateful.model import create_db
 from zavod.store import get_store
@@ -172,14 +172,14 @@ def run(
 
     if dataset.model.disabled:
         log.info("Dataset is disabled, skipping: %s" % dataset.name)
-        publish_failure(dataset, latest=latest)
+        archive_failure(dataset, latest=latest)
         sys.exit(0)
     # crawl if it's a dataset, just create a new version if it's a collection
     if dataset.model.entry_point is not None and not dataset.is_collection:
         try:
             crawl_dataset(dataset, dry_run=False)
         except RunFailedException:
-            publish_failure(dataset, latest=latest)
+            archive_failure(dataset, latest=latest)
             sys.exit(1)
     else:
         # crawl_dataset -> Context.begin does this in the case above
@@ -195,7 +195,7 @@ def run(
             validate_dataset(dataset, view)
     except Exception:
         log.exception("Validation failed for %r" % dataset.name)
-        publish_failure(dataset, latest=latest)
+        archive_failure(dataset, latest=latest)
         store.close()
         sys.exit(1)
     # Export and Publish

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -68,7 +68,7 @@ def publish_dataset(dataset: Dataset, latest: bool = True) -> None:
     _archive_artifacts(dataset)
 
 
-def publish_failure(dataset: Dataset, latest: bool = True) -> None:
+def archive_failure(dataset: Dataset, latest: bool = True) -> None:
     """Upload failure information about a dataset to the archive."""
     # Collections currently should never call publish_failure (as that only gets called for crawl and validate).
     # But if they ever did (for example to publish a failure in the export stage), we should think very well about
@@ -94,7 +94,6 @@ def publish_failure(dataset: Dataset, latest: bool = True) -> None:
     if not path.is_file():
         log.error("Metadata file not found: %s" % path, dataset=dataset.name)
         return
-    publish_resource(path, dataset.name, INDEX_FILE, latest=latest, mime_type=JSON)
     _archive_artifacts(dataset)
     dataset_resource_path(dataset.name, RESOURCES_FILE).unlink(missing_ok=True)
     dataset_resource_path(dataset.name, VERSIONS_FILE).unlink(missing_ok=True)

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -11,7 +11,7 @@ from zavod.crawl import crawl_dataset
 from zavod.store import get_store
 from zavod.exporters import export_dataset
 from zavod.integration import get_dataset_linker
-from zavod.publish import publish_dataset, publish_failure
+from zavod.publish import publish_dataset, archive_failure
 from zavod.exc import RunFailedException
 
 
@@ -79,7 +79,7 @@ def test_publish_failure(testdataset1: Dataset):
     try:
         crawl_dataset(testdataset1)
     except RunFailedException:
-        publish_failure(testdataset1, latest=True)
+        archive_failure(testdataset1, latest=True)
     clear_data_path(testdataset1.name)
 
     history = _read_history(testdataset1.name)
@@ -92,4 +92,7 @@ def test_publish_failure(testdataset1: Dataset):
     assert not latest_path.joinpath("issues.json").exists()
     assert artifact_path.joinpath("issues.json").exists()
     assert artifact_path.joinpath("index.json").exists()
-    assert latest_path.joinpath("index.json").exists()
+
+    # We don't want failed runs to end up in /datasets
+    assert not latest_path.joinpath("index.json").exists()
+    assert len(list(latest_path.glob("*"))) == 0


### PR DESCRIPTION
See https://github.com/opensanctions/opensanctions/issues/2541. Trying to make the PRs as small as possible to make it easy for my meager brain to reason about.

The website already reads the latest archived run to display metadata and issues, so this will continue working.
