### PR TITLE
Consistent hash review keys

### DIFF
--- a/datasets/tw/shtc/crawler.py
+++ b/datasets/tw/shtc/crawler.py
@@ -249,5 +249,4 @@ def crawl(context: Context):
         for row in csv.DictReader(infh):
             crawl_row(context, row)
 
-    # TODO: Stop raising once we're through the initial bunch of reviews.
-    assert_all_accepted(context, raise_on_unaccepted=True)
+    assert_all_accepted(context, raise_on_unaccepted=False)

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -480,10 +480,11 @@ def apply_names(
 def review_key_parts(entity: Entity, original: Names) -> List[str]:
     # Only use the non-empty props in the key so that adding props in
     # future doesn't change the key unless they're actually populated.
+    # Names within each prop are sorted so the key is stable regardless of source order.
     key_parts = [entity.schema.name]
     for prop, names_values in original.as_langtexts():
         key_parts.append(prop)
-        for names_value in names_values:
+        for names_value in sorted(names_values, key=lambda n: (n.lang or "", n.text)):
             if names_value.lang is not None:
                 key_parts.append(names_value.lang)
             key_parts.append(names_value.text)
@@ -519,20 +520,34 @@ def _review_names(
 
     # We don't include suggested in the key so that we don't automatically invalidate
     # the reviews just by changing heuristic or LLM suggestions.
+    # key_parts uses sorted names for a stable key regardless of source insertion order.
     key_parts = review_key_parts(entity, original)
 
-    # Only include the populated props in the source value for human readability
+    # Legacy unsorted key_parts for migrating reviews created before sorting was introduced.
+    legacy_key_parts: List[str] = [entity.schema.name]
+    for prop, names_values in original.as_langtexts():
+        legacy_key_parts.append(prop)
+        for names_value in names_values:
+            if names_value.lang is not None:
+                legacy_key_parts.append(names_value.lang)
+            legacy_key_parts.append(names_value.text)
+
+    # Only include the populated props in the source value for human readability.
+    # Sort within each prop so the source_value JSON is stable when source order changes.
+    populated_props: Dict[str, List[str | Dict[str, str | None]]] = {}
+    for prop, vals in source_names.original.as_langtexts():
+        populated_props[prop] = [
+            v.text if v.lang is None else cast(Dict[str, str | None], v.model_dump())
+            for v in sorted(vals, key=lambda v: (v.lang or "", v.text))
+        ]
     source_value_data: Dict[str, str | Dict[str, List[str | Dict[str, str | None]]]] = {
-        "entity_schema": entity.schema.name
+        "entity_schema": entity.schema.name,
+        "original": populated_props,
     }
-    populated_props: Dict[str, List[str | Dict[str, str | None]]] = {
-        k: [v.text if v.lang is None else v.model_dump() for v in vals]
-        for k, vals in source_names.original.as_langtexts()
-    }
-    source_value_data["original"] = populated_props
 
     source_value = JSONSourceValue(
         key_parts=key_parts,
+        legacy_key_parts=legacy_key_parts,
         label="names",
         data=cast(JsonValue, source_value_data),
     )

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -523,6 +523,7 @@ def _review_names(
     # key_parts uses sorted names for a stable key regardless of source insertion order.
     key_parts = review_key_parts(entity, original)
 
+    # TODO: Remove in https://github.com/opensanctions/opensanctions/issues/4148 after all crawlers have run.
     # Legacy unsorted key_parts for migrating reviews created before sorting was introduced.
     legacy_key_parts: List[str] = [entity.schema.name]
     for prop, names_values in original.as_langtexts():
@@ -532,7 +533,7 @@ def _review_names(
                 legacy_key_parts.append(names_value.lang)
             legacy_key_parts.append(names_value.text)
 
-    # Only include the populated props in the source value for human readability.
+    # For human readability, we only include the populated props in the source value.
     # Sort within each prop so the source_value JSON is stable when source order changes.
     populated_props: Dict[str, List[str | Dict[str, str | None]]] = {}
     for prop, vals in source_names.original.as_langtexts():
@@ -550,6 +551,7 @@ def _review_names(
 
     source_value = JSONSourceValue(
         key_parts=key_parts,
+        # TODO: Remove in https://github.com/opensanctions/opensanctions/issues/4148 after all crawlers have run.
         legacy_key_parts=legacy_key_parts,
         label="names",
         data=cast(JsonValue, source_value_data),

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -536,10 +536,13 @@ def _review_names(
     # Sort within each prop so the source_value JSON is stable when source order changes.
     populated_props: Dict[str, List[str | Dict[str, str | None]]] = {}
     for prop, vals in source_names.original.as_langtexts():
-        populated_props[prop] = [
-            v.text if v.lang is None else cast(Dict[str, str | None], v.model_dump())
-            for v in sorted(vals, key=lambda v: (v.lang or "", v.text))
-        ]
+        items: List[str | Dict[str, str | None]] = []
+        for v in sorted(vals, key=lambda v: (v.lang or "", v.text)):
+            if v.lang is None:
+                items.append(v.text)
+            else:
+                items.append(cast(Dict[str, str | None], v.model_dump()))
+        populated_props[prop] = items
     source_value_data: Dict[str, str | Dict[str, List[str | Dict[str, str | None]]]] = {
         "entity_schema": entity.schema.name,
         "original": populated_props,

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -480,9 +480,9 @@ def apply_names(
 def review_key_parts(entity: Entity, original: Names) -> List[str]:
     # Only use the non-empty props in the key so that adding props in
     # future doesn't change the key unless they're actually populated.
-    # Names within each prop are sorted so the key is stable regardless of source order.
+    # Both props and names within each prop are sorted for a stable key.
     key_parts = [entity.schema.name]
-    for prop, names_values in original.as_langtexts():
+    for prop, names_values in sorted(original.as_langtexts(), key=lambda x: x[0]):
         key_parts.append(prop)
         for names_value in sorted(names_values, key=lambda n: (n.lang or "", n.text)):
             if names_value.lang is not None:

--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -393,6 +393,9 @@ def review_key(parts: str | List[str]) -> str:
     """
     if isinstance(parts, str):
         parts = [parts]
+    # rigour.text_hash normalizes capitalization away. It's nice to distinguish
+    # capitalization so that a review with bad name capitalization doesn't overwrite
+    # one with good name capitalization.
     digest = sha1()
     for part in parts:
         digest.update(part.strip().encode("utf-8"))

--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -49,10 +49,8 @@ class Review(BaseModel, Generic[ModelType]):
 
     id: Optional[int] = None
     key: str
-    """A slug derived from some information from the source that uniquely and
-    consistently identifies the review within the dataset. For an enforcement action,
-    that might be an action reference number or publication url (for lack of a consistent identifier).
-    For a string of names that rarely changes, that string itself might work."""
+    """A SHA1 hash derived from key_parts that uniquely and consistently identifies
+    the review within the dataset."""
     dataset: str
     extraction_schema: JsonValue
     source_value: str
@@ -140,6 +138,27 @@ class Review(BaseModel, Generic[ModelType]):
         )
         return cls.load(conn, data_model, select_stmt)
 
+    def rename_key(self, conn: Connection, new_key: str) -> None:
+        """Rename this review's key in-place without creating a new revision.
+        Updates both the review table and the entity link table."""
+        conn.execute(
+            update(review_table)
+            .where(
+                review_table.c.key == self.key,
+                review_table.c.dataset == self.dataset,
+            )
+            .values(key=new_key)
+        )
+        conn.execute(
+            update(review_entity_table)
+            .where(
+                review_entity_table.c.review_key == self.key,
+                review_entity_table.c.dataset == self.dataset,
+            )
+            .values(review_key=new_key)
+        )
+        self.key = new_key
+
     def save(self, conn: Connection, new_revision: bool) -> None:
         values = {
             "key": self.key,
@@ -224,8 +243,10 @@ class SourceValue(ABC):
     """
 
     key_parts: str | List[str]
-    """The key parts will be slugified and shortened with a hash of all the
-    parts if the slug would be too long."""
+    """Parts that are SHA1-hashed to produce the review key."""
+    legacy_key_parts: Optional[str | List[str]] = None
+    """If set, the migration path in review_extraction() will also try the legacy
+    slug key derived from these parts. Use when key_parts ordering has changed."""
     mime_type: str
     label: str
     url: Optional[str]
@@ -276,14 +297,18 @@ class JSONSourceValue(SourceValue):
         label: str,
         data: JsonValue,
         url: Optional[str] = None,
+        legacy_key_parts: Optional[str | List[str]] = None,
     ):
         """
         Args:
             key_parts: Information from the source that uniquely and
                 consistently identifies the review within the dataset. For a JSON
                 object, that might be a unique id field or a url.
+            legacy_key_parts: If key_parts ordering has changed, supply the old
+                ordering here so the migration path can find existing reviews.
         """
         self.key_parts = key_parts
+        self.legacy_key_parts = legacy_key_parts
         self.label = label
         self.url = url
         options = orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2
@@ -354,18 +379,24 @@ def unicode_slug(parts: str | List[str]) -> Optional[str]:
 
 
 def review_key(parts: str | List[str]) -> str:
-    """Generates a unique key for a given string of party names.
-    If the slug would be longer than 255 chars, we include a truncated hash of the
-    string with part of the slug to ensure it's consistent, unique, and short enough.
-    """
+    """Generates a stable 40-char SHA1 key for a review.
+    Behaves like make_entity_id with no prefix: each part is stripped and hashed as-is."""
+    if isinstance(parts, str):
+        parts = [parts]
+    digest = sha1()
+    for part in parts:
+        digest.update(part.strip().encode("utf-8"))
+    return digest.hexdigest()
+
+
+def review_key_legacy(parts: str | List[str]) -> str:
+    """Returns the old slug-based key for migration lookups only. Do not use for new reviews."""
     slug = unicode_slug(parts)
     assert slug is not None
-    # Hardcoding based on model.KEY_LEN to prevent inadvertent key changes
     if len(slug) <= 255:
         return slug
-    else:
-        hash = sha1(slug.encode("utf-8")).hexdigest()
-        return f"{slug[:80]}-{hash[:10]}"
+    hash_ = sha1(slug.encode("utf-8")).hexdigest()
+    return f"{slug[:80]}-{hash_[:10]}"
 
 
 def review_extraction(
@@ -412,6 +443,22 @@ def review_extraction(
     review = Review[ModelType].by_key(
         context.conn, data_model, dataset=context.dataset.name, key=key_slug
     )
+    if review is None:
+        # Migrate from legacy slug-based keys (slug→hash migration for all types;
+        # legacy_key_parts also handles name-ordering changes for names reviews).
+        legacy_candidates: List[str | List[str]] = [source_value.key_parts]
+        if source_value.legacy_key_parts is not None:
+            legacy_candidates.append(source_value.legacy_key_parts)
+        for candidate in legacy_candidates:
+            legacy_slug = review_key_legacy(candidate)
+            legacy_review = Review[ModelType].by_key(
+                context.conn, data_model, dataset=context.dataset.name, key=legacy_slug
+            )
+            if legacy_review is not None:
+                legacy_review.rename_key(context.conn, key_slug)
+                context.log.debug("Migrated review key", old=legacy_slug, new=key_slug)
+                review = legacy_review
+                break
     save_new_revision = False
     if review is None:
         context.log.debug("Creating new review", key=key_slug)

--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -289,6 +289,11 @@ class TextSourceValue(SourceValue):
 
 
 class JSONSourceValue(SourceValue):
+    """
+    Sorts keys but not array values, so ensure array values are ordered consistently
+    for consistent comparison between existing reviews and source values.
+    """
+
     mime_type: str = "application/json"
 
     def __init__(
@@ -380,7 +385,9 @@ def unicode_slug(parts: str | List[str]) -> Optional[str]:
 
 def review_key(parts: str | List[str]) -> str:
     """Generates a stable 40-char SHA1 key for a review.
-    Behaves like make_entity_id with no prefix: each part is stripped and hashed as-is."""
+    String normalization should be no more aggressive than source value matching,
+    so that two source values don't match as keys but appear to be changing source values.
+    """
     if isinstance(parts, str):
         parts = [parts]
     digest = sha1()

--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -456,7 +456,8 @@ def review_extraction(
             )
             if legacy_review is not None:
                 legacy_review.rename_key(context.conn, key_slug)
-                context.log.debug("Migrated review key", old=legacy_slug, new=key_slug)
+                # info so we get migration in prod logs
+                context.log.info("Migrated review key", old=legacy_slug, new=key_slug)
                 review = legacy_review
                 break
     save_new_revision = False

--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -138,6 +138,7 @@ class Review(BaseModel, Generic[ModelType]):
         )
         return cls.load(conn, data_model, select_stmt)
 
+    # TODO: Remove in https://github.com/opensanctions/opensanctions/issues/4148 after all crawlers have run.
     def rename_key(self, conn: Connection, new_key: str) -> None:
         """Rename this review's key in-place without creating a new revision.
         Updates both the review table and the entity link table."""
@@ -244,6 +245,7 @@ class SourceValue(ABC):
 
     key_parts: str | List[str]
     """Parts that are SHA1-hashed to produce the review key."""
+    # TODO: Remove in https://github.com/opensanctions/opensanctions/issues/4148 after all crawlers have run.
     legacy_key_parts: Optional[str | List[str]] = None
     """If set, the migration path in review_extraction() will also try the legacy
     slug key derived from these parts. Use when key_parts ordering has changed."""
@@ -302,6 +304,7 @@ class JSONSourceValue(SourceValue):
         label: str,
         data: JsonValue,
         url: Optional[str] = None,
+        # TODO: Remove in https://github.com/opensanctions/opensanctions/issues/4148 after all crawlers have run.
         legacy_key_parts: Optional[str | List[str]] = None,
     ):
         """
@@ -396,6 +399,7 @@ def review_key(parts: str | List[str]) -> str:
     return digest.hexdigest()
 
 
+# TODO: Remove in https://github.com/opensanctions/opensanctions/issues/4148 after all crawlers have run.
 def review_key_legacy(parts: str | List[str]) -> str:
     """Returns the old slug-based key for migration lookups only. Do not use for new reviews."""
     slug = unicode_slug(parts)
@@ -451,6 +455,7 @@ def review_extraction(
         context.conn, data_model, dataset=context.dataset.name, key=key_slug
     )
     if review is None:
+        # TODO: Remove in https://github.com/opensanctions/opensanctions/issues/4148 after all crawlers have run.
         # Migrate from legacy slug-based keys (slug→hash migration for all types;
         # legacy_key_parts also handles name-ordering changes for names reviews).
         legacy_candidates: List[str | List[str]] = [source_value.key_parts]

--- a/zavod/zavod/tests/stateful/test_review.py
+++ b/zavod/zavod/tests/stateful/test_review.py
@@ -12,6 +12,7 @@ from zavod.stateful.review import (
     TextSourceValue,
     review_extraction,
     review_key,
+    review_key_legacy,
 )
 
 
@@ -50,7 +51,7 @@ def test_new_key_saved_and_accepted_false(testdataset1: Dataset):
 
     assert review.accepted is False
     context.flush()
-    row = get_row(context.conn, "key1")
+    row = get_row(context.conn, review_key("key1"))
     assert row is not None
     assert row["accepted"] is False
     context.close()
@@ -76,7 +77,8 @@ def test_no_change_updates_last_seen_version(testdataset1, monkeypatch):
         original_extraction=extracted_data,
         origin="test data",
     )
-    row = get_row(context1.conn, "key2")
+    key2 = review_key("key2")
+    row = get_row(context1.conn, key2)
     assert row and row["last_seen_version"] == context1_version
     monkeypatch.setattr(settings, "RUN_VERSION", "20240101010102-aaa")
     context2 = Context(testdataset1)
@@ -90,10 +92,10 @@ def test_no_change_updates_last_seen_version(testdataset1, monkeypatch):
         origin="test data",
     )
     # Updated in the db
-    row = get_row(context2.conn, "key2")
+    row = get_row(context2.conn, key2)
     assert row["last_seen_version"] == context2_version
     assert context1_version != context2_version
-    assert len(get_all_rows(context2.conn, "key2")) == 1
+    assert len(get_all_rows(context2.conn, key2)) == 1
     # Returned review is up to date
     assert review2.last_seen_version == context2_version
     context1.close()
@@ -133,7 +135,8 @@ def test_source_changed_resets_review(testdataset1: Dataset):
     review.extracted_data = DummyModel(foo="barrr")
     review.modified_by = "test@user.com"
     review.save(context1.conn, new_revision=True)
-    row = get_row(context1.conn, "key3")
+    key3 = review_key("key3")
+    row = get_row(context1.conn, key3)
     assert row["modified_by"] == "test@user.com"
 
     source_value2 = TextSourceValue(
@@ -149,13 +152,13 @@ def test_source_changed_resets_review(testdataset1: Dataset):
         origin="test data",
         default_accepted=False,
     )
-    new = get_row(context2.conn, "key3")
+    new = get_row(context2.conn, key3)
     assert new["accepted"] is False
     assert new["original_extraction"]["foo"] == "baz"
     assert new["extracted_data"]["foo"] == "baz"
     assert new["modified_by"] == "zavod"
     assert review.accepted is False
-    assert len(get_all_rows(context2.conn, "key3")) == 3  # original, edit, reset
+    assert len(get_all_rows(context2.conn, key3)) == 3  # original, edit, reset
     context1.close()
     context2.close()
 
@@ -177,8 +180,9 @@ def test_unaccepted_updates_original_extraction(testdataset1: Dataset):
         original_extraction=data1,
         origin="test data",
     )
+    key4 = review_key("key4")
     assert review1.accepted is False
-    row1 = get_row(context1.conn, "key4")
+    row1 = get_row(context1.conn, key4)
     assert row1 is not None
     assert row1["accepted"] is False
     assert row1["original_extraction"]["foo"] == "foo"
@@ -193,14 +197,14 @@ def test_unaccepted_updates_original_extraction(testdataset1: Dataset):
         original_extraction=data2,
         origin="test data",
     )
-    row2 = get_row(context2.conn, "key4")
+    row2 = get_row(context2.conn, key4)
     assert row2 is not None
     assert row2["accepted"] is False
     assert row2["original_extraction"]["foo"] == "bar"
     assert row2["extracted_data"]["foo"] == "bar"
     assert row2["modified_by"] == "zavod"
     # Expect this to be updated in-place because it's unaccepted.
-    assert len(get_all_rows(context2.conn, "key4")) == 1
+    assert len(get_all_rows(context2.conn, key4)) == 1
     context1.close()
     context2.close()
 
@@ -221,7 +225,8 @@ def test_crawler_version_bump_resets_review(testdataset1: Dataset):
     review.extracted_data = DummyModel(foo="barrr")
     review.modified_by = "test@user.com"
     review.save(context1.conn, new_revision=True)
-    row = get_row(context1.conn, "key5")
+    key5 = review_key("key5")
+    row = get_row(context1.conn, key5)
     assert row["modified_by"] == "test@user.com"
 
     class ClevererModel(BaseModel):
@@ -237,7 +242,7 @@ def test_crawler_version_bump_resets_review(testdataset1: Dataset):
         origin="test data",
         default_accepted=False,
     )
-    new = get_row(context2.conn, "key5")
+    new = get_row(context2.conn, key5)
     assert new["accepted"] is False
     assert new["original_extraction"]["foo"] == "bar"
     assert new["original_extraction"]["baz"] == "zab"
@@ -245,7 +250,7 @@ def test_crawler_version_bump_resets_review(testdataset1: Dataset):
     assert new["extracted_data"]["baz"] == "zab"
     assert new["modified_by"] == "zavod"
     assert review.accepted is False
-    assert len(get_all_rows(context2.conn, "key5")) == 3  # original, edit, reset
+    assert len(get_all_rows(context2.conn, key5)) == 3  # original, edit, reset
     context1.close()
     context2.close()
 
@@ -317,19 +322,74 @@ def test_text_source_comparison(testdataset1: Dataset):
 
 
 def test_review_key():
-    assert review_key("key1") == "key1"
-    assert review_key(["part1", "part2"]) == "part1-part2"
+    # Returns a 40-char hex SHA1
+    assert len(review_key("key1")) == 40
+    assert all(c in "0123456789abcdef" for c in review_key("key1"))
+    # Deterministic
+    assert review_key("key1") == review_key("key1")
+    assert review_key(["part1", "part2"]) == review_key(["part1", "part2"])
+    # Parts hashed separately — order matters at this level
+    assert review_key(["part1", "part2"]) != review_key(["part2", "part1"])
+    # Whitespace stripped from each part
+    assert review_key([" part1 ", "part2"]) == review_key(["part1", "part2"])
+
+
+def test_review_key_legacy():
+    # Preserves old slug behaviour for migration lookups
+    assert review_key_legacy("key1") == "key1"
+    assert review_key_legacy(["part1", "part2"]) == "part1-part2"
     assert (
-        review_key("key1" * 100)
+        review_key_legacy("key1" * 100)
         == "key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1key1-0ed37245d1"
     )
     assert (
-        review_key(["key1"] * 100)
+        review_key_legacy(["key1"] * 100)
         == "key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1-key1--5611368bed"
     )
-    # All punctuation incl / becomes dash (backward compatibility with normality slugify)
-    assert review_key("STEPHEN D/B/A S CONTRACTING") == "stephen-d-b-a-s-contracting"
-    # Non-ascii printable characters are kept
-    assert review_key("Север Мухамадмухтар Крот") == "север-мухамадмухтар-крот"
-    # Zero-width and other non-printable are removed
-    assert review_key("name\u200bwith\u200cweird\u200dchars") == "namewithweirdchars"
+    assert (
+        review_key_legacy("STEPHEN D/B/A S CONTRACTING")
+        == "stephen-d-b-a-s-contracting"
+    )
+    assert review_key_legacy("Север Мухамадмухтар Крот") == "север-мухамадмухтар-крот"
+    assert (
+        review_key_legacy("name\u200bwith\u200cweird\u200dchars")
+        == "namewithweirdchars"
+    )
+
+
+def test_slug_to_hash_migration(testdataset1: Dataset):
+    # Create a review under the old slug key directly (simulating a pre-migration DB row).
+    context1 = Context(testdataset1)
+    source_value = mock_source_value("mykey")
+    legacy_slug = review_key_legacy("mykey")
+    data = DummyModel(foo="bar")
+    # Insert directly with the legacy slug key
+    old_review = review_extraction(
+        context1,
+        crawler_version=1,
+        source_value=source_value,
+        original_extraction=data,
+        origin="test",
+    )
+    # Manually rename to the legacy slug to simulate pre-migration state
+    old_review.rename_key(context1.conn, legacy_slug)
+    assert get_row(context1.conn, legacy_slug) is not None
+    assert get_row(context1.conn, review_key("mykey")) is None
+
+    # Re-crawl: migration should rename slug key → hash key
+    context2 = Context(testdataset1)
+    review2 = review_extraction(
+        context2,
+        crawler_version=1,
+        source_value=source_value,
+        original_extraction=data,
+        origin="test",
+    )
+    new_key = review_key("mykey")
+    assert review2.key == new_key
+    assert get_row(context2.conn, new_key) is not None
+    assert get_row(context2.conn, legacy_slug) is None
+    # Only one active row
+    assert len(get_all_rows(context2.conn, new_key)) == 1
+    context1.close()
+    context2.close()


### PR DESCRIPTION
This is Step 1, migrating legacy review keys to new has-based keys
Step 2 is running each crawler with reviews
Step 3 is removing the legacy key/migration code.

It addresses these main issues:

- The review key is currently dependent on the order names are added. We don't want crawlers to be responsible for that. https://github.com/opensanctions/opensanctions/issues/4148
- We'd like review keys to be hashes rather than unicode-sensitive slugs https://github.com/opensanctions/opensanctions/issues/3206

It does this with the following changes:

- review keys are now sha1 hashes, and parts are only stripped for surrounding whitespace, not slugified.
- if a review is found with a legacy key, we update the key on all entries with that legacy key
- a legacy key can be from the key parts as given (names in a prop now ordered), or in current source order. We try both.

Claude picked up that name order changes can appear to be source value changes since the JsonSourceValue comparison assumes array values have stable ordering. This sorts names before adding to the JsonSourceValue but doesn't migrate old source values. If it looks like the source value changed, crawlers that were pre-filled with reviews with the crawler name cleaning subsequently removed will have their acceptance invalidated.