### PR TITLE
cli: zavod archive url --last-successful

### DIFF
--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -98,6 +98,9 @@ def get_dataset_artifact(
     return path
 
 
+# TODO(Leon Handreke): This function has some overlap with versions.get_history.
+# The right thing to do might be to have two functions, one to get the "root" version file
+# at artifacts/{dataset_name}/versions.json, and one to get the version file for a specific version.
 @lru_cache(maxsize=1000)
 def get_versions_data(
     dataset_name: str, version: Optional[str] = None

--- a/zavod/zavod/cli/archive.py
+++ b/zavod/zavod/cli/archive.py
@@ -3,9 +3,15 @@ from pathlib import Path
 import click
 
 from zavod import settings
-from zavod.archive import ARTIFACTS, STATEMENTS_FILE, iter_dataset_versions
+from zavod.archive import (
+    ARTIFACTS,
+    STATEMENTS_FILE,
+    get_versions_data,
+    iter_dataset_versions,
+)
 from zavod.cli import cli, DatasetInPath, _load_dataset
 from zavod.meta.dataset import Dataset
+from nomenklatura.versions import VersionHistory
 
 RESOURCE_FILENAMES = [STATEMENTS_FILE]
 
@@ -17,6 +23,20 @@ def _get_latest_version(dataset: Dataset) -> str:
     for v in iter_dataset_versions(dataset.name):
         return v.id
     raise click.ClickException(f"No version history found for dataset: {dataset.name}")
+
+
+def get_last_successful_version(dataset_name: str) -> str | None:
+    # TODO(Leon Handreke): We should really clean up the version mess. The fact that we're instantiating
+    # VersionHistory from nomenklatura here in the CLI is a code smell.
+    # We have some code in archive.py to read the "root" versions file (which is
+    # what we want here), and some code in versions.py to read the version file
+    # for a specific version with backfilling. We should really make the
+    # semantics more intuitive, document more and make it less likely we'll
+    # shoot ourselves in the foot in the future.
+    history = VersionHistory.from_json(get_versions_data(dataset_name) or "{}")
+    if history.last_successful:
+        return history.last_successful.id
+    return None
 
 
 @cli.group("archive", help="Archive-related utilities")
@@ -33,15 +53,38 @@ def archive() -> None:
     default=False,
     help="Resolve the latest version from versions.json",
 )
-def url(resource_filename: str, dataset_path: Path, latest: bool = False) -> None:
+@click.option(
+    "--last-successful",
+    is_flag=True,
+    default=False,
+    help="Resolve the URL for the last successful version.",
+)
+def url(
+    resource_filename: str,
+    dataset_path: Path,
+    latest: bool = False,
+    last_successful: bool = False,
+) -> None:
     dataset = _load_dataset(dataset_path)
 
-    if not latest:
+    if sum([latest, last_successful]) != 1:
         # No support for finding other versions yet
-        raise click.ClickException("--latest is required.")
+        raise click.ClickException(
+            "Exactly one of --latest or --last-successful is required."
+        )
 
+    version: str | None = None
     if latest:
         version = _get_latest_version(dataset)
-        click.echo(
-            f"{settings.ARCHIVE_SITE}/{ARTIFACTS}/{dataset.name}/{version}/{resource_filename}"
-        )
+    elif last_successful:
+        version = get_last_successful_version(dataset.name)
+        if version is None:
+            raise click.ClickException(
+                f"No last successful version found for dataset: {dataset.name}"
+            )
+
+    assert version is not None
+
+    click.echo(
+        f"{settings.ARCHIVE_SITE}/{ARTIFACTS}/{dataset.name}/{version}/{resource_filename}"
+    )


### PR DESCRIPTION
Adds a `--last-successful` flag to `zavod archive url` so we can resolve the URL for the last successful version of a dataset archive, not just the latest one.

Since we now have two flags, exactly one of `--latest` or `--last-successful` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)