### PR TITLE
kz_companies: Make typechecker happy

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -104,7 +104,6 @@ repos:
           datasets/kg|
           datasets/kp|
           datasets/ky|
-          datasets/kz|
           datasets/lt|
           datasets/lu|
           datasets/mc|

--- a/datasets/kz/companies/crawler.py
+++ b/datasets/kz/companies/crawler.py
@@ -95,10 +95,13 @@ def crawl_page(context: Context, page_number: int) -> int:
             context.emit(director)
             context.emit(link)
 
-    return data.get("totalPages", 1)
+    total_pages = data.get("totalPages", 1)
+    if not isinstance(total_pages, int):
+        raise ValueError(f"Expected int for totalPages, got {type(total_pages)}")
+    return total_pages
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     """
     Main function to crawl and process data from the Kazakhstan data portal.
     """


### PR DESCRIPTION
Fixes the two `mypy --strict` errors in the kz companies crawler:

- `crawl()` was missing `-> None`
- `data.get("totalPages", 1)` returns `Any` (since `fetch_json` returns `Any`); added an isinstance check + raise before returning so mypy knows it's an `int`

Also removes `datasets/kz` from the mypy-datasets exclusion list in `.pre-commit-config.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)