### PR TITLE
Set last_successful in versions.json

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 requires-python = ">= 3.12"
 dependencies = [
     "followthemoney == 4.5.3",
-    "nomenklatura == 4.7.0",
+    "nomenklatura == 4.7.1",
     "plyvel == 1.5.1",
     "rigour == 1.7.2",
     "datapatch >= 1.2.4, < 1.3",

--- a/zavod/zavod/cli.py
+++ b/zavod/zavod/cli.py
@@ -26,7 +26,7 @@ from zavod.logs import (
 )
 from zavod.meta import load_dataset_from_path, get_multi_dataset, Dataset
 from zavod.publish import publish_dataset, publish_failure
-from zavod.runtime.versions import make_version
+from zavod.runtime.versions import make_version, set_last_successful_version
 from zavod.stateful.model import create_db
 from zavod.store import get_store
 from zavod.tools.dump_file import dump_dataset_to_file
@@ -153,7 +153,13 @@ def publish(dataset_path: Path, latest: bool = False) -> None:
 
 @cli.command("run", help="Crawl, export and then publish a specific dataset")
 @click.argument("dataset_path", type=DatasetInPath)
-@click.option("-l", "--latest", is_flag=True, default=False)
+@click.option(
+    "-l",
+    "--latest",
+    is_flag=True,
+    default=False,
+    help="Whether to re-publish to /datasets/latest/, in addition to the timestamped/versioned prefixes.",
+)
 @click.option("--clear-data/--keep-data", is_flag=True, default=True)
 def run(
     dataset_path: Path,
@@ -195,6 +201,8 @@ def run(
     # Export and Publish
     try:
         export_dataset(dataset, view)
+        # Set the version as successful in the version file, which will be archived by publish_dataset.
+        set_last_successful_version(dataset, settings.RUN_VERSION)
         publish_dataset(dataset, latest=latest)
 
         if not dataset.is_collection and dataset.model.load_statements:

--- a/zavod/zavod/runtime/versions.py
+++ b/zavod/zavod/runtime/versions.py
@@ -24,11 +24,30 @@ def make_version(
     path = _versions_path(dataset.name)
     if path.exists() and not append_new_version_to_history:
         return
+    # get_versions_data always reads from the archive, never from the local file system.
     data = get_versions_data(dataset.name)
     history = VersionHistory.from_json(data or "{}")
     if version not in history.items:
         history = history.append(version)
 
+    with open(path, "w") as fh:
+        fh.write(history.to_json())
+
+
+def set_last_successful_version(dataset: Dataset, version: Version) -> None:
+    """Set the last successful version in the dataset history."""
+    path = _versions_path(dataset.name)
+    if not path.exists():
+        raise RuntimeError(
+            f"Version history file does not exist for dataset {dataset.name}"
+        )
+    with open(path, "r") as fh:
+        history = VersionHistory.from_json(fh.read())
+    if version not in history.items:
+        raise RuntimeError(
+            f"Version {version} is not in the version history for dataset {dataset.name}"
+        )
+    history.last_successful = version
     with open(path, "w") as fh:
         fh.write(history.to_json())
 

--- a/zavod/zavod/tests/test_cli.py
+++ b/zavod/zavod/tests/test_cli.py
@@ -1,9 +1,10 @@
 import shutil
 
 from click.testing import CliRunner
+from nomenklatura.versions import VersionHistory
 
 from zavod import settings
-from zavod.archive import dataset_state_path
+from zavod.archive import dataset_state_path, dataset_resource_path, VERSIONS_FILE
 from zavod.cli import cli
 from zavod.integration import get_resolver
 from zavod.meta import Dataset
@@ -112,6 +113,28 @@ def test_run_validation_failed(testdataset3: Dataset):
     assert "Assertion countries failed" in result.output, result.output
     with open(artifacts_path / "issues.json", "r") as f:
         assert "Assertion countries failed" in f.read()
+    shutil.rmtree(settings.DATA_PATH)
+
+
+def test_run_update_last_successful_version(
+    testdataset3: Dataset, testdataset1: Dataset
+):
+    runner = CliRunner()
+
+    # testdataset3 has validation errors, so last_successful should NOT be set
+    result = runner.invoke(cli, ["run", "--latest", DATASET_3_YML.as_posix()])
+    assert result.exit_code != 0, result.output
+    versions_path = dataset_resource_path(testdataset3.name, VERSIONS_FILE)
+    assert not versions_path.exists(), "versions.json should not exist after failed run"
+
+    # testdataset1 succeeds, so last_successful should be set
+    result = runner.invoke(cli, ["run", "--latest", DATASET_1_YML.as_posix()])
+    assert result.exit_code == 0, result.output
+    versions_path = dataset_resource_path(testdataset1.name, VERSIONS_FILE)
+    assert versions_path.exists(), "versions.json should exist after run"
+    history = VersionHistory.from_json(versions_path.read_text())
+    assert history.last_successful is not None
+    assert history.last_successful == settings.RUN_VERSION
     shutil.rmtree(settings.DATA_PATH)
 
 


### PR DESCRIPTION
I'm trying to be extremely conservative changing this logic, as I don't understand all the ways in which they play together. For now, I have only added this logic to `zavod run` - I'm not really sure who would use `zavod export`, but I guess it could theoretically be used to export half-crawled data?

Another step on the long road to https://github.com/opensanctions/opensanctions/issues/2541
