### PR TITLE
[wikidata] reduce cache expiry to fix wikipediaUrl faster

### DIFF
--- a/datasets/_externals/wikidata.yml
+++ b/datasets/_externals/wikidata.yml
@@ -73,7 +73,7 @@ inputs:
 config:
   type: nomenklatura.enrich.wikidata:WikidataEnricher
   label_cache_days: 90
-  cache_days: 19 # TODO: revert to 14 days when wikipedia URLs are fixed
+  cache_days: 17 # TODO: revert to 14 days when wikipedia URLs are fixed
   schemata:
     - Person
 


### PR DESCRIPTION
we're around 1000 per run and we want to be around 10,000 per day

https://github.com/opensanctions/opensanctions/issues/3820