### PR TITLE
eu_fsf finish names migration

### DIFF
--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -417,10 +417,11 @@ def derive_original_values(original: Names, extracted: Names) -> Dict[str, str]:
         (3) If some value in original contains it, we can use that the value from original as original_value.
         Otherwise leave blank - this is best-effort only.
     """
-    original_values: set[str] = set()
+    original_values: list[str] = []
     for _prop, values in original.as_langtexts():
         for value in values:
-            original_values.add(value.text)
+            original_values.append(value.text)
+    original_values.sort()  # sort to pick deterministically regardless of input order
 
     derived_originals: dict[str, str] = {}
     for _prop, extracted_values in extracted.as_langtexts():
@@ -429,7 +430,7 @@ def derive_original_values(original: Names, extracted: Names) -> Dict[str, str]:
 
             if len(original_values) == 1:
                 # (1) If there's exactly one value in original, use that for all names.
-                derived_originals[extracted_string] = next(iter(original_values))
+                derived_originals[extracted_string] = original_values[0]
             elif extracted_string in original_values:
                 # (2) Exact match exists, no original_value needed.
                 continue

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -417,10 +417,10 @@ def derive_original_values(original: Names, extracted: Names) -> Dict[str, str]:
         (3) If some value in original contains it, we can use that the value from original as original_value.
         Otherwise leave blank - this is best-effort only.
     """
-    original_values: List[str] = []
+    original_values: set[str] = set()
     for _prop, values in original.as_langtexts():
         for value in values:
-            original_values.append(value.text)
+            original_values.add(value.text)
 
     derived_originals: dict[str, str] = {}
     for _prop, extracted_values in extracted.as_langtexts():
@@ -429,13 +429,13 @@ def derive_original_values(original: Names, extracted: Names) -> Dict[str, str]:
 
             if len(original_values) == 1:
                 # (1) If there's exactly one value in original, use that for all names.
-                derived_originals[extracted_string] = original_values[0]
+                derived_originals[extracted_string] = next(iter(original_values))
+            elif extracted_string in original_values:
+                # (2) Exact match exists, no original_value needed.
+                continue
             else:
                 for original_string in original_values:
-                    if original_string == extracted_string:
-                        # (2) Exact match, no original_value needed.
-                        continue
-                    elif extracted_string in original_string:
+                    if extracted_string in original_string:
                         # (3) Extracted text is contained in original value, use as original_value.
                         derived_originals[extracted_string] = original_string
                         break

--- a/zavod/zavod/shed/fsf.py
+++ b/zavod/zavod/shed/fsf.py
@@ -151,10 +151,23 @@ def parse_entry(context: Context, entry: Element) -> None:
 
     original = h.Names()
     for name, lang in name_el_to_lang.items():
+        name_prop = "name"
+
+        # Often there will be translations of organization names to every EU language under the sun,
+        # and those can feature less prominently when we have geopolitically-interesting languages.
+        interesting_languages = {None, "eng", "zho", "rus", "fas", "ara"}
+        # If we have at least one name in English/Chinese/Russian/Farsi/Arabic or with no language tag,
+        # put the interesting language names in `name` and other languages in `alias`.
+        # Otherwise leave them all in name.
+        if len(set(name_el_to_lang.values()) & interesting_languages) > 0:
+            if lang not in interesting_languages:
+                name_prop = "alias"
+
+        # Let the EU's weak alias decisions override our language logic
+
         is_weak = not as_bool(name.get("strong"))
         remark = name.findtext("./remark")
         if remark is not None:
-            # context.inspect(name)
             lremark = remark.lower()
             if "low quality" in lremark or "lo quality" in lremark:
                 is_weak = True
@@ -171,53 +184,27 @@ def parse_entry(context: Context, entry: Element) -> None:
                 context.log.warning("Unknown alias remark", remark=remark)
             entity.add("notes", remark, quiet=True)
 
-        # Often there will be translations of organization names to every EU language under the sun,
-        # and we don't much care for those.
-        #
-        # If we have at least one name in English/Chinese/Russian/Farsi/Arabic or with no language tag,
-        # put it in the name field and treat the other languages as aliases.
-        interesting_languages = {None, "eng", "zho", "rus", "fas", "ara"}
-        if len(set(name_el_to_lang.values()) & interesting_languages) > 0:
-            treat_as_alias = lang not in interesting_languages
-        else:
-            # If all names we have are in the languages that we commonly assume are translated,
-            # put them all in the name field. This happens e.g. for Spanish-name terrorists.
-            treat_as_alias = False
-
         full_name = name.get("wholeName")
         first_name = name.get("firstName")
         middle_name = name.get("middleName")
         last_name = name.get("lastName")
-        if is_weak:
-            h.apply_name(
-                entity,
+        if not full_name and (first_name and last_name):
+            # Currently full_name always exists with first and last, but just make sure.
+            full_name = h.make_name(
                 full=full_name,
                 first_name=first_name,
                 middle_name=middle_name,
                 last_name=last_name,
-                is_weak=True,
-                quiet=True,
-                lang=lang,
             )
-            original.add("weakAlias", full_name, lang=lang)
+
+        if is_weak:
+            name_prop = "weakAlias"
         else:
-            if not full_name and (first_name and last_name):
-                # Currently full_name always exists with first and last, but just make sure.
-                full_name = h.make_name(
-                    first_name=first_name,
-                    middle_name=middle_name,
-                    last_name=last_name,
-                )
-            h.apply_reviewed_name_string(
-                context,
-                entity,
-                string=full_name,
-                original_prop="alias" if treat_as_alias else "name",
-            )
-            original.add("alias" if treat_as_alias else "name", full_name, lang=lang)
             entity.add("firstName", first_name, quiet=True, lang=lang)
             entity.add("middleName", middle_name, quiet=True, lang=lang)
             entity.add("lastName", last_name, quiet=True, lang=lang)
+
+        original.add(name_prop, full_name, lang=lang)
 
         # split "(a) Mullah, (b) Maulavi" into ["Mullah", "Maulavi"]
         titles = [
@@ -235,10 +222,9 @@ def parse_entry(context: Context, entry: Element) -> None:
             entity.add("notes", name.get("function"), lang=lang)
         entity.add("gender", name.get("gender"), quiet=True, lang=lang)
 
-    # TODO: Change to apply_reviewed_names and remove the per-name
-    # apply_reviewed_name_string and apply_name calls above.
-    # https://github.com/opensanctions/opensanctions/issues/3603
-    h.review_names(context, entity, original=original)
+    # Apply after looping over name language elements in the source
+    # and adding each real name to 'original'.
+    h.apply_reviewed_names(context, entity, original=original)
 
     for node in entry.findall("./identification"):
         doc_type = node.get("identificationTypeCode")

--- a/zavod/zavod/tests/helpers/names/test_derive_originals.py
+++ b/zavod/zavod/tests/helpers/names/test_derive_originals.py
@@ -27,12 +27,13 @@ def test_derive_original_values_exact_match():
 
 def test_derive_original_values_substring_match():
     """When an extracted value is contained in an original, it maps to that original."""
-    original = Names(name="John Doe; Brandon Doe", alias="J. Doe")
-    extracted = Names(name="John Brandon Doe", alias="Brandon Doe")
+    original = Names(name="John Doe; Brandon Doe", alias="John Doe")
+    extracted = Names(name="John Doe", alias="Brandon Doe")
 
     result = derive_original_values(original, extracted)
 
-    # John Brandon Doe isn't contained exactly. We're not getting more fancy with this.
+    # John Doe is contained exactly so no original_value needed.
+    # Brandon Doe is only contained partially, so maps to the containing original.
     assert result == {"Brandon Doe": "John Doe; Brandon Doe"}
 
 

--- a/zavod/zavod/tests/helpers/names/test_derive_originals.py
+++ b/zavod/zavod/tests/helpers/names/test_derive_originals.py
@@ -27,28 +27,15 @@ def test_derive_original_values_exact_match():
 
 def test_derive_original_values_substring_match():
     """When an extracted value is contained in an original, it maps to that original."""
-    original = Names(name="John Doe; Brandon Doe", alias="J. Doe")
-    extracted = Names(name="John Brandon Doe", alias="Brandon Doe")
+    original = Names(name=["John Doe; Brandon Doe", "John Brandon Doe", "John Doe"])
+    extracted = Names(name="John Doe", alias="Brandon Doe")
 
     result = derive_original_values(original, extracted)
 
-    # John Brandon Doe isn't contained exactly. We're not getting more fancy with this.
-    assert result == {
-        "Brandon Doe": "John Doe; Brandon Doe",
-    }
-
-
-def test_derive_original_values_first_match_wins():
-    """When multiple originals contain the extracted value, the first match is used."""
-    original = Names(name=["John Brandon Doe", "John Smith"])
-    extracted = Names(name="John")
-
-    result = derive_original_values(original, extracted)
-
-    # "John" is in both originals, but the first one should win
-    assert result == {
-        "John": "John Brandon Doe",
-    }
+    # Brandon Doe isn't contained exactly.
+    # Either of "John Doe; Brandon Doe" or "John Brandon Doe" could be used.
+    assert len(result) == 1
+    assert "Brandon Doe" in result["Brandon Doe"]
 
 
 def test_derive_original_values_no_match():

--- a/zavod/zavod/tests/helpers/names/test_derive_originals.py
+++ b/zavod/zavod/tests/helpers/names/test_derive_originals.py
@@ -21,21 +21,30 @@ def test_derive_original_values_exact_match():
 
     result = derive_original_values(original, extracted)
 
-    # John Doe isn't contained exactly, and Jhon doe matches exactly so doesn't need an original_value
+    # Jon Doe isn't contained exactly, and John Doe matches exactly so doesn't need an original_value
     assert result == {}
 
 
 def test_derive_original_values_substring_match():
     """When an extracted value is contained in an original, it maps to that original."""
-    original = Names(name=["John Doe; Brandon Doe", "John Brandon Doe", "John Doe"])
-    extracted = Names(name="John Doe", alias="Brandon Doe")
+    original = Names(name="John Doe; Brandon Doe", alias="J. Doe")
+    extracted = Names(name="John Brandon Doe", alias="Brandon Doe")
 
     result = derive_original_values(original, extracted)
 
-    # Brandon Doe isn't contained exactly.
-    # Either of "John Doe; Brandon Doe" or "John Brandon Doe" could be used.
-    assert len(result) == 1
-    assert "Brandon Doe" in result["Brandon Doe"]
+    # John Brandon Doe isn't contained exactly. We're not getting more fancy with this.
+    assert result == {"Brandon Doe": "John Doe; Brandon Doe"}
+
+
+def test_derive_original_values_substring_match_stable_selection():
+    """When multiple originals contain the extracted value,
+    the alphabetic first match is used regardless of input order."""
+    original = Names(name=["b) Jonathan", "a) Jonny", "c) Jon"])
+    extracted = Names(name="Jon")
+
+    result = derive_original_values(original, extracted)
+
+    assert result == {"Jon": "a) Jonny"}
 
 
 def test_derive_original_values_no_match():


### PR DESCRIPTION
Fixes https://github.com/opensanctions/opensanctions/issues/3603

✅  ~Let's wait until name->alias moves are confirmed/fixed in eu_travel_bans, and eu_fsf is fully reviewed, before merging this.~ 

✅  Let's also see if the eu_fsf delta makes this disruptive. It probably shouldn't, because we don't anticipate a lot of changes, if we're reviewing consistently.

```
Delta export complete [eu_fsf] added=0 deleted=0 metric=delta_counts modified=105
```

eu_fsf most common change seems to be emitting names with language when not doing so before. Some name prop demotions.

```
Delta export complete [eu_travel_bans] added=0 deleted=0 metric=delta_counts modified=61 version=20260417131040-mlp
```

eu_travel_bans most changes seem to be good name prop demotions

- Replaces direct `apply_name` call and single-name `apply_reviewed_name_string` with one `apply_reviewed_names` for all names for one entity
- Fixes bug where we were deriving original_value as one of the strings containing a name when the name occurred exactly in the source, merely because of the ordering of original name values.