### PR TITLE
Fix typo tag jusris.eu → juris.eu in ie_unlawful_organizations

### DIFF
--- a/datasets/ie/unlawful_organizations/ie_unlawful_organizations.yml
+++ b/datasets/ie/unlawful_organizations/ie_unlawful_organizations.yml
@@ -14,7 +14,7 @@ description: |
   the authority of the Offences Against the State Act 1939, officially declare
   specific organisations as unlawful due to their involvement in activities that
   threaten public safety and order. The 1983 order designates the Irish National
-  Liberation Army (INLA) as an unlawful organisation, while the 1939 order 
+  Liberation Army (INLA) as an unlawful organisation, while the 1939 order
   targets the Irish Republican Army (IRA), also known as Oglaigh na héireann.
   Both orders mandate the suppression of these organisations in the public interest.
 publisher:
@@ -36,7 +36,7 @@ data:
 tags:
   - list.sanction
   - target.ie
-  - jusris.eu
+  - juris.eu
 
 assertions:
   min:

--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -144,7 +144,7 @@ class Dataset(FollowTheMoneyDataset):
         for resource in data.get("resources", []):
             resource["path"] = resource["name"]
         if self.is_collection:
-            # HACK backwards compatibility
+            # As of mid-2025, the same is now in `children`, but we keep it in `datasets` for backward compatibility.
             data["datasets"] = [d.name for d in self.datasets]
             data["datasets"].remove(self.name)
         else:
@@ -154,13 +154,16 @@ class Dataset(FollowTheMoneyDataset):
         return data
 
     def to_opensanctions_dict(self, catalog: "ArchiveBackedCatalog") -> Dict[str, Any]:
-        """Generate a backward-compatible metadata export."""
+        """Generate a metadata export in the format expected by the OpenSanctions catalog."""
         data = self.to_dict()
         assert self._type in ("collection", "source", "external"), self._type
         data.pop("resources", None)
         data.pop("version", None)
 
+        # Add the type field: collection, source, or external
         data["type"] = self._type
+
+        # Add the list of collections that this dataset belongs to
         if not self.is_collection:
             collections = [
                 p.name for p in catalog.datasets if self in p.datasets and p != self


### PR DESCRIPTION
Typo in the tags of `ie_unlawful_organizations` — `jusris.eu` should be `juris.eu`. Spotted while analysing tag values across the full catalog, brought to you by the vibes without me even asking it :)

🤖 Generated with [Claude Code](https://claude.com/claude-code)