### PR TITLE
fix program dataset values

### DIFF
--- a/meta/programs/UN-SC1737.yml
+++ b/meta/programs/UN-SC1737.yml
@@ -9,4 +9,4 @@ summary: UN Security Council resolution 1737 (2006) imposes sanctions on Iran fo
 issuer: zz_unsc
 dataset: un_sc_sanctions
 target_territories:
-  - ir
+- ir

--- a/meta/programs/UN-SC1737.yml
+++ b/meta/programs/UN-SC1737.yml
@@ -7,6 +7,6 @@ summary: UN Security Council resolution 1737 (2006) imposes sanctions on Iran fo
   a ban the supply of nuclear-related technology and materials and imposes assets
   freeze on key individuals and companies related to the enrichment programme.
 issuer: zz_unsc
-dataset: un_sc_sanctions,fr_tresor_gels_avoir
+dataset: un_sc_sanctions
 target_territories:
-- ir
+  - ir

--- a/meta/programs/US-DDTC-AD.yml
+++ b/meta/programs/US-DDTC-AD.yml
@@ -9,4 +9,4 @@ summary: The US Department of State's Directorate of Defense Trade Controls (DDT
   convictions, administrative debarments are civil enforcement actions that prohibit
   designated persons from participating in defense trade activities.
 issuer: us_state
-dataset: US-DDTC-AD
+dataset: us_ddtc_debarred


### PR DESCRIPTION
The dataset values were incorrect; one with two values and the other referencing the program key instead of the dataset slug.