### PR TITLE
[am] Add return type annotations to pass mypy --strict

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -77,7 +77,6 @@ repos:
           datasets/_testing|
           datasets/_wikidata|
           datasets/ae|
-          datasets/am|
           datasets/at|
           datasets/ba|
           datasets/be|

--- a/datasets/am/hetq/crawler.py
+++ b/datasets/am/hetq/crawler.py
@@ -169,7 +169,7 @@ def crawl_list(
     data: List[Dict[str, Any]],
     year: int,
     lang: SupportedLanguage,
-):
+) -> None:
     """Accumulate person info from yearly list.  Do not actually
     create entities yet because they are duplicated in multiple years."""
     for entry in data:
@@ -206,7 +206,7 @@ def crawl_missing_pois(
     zipfh: ZipFile,
     missing_pois: Dict[int, Any],
     persons: Dict[int, Dict[str, Any]],
-):
+) -> None:
     """Create an entity for a person of interest not named in the
     front-page list of PEPs."""
     # We should have downloaded these in download.py (at first we didn't)
@@ -222,7 +222,7 @@ def crawl_missing_pois(
 
 def crawl_relations(
     context: Context, zipfh: ZipFile, persons: Dict[int, Dict[str, Any]], person_id: int
-):
+) -> None:
     """Read relation graph and create entities."""
     # There should always be a person / entity for the source
     assert person_id in persons
@@ -288,7 +288,7 @@ def crawl_relations(
         context.emit(relation)
 
 
-def crawl_lists(context: Context, zipfh: ZipFile):
+def crawl_lists(context: Context, zipfh: ZipFile) -> None:
     """Read lists of persons for each year covered, matching names and
     accumulating years in which the person was active."""
     persons: Dict[int, Dict[str, Any]] = {}
@@ -315,7 +315,7 @@ def crawl_lists(context: Context, zipfh: ZipFile):
         crawl_relations(context, zipfh, persons, person_id)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     """Download the zip of Hetq data and create Person entities."""
 
     data_path = context.get_resource_path("hetq-data.zip")

--- a/datasets/am/hetq/download.py
+++ b/datasets/am/hetq/download.py
@@ -24,7 +24,7 @@ CHROME_HEADER = {
 }
 
 
-def build_front_url(lang: LANGUAGE, year: int, offset: int):
+def build_front_url(lang: LANGUAGE, year: int, offset: int) -> str:
     url = FRONTPAGE % {"lang": lang}
     return "?".join(
         (
@@ -41,11 +41,11 @@ def build_front_url(lang: LANGUAGE, year: int, offset: int):
     )
 
 
-def build_relations_url(lang: LANGUAGE, person_id: int):
+def build_relations_url(lang: LANGUAGE, person_id: int) -> str:
     return RELATIONS % {"lang": lang, "person": person_id}
 
 
-def download_front_page(lang: LANGUAGE, outdir: Path):
+def download_front_page(lang: LANGUAGE, outdir: Path) -> None:
     """Download all data from the front page for each year available."""
     pagepath = outdir / "front" / f"{lang}.html"
     pagepath.parent.mkdir(parents=True, exist_ok=True)
@@ -84,7 +84,7 @@ def download_front_page(lang: LANGUAGE, outdir: Path):
             json.dump(entries, outfh, indent=2, ensure_ascii=False)
 
 
-def download_people_page(lang: LANGUAGE, outdir: Path, person: int):
+def download_people_page(lang: LANGUAGE, outdir: Path, person: int) -> None:
     personpath = outdir / "person" / f"{person}-{lang}.html"
     if personpath.exists():
         LOGGER.info("Skipping existing file %s", personpath)
@@ -100,7 +100,7 @@ def download_people_page(lang: LANGUAGE, outdir: Path, person: int):
         page.write(r.text)
 
 
-def download_people_pages(lang: LANGUAGE, outdir: Path):
+def download_people_pages(lang: LANGUAGE, outdir: Path) -> Set[int]:
     """Get the page for each PEP (no JSON available it seems)."""
     frontdir = outdir / "front"
     # Merge all of them to get unique person ids
@@ -115,7 +115,9 @@ def download_people_pages(lang: LANGUAGE, outdir: Path):
     return person_ids
 
 
-def download_relations_pages(person_ids: Set[int], lang: LANGUAGE, outdir: Path):
+def download_relations_pages(
+    person_ids: Set[int], lang: LANGUAGE, outdir: Path
+) -> None:
     """Get relation graph for each PEP (in JSON not SVG thankfully)."""
     (outdir / "relations").mkdir(parents=True, exist_ok=True)
     more_person_ids = set()
@@ -149,7 +151,7 @@ def download_relations_pages(person_ids: Set[int], lang: LANGUAGE, outdir: Path)
     person_ids.update(more_person_ids)
 
 
-def download_officialtypes(outdir: Path):
+def download_officialtypes(outdir: Path) -> None:
     """Get the list of official types (just for completeness really)"""
     officialtypes = outdir / "officialtypes.json"
     if officialtypes.exists():
@@ -166,7 +168,7 @@ def download_officialtypes(outdir: Path):
         json.dump(r.json(), page, indent=2, ensure_ascii=False)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("outdir", help="Path to output directory", type=Path)
     args = parser.parse_args()


### PR DESCRIPTION
Adds missing return type annotations to `datasets/am/hetq/crawler.py` and `download.py` so they pass `mypy --strict`. Also removes `datasets/am` from the pre-commit mypy exclusion list.

No logic changes — purely annotation additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)