### PR TITLE
Rename categorise(is_pep=) → default_is_pep, make keyword-only

### DIFF
--- a/datasets/_global/everypolitician/crawler.py
+++ b/datasets/_global/everypolitician/crawler.py
@@ -192,7 +192,7 @@ def parse_membership(
             country=country,
             topics=["gov.national", "gov.legislative"],
         )
-        categorisation = categorise(context, position, True)
+        categorisation = categorise(context, position, default_is_pep=True)
 
         position_property = post_summary(org_name, role, starts, ends, [])
         person = context.make("Person")

--- a/datasets/am/hetq/crawler.py
+++ b/datasets/am/hetq/crawler.py
@@ -139,7 +139,7 @@ def crawl_person(
             lang=position_lang,
         )
         # Do usual PEP logic for positions/occupancies
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if categorisation.is_pep:
             occupancy = h.make_occupancy(
                 context,

--- a/datasets/ar/parliament/crawler.py
+++ b/datasets/ar/parliament/crawler.py
@@ -27,7 +27,7 @@ def crawl(context: Context) -> None:
                 topics=["gov.legislative", "gov.national"],
                 lang="eng",
             )
-            categorisation = categorise(context, position, is_pep=True)
+            categorisation = categorise(context, position, default_is_pep=True)
 
             occupancy = h.make_occupancy(
                 context,

--- a/datasets/at/meine_abgeordneten/crawler.py
+++ b/datasets/at/meine_abgeordneten/crawler.py
@@ -127,7 +127,7 @@ def crawl_mandate(context, url, person, el):
         return
 
     position = h.make_position(context, position_name, country="at", lang="deu")
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 
@@ -155,7 +155,7 @@ def crawl_title(context, url, person, el):
     h1 = el.find(".//h1")
     position_name = h1.getnext().text_content().strip()
     position = h.make_position(context, position_name, country="at", lang="deu")
-    categorisation = categorise(context, position, is_pep=None)
+    categorisation = categorise(context, position, default_is_pep=None)
     if not categorisation.is_pep:
         if categorisation.is_pep is None:
             context.log.warning(

--- a/datasets/be/chamber/crawler.py
+++ b/datasets/be/chamber/crawler.py
@@ -91,7 +91,7 @@ def crawl_person(
         topics=POSITION_TOPICS,
         lang="eng",
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/be/flemish_parliament/crawler.py
+++ b/datasets/be/flemish_parliament/crawler.py
@@ -78,7 +78,7 @@ def crawl_member(context: Context, position: Entity, node: Dict[str, Any]) -> No
     if fractie_node is not None:
         person.add("political", fractie_node.pop("naam"))
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/be/walloon_parliament/crawler.py
+++ b/datasets/be/walloon_parliament/crawler.py
@@ -56,7 +56,7 @@ def crawl_item(context: Context, item: Dict[str, Any]) -> None:
     # https://github.com/opensanctions/countrynames/issues/55
     position.add("subnationalArea", item.pop("dep_province"))
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/bg/jud_declarations/crawler.py
+++ b/datasets/bg/jud_declarations/crawler.py
@@ -183,7 +183,7 @@ def crawl_row(context: Context, row: Dict[str, HtmlElement], index_url: str):
         context, position, "bul", position_name, TRANSLIT_OUTPUT, POSITION_PROMPT
     )
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/br/pep/crawler.py
+++ b/datasets/br/pep/crawler.py
@@ -61,7 +61,7 @@ def create_entity(raw_entity: Dict[str, Any], context: Context) -> None:
 
     position_name = f"{raw_entity['Descrição_Função']}, {raw_entity['Nome_Órgão']}"
     position = h.make_position(context, position_name, country="br")
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     if not categorisation.is_pep:
         return

--- a/datasets/ca/foreign_reps/crawler.py
+++ b/datasets/ca/foreign_reps/crawler.py
@@ -68,7 +68,7 @@ def crawl(context: Context):
             country=country,
             topics=["gov.national", "role.diplo"],
         )
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if categorisation.is_pep:
             occupancy = h.make_occupancy(context, person, position)
             if spouse:

--- a/datasets/ch/parlament/crawler.py
+++ b/datasets/ch/parlament/crawler.py
@@ -100,7 +100,7 @@ def crawl_councillor(context: Context, councillor_id: int) -> None:
             topics=["gov.legislative", "gov.national"],
             # lang="eng",
         )
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:
             continue
         context.emit(position)

--- a/datasets/cl/info_probidad/crawler.py
+++ b/datasets/cl/info_probidad/crawler.py
@@ -73,7 +73,7 @@ def crawl_row(context: Context, declaration_id: int):
         )
         return
 
-    categorisation = categorise(context, position, res.is_pep)
+    categorisation = categorise(context, position, default_is_pep=res.is_pep)
 
     if not categorisation.is_pep:
         return

--- a/datasets/cn/peoples_congress_wikipedia/crawler.py
+++ b/datasets/cn/peoples_congress_wikipedia/crawler.py
@@ -111,7 +111,7 @@ def crawl_item(
     position = h.make_position(
         context, "Member of the National People’s Congress", country="cn"
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     occupancy = h.make_occupancy(
         context,

--- a/datasets/co/join_dots/crawler.py
+++ b/datasets/co/join_dots/crawler.py
@@ -102,7 +102,7 @@ def crawl_node(context: Context, peps: dict[str, Entity], node: dict[str, str]) 
             position = h.make_position(
                 context, res.name, country="co", topics=res.topics
             )
-            categorisation = categorise(context, position, True)
+            categorisation = categorise(context, position, default_is_pep=True)
             if categorisation.is_pep:
                 occupancy = h.make_occupancy(
                     context, entity, position, status=OccupancyStatus.UNKNOWN

--- a/datasets/cu/inventario_legislatura/crawler.py
+++ b/datasets/cu/inventario_legislatura/crawler.py
@@ -39,7 +39,7 @@ def crawl(context: Context) -> None:
         inception_date=inception_date,
         dissolution_date=dissolution_date,
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)
 
     doc = context.fetch_html(context.data_url)

--- a/datasets/cz/pep_declarations/crawler.py
+++ b/datasets/cz/pep_declarations/crawler.py
@@ -65,7 +65,7 @@ def crawl_person(context: Context, item: Dict[str, Any]) -> None:
         )
         entity.add("position", position_name)
 
-        categorisation = categorise(context, position, is_pep=is_pep)
+        categorisation = categorise(context, position, default_is_pep=is_pep)
         if not categorisation.is_pep:
             continue
 

--- a/datasets/de/bundesrat/crawler.py
+++ b/datasets/de/bundesrat/crawler.py
@@ -92,7 +92,7 @@ def crawl_item(context: Context, item: HtmlElement) -> None:
         lang="deu",
         wikidata_id="Q15835370",
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     if categorisation.is_pep:
         occupancy = h.make_occupancy(

--- a/datasets/dk/pep/crawler.py
+++ b/datasets/dk/pep/crawler.py
@@ -49,7 +49,7 @@ def crawl_current_pep_item(
     assert position_name is not None, entity.id
 
     position = h.make_position(context, position_name, country=country, lang=lang)
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     listing_date = row.pop("listing_date")
     assert listing_date is not None, row
@@ -94,7 +94,7 @@ def crawl_old_pep_item(
         position,
         True,
         end_date=removal_date.strip(),
-        categorisation=categorise(context, position, is_pep=True),
+        categorisation=categorise(context, position, default_is_pep=True),
     )
 
     if occupation:

--- a/datasets/ee/riigikogu/crawler.py
+++ b/datasets/ee/riigikogu/crawler.py
@@ -55,7 +55,7 @@ def crawl_item(member_url: str, context: Context):
         country="ee",
         topics=["gov.national", "gov.legislative"],
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
     occupancy = h.make_occupancy(

--- a/datasets/es/mayors_councillors/crawler.py
+++ b/datasets/es/mayors_councillors/crawler.py
@@ -87,7 +87,7 @@ def crawl_item(
         lang="spa",
         topics=topics,
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     occupancy = h.make_occupancy(
         context,

--- a/datasets/es/parliament/crawler.py
+++ b/datasets/es/parliament/crawler.py
@@ -45,7 +45,7 @@ def emit_pep_entities(
         topics=["gov.legislative", "gov.national"],
         wikidata_id=wikidata_id,
     )
-    categorisation = categorise(context, position, is_pep=is_pep)
+    categorisation = categorise(context, position, default_is_pep=is_pep)
     occupancy = h.make_occupancy(
         context,
         person,

--- a/datasets/eu/cor_members/crawler.py
+++ b/datasets/eu/cor_members/crawler.py
@@ -33,7 +33,7 @@ def crawl_person(context: Context, item: Dict[str, Any]) -> None:
     position = h.make_position(
         context, name=position_name, country="eu", topics=["gov.igo"]
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
     occupancy = h.make_occupancy(

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -76,7 +76,7 @@ def crawl(context: Context):
         country="eu",
         topics=["gov.igo", "gov.legislative"],
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)
     for node in doc.findall(".//mep"):
         crawl_node(context, node, position, categorisation)

--- a/datasets/eu/public_functions/crawler.py
+++ b/datasets/eu/public_functions/crawler.py
@@ -19,7 +19,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
     description_alt_lang = collapse_spaces(row.pop("Description alt lang"))
     if description_alt_lang:
         position.add("description", description_alt_lang, lang=row.pop("alt lang"))
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if categorisation.is_pep:
         context.emit(position)
 

--- a/datasets/fi/eduskunta/crawler.py
+++ b/datasets/fi/eduskunta/crawler.py
@@ -105,7 +105,7 @@ def crawl(context: Context) -> None:
             lang="eng",
         )
 
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:
             continue
 

--- a/datasets/fr/assemblee/crawler.py
+++ b/datasets/fr/assemblee/crawler.py
@@ -139,7 +139,7 @@ def crawl_acteur(context: Context, data: dict[str, Any]) -> None:
         country="fr",
         topics=["gov.national", "gov.legislative"],
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         context.log.warning(f"Member {given_name} {family_name} is not PEP")
         return

--- a/datasets/fr/hatvp_declarations/crawler.py
+++ b/datasets/fr/hatvp_declarations/crawler.py
@@ -39,7 +39,7 @@ def crawl_row(context: Context, row: Dict[str, str | None]) -> None:
         country="fr",
     )
 
-    categorisation = categorise(context, position, is_pep=None)
+    categorisation = categorise(context, position, default_is_pep=None)
     if not categorisation.is_pep:
         return
 

--- a/datasets/fr/maires/crawler.py
+++ b/datasets/fr/maires/crawler.py
@@ -56,7 +56,7 @@ def crawl_row(
     )
 
     # is_pep=True because we expect all mayors to be PEPs
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         context.log.warning(f"Mayor {given_name} {family_name} is not PEP")
         return

--- a/datasets/fr/senat/crawler.py
+++ b/datasets/fr/senat/crawler.py
@@ -84,7 +84,7 @@ def crawl_row(
         topics=["gov.national", "gov.legislative"],
     )
     # is_pep=True because we expect all senators to be PEPs
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         context.log.warning(f"Senator {given_name} {family_name} is not PEP")
         return

--- a/datasets/ge/declarations/crawler.py
+++ b/datasets/ge/declarations/crawler.py
@@ -329,7 +329,7 @@ def crawl_declaration(context: Context, *, item: dict[str, Any]) -> None:
     apply_translit_full_name(
         context, position, "kat", position_name_kat, TRANSLIT_OUTPUT, POSITION_PROMPT
     )
-    categorisation = categorise(context, position, is_pep=None)
+    categorisation = categorise(context, position, default_is_pep=None)
     if not categorisation.is_pep:
         return
     occupancy = h.make_occupancy(

--- a/datasets/gr/parliament/crawler.py
+++ b/datasets/gr/parliament/crawler.py
@@ -77,7 +77,7 @@ def crawl_row(
         lang="eng",
         wikidata_id="Q18915989",
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     if categorisation.is_pep:
         occupancy = h.make_occupancy(

--- a/datasets/hr/public_officials/crawler.py
+++ b/datasets/hr/public_officials/crawler.py
@@ -86,7 +86,7 @@ def make_affiliation_entities(
 
     position = h.make_position(context, position_name, country="HR")
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     occupancy = h.make_occupancy(
         context,
         person,

--- a/datasets/hu/national_assembly/crawler.py
+++ b/datasets/hu/national_assembly/crawler.py
@@ -14,7 +14,7 @@ def categorise_and_emit(
     end_date: str | None,
     is_pep: bool | None,
 ) -> None:
-    categorisation = categorise(context, position, is_pep=is_pep)
+    categorisation = categorise(context, position, default_is_pep=is_pep)
     if not categorisation.is_pep:
         return
 

--- a/datasets/id/regional_2018/crawler.py
+++ b/datasets/id/regional_2018/crawler.py
@@ -47,7 +47,7 @@ def crawl_person(
         subnational_area=jurisdiction,
     )
     position.add("description", position_eng)
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     occupancy = h.make_occupancy(
         context,
         entity,

--- a/datasets/ie/parliament/crawler.py
+++ b/datasets/ie/parliament/crawler.py
@@ -45,7 +45,7 @@ def crawl_member(context: Context, member: Dict[str, Any]) -> None:
             wikidata_id=wikidata_id,
         )
 
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:
             continue
 
@@ -81,7 +81,7 @@ def crawl_member(context: Context, member: Dict[str, Any]) -> None:
                 topics=["gov.national"],
                 country=["ie"],
             )
-            categorisation = categorise(context, position_other, is_pep=True)
+            categorisation = categorise(context, position_other, default_is_pep=True)
             if not categorisation.is_pep:
                 continue
 

--- a/datasets/il/knesset_members/crawler.py
+++ b/datasets/il/knesset_members/crawler.py
@@ -104,7 +104,7 @@ def crawl_positions(
         country="il",
         topics=["gov.national", "gov.legislative"],
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
     context.emit(position)

--- a/datasets/is/althingi/crawler.py
+++ b/datasets/is/althingi/crawler.py
@@ -52,7 +52,7 @@ def crawl_item(
 
     person.add("sourceUrl", member_url)
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/it/deputies/crawler.py
+++ b/datasets/it/deputies/crawler.py
@@ -93,7 +93,7 @@ def crawl_item(context: Context, item: dict[str, Any]) -> None:
         topics=["gov.legislative", "gov.national"],
         lang="eng",
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/it/senate/crawler.py
+++ b/datasets/it/senate/crawler.py
@@ -42,7 +42,7 @@ def crawl_item(context: Context, item: Dict[str, Any]) -> None:
         topics=["gov.legislative", "gov.national"],
         lang="eng",
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/ky/judicial/crawler.py
+++ b/datasets/ky/judicial/crawler.py
@@ -63,7 +63,7 @@ def crawl_page(context: Context, person_url):
             name=position,
             country="Cayman Islands",
         )
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:
             continue
         occupancy = h.make_occupancy(

--- a/datasets/ky/parliament/crawler.py
+++ b/datasets/ky/parliament/crawler.py
@@ -79,7 +79,7 @@ def crawl_card_2025(
         topics=TOPICS,
         country="ky",
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return None
     occupancy = h.make_occupancy(
@@ -123,7 +123,7 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
         topics=TOPICS,
         country="ky",
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/lt/pep_declarations/crawler.py
+++ b/datasets/lt/pep_declarations/crawler.py
@@ -125,7 +125,7 @@ def parse_affiliations(
             categorisation = categorise(
                 context,
                 position,
-                is_pep=True,
+                default_is_pep=True,
             )
             if affiliation_start_date > str(datetime.now().year):
                 status = OccupancyStatus.CURRENT

--- a/datasets/lu/chamber/crawler.py
+++ b/datasets/lu/chamber/crawler.py
@@ -33,7 +33,7 @@ def crawl_row(context: Context, row: dict[str, str], position: Entity) -> None:
     entity.add("citizenship", "lu")
     h.apply_date(entity, "birthDate", dob)
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/lv/saeima/crawler.py
+++ b/datasets/lv/saeima/crawler.py
@@ -42,7 +42,7 @@ def crawl_item(context: Context, unid: str) -> None:
     entity.add("email", h.element_text(email_el))
 
     position = h.make_position(context, "deputy of Saeima", country="lv")
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     occupancy = h.make_occupancy(
         context,

--- a/datasets/me/acp_peps/crawler.py
+++ b/datasets/me/acp_peps/crawler.py
@@ -163,7 +163,7 @@ def emit_affiliated_position(
         context, position, "cnr", position_name, TRANSLIT_OUTPUT, POSITION_PROMPT
     )
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 
@@ -244,7 +244,7 @@ def crawl_person(context: Context, person_data: dict[str, Any]) -> bool:
     else:
         for label in function_labels:
             position = h.make_position(context, label, country="me")
-            categorisation = categorise(context, position, is_pep=True)
+            categorisation = categorise(context, position, default_is_pep=True)
             if not categorisation.is_pep:
                 continue
             occupancy = h.make_occupancy(

--- a/datasets/mk/officials/crawler.py
+++ b/datasets/mk/officials/crawler.py
@@ -48,7 +48,7 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
     )
     position.add("name", position_names[1:])
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     if not categorisation.is_pep:
         return

--- a/datasets/mx/deputies/crawler.py
+++ b/datasets/mx/deputies/crawler.py
@@ -37,7 +37,7 @@ def crawl_item(context: Context, input_dict: dict[str, Any]) -> None:
     position = h.make_position(
         context, "Member of the Chamber of Deputies of Mexico", country="mx"
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     occupancy = h.make_occupancy(
         context,

--- a/datasets/mx/governors/crawler.py
+++ b/datasets/mx/governors/crawler.py
@@ -92,7 +92,7 @@ def crawl_item(context: Context, input_html: Element) -> None:
 
     name_of_position = "Governor of " + state.title()
     position = h.make_position(context, name_of_position, country="mx")
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     occupancy = h.make_occupancy(
         context,

--- a/datasets/mx/senators/crawler.py
+++ b/datasets/mx/senators/crawler.py
@@ -130,7 +130,7 @@ def crawl(context: Context) -> None:
 
     # We first define the Mexico Senator Position
     position = h.make_position(context, "Member of the Senate of Mexico", country="mx")
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)
 
     for item in senators:

--- a/datasets/ng/chipper_peps/crawler.py
+++ b/datasets/ng/chipper_peps/crawler.py
@@ -61,7 +61,7 @@ def crawl_position(context: Context, entity: Entity, name: str):
         status = OccupancyStatus.UNKNOWN
 
     position = h.make_position(context, name, country="ng")
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if categorisation.is_pep:
         occupancy = h.make_occupancy(
             context,

--- a/datasets/ng/join_dots/crawler.py
+++ b/datasets/ng/join_dots/crawler.py
@@ -108,7 +108,7 @@ def crawl_pep(context: Context, row) -> Tuple[Optional[str], Optional[str]]:
             topics=topics,
             subnational_area=subnational_area,
         )
-        categorisation = categorise(context, position, True)
+        categorisation = categorise(context, position, default_is_pep=True)
 
         start_date, end_date = parse_position_dates(row.pop("period", None))
         if categorisation.is_pep:

--- a/datasets/nl/house_of_representatives/crawler.py
+++ b/datasets/nl/house_of_representatives/crawler.py
@@ -73,7 +73,7 @@ def crawl(context: Context) -> None:
         country="nl",
         summary="Member of the lower house of the bicameral parliament of the Netherlands, the States General",
     )
-    categorise(context, position, True)
+    categorise(context, position, default_is_pep=True)
     context.emit(position)
 
     view_dom_id = "whatever"

--- a/datasets/nl/senate/crawler.py
+++ b/datasets/nl/senate/crawler.py
@@ -92,7 +92,7 @@ def crawl_member(context: Context, member_el: _Element) -> None:
         lang="eng",
         wikidata_id="Q19305384",
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     if categorisation.is_pep:
         occupancy = h.make_occupancy(

--- a/datasets/no/brreg/crawler.py
+++ b/datasets/no/brreg/crawler.py
@@ -198,7 +198,7 @@ def crawl_soe_peps(
                 country=["no"],
                 organization=entity,
             )
-            categorisation = categorise(context, position, is_pep=True)
+            categorisation = categorise(context, position, default_is_pep=True)
 
             if not categorisation.is_pep:
                 continue

--- a/datasets/no/storting/crawler.py
+++ b/datasets/no/storting/crawler.py
@@ -116,7 +116,7 @@ def crawl_item(context: Context, item: dict[str, Any], term: str) -> None:
         topics=["gov.legislative", "gov.national"],
         lang="eng",
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/pl/sejm/crawler.py
+++ b/datasets/pl/sejm/crawler.py
@@ -61,7 +61,7 @@ def crawl_person(context: Context, url: str) -> None:
         topics=["gov.legislative", "gov.national"],
         lang="eng",
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/pl/senate/crawler.py
+++ b/datasets/pl/senate/crawler.py
@@ -85,7 +85,7 @@ def crawl(context: Context) -> None:
             topics=["gov.legislative", "gov.national"],
             lang="eng",
         )
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:
             continue
 

--- a/datasets/pt/parliament/crawler.py
+++ b/datasets/pt/parliament/crawler.py
@@ -45,7 +45,7 @@ def crawl_parliament(context: Context, url: str) -> None:
             country=["pt"],
             wikidata_id="Q19953703",
         )
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
 
         if not categorisation.is_pep:
             continue
@@ -94,7 +94,7 @@ def crawl_parliament(context: Context, url: str) -> None:
                 country=["pt"],
             )
             categorisation_leadership = categorise(
-                context, position_leadership, is_pep=None
+                context, position_leadership, default_is_pep=None
             )
             if not categorisation_leadership.is_pep:
                 continue

--- a/datasets/ro/fiu_declarations/crawler.py
+++ b/datasets/ro/fiu_declarations/crawler.py
@@ -30,7 +30,7 @@ def crawl(context: Context):
                 name="Financial Intelligence Unit Official",
                 country="ro",
             )
-            categorisation = categorise(context, position, True)
+            categorisation = categorise(context, position, default_is_pep=True)
             if categorisation:
                 occupancy = h.make_occupancy(
                     context,

--- a/datasets/se/riksdag/crawler.py
+++ b/datasets/se/riksdag/crawler.py
@@ -82,7 +82,7 @@ def crawl(context: Context) -> None:
             lang="eng",
         )
 
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:
             continue
 

--- a/datasets/se/soe/crawler.py
+++ b/datasets/se/soe/crawler.py
@@ -68,7 +68,7 @@ def crawl(context: Context) -> None:
                 country="se",
                 organization=company,
             )
-            categorisation = categorise(context, position, is_pep=True)
+            categorisation = categorise(context, position, default_is_pep=True)
 
             occupancy = h.make_occupancy(
                 context,

--- a/datasets/sg/gov_dir/crawler.py
+++ b/datasets/sg/gov_dir/crawler.py
@@ -210,7 +210,7 @@ def crawl_person(
                     person.add("email", email)
 
     position = h.make_position(context, name=position_name, country="sg")
-    categorisation = categorise(context, position, is_pep=pep_status)
+    categorisation = categorise(context, position, default_is_pep=pep_status)
     if categorisation.is_pep:
         occupancy = h.make_occupancy(context, person, position)
         if occupancy:

--- a/datasets/si/zvezoskop/crawler.py
+++ b/datasets/si/zvezoskop/crawler.py
@@ -138,7 +138,7 @@ def crawl_cv_entry(context: Context, entities: Dict[str, Entity], row: Dict[str,
 
     position = h.make_position(context, label_en, country="si")
     position.add("name", label_si, lang="slv")
-    categorisation = categorise(context, position, is_pep=None)
+    categorisation = categorise(context, position, default_is_pep=None)
     if not categorisation.is_pep:
         return False
     start_day = row.pop("start_day")

--- a/datasets/sk/public_officials/crawler.py
+++ b/datasets/sk/public_officials/crawler.py
@@ -103,7 +103,7 @@ def crawl_person(
             context, position, "slk", pos, TRANSLIT_OUTPUT, POSITION_PROMPT
         )
 
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:
             return
 

--- a/datasets/th/cabinet/crawler.py
+++ b/datasets/th/cabinet/crawler.py
@@ -34,7 +34,7 @@ def crawl_person(context: Context, name: str, role: str) -> None:
         lang="eng",
         topics=["gov.executive", "gov.national"],
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
 

--- a/datasets/tr/parliament/crawler.py
+++ b/datasets/tr/parliament/crawler.py
@@ -99,7 +99,7 @@ def crawl_item(context: Context, item: etree):
     position = h.make_position(
         context, "Member of the Grand National Assembly", country="tr"
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
 
     occupancy = h.make_occupancy(
         context,

--- a/datasets/us/cia_world_leaders/crawler.py
+++ b/datasets/us/cia_world_leaders/crawler.py
@@ -83,7 +83,7 @@ def crawl_leader(
         topics=position_topics,
         id_hash_prefix="us_cia_world_leaders",
     )
-    categorisation = categorise(context, position, True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if categorisation.is_pep:
         occupancy = h.make_occupancy(
             context, person, position, categorisation=categorisation

--- a/datasets/us/navy/crawler.py
+++ b/datasets/us/navy/crawler.py
@@ -53,7 +53,7 @@ def emit_person(
 
     position = h.make_position(context, role, country=country, topics=["gov.security"])
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if categorisation.is_pep:
         occupancy = h.make_occupancy(context, person, position)
         if occupancy:

--- a/datasets/us/plum_book/crawler.py
+++ b/datasets/us/plum_book/crawler.py
@@ -56,7 +56,7 @@ def crawl(context: Context) -> None:
                 country="us",
             )
 
-            categorisation = categorise(context, position, is_pep=True)
+            categorisation = categorise(context, position, default_is_pep=True)
             if not categorisation.is_pep:
                 continue
             occupancy = h.make_occupancy(

--- a/datasets/us/plural_legislators/crawler.py
+++ b/datasets/us/plural_legislators/crawler.py
@@ -20,7 +20,7 @@ REGEX_JURISDICTION = re.compile(
 
 
 def make_source_url(id: str) -> str:
-    return f'https://pluralpolicy.com/app/person/{id.replace("ocd-person/", "")}'
+    return f"https://pluralpolicy.com/app/person/{id.replace('ocd-person/', '')}"
 
 
 def crawl_person(context, jurisdictions, house_positions, data: dict[str, Any]):
@@ -99,7 +99,7 @@ def crawl_person(context, jurisdictions, house_positions, data: dict[str, Any]):
         position = h.make_position(
             context, position_name, country="us", subnational_area=jurisdiction_name
         )
-        categorisation = categorise(context, position, True)
+        categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:
             return
         start_date = role.get("start_date", None)
@@ -162,15 +162,15 @@ def crawl_jurisdictions(context: Context):
             for org in jurisdiction["organizations"]:
                 type = org["classification"]
                 if type == "legislature":
-                    house_positions[(code, type)] = f'Member of the {org["name"]}'
+                    house_positions[(code, type)] = f"Member of the {org['name']}"
                 if type == "upper":
                     house_positions[(code, type)] = (
-                        f'Member of the {name} {org["name"]}'
+                        f"Member of the {name} {org['name']}"
                     )
                 if type == "lower":
                     representative = org["districts"][0]["role"]
                     house_positions[(code, type)] = (
-                        f'Member of the {name} {org["name"]} of {representative}s'
+                        f"Member of the {name} {org['name']} of {representative}s"
                     )
 
         if query.get("page") == result.get("pagination").get("max_page", None):

--- a/datasets/za/mm_officials/crawler.py
+++ b/datasets/za/mm_officials/crawler.py
@@ -119,7 +119,7 @@ def crawl(context: Context):
             subnational_area=municipality_code,
         )
 
-        categorisation = categorise(context, position, is_pep)
+        categorisation = categorise(context, position, default_is_pep=is_pep)
 
         if not categorisation.is_pep:
             continue

--- a/datasets/za/pmg_legislators/crawler.py
+++ b/datasets/za/pmg_legislators/crawler.py
@@ -157,7 +157,7 @@ def crawl_membership(
     )
 
     # Always PEP because filtered by known position label patterns
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     override_status = OccupancyStatus.UNKNOWN if not (start_date or end_date) else None
     occupancy = h.make_occupancy(
         context,

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -190,7 +190,7 @@ def wikidata_position(
         topics.discard("gov.head")
 
     position.add("topics", topics)
-    categorisation = categorise(context, position, is_pep=is_pep)
+    categorisation = categorise(context, position, default_is_pep=is_pep)
     if not categorisation.is_pep:
         return None
     real_topics = set(categorisation.topics)

--- a/zavod/zavod/stateful/positions.py
+++ b/zavod/zavod/stateful/positions.py
@@ -46,8 +46,17 @@ class PositionCategorisation(object):
 def categorise(
     context: Context,
     position: Entity,
-    is_pep: Optional[bool] = True,
+    *,
+    default_is_pep: Optional[bool] = True,
 ) -> PositionCategorisation:
+    """Return the reviewed categorisation (topics, is_pep) for a position.
+
+    If the position has already been reviewed, the reviewed values are
+    returned and override `default_is_pep` and the topics on the entity.
+    Otherwise, the position is enrolled into the review UI with the
+    crawler-supplied topics and `default_is_pep`, and those defaults are
+    returned; later calls will pick up any edits made through the UI.
+    """
     countries = sorted(position.get("country"))
     stmt = position_table.select()
     stmt = stmt.filter(position_table.c.entity_id == position.id)
@@ -82,12 +91,12 @@ def categorise(
         "topics": position.get("topics"),
         "dataset": position.dataset.name,
         "created_at": settings.RUN_TIME,
-        "is_pep": is_pep,
+        "is_pep": default_is_pep,
     }
     istmt = position_table.insert()
     istmt = istmt.values(body)
     context.conn.execute(istmt)
-    return PositionCategorisation(topics=position.get("topics"), is_pep=is_pep)
+    return PositionCategorisation(topics=position.get("topics"), is_pep=default_is_pep)
 
 
 def categorise_many(

--- a/zavod/zavod/tests/stateful/test_positions.py
+++ b/zavod/zavod/tests/stateful/test_positions.py
@@ -167,7 +167,7 @@ def test_categorise_flow(testdataset1: Dataset):
     context = Context(testdataset1)
     position = make_position(context, "A position", country="ls")
     assert len(context.conn.execute(position_table.select()).fetchall()) == 0
-    categorisation = categorise(context, position, is_pep=None)
+    categorisation = categorise(context, position, default_is_pep=None)
     assert categorisation.is_pep is None
     positions = context.conn.execute(position_table.select()).fetchall()
     assert len(positions) == 1
@@ -178,7 +178,7 @@ def test_categorise_flow(testdataset1: Dataset):
     assert pos.topics == []
     assert pos.is_pep is None
     categorise.cache_clear()
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     assert categorisation.is_pep is None
 
     position2 = make_position(context, "Other position", country="de")
@@ -193,7 +193,7 @@ def test_categorise_flow(testdataset1: Dataset):
     }
     ins = position_table.insert().values(**values)
     context.conn.execute(ins)
-    categorisation = categorise(context, position2, is_pep=True)
+    categorisation = categorise(context, position2, default_is_pep=True)
     assert categorisation.is_pep is True
     assert categorisation.topics == ["gov.igo"]
     context.close()


### PR DESCRIPTION
## Summary

- Renames `categorise(is_pep=)` to `categorise(default_is_pep=)` in `zavod.stateful.positions`, and makes the parameter keyword-only.
- Updates ~73 crawlers, the wikidata position helper, and tests.

The supplied value is only used the very first time a position is seen — after that, `categorise()` returns whatever `is_pep` value was set via the human review UI. Calling the param `is_pep` made it look like an assertion ("this position *is* a PEP") when it's really just a default while the position hasn't been reviewed yet. Keyword-only forces every call site to spell it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)