### PR TITLE
multi_split: don't log warning if splitters unsorted

### DIFF
--- a/zavod/zavod/helpers/text.py
+++ b/zavod/zavod/helpers/text.py
@@ -58,10 +58,6 @@ def _validate_splitters(splitters: Tuple[str, ...]) -> None:
         if not isinstance(splitter, str):
             log.warning(f"multi_split: not a string: {splitter!r}")
             continue
-        for prev in previous:
-            if prev in splitter:
-                msg = f"multi_split: {splitter!r} is a substring of preceding {prev!r}"
-                log.warning(msg)
         previous.append(splitter)
 
 


### PR DESCRIPTION
We already have the warning if the outcome is different. We fix all those, and then switch to sorted once they're all resolved.

https://github.com/opensanctions/opensanctions/issues/3810
