### PR TITLE
Issues 2026-05-06

### DIFF
--- a/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
+++ b/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
@@ -1444,6 +1444,59 @@ lookups:
           - "1521418"
           - "97947 "
         value: SAME
+      - match: "'0012021"
+        props:
+          registrationNumber: "0012021"
+      - match: "Corporate Identification Number (CIN): U74999HR2023OPC109285"
+        props:
+          registrationNumber: "U74999HR2023OPC109285"
+      - match: "Corporate Identification Number: U80900DL2023NPL410201"
+        props:
+          registrationNumber: "U80900DL2023NPL410201"
+      - match: "India CIN: U63030MH2016PTC286797"
+        props:
+          registrationNumber: "U63030MH2016PTC286797"
+      - match: "India CIN: U78100MH2023PTC409367"
+        props:
+          registrationNumber: "U78100MH2023PTC409367"
+      - match: "India PAN - AAYCA2604D"
+        props:
+          taxNumber: "AAYCA2604D"
+      - match: "India PAN - AACCZ1381Q"
+        props:
+          taxNumber: "AACCZ1381Q"
+      - match: "India PAN: AALCB8806B"
+        props:
+          taxNumber: "AALCB8806B"
+      - match: "India GSTIN: 27AACCO3869L1ZW"
+        props:
+          taxNumber: "27AACCO3869L1ZW"
+      - match: "Thai business register number: 0105566092852 "
+        props:
+          registrationNumber: "0105566092852"
+      - match: "Thai business registry number: 0105554079139"
+        props:
+          registrationNumber: "0105554079139"
+      - match: "Thai business registry number: 0205566027596"
+        props:
+          registrationNumber: "0205566027596"
+      - match: "Business Registration Number - 67092371"
+        props:
+          registrationNumber: "67092371"
+      - match: "CR number: 2469563 "
+        props:
+          registrationNumber: "2469563"
+      - match: "France SIREN Number - 889 164 687"
+        props:
+          registrationNumber: "889164687"
+      - match: "INN: 7810540857OGRN:  1087847024363"
+        props:
+          innCode: "7810540857"
+          ogrnCode: "1087847024363"
+      - match: "310115002630983Unified Social Credit Code: 9131011533249393X3"
+        props:
+          registrationNumber: "310115002630983"
+          uscCode: "9131011533249393X3"
   companies:
     normalize: true
     options:
@@ -2452,3 +2505,7 @@ lookups:
           - ASSOCIATION 'CTT 'ACADEMNOVOTECH'
           - NON-COMMERCIAL PARTNERSHIP INNOVATION-IMPLEMENTATION CENTER
           - ASSOCIATION TECHNOLOGICAL PLATFORM AIR MOBILITY AND AVIATION TECHNOLOGIES
+      - match: M9 LOGISTICS (HK) LIMITED
+        value: M9 LOGISTICS (HK) LIMITED
+      - match: M9 LOGISTICS CO., LTD.
+        value: M9 LOGISTICS CO., LTD.

--- a/datasets/tw/shtc/crawler.py
+++ b/datasets/tw/shtc/crawler.py
@@ -11,6 +11,7 @@ from typing import Set
 
 import datapatch
 from rigour.mime.types import CSV
+from rigour.text import is_nullword
 from zavod.extract.names.clean import Names
 from zavod.extract.zyte_api import fetch_html
 from zavod.stateful.review import (
@@ -219,7 +220,9 @@ def crawl_row(context: Context, row):
             entity.add("idNumber", id_number)
 
     for country in row.pop("國家代碼country code").split(";"):
-        entity.add("country", country)
+        # Sometimes the country code is "null"
+        if not is_nullword(country):
+            entity.add("country", country)
     entity.add("topics", "export.control")
 
     context.emit(entity)

--- a/datasets/us/ca/med_exclusions/crawler.py
+++ b/datasets/us/ca/med_exclusions/crawler.py
@@ -90,7 +90,7 @@ def crawl_data_url(context: Context) -> str:
     assert dataset_url is not None, "Could not find dataset URL"
 
     dataset_doc = context.fetch_html(dataset_url, cache_days=1, absolute_links=True)
-    resource_url = h.xpath_string(dataset_doc, xpath + "/@href")
+    resource_url = h.xpath_strings(dataset_doc, xpath + "/@href")[0]
     assert resource_url is not None, "Could not find resource URL"
 
     resource_doc = context.fetch_html(resource_url, cache_days=1, absolute_links=True)

--- a/datasets/ve/asamblea_nacional/crawler.py
+++ b/datasets/ve/asamblea_nacional/crawler.py
@@ -162,16 +162,13 @@ def crawl_members(context: Context, page: ElementOrTree) -> None:
             continue
         member_link = el.find(".//a")
 
-        party_el, state_el = h.xpath_elements(el, ".//small")
-        bold_els = party_el.findall(".//b")
-        if bold_els:
-            party = h.xpath_string(party_el, ".//b/text()")
-        else:
-            party = h.element_text(party_el)
-        state = h.xpath_string(state_el, "./text()")
-        assert "Partido" not in party, f"Unexpected party format: {party}"
-        assert "Estado:" in state, f"Unexpected state format: {state}"
-        state = state.split("Estado: ")[1].strip()
+        party_el, state_el = h.xpath_elements(el, ".//small", expect_exactly=2)
+        party_raw = h.element_text(party_el)
+        state_raw = h.element_text(state_el)
+        assert "Partido" in party_raw, f"Unexpected party format: {party_raw}"
+        assert "Estado:" in state_raw, f"Unexpected state format: {state_raw}"
+        state = state_raw.split("Estado: ")[1].strip()
+        party = party_raw.split("Partido: ")[1].strip()
 
         if member_link is None:
             context.log.error(f"No page found in element {el}")
@@ -206,7 +203,7 @@ def crawl_member_list(context: Context) -> Iterator[ElementOrTree]:
             if next_page == page_number + 1:
                 break
         else:
-            context.log.error(f"Link to {page_number + 1} not found")
+            context.log.error(f"Link to page {page_number + 1} not found")
         page_number = next_page
         context.log.debug(f"Fetching page {page_number} from {href}")
         page = zyte_api.fetch_html(context, href, ".//h3", cache_days=1)


### PR DESCRIPTION
- **[ve_asamblea_nacional] Make parsing more robust, some don't have a party**
  

- **gb_fcdo_sanctions: add reg_number and companies lookups**
  Resolves 137 unmatched-lookup warnings from the latest crawl:
  - 17 new reg_number entries: India PAN/CIN/GSTIN, Thai business
    registry numbers, France SIREN, HK CR/Business Registration,
    a stuck-together INN/OGRN and a Chinese reg + USC code combo,
    plus a leading-apostrophe Excel artefact ('0012021).
  - 2 new companies entries (M9 LOGISTICS variants).
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  

- **[tw_shtc] ignore "null" country**
  

- **[us_ca_med_exclusions] fix crawler after migration yesterday**
  