### PR TITLE
Fix CI shell injection from PR filenames (ONS-005, operations#2333)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,21 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: "datasets/**"
+          separator: "\n"
       - name: Crawl modified datasets
         if: ${{ steps.changed-files.outputs.all_changed_files != '' && github.ref != 'refs/heads/main'}}
+        env:
+          # For security reasons, pass possibly attacker-chosen filenames via
+          # env var (not direct ${{ }} interpolation into shell) to prevent
+          # command injection through crafted PR filenames containing shell
+          # metacharacters.
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           set -euo pipefail
-          datasets=$(python contrib/ci_datasets.py ${{ steps.changed-files.outputs.all_changed_files }})
+          # Read into an array so each filename is passed as its own quoted argv
+          # entry (a bare `for f in $CHANGED_FILES` would word-split unsafely).
+          mapfile -t files <<< "$CHANGED_FILES"
+          datasets=$(python contrib/ci_datasets.py "${files[@]}")
           echo "$datasets"
           for dataset in $datasets
           do
@@ -83,9 +93,16 @@ jobs:
           done
       - name: Validate modified datasets
         if: ${{ steps.changed-files.outputs.all_changed_files != '' && github.ref != 'refs/heads/main'}}
+        env:
+          # See note above: env var + quoted expansion avoids shell injection
+          # via filenames in PRs.
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           set -euo pipefail
-          datasets=$(python contrib/ci_datasets.py ${{ steps.changed-files.outputs.all_changed_files }})
+          # Read into an array so each filename is passed as its own quoted argv
+          # entry (a bare `for f in $CHANGED_FILES` would word-split unsafely).
+          mapfile -t files <<< "$CHANGED_FILES"
+          datasets=$(python contrib/ci_datasets.py "${files[@]}")
           for dataset in $datasets
           do
               echo Validating $dataset
@@ -93,9 +110,16 @@ jobs:
           done
       - name: Export modified datasets
         if: ${{ steps.changed-files.outputs.all_changed_files != '' && github.ref != 'refs/heads/main'}}
+        env:
+          # See note above: env var + quoted expansion avoids shell injection
+          # via filenames in PRs.
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           set -euo pipefail
-          datasets=$(python contrib/ci_datasets.py ${{ steps.changed-files.outputs.all_changed_files }})
+          # Read into an array so each filename is passed as its own quoted argv
+          # entry (a bare `for f in $CHANGED_FILES` would word-split unsafely).
+          mapfile -t files <<< "$CHANGED_FILES"
+          datasets=$(python contrib/ci_datasets.py "${files[@]}")
           for dataset in $datasets
           do
               echo Exporting $dataset

--- a/.github/workflows/lint_crawlers.yml
+++ b/.github/workflows/lint_crawlers.yml
@@ -17,20 +17,33 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: 'datasets/**/*.y*ml'
+          separator: "\n"
       - name: Lint modiied dataset yamls
         if: ${{ steps.changed-yamls.outputs.all_changed_files != '' }}
+        env:
+          # For security reasons, pass possibly attacker-chosen filenames via
+          # env var (not direct ${{ }} interpolation into shell) to prevent
+          # command injection through crafted PR filenames containing shell
+          # metacharacters.
+          CHANGED_FILES: ${{ steps.changed-yamls.outputs.all_changed_files }}
         run: |
-          yamllint ${{ steps.changed-yamls.outputs.all_changed_files }}
+          set -euo pipefail
+          # Read into an array so each filename is passed as its own quoted argv
+          # entry (a bare `for f in $CHANGED_FILES` would word-split unsafely).
+          mapfile -t files <<< "$CHANGED_FILES"
+          yamllint "${files[@]}"
       - name: Get modified dataset python
         id: changed-python
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: 'datasets/**/*.py'
+          separator: "\n"
       - name: Get all modified files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: 'datasets/**'
+          separator: "\n"
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -41,16 +54,27 @@ jobs:
           pip install -q -e ".[dev]"
       - name: Lint modified dataset python
         if: ${{ steps.changed-python.outputs.all_changed_files != '' }}
+        env:
+          # See note above: env var + quoted expansion avoids shell injection
+          # via filenames in PRs.
+          CHANGED_FILES: ${{ steps.changed-python.outputs.all_changed_files }}
         run: |
           set -euxo pipefail
-          for dataset in ${{ steps.changed-python.outputs.all_changed_files }}
-          do
-              echo Linting $dataset
-              ruff check $dataset
-              ruff format --check --diff $dataset
-          done
+          while IFS= read -r dataset; do
+            [ -z "$dataset" ] && continue
+            echo Linting "$dataset"
+            ruff check "$dataset"
+            ruff format --check --diff "$dataset"
+          done <<< "$CHANGED_FILES"
       - name: Run prek pre-commit hooks on modified files
         if: ${{ steps.changed-python.outputs.all_changed_files != '' }}
+        env:
+          # See note above: env var + quoted expansion avoids shell injection
+          # via filenames in PRs.
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           set -euxo pipefail
-          prek run --files ${{ steps.changed-files.outputs.all_changed_files }}
+          # Read into an array so each filename is passed as its own quoted argv
+          # entry (a bare `for f in $CHANGED_FILES` would word-split unsafely).
+          mapfile -t files <<< "$CHANGED_FILES"
+          prek run --files "${files[@]}"


### PR DESCRIPTION
## Summary
- Fixes the CI command-injection issue ONS-005, discovered during the pentest and outlined by jbothma in https://github.com/opensanctions/operations/issues/2333.
- `.github/workflows/build.yml` and `.github/workflows/lint_crawlers.yml` interpolated `${{ steps.changed-files.outputs.all_changed_files }}` directly into shell `run:` blocks, so a PR author could inject shell metacharacters via crafted filenames.
- Each affected step now passes the filename list through a `CHANGED_FILES` env var and expands it via a `mapfile` array (or `while read` loop), so filenames reach the underlying tools (`yamllint`, `prek`, `ruff`, `ci_datasets.py`) as properly-quoted argv entries instead of raw shell text.
- Set `separator: "\n"` on every `tj-actions/changed-files` invocation — without this the default space separator would collapse the list into a single "filename" and break the array splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)