### PR TITLE
Helper for term start dates

### DIFF
--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -9,8 +9,10 @@ from zavod import settings
 from zavod.context import Context
 from zavod.entity import Entity
 from zavod.stateful.positions import (
+    DEFAULT_AFTER_OFFICE,
     OccupancyStatus,
     PositionCategorisation,
+    get_after_office,
     occupancy_status,
 )
 
@@ -200,3 +202,28 @@ def make_occupancy(
                 person.add("country", country)
 
     return occupancy
+
+
+def earliest_term_start(topics: List[str] = ["gov.national"]) -> str:
+    """Returns a date that can be used as a cut-off date for parliamentary or government terms
+    when crawling historical data. For example, if a dataset is known to include data from the
+    inception of a country, but we only want to consider people as PEPs if they held a position
+    within the last 20 years, we can use this function to determine the earliest term start date
+    to consider when crawling.
+
+    The date is framed as a start date but should include sufficient slack to also be used as a
+    filter on end dates if just those are available.
+
+    Args:
+        topics: A list of topics to determine the earliest term start date for.
+            For example, ["gov.national"] for national-level positions or ["gov.state"] for
+            subnational positions. ["gov.diplo"] for international diplomatic positions.
+            The default is ["gov.national"].
+
+    Returns:
+        A date string in ISO format representing the earliest term start date to consider.
+    """
+    after_office = get_after_office(topics)
+    after_office = after_office + (DEFAULT_AFTER_OFFICE * 2)  # Add extra slack
+    earliest_date = (settings.RUN_TIME - after_office).date().isoformat()
+    return earliest_date

--- a/zavod/zavod/tests/helpers/test_positions.py
+++ b/zavod/zavod/tests/helpers/test_positions.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
+from zavod import settings
 from zavod.context import Context
 from zavod.meta import Dataset
-from zavod.helpers.positions import make_position, make_occupancy
+from zavod.helpers.positions import make_position, make_occupancy, earliest_term_start
 
 
 def test_make_position(testdataset1: Dataset):
@@ -168,3 +169,20 @@ def test_occupancy_dataset_coverage():
     assert occupancy2.get("endDate") == ["2021-01-05"]
     context1.close()
     context2.close()
+
+
+def test_earliest_term_start():
+    def _years_ago(years):
+        return (settings.RUN_TIME - timedelta(days=365 * years)).date().isoformat()
+
+    # For national positions, the earliest term start should be 20 years + after-office threshold ago
+    topics = ["gov.national"]
+    assert earliest_term_start(topics) < _years_ago(1)
+    assert earliest_term_start(topics) < _years_ago(10)
+    assert earliest_term_start(topics) > _years_ago(50)
+
+    # For subnational positions, the earliest term start should be 20 years + after-office threshold ago
+    topics = ["gov.state"]
+    assert earliest_term_start(topics) < _years_ago(1)
+    assert earliest_term_start(topics) < _years_ago(10)
+    assert earliest_term_start(topics) > _years_ago(16)


### PR DESCRIPTION
Here's a proposal for a very specific helper to bound PEP crawlers. Currently, it adds ten years of extra buffer, which may be a bit generous. Does this fix the need from #3252? 

Refs #3750