### PR TITLE
Support tagging gov.admin to clarify civil service positions

### DIFF
--- a/ui/app/positions/PositionTagger.tsx
+++ b/ui/app/positions/PositionTagger.tsx
@@ -77,9 +77,9 @@ export default async function PositionTagger({ searchParams }: { searchParams: S
             <li><kbd>Q</kbd> Head</li>
             <li><kbd>W</kbd> Executive</li>
             <li><kbd>E</kbd> Legislative</li>
-            <li><kbd>R</kbd> Judicial</li>
-            <li><kbd>T</kbd> Security</li>
-            <li><kbd>Y</kbd> Financial</li>
+            <li><kbd>R</kbd> Administrative (Civil service)</li>
+            <li><kbd>T</kbd> Judicial</li>
+            <li><kbd>Y</kbd> Security</li>
           </ul>
         </div>
       </div>

--- a/ui/app/positions/PositionTaggerRow.tsx
+++ b/ui/app/positions/PositionTaggerRow.tsx
@@ -21,6 +21,7 @@ const ROLE_ENTRIES = [
   ["gov.head", "Head"],
   ["gov.executive", "Exec"],
   ["gov.legislative", "Legis"],
+  ["gov.admin", "Admin"],
   ["gov.judicial", "Juris"],
   ["gov.security", "Secur"],
   ["gov.financial", "Fin"],


### PR DESCRIPTION
Some civil servants are concerned about being labeled politicians. We've fixed the Politician label. Senior civil servants are still PEPs according to FATF definitions, and thorougly in scope of PEP checks.

<img width="1970" height="520" alt="image" src="https://github.com/user-attachments/assets/7b49625a-9330-4eb5-94ef-15ed5910c942" />

This is a standard question when buying a house in South Africa and the UK

<img width="1406" height="214" alt="image" src="https://github.com/user-attachments/assets/ee655644-e57c-4298-abed-883f648586ea" />
