### PR TITLE
cleaning: implement `silence_warnings: [address-too-short]` syntax

### DIFF
--- a/contrib/issues_agent/prompt.md
+++ b/contrib/issues_agent/prompt.md
@@ -62,14 +62,23 @@ For merged countries `France / Syria`, make multiple `values` (`France`, `Syria`
 
 Try to remove or substitute the HTML content, leaving any text content in place: `<p>Hello</p>` -> `Hello`.
 
+If the content was erroneously marked as HTML, silence the warning:
+
+```
+  type.text:
+    options:
+      - match: "Also known under the pseudonym <tramp>"
+        silence_warnings: [xss-html-smell]
+```
+
 ### `Property for address looks too short for an address: Zug`
 
-If the string looks like a valid place name or address, introduce a lookup with the same return value:
+If the string looks like a valid place name or address, silence the warning:
 
 ```
 options:
   - match: Zug
-    value: Zug
+    silence_warnings: [address-too-short]
 ```
 
 If the value is not an address or location name, set the value to `null` (unquoted YAML null value).

--- a/datasets/ch/parlament/ch_parlament.yml
+++ b/datasets/ch/parlament/ch_parlament.yml
@@ -63,16 +63,11 @@ lookups:
 
   type.address:
     options:
-      # Short addresses that we want to bypass the warnings for
-      - match: "Egg"
-        value: "Egg"
-      - match: "Uri"
-        value: "Uri"
-      - match: "Lü" # Lü is a village in the Val Müstair municipality in the district of Inn in the Swiss canton of Graubünden.
-        value: "Lü"
-      - match: "Lax"
-        value: "Lax"
-      - match: "Elm"
-        value: "Elm"
-      - match: "Bex"
-        value: "Bex"
+      - match:
+          - "Egg"
+          - "Uri"
+          - "Lü" # Lü is a village in the Val Müstair municipality in the district of Inn in the Swiss canton of Graubünden.
+          - "Lax"
+          - "Elm"
+          - "Bex"
+        silence_warnings: [address-too-short]

--- a/zavod/zavod/runtime/cleaning.py
+++ b/zavod/zavod/runtime/cleaning.py
@@ -8,7 +8,11 @@ from followthemoney import registry, Property, model
 from followthemoney.statement.util import NON_LANG_TYPE_NAMES
 
 from zavod.logs import get_logger
-from zavod.runtime.lookups import is_type_lookup_value, prop_lookup
+from zavod.runtime.lookups import (
+    get_type_lookup_silence_warnings,
+    is_type_lookup_value,
+    prop_lookup,
+)
 from zavod.runtime.safety import check_xss_html_smell
 
 
@@ -144,7 +148,17 @@ def value_clean(
             # This is not a general restriction on addresses that should be in FtM,
             # but rather a smell that can indicate a crawler bug.
             if prop_.type == registry.address and len(clean) <= 3:
-                if not is_type_lookup_value(entity, registry.address, item):
+                warn_address_too_short = True
+
+                if "address-too-short" in get_type_lookup_silence_warnings(
+                    entity, registry.address, item
+                ):
+                    warn_address_too_short = False
+                # TODO: Phase this out in favor of silence_warnings
+                if is_type_lookup_value(entity, registry.address, item):
+                    warn_address_too_short = False
+
+                if warn_address_too_short:
                     log.warning(
                         f"Property for {prop_.name} looks too short for an address: {value}",
                         entity_id=entity.id,

--- a/zavod/zavod/runtime/lookups.py
+++ b/zavod/zavod/runtime/lookups.py
@@ -38,6 +38,18 @@ def match_type_lookup(
     return lookup.match(value) if lookup is not None else None
 
 
+def get_type_lookup_silence_warnings(
+    entity: "Entity", type_: PropertyType, value: Optional[str]
+) -> set[str]:
+    """Get the set of warnings that should be silenced for a given value based on a type lookup."""
+    lookup_result = match_type_lookup(entity, type_, value)
+    return (
+        set(lookup_result.silence_warnings or [])
+        if lookup_result is not None
+        else set()
+    )
+
+
 def type_lookup(
     dataset: Dataset, type_: PropertyType, value: Optional[str]
 ) -> List[str]:

--- a/zavod/zavod/runtime/safety.py
+++ b/zavod/zavod/runtime/safety.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional
 from followthemoney import registry, Property
 
 from zavod.logs import get_logger
-from zavod.runtime.lookups import is_type_lookup_value, match_type_lookup
+from zavod.runtime.lookups import get_type_lookup_silence_warnings, is_type_lookup_value
 
 
 if TYPE_CHECKING:
@@ -68,11 +68,10 @@ def check_xss_html_smell(
         return cleaned_value
 
     # Allow settings silence_warnings: [xss-html-smell] for certain values
-    lookup_result = match_type_lookup(entity, prop.type, cleaned_value)
-    if lookup_result is not None:
-        silence_warnings = lookup_result.silence_warnings or set()
-        if SILENCE_WARNING_TYPE in silence_warnings:
-            return cleaned_value
+    if SILENCE_WARNING_TYPE in get_type_lookup_silence_warnings(
+        entity, prop.type, cleaned_value
+    ):
+        return cleaned_value
 
     # TODO: Phase this out in favor of silence_warnings
     if is_type_lookup_value(entity, prop.type, cleaned_value):


### PR DESCRIPTION
- **cleaning: implement `silence_warnings: [address-too-short]` syntax**
- **cleaning: also let xss-html-smell use `get_type_lookup_silence_warnings`**
