### PR TITLE
Issues 2026-05-04

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -174,7 +174,6 @@ repos:
           datasets/us/cuba_sanctions|
           datasets/us/md/med_exclusions|
           datasets/us/ks/med_exclusions|
-          datasets/us/ne/med_exclusions|
           datasets/us/hi/med_exclusions|
           datasets/us/de/med_exclusions|
           datasets/us/fdic_failed_banks|

--- a/datasets/jp/meti_ru/crawler.py
+++ b/datasets/jp/meti_ru/crawler.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 import pdfplumber
 from lxml import html
 from rigour.mime.types import CSV, PDF
-from rigour.text.scripts import get_script
+from rigour.text.scripts import text_scripts
 
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
@@ -39,7 +39,7 @@ def detect_script(context: Context, text: str) -> Optional[str]:
     Detect script in a string. Return 'jpn' or 'eng' if confident, else None.
     Used primarily not to misclassify Chinese names as Japanese.
     """
-    scripts = [get_script(ord(ch)) for ch in text if get_script(ord(ch))]
+    scripts = text_scripts(text)
     if not scripts:
         context.log.warning(f"Could not detect script for: {text}")
         return None

--- a/datasets/us/al/med_exclusions/crawler.py
+++ b/datasets/us/al/med_exclusions/crawler.py
@@ -1,12 +1,12 @@
 import re
-from typing import Dict, List
+from typing import Any, List
 
 from pdfplumber.page import Page
 from pydantic import BaseModel, Field
 from rigour.mime.types import PDF
 from rigour.names.org_types import extract_org_types
 from zavod.extract.llm import DEFAULT_MODEL, run_typed_text_prompt
-from zavod.extract.zyte_api import fetch_html, fetch_resource
+from zavod.extract import zyte_api
 from zavod.stateful.review import (
     TextSourceValue,
     assert_all_accepted,
@@ -118,7 +118,7 @@ Specific fields:
 """
 
 
-def apply_comma_name(entity: entity.Entity, name: str):
+def apply_comma_name(entity: entity.Entity, name: str) -> None:
     parts = name.split(",")
     if (
         len(parts) == 2
@@ -140,7 +140,9 @@ def apply_comma_name(entity: entity.Entity, name: str):
         entity.add("name", name)
 
 
-def crawl_row(context, names, category, start_date, filename: str):
+def crawl_row(
+    context: Context, names: str, category: str | None, start_date: str, filename: str
+) -> None:
     origin = None
     entity_data = None
     if SIMPLE_NAME_REGEX.fullmatch(names):
@@ -251,13 +253,17 @@ def crawl_row(context, names, category, start_date, filename: str):
         context.emit(sanction)
 
 
-def crawl_data_url(context: Context):
+def crawl_data_url(context: Context) -> str:
     file_xpath = "//a[contains(., 'PDF Version')]"
-    doc = fetch_html(context, context.data_url, file_xpath, absolute_links=True)
-    return doc.xpath(file_xpath)[0].get("href")
+    doc = zyte_api.fetch_html(
+        context, context.data_url, unblock_validator=file_xpath, absolute_links=True
+    )
+    url = h.xpath_string(doc, file_xpath + "/@href")
+    assert url is not None, "Could not find PDF URL"
+    return url
 
 
-def page_settings(page: Page) -> Dict:
+def page_settings(page: Page) -> tuple[Page, dict[str, Any]]:
     settings = {"join_y_tolerance": 15}
     if page.page_number == 1:
         # The table header is a little box above the main table, so it gets detected as a separate table.
@@ -279,7 +285,9 @@ def crawl(context: Context) -> None:
 
     # First we find the link to the PDF file
     url = crawl_data_url(context)
-    _, _, _, path = fetch_resource(context, "source.pdf", url, expected_media_type=PDF)
+    _, _, _, path = zyte_api.fetch_resource(
+        context, "source.pdf", url, expected_media_type=PDF
+    )
     context.export_resource(path, PDF, title=context.SOURCE_TITLE)
     filename = url.split("/")[-1]
     assert ".pdf" in filename, filename

--- a/datasets/us/ar/med_exclusions/crawler.py
+++ b/datasets/us/ar/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict
 import csv
 from rigour.mime.types import CSV
 
@@ -10,7 +9,7 @@ REGEX_AKA = re.compile(r"\baka\b", re.IGNORECASE)
 REGEX_WORD = re.compile(r"\w{2,}")
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     zip_code = row.pop("Zip")
     division = row.pop("Division")
 

--- a/datasets/us/az/med_exclusions/crawler.py
+++ b/datasets/us/az/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import PDF
 
 from zavod import Context, helpers as h
@@ -6,7 +5,7 @@ from zavod.extract.zyte_api import fetch_resource
 from normality import slugify, stringify
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     if not row.get("name_provider") and not row.get("npi"):
         return
 

--- a/datasets/us/ca/med_exclusions/crawler.py
+++ b/datasets/us/ca/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 import csv
-from typing import Dict
 
 from normality import slugify
 from rigour.ids.npi import NPI
@@ -10,7 +9,7 @@ from zavod import Context
 from zavod import helpers as h
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     addresses = row.pop("address_es")
     first_name = row.pop("first_name")
     middle_name = row.pop("middle_name")
@@ -75,7 +74,7 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_data_url(context: Context):
+def crawl_data_url(context: Context) -> str:
     # Landing page
     xpath = ".//a[contains(text(), 'Suspended')][contains(text(), 'Ineligible')][contains(text(), 'List')]"
 
@@ -87,14 +86,17 @@ def crawl_data_url(context: Context):
         cache_days=1,
         absolute_links=True,
     )
-    dataset_url = landing_doc.xpath(xpath)[0].get("href")
+    dataset_url = h.xpath_string(landing_doc, xpath + "/@href")
+    assert dataset_url is not None, "Could not find dataset URL"
 
     dataset_doc = context.fetch_html(dataset_url, cache_days=1, absolute_links=True)
-    resource_url = dataset_doc.xpath(xpath)[0].get("href")
+    resource_url = h.xpath_string(dataset_doc, xpath + "/@href")
+    assert resource_url is not None, "Could not find resource URL"
 
     resource_doc = context.fetch_html(resource_url, cache_days=1, absolute_links=True)
     file_xpath = ".//a[contains(@href, '.csv')]"
-    file_url = resource_doc.xpath(file_xpath)[0].get("href")
+    file_url = h.xpath_string(resource_doc, file_xpath + "/@href")
+    assert file_url is not None, "Could not find CSV file URL"
     return file_url
 
 

--- a/datasets/us/co/med_exclusions/crawler.py
+++ b/datasets/us/co/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
@@ -6,7 +5,7 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     name = row.pop("provider_name")
     npi = row.pop("npi")
     if not name:

--- a/datasets/us/de/med_exclusions/crawler.py
+++ b/datasets/us/de/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import PDF
 import re
 
@@ -13,7 +12,7 @@ REGEX_AKA = re.compile(r"\baka\b|a\.k\.a\.?", re.IGNORECASE)
 REGEX_JOB_ROLE = re.compile(r"^(?P<name>.+)[,\s]+(?P<role>([A-Z\.,/-]+|\([^\)]+\)))$")
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     raw_name = squash_spaces(row.pop("sanctioned_provider_name"))
     npi = row.pop("npi")
     # Skip empty rows

--- a/datasets/us/hi/med_exclusions/crawler.py
+++ b/datasets/us/hi/med_exclusions/crawler.py
@@ -1,16 +1,15 @@
 import re
-from typing import Dict
 from rigour.mime.types import PDF
 
 from zavod import Context, helpers as h
 from normality import squash_spaces
 
-from zavod.extract.zyte_api import fetch_html, fetch_resource
+from zavod.extract import zyte_api
 
 AKA_SPLIT = r"\baka\b|\ba\.k\.a\b|\bAKA\b|\bor\b"
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     if raw_first_name := row.pop("first_name"):
         entity = context.make("Person")
 
@@ -63,16 +62,22 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_pdf_url(context: Context):
+def crawl_pdf_url(context: Context) -> str:
     download_xpath = ".//a[contains(text(), 'Med Prov Excl-Rein List')]"
-    doc = fetch_html(
-        context, context.data_url, download_xpath, geolocation="us", absolute_links=True
+    doc = zyte_api.fetch_html(
+        context,
+        context.data_url,
+        unblock_validator=download_xpath,
+        geolocation="us",
+        absolute_links=True,
     )
-    return doc.xpath(download_xpath)[0].get("href")
+    url = h.xpath_string(doc, download_xpath + "/@href")
+    assert url is not None, "Could not find PDF URL"
+    return url
 
 
 def crawl(context: Context) -> None:
-    _, _, _, path = fetch_resource(
+    _, _, _, path = zyte_api.fetch_resource(
         context, "source.pdf", crawl_pdf_url(context), PDF, geolocation="us"
     )
     context.export_resource(path, PDF, title=context.SOURCE_TITLE)

--- a/datasets/us/ia/med_exclusions/crawler.py
+++ b/datasets/us/ia/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import Dict
 
 from normality import slugify
 from openpyxl import load_workbook
@@ -9,7 +8,7 @@ from zavod import Context, helpers as h
 from zavod.stateful.positions import YEAR_DAYS
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     enrollment_type = row.pop("enrollment_type")
     npi = row.pop("npi")
     license_type = row.pop("state_license_type")

--- a/datasets/us/ks/med_exclusions/crawler.py
+++ b/datasets/us/ks/med_exclusions/crawler.py
@@ -1,16 +1,15 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 import re
 
 from zavod import Context, helpers as h
-from zavod.extract.zyte_api import fetch_html, fetch_resource
+from zavod.extract import zyte_api
 
 # Regular expression to match the comma before "Inc."
 INC_PATTERN = r",\s*Inc\."
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     if not row.get("name"):
         return
 
@@ -44,16 +43,20 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     file_xpath = "//*[text()='Termination List (XLSX)']"
-    doc = fetch_html(context, context.data_url, file_xpath, absolute_links=True)
-    return doc.xpath(file_xpath)[0].get("href")
+    doc = zyte_api.fetch_html(
+        context, context.data_url, unblock_validator=file_xpath, absolute_links=True
+    )
+    url = h.xpath_string(doc, file_xpath + "/../@href")
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:
     # First we find the link to the excel file
     excel_url = crawl_excel_url(context)
-    _, _, _, path = fetch_resource(
+    _, _, _, path = zyte_api.fetch_resource(
         context, "source.xlsx", excel_url, expected_media_type=XLSX
     )
     context.export_resource(path, XLSX, title=context.SOURCE_TITLE)

--- a/datasets/us/ky/med_exclusions/crawler.py
+++ b/datasets/us/ky/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
@@ -9,7 +8,7 @@ from zavod.extract.zyte_api import fetch_resource
 REGEX_DBA = re.compile(r"\bdba\b", re.IGNORECASE)
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     period = row.pop("timeframe_of_term_exclusion")
     if not context.lookup("period", period):
         context.log.warning("Unexpected exclusion period", period=period, row=row)

--- a/datasets/us/la/med_exclusions/crawler.py
+++ b/datasets/us/la/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 from itertools import product
-from typing import Dict
 import re
 from normality import slugify
 from rigour.mime.types import CSV
@@ -7,14 +6,14 @@ import csv
 
 
 from zavod import Context, helpers as h
-from zavod.extract.zyte_api import fetch_html, fetch_resource
+from zavod.extract import zyte_api
 
 REGEX_DBA = re.compile(r"\bdba\b", re.IGNORECASE)
 REGEX_AKA = re.compile(r"\(?a\.?k\.?a\b\.?|\)", re.IGNORECASE)
 REGEX_WORD = re.compile(r"\w{2,}")
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     if row.pop(" Type of Exclusion") == "OIG":
         return
 
@@ -98,15 +97,19 @@ def crawl_item(row: Dict[str, str], context: Context):
     )
 
 
-def crawl_csv_url(context: Context):
+def crawl_csv_url(context: Context) -> str:
     file_xpath = ".//a[contains(text(), 'Download CSV')]"
-    doc = fetch_html(context, context.data_url, file_xpath, absolute_links=True)
-    return doc.xpath(file_xpath)[0].get("href")
+    doc = zyte_api.fetch_html(
+        context, context.data_url, unblock_validator=file_xpath, absolute_links=True
+    )
+    url = h.xpath_string(doc, file_xpath + "/@href")
+    assert url is not None, "Could not find CSV file URL"
+    return url
 
 
 def crawl(context: Context) -> None:
     csv_url = crawl_csv_url(context)
-    _, _, _, path = fetch_resource(
+    _, _, _, path = zyte_api.fetch_resource(
         context,
         "source.csv",
         csv_url,

--- a/datasets/us/ma/med_exclusions/crawler.py
+++ b/datasets/us/ma/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from openpyxl import load_workbook
 
 from zavod import Context, helpers as h
@@ -16,7 +15,7 @@ HEADERS = {
 }
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     name = row.pop("provider_name")
 
     if not name:
@@ -42,12 +41,14 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     xlsx_xpath = "//*[contains(text(), 'XLSX')]/../@href"
     doc = zyte_api.fetch_html(
         context, context.data_url, unblock_validator=xlsx_xpath, absolute_links=True
     )
-    return doc.xpath(xlsx_xpath)[0]
+    url = h.xpath_string(doc, xlsx_xpath)
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/md/med_exclusions/crawler.py
+++ b/datasets/us/md/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
@@ -6,7 +5,7 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     if not row.get("first_name"):
         entity = context.make("Company")
         entity.id = context.make_id(row.get("last_name_organization"))

--- a/datasets/us/mi/med_exclusions/crawler.py
+++ b/datasets/us/mi/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
@@ -8,7 +7,7 @@ from zavod.extract import zyte_api
 URL_XPATH = "//*[text()='List of Sanctioned Providers (XLSX)']/ancestor::a"
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     sanction_date_1 = row.pop("sanction_date1")
     sanction_date_1 = sanction_date_1.split() if sanction_date_1 else None
     sanction_date_2 = row.pop("sanction_date2")

--- a/datasets/us/mn/med_exclusions/crawler.py
+++ b/datasets/us/mn/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
@@ -6,7 +5,7 @@ from zavod import Context, helpers as h
 from zavod.extract.zyte_api import fetch_html, fetch_resource
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     is_company = "practice_name" in row
 
     address = h.make_address(
@@ -64,14 +63,15 @@ def unblock_validator(doc) -> bool:
     )
 
 
-def crawl_excel_urls(context: Context):
+def crawl_excel_urls(context: Context) -> tuple[str, str]:
     groups_xpath = ".//span[text()='MHCP Excluded Group Providers']/.."
     individuals_xpath = ".//span[text()='MHCP Excluded Individual Providers']/.."
     doc = fetch_html(context, context.data_url, groups_xpath, geolocation="US")
-    return (
-        doc.xpath(groups_xpath)[0].get("href"),
-        doc.xpath(individuals_xpath)[0].get("href"),
-    )
+    groups_url = h.xpath_string(doc, groups_xpath + "/@href")
+    individuals_url = h.xpath_string(doc, individuals_xpath + "/@href")
+    assert groups_url is not None, "Could not find Group Providers Excel URL"
+    assert individuals_url is not None, "Could not find Individual Providers Excel URL"
+    return groups_url, individuals_url
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/ms/med_exclusions/crawler.py
+++ b/datasets/us/ms/med_exclusions/crawler.py
@@ -1,11 +1,10 @@
 import openpyxl
 from rigour.mime.types import XLSX
-from typing import Dict
 
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     if not any(row.values()):  # Skip empty rows
         return
 
@@ -57,9 +56,11 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row, ignore=["column_0", "sanction_type"])
 
 
-def crawl_data_url(context: Context):
+def crawl_data_url(context: Context) -> str:
     doc = context.fetch_html(context.data_url, absolute_links=True)
-    return doc.xpath("//a[contains(text(), 'Sanctioned Provider List')]/@href")[0]
+    url = h.xpath_string(doc, "//a[contains(text(), 'Sanctioned Provider List')]/@href")
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/mt/med_exclusions/crawler.py
+++ b/datasets/us/mt/med_exclusions/crawler.py
@@ -1,16 +1,15 @@
 import re
-from typing import Dict
-
 from openpyxl import load_workbook
 from rigour.mime.types import XLSX
 
 from zavod import Context
 from zavod import helpers as h
+from zavod.entity import Entity
 
 REGEX_AKA = re.compile(r"^a\.k\.a\.? ", re.IGNORECASE)
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> tuple[Entity, Entity]:
     if ", " not in row.get("terminated_excluded_provider_s"):
         entity = context.make("Company")
         entity.id = context.make_id(row.get("terminated_excluded_provider_s"))
@@ -33,11 +32,14 @@ def crawl_item(row: Dict[str, str], context: Context):
     return entity, sanction
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     doc = context.fetch_html(context.data_url, absolute_links=True)
-    return doc.xpath(
-        ".//a[text()='Download Excluded or Terminated Provider list in Excel']"
-    )[0].get("href")
+    url = h.xpath_string(
+        doc,
+        ".//a[text()='Download Excluded or Terminated Provider list in Excel']/@href",
+    )
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/nc/med_exclusions/crawler.py
+++ b/datasets/us/nc/med_exclusions/crawler.py
@@ -1,12 +1,10 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: Dict[str, str], context: Context):
-
+def crawl_item(row: dict[str, str], context: Context) -> None:
     entity = context.make("LegalEntity")
     entity.id = context.make_id(
         row.get("excluded_entity"), row.get("npi_atypical_id_excluded")
@@ -45,13 +43,14 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     doc = context.fetch_html(context.data_url, absolute_links=True)
-    return doc.xpath("//*[text() = 'State Excluded Provider List']")[0].get("href")
+    url = h.xpath_string(doc, "//*[text() = 'State Excluded Provider List']/@href")
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:
-
     excel_url = crawl_excel_url(context)
 
     path = context.fetch_resource("list.xlsx", excel_url)

--- a/datasets/us/nd/med_exclusions/crawler.py
+++ b/datasets/us/nd/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 import re
@@ -8,7 +7,7 @@ from zavod import Context, helpers as h
 AKA_MATCH = r"\(aka ([^)]+)\)"
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     provider_name = row.pop("provider_name")
     if not provider_name:
         return
@@ -66,10 +65,12 @@ def crawl_item(row: Dict[str, str], context: Context):
     )
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     doc = context.fetch_html(context.data_url, absolute_links=True)
     xpath = "//a[contains(text(), 'ND Medicaid Provider Exclusion List')][substring(@href, string-length(@href) - 4) = '.xlsx']/@href"
-    return h.xpath_string(doc, xpath)
+    url = h.xpath_string(doc, xpath)
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/ne/med_exclusions/crawler.py
+++ b/datasets/us/ne/med_exclusions/crawler.py
@@ -7,16 +7,17 @@ from zavod.extract.zyte_api import fetch_resource
 PAGE_SETTINGS = {"join_y_tolerance": 2}
 
 
-def key_from_prefix(row: Dict[str, str], prefix: str) -> str:
+def key_from_prefix(row: Dict[str, str | None], prefix: str) -> str:
     key = [k for k in row.keys() if k.startswith(prefix)]
     assert len(key) == 1, ("Cannot find key.", key, row)
     return key[0]
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: Dict[str, str | None], context: Context) -> None:
     name = row.pop(key_from_prefix(row, "provider_name"))
     listing_date = row.pop(key_from_prefix(row, "date_added_to_nmep"))
     npi = row.pop("provider_npi")
+
     if organization_name := row.pop("organization_name"):
         entity = context.make("Company")
         entity.id = context.make_id(organization_name, npi)
@@ -25,7 +26,9 @@ def crawl_item(row: Dict[str, str], context: Context):
         entity = context.make("Person")
         entity.id = context.make_id(name, npi)
         entity.add("name", name)
-        assert organization_name in ("", None), row
+        assert organization_name in ("", None), (
+            "Cannot have both person and organization name."
+        )
 
     entity.add("npiCode", npi)
     entity.add("sector", row.pop("provider_type_code"))
@@ -54,7 +57,7 @@ def crawl(context: Context) -> None:
     for item in h.parse_pdf_table(
         context,
         path,
-        headers_per_page=False,
+        headers_per_page=True,
         page_settings=lambda page: (page, PAGE_SETTINGS),
     ):
         crawl_item(item, context)

--- a/datasets/us/nh/med_exclusions/crawler.py
+++ b/datasets/us/nh/med_exclusions/crawler.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from openpyxl import load_workbook
 from zavod.extract import zyte_api
 
@@ -7,7 +5,7 @@ from zavod import Context
 from zavod import helpers as h
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     first_name = row.pop("provider_individual_first_name")
     business_name = row.pop("business_name")
     npi = row.pop("national_provider_identifier_npi")
@@ -53,7 +51,7 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     sanction_list_xpath = (
         "//*[contains(text(), 'Medicaid Provider Exclusion and Sanction List')]"
     )
@@ -63,7 +61,9 @@ def crawl_excel_url(context: Context):
         unblock_validator=sanction_list_xpath,
         absolute_links=True,
     )
-    return doc.xpath(sanction_list_xpath)[0].get("href")
+    url = h.xpath_string(doc, sanction_list_xpath + "/@href")
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/nj/med_exclusions/crawler.py
+++ b/datasets/us/nj/med_exclusions/crawler.py
@@ -1,10 +1,9 @@
-from typing import Dict
 from rigour.mime.types import PDF
 
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     zip_code = row.pop("zip")
     npi = row.pop("npi_number")
 
@@ -44,8 +43,8 @@ def crawl_item(row: Dict[str, str], context: Context):
 
 
 def translate_keys(
-    context: Context, lookup: str, row: Dict[str, str]
-) -> Dict[str, str]:
+    context: Context, lookup: str, row: dict[str, str]
+) -> dict[str, str]:
     return {context.lookup_value(lookup, k, k): v for k, v in row.items()}
 
 

--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any
 from rigour.mime.types import PDF
 from pdfplumber.page import Page
 
@@ -6,7 +6,7 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     # We already crawl the federal dataset on another crawler
     sanction_tier = row.pop("nevada_medicaid_sanction_tier")
     if sanction_tier.lower() == "federal":
@@ -81,20 +81,21 @@ def crawl_item(row: Dict[str, str], context: Context):
     )
 
 
-def page_settings(page: Page):
+def page_settings(page: Page) -> tuple[Page, dict[str, Any]]:
     # Find the bottom of the bottom-most rectangle on the page
     bottom = max(page.height - rect["y0"] for rect in page.rects)
     assert bottom < (page.height - 5), (bottom, page.height)
     return page, {"explicit_horizontal_lines": [bottom]}
 
 
-def crawl_pdf_url(context: Context):
+def crawl_pdf_url(context: Context) -> str:
     pdf_link_xpath = "//*[text()='NV Exclusion List ']"
     doc = zyte_api.fetch_html(
         context, context.data_url, pdf_link_xpath, geolocation="US", absolute_links=True
     )
-    # doc = context.fetch_html(context.data_url)
-    return doc.xpath(pdf_link_xpath)[0].get("href")
+    url = h.xpath_string(doc, pdf_link_xpath + "/@href")
+    assert url is not None, "Could not find PDF URL"
+    return url
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/ny/med_exclusions/crawler.py
+++ b/datasets/us/ny/med_exclusions/crawler.py
@@ -1,11 +1,10 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     name = row.pop("provider_name")
 
     if not name:

--- a/datasets/us/oh/med_exclusions/crawler.py
+++ b/datasets/us/oh/med_exclusions/crawler.py
@@ -1,17 +1,16 @@
 from itertools import product
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 import re
 
 from zavod import Context, helpers as h
-from zavod.extract.zyte_api import fetch_html, fetch_resource
+from zavod.extract import zyte_api
 
 REGEX_DBA = re.compile(r"\bdba\b", re.IGNORECASE)
 REGEX_AKA = re.compile(r"\(?a\.?k\.?a\b\.?|\)", re.IGNORECASE)
 
 
-def crawl_individual(row: Dict[str, str], context: Context):
+def crawl_individual(row: dict[str, str], context: Context) -> None:
     entity = context.make("Person")
     entity.id = context.make_id(
         row.get("last_name"), row.get("first_name"), row.get("npi")
@@ -50,7 +49,7 @@ def crawl_individual(row: Dict[str, str], context: Context):
     context.audit_data(row, ignore=["date_added"])
 
 
-def crawl_organization(row: Dict[str, str], context: Context):
+def crawl_organization(row: dict[str, str], context: Context) -> None:
     entity = context.make("Company")
     entity.id = context.make_id(row.get("organization_name"))
     names = REGEX_DBA.split(row.pop("organization_name"))
@@ -107,16 +106,18 @@ def crawl_organization(row: Dict[str, str], context: Context):
     context.audit_data(row, ignore=["date_added"])
 
 
-def crawl_excel_url(context: Context):
-    file_xpath = ".//a[contains(text(), 'Medicaid') and contains(text(), 'Exclusion') and contains(text(), 'Suspension') and contains(@href, 'xlsx')]"
-    doc = fetch_html(context, context.data_url, file_xpath, geolocation="US")
-    return doc.xpath(file_xpath)[0].get("href")
+def crawl_excel_url(context: Context) -> str:
+    file_a_xpath = ".//a[contains(text(), 'Medicaid') and contains(text(), 'Exclusion') and contains(text(), 'Suspension') and contains(@href, 'xlsx')]"
+    doc = zyte_api.fetch_html(context, context.data_url, unblock_validator=file_a_xpath)
+    url = h.xpath_string(doc, file_a_xpath + "/@href")
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:
     # First we find the link to the excel file
     excel_url = crawl_excel_url(context)
-    _, _, _, path = fetch_resource(
+    _, _, _, path = zyte_api.fetch_resource(
         context, "source.xlsx", excel_url, expected_media_type=XLSX, geolocation="US"
     )
     context.export_resource(path, XLSX, title=context.SOURCE_TITLE)

--- a/datasets/us/pa/med_exclusions/crawler.py
+++ b/datasets/us/pa/med_exclusions/crawler.py
@@ -1,11 +1,10 @@
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod import Context, helpers as h
 import csv
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     start_date = row.pop("BeginDate")
     end_date = row.pop("EndDate")
     status = row.pop("Status")

--- a/datasets/us/sc/med_exclusions/crawler.py
+++ b/datasets/us/sc/med_exclusions/crawler.py
@@ -1,15 +1,14 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
 from zavod import Context, helpers as h
-from zavod.extract.zyte_api import fetch_html, fetch_resource
+from zavod.extract import zyte_api
 import re
 
 REGEX_ALIAS = re.compile(r"\ba\.k\.a\.?|\baka\b|\bf/k/a\b|\bdba\b", re.IGNORECASE)
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     entity = context.make("LegalEntity")
     npi = row.pop("npi")
     entity.id = context.make_id(row.get("individual_entity"), npi)
@@ -43,16 +42,18 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     file_xpath = ".//a[contains(text(), 'South Carolina Medicaid Excluded/Terminated Providers')]"
-    doc = fetch_html(context, context.data_url, file_xpath)
-    return doc.xpath(file_xpath)[0].get("href")
+    doc = zyte_api.fetch_html(context, context.data_url, unblock_validator=file_xpath)
+    url = h.xpath_string(doc, file_xpath + "/@href")
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:
     excel_url = crawl_excel_url(context)
 
-    _, _, _, path = fetch_resource(
+    _, _, _, path = zyte_api.fetch_resource(
         context, "source.xlsx", excel_url, geolocation="US", expected_media_type=XLSX
     )
     context.export_resource(path, XLSX, title=context.SOURCE_TITLE)

--- a/datasets/us/wa/med_exclusions/crawler.py
+++ b/datasets/us/wa/med_exclusions/crawler.py
@@ -1,11 +1,10 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     name = row.pop("name")
     if len(name.split("\n")) == 1:
         aliases = []
@@ -38,11 +37,13 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     doc = context.fetch_html(context.data_url, absolute_links=True)
-    return doc.xpath(".//a[contains(text(), 'the HCA Medicaid providers listing')]")[
-        0
-    ].get("href")
+    url = h.xpath_string(
+        doc, ".//a[contains(text(), 'the HCA Medicaid providers listing')]/@href"
+    )
+    assert url is not None, "Could not find Excel file URL"
+    return url
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/wv/med_exclusions/crawler.py
+++ b/datasets/us/wv/med_exclusions/crawler.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from zavod import Context, helpers as h
 from rigour.mime.types import PDF
 
@@ -14,11 +12,11 @@ prompt = """
 """
 
 
-def flat(multiline):
+def flat(multiline: str) -> str:
     return multiline.replace("\n", " ")
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     address = h.make_address(
         context,
         street=flat(row.pop("address_1")),
@@ -63,7 +61,7 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_pdf_url(context: Context):
+def crawl_pdf_url(context: Context) -> str:
     doc = context.fetch_html(context.data_url)
     # Construct the URL from bits in the table because they'd rather do that than just construct a working URL.
     rows = doc.xpath("//tr[@class='rgRow']")  # RadGrid row
@@ -73,10 +71,6 @@ def crawl_pdf_url(context: Context):
     doc_name = link_element.text_content().strip().replace(" ", "%20")
     parent_folder = row.xpath(".//td[@style='display:none;']")[0].text_content().strip()
     return f"https://www.wvmmis.com/SharepointDownload?parent={parent_folder}&docname={doc_name}"
-
-
-def page_settings(page):
-    return page, {"text_x_tolerance": 1}
 
 
 def crawl(context: Context) -> None:
@@ -89,6 +83,6 @@ def crawl(context: Context) -> None:
         context,
         path,
         headers_per_page=False,
-        page_settings=page_settings,
+        page_settings=lambda page: (page, {"text_x_tolerance": 1}),
     ):
         crawl_item(item, context)

--- a/datasets/us/wy/med_exclusions/crawler.py
+++ b/datasets/us/wy/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 from rigour.mime.types import PDF
-from typing import Dict
 import re
 
 from zavod import Context, helpers as h
@@ -10,7 +9,7 @@ AKA_PATTERN = r"\ba\.?k\.?a[\. -]*"
 PAGE_SETTINGS = {"join_y_tolerance": 100}
 
 
-def crawl_item(row: Dict[str, str], context: Context):
+def crawl_item(row: dict[str, str], context: Context) -> None:
     address = h.make_address(
         context, city=row.pop("city"), state=row.pop("state"), country_code="US"
     )
@@ -79,12 +78,16 @@ def crawl_item(row: Dict[str, str], context: Context):
     context.audit_data(row)
 
 
-def crawl_excel_url(context: Context):
+def crawl_excel_url(context: Context) -> str:
     file_xpath = (
         ".//a[contains(text(), 'Wyoming Medicaid Provider Exclusion List')]/@href"
     )
     doc = fetch_html(context, context.data_url, file_xpath, geolocation="us")
-    return h.xpath_string(doc, file_xpath)
+    url = h.xpath_string(doc, file_xpath)
+    assert url is not None, (
+        "Could not find Wyoming Medicaid Provider Exclusion List URL"
+    )
+    return url
 
 
 def crawl(context: Context) -> None:


### PR DESCRIPTION
- **[us_ne_med_exclusions] Fix PDF parsing and types**
  

- **Add return type annotations to us/*/med_exclusions crawlers**
  Fixes mypy --strict errors across 29 state Medicaid exclusion crawlers:
  - Add `-> None` to all crawl_item/crawl_row/helper functions
  - Add `-> str` to all crawl_*_url functions, switching from
    `doc.xpath(...)[0].get("href")` to `h.xpath_string()` + assert
  - Migrate remaining `fetch_html`/`fetch_resource` imports to
    `zyte_api.*` with `unblock_validator=` kwarg
  - Replace `Dict[str, str]` with `dict[str, str]` throughout
  - Type page_settings return as `tuple[Page, dict[str, Any]]`
    or inline as lambdas where appropriate
  
  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
  

- **[jp_meti_ru] Fix rigour breakage**
  