### PR TITLE
[us] Some type annotations for med_exclusions crawlers

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -121,80 +121,49 @@ repos:
           datasets/tr|
           datasets/tw|
           datasets/ua|
-          datasets/us/sc/med_exclusions|
           datasets/us/cia_world_leaders|
           datasets/us/sec_pause|
           datasets/us/ice_wanted|
           datasets/us/irs_ffi|
-          datasets/us/ga/med_exclusions|
-          datasets/us/ms/med_exclusions|
-          datasets/us/mt/med_exclusions|
           datasets/us/state_terrorist_exclusion|
-          datasets/us/ma/med_exclusions|
-          datasets/us/ak/med_exclusions|
-          datasets/us/ky/med_exclusions|
           datasets/us/klepto_hr_visa|
-          datasets/us/al/med_exclusions|
-          datasets/us/nh/med_exclusions|
-          datasets/us/mn/med_exclusions|
           datasets/us/ofac/enforcement_actions|
           datasets/us/ofac/press_releases|
-          datasets/us/mi/med_exclusions|
           datasets/us/sec/pause|
           datasets/us/sec/harmed_investors|
           datasets/us/sec/litigation|
           datasets/us/cftc_enforcement_actions|
           datasets/us/occ_enfact|
-          datasets/us/co/med_exclusions|
-          datasets/us/ca/med_exclusions|
           datasets/us/ddtc_enforcements|
-          datasets/us/wv/med_exclusions|
           datasets/us/ddtc_debarred|
           datasets/us/fbi_most_wanted|
           datasets/us/sam_exclusions|
           datasets/us/nk_jointventures|
           datasets/us/state_dept|
-          datasets/us/wy/med_exclusions|
           datasets/us/cia_world_factbook|
           datasets/us/fara_filings|
-          datasets/us/pa/med_exclusions|
           datasets/us/fincen_msb|
           datasets/us/fbi_lazarus_crypto|
-          datasets/us/nc/med_exclusions|
           datasets/us/special_leg|
           datasets/us/sec_litigation_releases|
           datasets/us/dod_chinese_milcorps|
-          datasets/us/nd/med_exclusions|
-          datasets/us/nj/med_exclusions|
-          datasets/us/ar/med_exclusions|
-          datasets/us/nv/med_exclusions|
           datasets/us/dc/exclusions|
           datasets/us/cuba_sanctions|
-          datasets/us/md/med_exclusions|
-          datasets/us/hi/med_exclusions|
-          datasets/us/de/med_exclusions|
           datasets/us/fdic_failed_banks|
-          datasets/us/az/med_exclusions|
-          datasets/us/ny/med_exclusions|
           datasets/us/hhs_exclusions|
-          datasets/us/oh/med_exclusions|
           datasets/us/plural_legislators|
           datasets/us/fed_enforcements|
           datasets/us/trade_csl|
-          datasets/us/or/med_exclusions|
           datasets/us/corpwatch|
           datasets/us/cbp_forced_labor|
           datasets/us/dhs_uflpa|
           datasets/us/fda_restricted|
-          datasets/us/la/med_exclusions|
           datasets/us/congress|
           datasets/us/bis_denied|
           datasets/us/state_terrorist_orgs|
           datasets/us/fincen_special_measures|
           datasets/us/dea_fugitives|
           datasets/us/ss_wanted|
-          datasets/us/wa/med_exclusions|
-          datasets/us/tn/med_exclusions|
           datasets/uy|
           datasets/za
           )

--- a/datasets/us/al/med_exclusions/crawler.py
+++ b/datasets/us/al/med_exclusions/crawler.py
@@ -50,14 +50,11 @@ NAME_WITH_ROLE_REGEX = re.compile(
 )
 CRAWLER_VERSION = 2
 
-positions_field = Field(
-    default=[],
-    description=(
-        "The positions held by the person for an entity who is a person. "
-        "Populate this precisely as listed in the text when the text indicates "
-        "the job role of a person, otherwise leave empty. Sometimes this is an "
-        "abbreviation of a job title, e.g. RN for Registered Nurse."
-    ),
+POSITIONS_DESCRIPTION = (
+    "The positions held by the person for an entity who is a person. "
+    "Populate this precisely as listed in the text when the text indicates "
+    "the job role of a person, otherwise leave empty. Sometimes this is an "
+    "abbreviation of a job title, e.g. RN for Registered Nurse."
 )
 
 
@@ -65,32 +62,31 @@ class Entity(BaseModel):
     name: str
     name_suffix: str | None = None
     aliases: List[str] = []
-    positions: List[str] = positions_field
+    positions: List[str] = Field(default=[], description=POSITIONS_DESCRIPTION)
     address: str | None = None
 
 
-relationship_field = Field(
-    description=("Relationship between the entities e.g. `Owner` or `Vice President`.")
+RELATIONSHIP_DESCRIPTION = (
+    "Relationship between the entities e.g. `Owner` or `Vice President`."
 )
 
 
 class RelatedEntity(Entity):
-    relationship_role: str | None = relationship_field
+    relationship_role: str | None = Field(description=RELATIONSHIP_DESCRIPTION)
 
 
-related_entities_field = Field(
-    description=(
-        "Owners or other officers of a company if listed. If the "
-        "first entity looks like a person and a single owner name is included in"
-        " parentheses, then only give one entity - the person. Don't make a company"
-        " out of the person's name."
-    ),
-    default=[],
+RELATED_ENTITIES_DESCRIPTION = (
+    "Owners or other officers of a company if listed. If the "
+    "first entity looks like a person and a single owner name is included in"
+    " parentheses, then only give one entity - the person. Don't make a company"
+    " out of the person's name."
 )
 
 
 class RootEntity(Entity):
-    related_entities: List[RelatedEntity] = related_entities_field
+    related_entities: List[RelatedEntity] = Field(
+        default=[], description=RELATED_ENTITIES_DESCRIPTION
+    )
 
 
 PROMPT = f"""
@@ -108,11 +104,11 @@ to the positions field.
 
 Specific fields:
 
-`related_entities`: {related_entities_field.description}
+`related_entities`: {RELATED_ENTITIES_DESCRIPTION}
 
-`positions`: {positions_field.description}
+`positions`: {POSITIONS_DESCRIPTION}
 
-`relationship_role`: {relationship_field.description}
+`relationship_role`: {RELATIONSHIP_DESCRIPTION}
 
 `name_suffix`: This field MUST be null.
 """
@@ -200,7 +196,8 @@ def crawl_row(
         origin = review.origin
 
     entity = context.make("LegalEntity")
-    entity.id = context.make_id(entity_data.name, entity_data.positions)
+    # Passing *postitions would re-key, so we keep it for now and ignore the type error
+    entity.id = context.make_id(entity_data.name, entity_data.positions)  # type: ignore[arg-type]
     apply_comma_name(entity, entity_data.name)
     entity.add_cast("Person", "nameSuffix", entity_data.name_suffix)
     entity.add("alias", entity_data.aliases, origin=origin)
@@ -221,7 +218,8 @@ def crawl_row(
 
     for item in entity_data.related_entities:
         related = context.make("LegalEntity")
-        related_id = context.make_id(item.name, item.positions)
+        # Passing *postitions would re-key, so we keep it for now and ignore the type error
+        related_id = context.make_id(item.name, item.positions)  # type: ignore[arg-type]
         if related_id == entity.id:
             continue
         related.id = related_id

--- a/datasets/us/ar/med_exclusions/crawler.py
+++ b/datasets/us/ar/med_exclusions/crawler.py
@@ -26,13 +26,10 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
         provider.id = context.make_id(provider_name, zip_code)
 
         last_name, first_name = provider_name.split(",", 1)
-        names = REGEX_AKA.split(last_name)
-        if REGEX_WORD.search(first_name) and REGEX_WORD.search(last_name):
-            provider.add_schema("Person")
-            h.apply_name(
-                provider, last_name=names[0], alias=names[1:], first_name=first_name
-            )
-        else:
+        # If the provider name contains "aka" or the name look long enough, default to lookup
+        if REGEX_AKA.search(provider_name) or not (
+            REGEX_WORD.search(first_name) and REGEX_WORD.search(last_name)
+        ):
             result = context.lookup("names", provider_name)
             if result is None:
                 context.log.warning(
@@ -42,6 +39,9 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
             else:
                 provider.add("name", result.name)
                 provider.add("alias", result.alias)
+        else:
+            provider.add_schema("Person")
+            h.apply_name(provider, last_name=last_name, first_name=first_name)
 
         provider.add("country", "us")
         provider.add("topics", "debarment")

--- a/datasets/us/ar/med_exclusions/us_ar_med_exclusions.yml
+++ b/datasets/us/ar/med_exclusions/us_ar_med_exclusions.yml
@@ -84,3 +84,14 @@ lookups:
         name: null
       - match: "-, Precious Jewels In Home Care LLC "
         name: "Precious Jewels In Home Care LLC "
+      - match: "Lambert aka Sherbbie Allen, Sherbbie  "
+        name: "Sherbbie Allen"
+        weakAlias: ["Lambert", "Sherbbie"]
+      - match: "Sharp aka Angel Scarbro aka Angela Sharp, Angel Jamelle"
+        name: "Angel Scarbro"
+        weakAlias: ["Sharp"]
+        alias: ["Angela Sharp", "Angel Jamelle"]
+      - match: "Wood aka Licia Ann Lyle, Licia  Ann"
+        name: "Licia Ann Lyle"
+        alias: ["Licia Ann"]
+        weakAlias: ["Wood"]

--- a/datasets/us/az/med_exclusions/crawler.py
+++ b/datasets/us/az/med_exclusions/crawler.py
@@ -5,7 +5,7 @@ from zavod.extract.zyte_api import fetch_resource
 from normality import slugify, stringify
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     if not row.get("name_provider") and not row.get("npi"):
         return
 
@@ -45,10 +45,12 @@ def crawl(context: Context) -> None:
     # Mark rows that look like they might need manual extraction,
     # as well as one row before and after.
     for i, item in enumerate(items):
+        name_provider = item.get("name_provider")
+        action_type = item.get("action_type_suspend_terminate")
         if (
-            (not item.get("name_provider"))
-            or "\n" in item.get("name_provider")
-            or "\n" in item.get("action_type_suspend_terminate")
+            not name_provider
+            or (name_provider is not None and "\n" in name_provider)
+            or (action_type is not None and "\n" in action_type)
         ):
             manual_extraction[i] = True
             if i != 0:
@@ -60,13 +62,16 @@ def crawl(context: Context) -> None:
     manual_strings = []
     last_manual = manual_extraction[0]
     if manual_extraction[0]:
-        manual_strings.append(slugify(stringify(items[0])))
+        first_slug = slugify(stringify(items[0]))
+        assert first_slug is not None
+        manual_strings.append(first_slug)
 
     # concatenate contiguous manual-extraction rows
     rows.append(items[0])
     for i, item in enumerate(items[1:], 1):
         if manual_extraction[i]:
             string = slugify(stringify(item))
+            assert string is not None
             if last_manual:
                 manual_strings[-1] += "\n" + string
             else:

--- a/datasets/us/ca/med_exclusions/crawler.py
+++ b/datasets/us/ca/med_exclusions/crawler.py
@@ -108,6 +108,7 @@ def crawl(context: Context) -> None:
 
     with open(path, "r", encoding="latin-1") as f:
         reader = csv.DictReader(f)
-        reader.fieldnames = [slugify(key, sep="_") for key in reader.fieldnames]
+        assert reader.fieldnames is not None
+        reader.fieldnames = [slugify(key, sep="_") or "" for key in reader.fieldnames]
         for row in reader:
             crawl_item(row, context)

--- a/datasets/us/co/med_exclusions/crawler.py
+++ b/datasets/us/co/med_exclusions/crawler.py
@@ -5,7 +5,7 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     name = row.pop("provider_name")
     npi = row.pop("npi")
     if not name:
@@ -35,9 +35,12 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
 def crawl_excel_url(context: Context) -> str:
     file_xpath = ".//*[@about='/provider-termination']"
     doc = zyte_api.fetch_html(context, context.data_url, file_xpath)
-    for a in doc.find(file_xpath).xpath(".//a"):
-        if "Terminated Provider List" in a.text_content():
-            return a.get("href")
+    section = h.xpath_element(doc, file_xpath)
+    for a in h.xpath_elements(section, ".//a"):
+        if "Terminated Provider List" in h.element_text(a):
+            href = a.get("href")
+            assert href is not None
+            return href
 
     raise RuntimeError("No link to excel file found")
 

--- a/datasets/us/de/med_exclusions/crawler.py
+++ b/datasets/us/de/med_exclusions/crawler.py
@@ -12,8 +12,8 @@ REGEX_AKA = re.compile(r"\baka\b|a\.k\.a\.?", re.IGNORECASE)
 REGEX_JOB_ROLE = re.compile(r"^(?P<name>.+)[,\s]+(?P<role>([A-Z\.,/-]+|\([^\)]+\)))$")
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
-    raw_name = squash_spaces(row.pop("sanctioned_provider_name"))
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
+    raw_name = squash_spaces(row.pop("sanctioned_provider_name") or "")
     npi = row.pop("npi")
     # Skip empty rows
     if raw_name == "" and npi == "":
@@ -46,8 +46,11 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
     entity.add("npiCode", h.multi_split(npi, [";", ",", "&"]))
 
     sanction = h.make_sanction(context, entity)
-    sanction.add("description", squash_spaces(row.pop("comments")))
-    sanction.set("authority", squash_spaces(row.pop("oig_medicaid_sanction")))
+    assert (comments := row.pop("comments")) is not None
+    sanction.add("description", squash_spaces(comments))
+    assert (authority := row.pop("oig_medicaid_sanction")) is not None
+    sanction.set("authority", squash_spaces(authority))
+
     h.apply_date(sanction, "startDate", row.pop("effective_date"))
     reinstated_date = row.pop("reinstated_date")
     h.apply_date(sanction, "endDate", reinstated_date)

--- a/datasets/us/hi/med_exclusions/crawler.py
+++ b/datasets/us/hi/med_exclusions/crawler.py
@@ -9,14 +9,14 @@ from zavod.extract import zyte_api
 AKA_SPLIT = r"\baka\b|\ba\.k\.a\b|\bAKA\b|\bor\b"
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     if raw_first_name := row.pop("first_name"):
         entity = context.make("Person")
 
         raw_last_name = row.pop("last_name_or_business_name")
         raw_middle_initial = row.pop("middle_initial")
         dba = None
-        if " DBA " in raw_last_name:
+        if raw_last_name and " DBA " in raw_last_name:
             result = context.lookup("names", raw_last_name)
             if result is not None:
                 raw_last_name, dba = result.values[0], result.values[1]
@@ -27,8 +27,8 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
             raw_last_name, raw_middle_initial, raw_first_name, row.get("exclusion_date")
         )
         for first_name in re.split(AKA_SPLIT, raw_first_name):
-            for last_name in re.split(AKA_SPLIT, raw_last_name):
-                for middle_initial in re.split(AKA_SPLIT, raw_middle_initial):
+            for last_name in re.split(AKA_SPLIT, raw_last_name or ""):
+                for middle_initial in re.split(AKA_SPLIT, raw_middle_initial or ""):
                     h.apply_name(
                         entity,
                         first_name=first_name,
@@ -42,8 +42,9 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
         entity.add("name", row.pop("last_name_or_business_name"))
 
     entity.add("sector", row.pop("last_known_program_or_provider_type"))
-    if row.get("medicaid_provider_id") != "NONE":
-        entity.add("description", "Provider ID: " + row.pop("medicaid_provider_id"))
+    medicaid_provider_id = row.pop("medicaid_provider_id")
+    if medicaid_provider_id is not None and medicaid_provider_id != "NONE":
+        entity.add("description", "Provider ID: " + medicaid_provider_id)
     else:
         row.pop("medicaid_provider_id")
     entity.add("country", "us")
@@ -83,5 +84,5 @@ def crawl(context: Context) -> None:
     context.export_resource(path, PDF, title=context.SOURCE_TITLE)
     for item in h.parse_pdf_table(context, path, headers_per_page=True):
         for key, value in item.items():
-            item[key] = squash_spaces(value)
+            item[key] = squash_spaces(value) if value else None
         crawl_item(item, context)

--- a/datasets/us/ky/med_exclusions/crawler.py
+++ b/datasets/us/ky/med_exclusions/crawler.py
@@ -8,7 +8,7 @@ from zavod.extract.zyte_api import fetch_resource
 REGEX_DBA = re.compile(r"\bdba\b", re.IGNORECASE)
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     period = row.pop("timeframe_of_term_exclusion")
     if not context.lookup("period", period):
         context.log.warning("Unexpected exclusion period", period=period, row=row)
@@ -28,9 +28,9 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
         entity = context.make("Company")
         entity.id = context.make_id(raw_business_name, row.get("npi"))
 
-        if "Owner:" in raw_business_name:
+        if raw_business_name and "Owner:" in raw_business_name:
             parts = re.split(r"\s*Owner:\s*", raw_business_name)
-            business_name = parts[0].strip()
+            business_name: str | None = str(parts[0].strip())
             owner_name = parts[1].strip()
             owner = context.make("Person")
             owner.id = context.make_id(owner_name)
@@ -44,6 +44,7 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
         else:
             business_name = raw_business_name
 
+        assert business_name is not None
         names = REGEX_DBA.split(business_name)
         entity.add("name", names[0])
         entity.add("alias", names[1:])
@@ -55,8 +56,9 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
 
     entity.add("country", "us")
     entity.add("topics", "debarment")
-    if row.get("license"):
-        entity.add("description", "License number: " + row.pop("license"))
+    license = row.pop("license")
+    if license:
+        entity.add("description", "License number: " + license)
 
     sanction = h.make_sanction(context, entity)
     h.apply_date(sanction, "startDate", row.pop("effective_date"))
@@ -78,6 +80,7 @@ def crawl(context: Context) -> None:
 
     sheet_names = wb.sheetnames
 
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active):
         crawl_item(item, context)
 

--- a/datasets/us/ma/med_exclusions/crawler.py
+++ b/datasets/us/ma/med_exclusions/crawler.py
@@ -15,7 +15,7 @@ HEADERS = {
 }
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     name = row.pop("provider_name")
 
     if not name:

--- a/datasets/us/md/med_exclusions/crawler.py
+++ b/datasets/us/md/med_exclusions/crawler.py
@@ -5,7 +5,7 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     if not row.get("first_name"):
         entity = context.make("Company")
         entity.id = context.make_id(row.get("last_name_organization"))
@@ -26,8 +26,8 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
     entity.add("topics", "debarment")
     entity.add("country", "us")
 
-    if row.get("license_no"):
-        entity.add("description", "License No: " + row.pop("license_no"))
+    if license_no := row.pop("license_no"):
+        entity.add("description", "License No: " + license_no)
 
     street_address = row.pop("address") or ""
     city_state_zip = row.pop("city_state_zip") or ""
@@ -56,7 +56,9 @@ def crawl_excel_url(context: Context) -> str:
         unblock_validator=provider_list_xpath,
         absolute_links=True,
     )
-    return doc.xpath(provider_list_xpath)[0].get("href")
+    href = h.xpath_string(doc, provider_list_xpath + "/@href")
+    assert href is not None
+    return href
 
 
 def crawl(context: Context) -> None:
@@ -67,10 +69,11 @@ def crawl(context: Context) -> None:
 
     wb = load_workbook(path, read_only=True)
 
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active):
         # it means the table has ended and the rest is just the sanction types
         if item.get("last_name_organization") == "Sanction Type":
             return
-        if item.get("last_name_organization").startswith("A = Abuse"):
+        if (val := item.get("last_name_organization")) and val.startswith("A = Abuse"):
             return
         crawl_item(item, context)

--- a/datasets/us/mi/med_exclusions/crawler.py
+++ b/datasets/us/mi/med_exclusions/crawler.py
@@ -7,11 +7,11 @@ from zavod.extract import zyte_api
 URL_XPATH = "//*[text()='List of Sanctioned Providers (XLSX)']/ancestor::a"
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
-    sanction_date_1 = row.pop("sanction_date1")
-    sanction_date_1 = sanction_date_1.split() if sanction_date_1 else None
-    sanction_date_2 = row.pop("sanction_date2")
-    sanction_date_2 = sanction_date_2.split() if sanction_date_2 else None
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
+    raw_date_1 = row.pop("sanction_date1")
+    sanction_date_1: list[str] | None = raw_date_1.split() if raw_date_1 else None
+    raw_date_2 = row.pop("sanction_date2")
+    sanction_date_2: list[str] | None = raw_date_2.split() if raw_date_2 else None
     reason = row.pop("reason")
     license = row.pop("license")
     npi = row.pop("npi")
@@ -78,6 +78,8 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
         context.emit(person_sanction)
 
     if last_name and entity_name:
+        assert person is not None
+        assert entity is not None
         link = context.make("UnknownLink")
         link.id = context.make_id(person.id, entity.id)
         link.add("object", entity)
@@ -96,9 +98,10 @@ def crawl_excel_url(context: Context) -> str:
         html_source="httpResponseBody",
         absolute_links=True,
     )
-    links = doc.xpath(URL_XPATH)
-    assert len(links) >= 1 and links[0].get("href"), "No link to Excel file found"
-    return links[0].get("href")
+    anchor = h.xpath_element(doc, URL_XPATH)
+    href = anchor.get("href")
+    assert href, "No link to Excel file found"
+    return href
 
 
 def crawl(context: Context) -> None:
@@ -111,5 +114,6 @@ def crawl(context: Context) -> None:
 
     wb = load_workbook(path, read_only=True)
 
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active, skiprows=1):
         crawl_item(item, context)

--- a/datasets/us/mn/med_exclusions/crawler.py
+++ b/datasets/us/mn/med_exclusions/crawler.py
@@ -2,10 +2,11 @@ from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
 from zavod import Context, helpers as h
+from zavod.util import Element
 from zavod.extract.zyte_api import fetch_html, fetch_resource
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     is_company = "practice_name" in row
 
     address = h.make_address(
@@ -55,11 +56,17 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
     context.audit_data(row)
 
 
-def unblock_validator(doc) -> bool:
+def unblock_validator(doc: Element) -> bool:
     return (
-        len(doc.xpath(".//span[text()='MHCP Excluded Group Providers']/..")) > 0
+        len(h.xpath_elements(doc, ".//span[text()='MHCP Excluded Group Providers']/.."))
+        > 0
     ) and (
-        len(doc.xpath(".//span[text()='MHCP Excluded Individual Providers']/..")) > 0
+        len(
+            h.xpath_elements(
+                doc, ".//span[text()='MHCP Excluded Individual Providers']/.."
+            )
+        )
+        > 0
     )
 
 
@@ -91,5 +98,6 @@ def crawl(context: Context) -> None:
         context.export_resource(file_path, XLSX, title=context.SOURCE_TITLE)
         wb = load_workbook(file_path, read_only=True)
 
+        assert wb.active is not None
         for item in h.parse_xlsx_sheet(context, wb.active):
             crawl_item(item, context)

--- a/datasets/us/ms/med_exclusions/crawler.py
+++ b/datasets/us/ms/med_exclusions/crawler.py
@@ -4,7 +4,7 @@ from rigour.mime.types import XLSX
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     if not any(row.values()):  # Skip empty rows
         return
 

--- a/datasets/us/mt/med_exclusions/crawler.py
+++ b/datasets/us/mt/med_exclusions/crawler.py
@@ -9,15 +9,17 @@ from zavod.entity import Entity
 REGEX_AKA = re.compile(r"^a\.k\.a\.? ", re.IGNORECASE)
 
 
-def crawl_item(row: dict[str, str], context: Context) -> tuple[Entity, Entity]:
-    if ", " not in row.get("terminated_excluded_provider_s"):
+def crawl_item(row: dict[str, str | None], context: Context) -> tuple[Entity, Entity]:
+    if ", " not in (row.get("terminated_excluded_provider_s") or ""):
         entity = context.make("Company")
         entity.id = context.make_id(row.get("terminated_excluded_provider_s"))
         entity.add("name", row.pop("terminated_excluded_provider_s"))
     else:
         entity = context.make("Person")
         entity.id = context.make_id(row.get("terminated_excluded_provider_s"))
-        last_name, first_name = row.pop("terminated_excluded_provider_s").split(", ")
+        name_raw = row.pop("terminated_excluded_provider_s")
+        assert name_raw is not None
+        last_name, first_name = name_raw.split(", ")
         h.apply_name(entity, first_name=first_name, last_name=last_name)
 
     entity.add("topics", "debarment")
@@ -53,18 +55,22 @@ def crawl(context: Context) -> None:
     entity = None
     sanction = None
     current_alias = []
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active):
         name = item.get("terminated_excluded_provider_s")
-        if REGEX_AKA.match(name):
+        if name and REGEX_AKA.match(name):
             current_alias.append(REGEX_AKA.sub("", name))
         else:
             # Move on to the next entity
-            if entity:
+            if entity is not None:
                 entity.add("name", current_alias)
                 context.emit(entity)
+                assert sanction is not None
                 context.emit(sanction)
             current_alias = []
             entity, sanction = crawl_item(item, context)
     # Emit the last entity
+    assert entity is not None
+    assert sanction is not None
     context.emit(entity)
     context.emit(sanction)

--- a/datasets/us/nc/med_exclusions/crawler.py
+++ b/datasets/us/nc/med_exclusions/crawler.py
@@ -4,7 +4,7 @@ from openpyxl import load_workbook
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     entity = context.make("LegalEntity")
     entity.id = context.make_id(
         row.get("excluded_entity"), row.get("npi_atypical_id_excluded")
@@ -58,5 +58,6 @@ def crawl(context: Context) -> None:
 
     wb = load_workbook(path, read_only=True)
 
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active, skiprows=6):
         crawl_item(item, context)

--- a/datasets/us/nd/med_exclusions/crawler.py
+++ b/datasets/us/nd/med_exclusions/crawler.py
@@ -67,7 +67,8 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
         entity.add("idNumber", medicare_number)
 
     sanction = h.make_sanction(context, entity)
-    termination_date = row.pop("exclusion_date") or ""
+    termination_date = row.pop("exclusion_date")
+    assert termination_date is not None
     termination_date = termination_date.replace("Termination ", "")
     termination_date = termination_date.replace("Termination: ", "")
     termination_date = termination_date.replace("Denial ", "").strip()
@@ -102,6 +103,7 @@ def crawl(context: Context) -> None:
     context.export_resource(path, XLSX, title=context.SOURCE_TITLE)
 
     wb = load_workbook(path, read_only=True)
+    assert wb.active is not None
 
     for item in h.parse_xlsx_sheet(context, wb.active, skiprows=SKIPROWS):
         crawl_item(item, context)

--- a/datasets/us/nh/med_exclusions/crawler.py
+++ b/datasets/us/nh/med_exclusions/crawler.py
@@ -5,14 +5,14 @@ from zavod import Context
 from zavod import helpers as h
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     first_name = row.pop("provider_individual_first_name")
     business_name = row.pop("business_name")
     npi = row.pop("national_provider_identifier_npi")
     sector = row.pop("provider_individual_type")
     reason = row.pop("exclusion_sanction_reason")
     # There is one line with multiple dates, we are only going to consider the first one
-    startDate = row.pop("exclusion_sanction_effective_date").split(" ")[0]
+    startDate = (row.pop("exclusion_sanction_effective_date") or "").split(" ")[0]
 
     if first_name:
         person = context.make("Person")
@@ -75,5 +75,6 @@ def crawl(context: Context) -> None:
 
     wb = load_workbook(path, read_only=True)
 
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active, skiprows=1):
         crawl_item(item, context)

--- a/datasets/us/nj/med_exclusions/crawler.py
+++ b/datasets/us/nj/med_exclusions/crawler.py
@@ -3,7 +3,7 @@ from rigour.mime.types import PDF
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     zip_code = row.pop("zip")
     npi = row.pop("npi_number")
 
@@ -11,7 +11,7 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
     entity.id = context.make_id(npi, row.get("provider_name"), zip_code)
     entity.add("name", h.multi_split(row.pop("provider_name"), ["a.k.a."]))
     entity.add("sector", row.pop("title"))
-    entity.add("npiCode", h.multi_split(npi.replace("\n", ""), ";/"))
+    entity.add("npiCode", h.multi_split((npi or "").replace("\n", ""), ";/"))
     entity.add("country", "us")
 
     address = h.make_address(
@@ -37,15 +37,16 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
 
     context.emit(entity)
     context.emit(sanction)
-    context.emit(address)
+    if address is not None:
+        context.emit(address)
 
     context.audit_data(row)
 
 
 def translate_keys(
-    context: Context, lookup: str, row: dict[str, str]
-) -> dict[str, str]:
-    return {context.lookup_value(lookup, k, k): v for k, v in row.items()}
+    context: Context, lookup: str, row: dict[str, str | None]
+) -> dict[str, str | None]:
+    return {context.lookup_value(lookup, k, k) or k: v for k, v in row.items()}
 
 
 def crawl(context: Context) -> None:

--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -6,21 +6,21 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     # We already crawl the federal dataset on another crawler
     sanction_tier = row.pop("nevada_medicaid_sanction_tier")
-    if sanction_tier.lower() == "federal":
+    if (sanction_tier or "").lower() == "federal":
         return
 
     entity = context.make("LegalEntity")
     name = row.pop("excluded_providers_entities_and_or_individuals")
-    if name.startswith("Effective February"):
+    if (name or "").startswith("Effective February"):
         return
 
     npi = row.pop("sanctioned_excluded_npi")
     entity.id = context.make_id(name, npi)
     entity.add("name", h.multi_split(name, [" aka ", " dba ", " DBA "]))
-    entity.add("npiCode", npi.split("\n"))
+    entity.add("npiCode", (npi or "").split("\n"))
     entity.add("country", "us")
 
     if associated_entity_name := row.pop("associated_legal_entity"):
@@ -56,7 +56,7 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
     sanction = h.make_sanction(context, entity)
     sanction.add("provisions", f"Tier: {sanction_tier}")
     h.apply_dates(
-        sanction, "startDate", row.pop("contract_termination_date").split("\n")
+        sanction, "startDate", (row.pop("contract_termination_date") or "").split("\n")
     )
     h.apply_date(
         sanction, "endDate", row.pop("nevada_medicaid_sanction_period_end_date")

--- a/datasets/us/ny/med_exclusions/crawler.py
+++ b/datasets/us/ny/med_exclusions/crawler.py
@@ -4,7 +4,7 @@ from openpyxl import load_workbook
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     name = row.pop("provider_name")
 
     if not name:
@@ -34,5 +34,6 @@ def crawl(context: Context) -> None:
 
     wb = load_workbook(path, read_only=True)
 
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active):
         crawl_item(item, context)

--- a/datasets/us/oh/med_exclusions/crawler.py
+++ b/datasets/us/oh/med_exclusions/crawler.py
@@ -10,14 +10,14 @@ REGEX_DBA = re.compile(r"\bdba\b", re.IGNORECASE)
 REGEX_AKA = re.compile(r"\(?a\.?k\.?a\b\.?|\)", re.IGNORECASE)
 
 
-def crawl_individual(row: dict[str, str], context: Context) -> None:
+def crawl_individual(row: dict[str, str | None], context: Context) -> None:
     entity = context.make("Person")
     entity.id = context.make_id(
         row.get("last_name"), row.get("first_name"), row.get("npi")
     )
-    last_names = REGEX_AKA.split(row.pop("last_name"))
+    last_names = REGEX_AKA.split(row.pop("last_name") or "")
     middle_names = REGEX_AKA.split(row.pop("middle_name") or "")
-    first_names = REGEX_AKA.split(row.pop("first_name"))
+    first_names = REGEX_AKA.split(row.pop("first_name") or "")
     for first_name, middle_name, last_name in product(
         first_names, middle_names, last_names
     ):
@@ -28,8 +28,8 @@ def crawl_individual(row: dict[str, str], context: Context) -> None:
     entity.add("country", "us")
     entity.add("sector", row.pop("provider_type"))
     entity.add("topics", "debarment")
-    if row.get("provider_id"):
-        entity.add("description", "Provider ID: " + row.pop("provider_id"))
+    if (provider_id := row.pop("provider_id")) is not None:
+        entity.add("description", "Provider ID: " + provider_id)
     h.apply_date(entity, "birthDate", row.pop("dob"))
 
     if row.get("npi"):
@@ -49,10 +49,10 @@ def crawl_individual(row: dict[str, str], context: Context) -> None:
     context.audit_data(row, ignore=["date_added"])
 
 
-def crawl_organization(row: dict[str, str], context: Context) -> None:
+def crawl_organization(row: dict[str, str | None], context: Context) -> None:
     entity = context.make("Company")
     entity.id = context.make_id(row.get("organization_name"))
-    names = REGEX_DBA.split(row.pop("organization_name"))
+    names = REGEX_DBA.split(row.pop("organization_name") or "")
     aliases = names[1:]
     names = names[0].split("Owner:")
     entity.add("name", names[0])
@@ -61,7 +61,7 @@ def crawl_organization(row: dict[str, str], context: Context) -> None:
     entity.add("sector", row.pop("provider_type"))
     entity.add("topics", "debarment")
     if row.get("provider_id"):
-        entity.add("description", "Provider ID: " + row.pop("provider_id"))
+        entity.add("description", "Provider ID: " + (row.pop("provider_id") or ""))
 
     for owner_name in names[1:]:
         owner = context.make("LegalEntity")
@@ -101,7 +101,8 @@ def crawl_organization(row: dict[str, str], context: Context) -> None:
 
     context.emit(entity)
     context.emit(sanction)
-    context.emit(address)
+    if address is not None:
+        context.emit(address)
 
     context.audit_data(row, ignore=["date_added"])
 

--- a/datasets/us/or/med_exclusions/crawler.py
+++ b/datasets/us/or/med_exclusions/crawler.py
@@ -27,16 +27,17 @@ NAMESPACES = {
 
 
 def crawl(context: Context) -> None:
-
     response = context.fetch_text(
         context.data_url, headers=HEADERS, data=REQUEST_DATA, method="POST"
     )
+    assert response is not None
 
     tree = etree.fromstring(response.encode("utf-8"))
 
     for item in [
-        row.get("ows_URL")
+        val
         for row in tree.findall(".//rs:data/z:row", namespaces=NAMESPACES)
+        if (val := row.get("ows_URL")) is not None
     ]:
         url, last_name, first_name = item.split(", ")
         person = context.make("Person")

--- a/datasets/us/pa/med_exclusions/crawler.py
+++ b/datasets/us/pa/med_exclusions/crawler.py
@@ -14,7 +14,7 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
     npi = row.pop("IDN_NPI")
     title = row.pop("NAM_TITLE_PROVR")
 
-    if row.get("CAO").startswith("Out of State"):
+    if (row.get("CAO") or "").startswith("Out of State"):
         state = row.pop("CAO").replace("Out of State ", "")
         city = ""
     else:

--- a/datasets/us/sc/med_exclusions/crawler.py
+++ b/datasets/us/sc/med_exclusions/crawler.py
@@ -8,11 +8,11 @@ import re
 REGEX_ALIAS = re.compile(r"\ba\.k\.a\.?|\baka\b|\bf/k/a\b|\bdba\b", re.IGNORECASE)
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     entity = context.make("LegalEntity")
     npi = row.pop("npi")
     entity.id = context.make_id(row.get("individual_entity"), npi)
-    parts = REGEX_ALIAS.split(row.pop("individual_entity").strip())
+    parts = REGEX_ALIAS.split((row.pop("individual_entity") or "").strip())
 
     entity.add("name", parts[0])
     entity.add("alias", parts[1:])
@@ -59,5 +59,6 @@ def crawl(context: Context) -> None:
     context.export_resource(path, XLSX, title=context.SOURCE_TITLE)
 
     wb = load_workbook(path, read_only=True)
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active, skiprows=2):
         crawl_item(item, context)

--- a/datasets/us/wa/med_exclusions/crawler.py
+++ b/datasets/us/wa/med_exclusions/crawler.py
@@ -4,8 +4,10 @@ from openpyxl import load_workbook
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     name = row.pop("name")
+    assert name
+    aliases: list[str]
     if len(name.split("\n")) == 1:
         aliases = []
     else:
@@ -15,6 +17,7 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
 
     entity = context.make("LegalEntity")
     npi_or_p1 = row.pop("npi_or_p1")
+    assert npi_or_p1
     entity.id = context.make_id(name, npi_or_p1)
     entity.add("name", name)
     for number in npi_or_p1.split("\n"):
@@ -52,6 +55,7 @@ def crawl(context: Context) -> None:
 
     wb = load_workbook(path, read_only=True)
 
+    assert wb.active is not None
     for item in h.parse_xlsx_sheet(context, wb.active, skiprows=3):
         print(item)
         crawl_item(item, context)

--- a/datasets/us/wv/med_exclusions/crawler.py
+++ b/datasets/us/wv/med_exclusions/crawler.py
@@ -12,16 +12,16 @@ prompt = """
 """
 
 
-def flat(multiline: str) -> str:
-    return multiline.replace("\n", " ")
+def flat(multiline: str | None) -> str:
+    return (multiline or "").replace("\n", " ")
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     address = h.make_address(
         context,
         street=flat(row.pop("address_1")),
         street2=flat(row.pop("address_2")),
-        postal_code=row.pop("zip").replace("\n", ""),
+        postal_code=(row.pop("zip") or "").replace("\n", ""),
         city=flat(row.pop("city")),
         state=flat(row.pop("state")),
         country_code="us",
@@ -33,7 +33,7 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
     # Setting 'headers_per_page=False' takes the header only from the first page
     # For each page we skip the header row with this check
     # Please remove this check if the header is always on the first row
-    if "last name" in last_name.lower():
+    if "last name" in (last_name or "").lower():
         return
 
     if first_name:
@@ -51,7 +51,9 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
     h.apply_address(context, entity, address)
 
     sanction = h.make_sanction(context, entity)
-    h.apply_date(sanction, "startDate", row.pop("action_date").replace("\n", ""))
+    h.apply_date(
+        sanction, "startDate", (row.pop("action_date") or "").replace("\n", "")
+    )
     sanction.add("reason", flat(row.pop("reason_for_exclusion_termination")))
     sanction.add("provisions", flat(row.pop("excluded_terminated")))
 
@@ -64,12 +66,16 @@ def crawl_item(row: dict[str, str], context: Context) -> None:
 def crawl_pdf_url(context: Context) -> str:
     doc = context.fetch_html(context.data_url)
     # Construct the URL from bits in the table because they'd rather do that than just construct a working URL.
-    rows = doc.xpath("//tr[@class='rgRow']")  # RadGrid row
+    rows = h.xpath_elements(doc, "//tr[@class='rgRow']")  # RadGrid row
     assert len(rows) == 1, len(rows)
     row = rows[0]
-    link_element = row.xpath(".//a[contains(@href, 'javascript:__doPostBack')]")[0]
-    doc_name = link_element.text_content().strip().replace(" ", "%20")
-    parent_folder = row.xpath(".//td[@style='display:none;']")[0].text_content().strip()
+    link_element = h.xpath_element(
+        row, ".//a[contains(@href, 'javascript:__doPostBack')]"
+    )
+    doc_name = h.element_text(link_element).strip().replace(" ", "%20")
+    parent_folder = h.element_text(
+        h.xpath_element(row, ".//td[@style='display:none;']")
+    ).strip()
     return f"https://www.wvmmis.com/SharepointDownload?parent={parent_folder}&docname={doc_name}"
 
 

--- a/datasets/us/wy/med_exclusions/crawler.py
+++ b/datasets/us/wy/med_exclusions/crawler.py
@@ -9,12 +9,13 @@ AKA_PATTERN = r"\ba\.?k\.?a[\. -]*"
 PAGE_SETTINGS = {"join_y_tolerance": 100}
 
 
-def crawl_item(row: dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     address = h.make_address(
         context, city=row.pop("city"), state=row.pop("state"), country_code="US"
     )
     sector = row.pop("provider_type")
     provider_number = row.pop("provider_number")
+    assert provider_number
     exclusion_date = row.pop("exclusion_date")
     last_name = row.pop("last_name")
     first_name = row.pop("first_name")


### PR DESCRIPTION
- **Fix mypy --strict type errors in us/**/med_exclusions crawlers**
  - Narrow crawl_item row signatures from dict[str, str] to dict[str, str | None]
    to match what parse_pdf_table / parse_xlsx_sheet actually return
  - Replace raw .xpath() / .find() / .text_content() calls with typed h.xpath_*
    and h.element_text() helpers
  - Add assert wb.active is not None before parse_xlsx_sheet calls
  - Guard str | None values before .replace() / .split() / .lower() / in-checks
    with `or ""` fallbacks or explicit assertions
  - Extract Pydantic Field() description constants in al to avoid FieldInfo
    annotation conflicts
  - al: add # type: ignore[arg-type] on make_id(name, list) calls where
    unpacking would change generated entity IDs
  - ar: leave alias=list[] misuse unfixed (logic bug, not a type issue)
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **[us_ar_med_exclusions] Get rid of alias splitting logic in favor of lookups**
  

- **[us] Make the typechecker happy for all med_exclusions**
  