### PR TITLE
Add irregularity checks to fix and simplify ca_sema_sanctions_news

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           files: "datasets/**"
           separator: "\n"
+          safe_output: false  # false because we are using an environment variable to store the output and avoid command injection.
       - name: Crawl modified datasets
         if: ${{ steps.changed-files.outputs.all_changed_files != '' && github.ref != 'refs/heads/main'}}
         env:

--- a/.github/workflows/lint_crawlers.yml
+++ b/.github/workflows/lint_crawlers.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           files: 'datasets/**/*.y*ml'
           separator: "\n"
+          safe_output: false  # false because we are using an environment variable to store the output and avoid command injection.
       - name: Lint modiied dataset yamls
         if: ${{ steps.changed-yamls.outputs.all_changed_files != '' }}
         env:
@@ -38,12 +39,14 @@ jobs:
         with:
           files: 'datasets/**/*.py'
           separator: "\n"
+          safe_output: false  # false because we are using an environment variable to store the output and avoid command injection.
       - name: Get all modified files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: 'datasets/**'
           separator: "\n"
+          safe_output: false  # false because we are using an environment variable to store the output and avoid command injection.
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/datasets/ca/sema_sanctions_news/ca_sema_sanctions_news.yml
+++ b/datasets/ca/sema_sanctions_news/ca_sema_sanctions_news.yml
@@ -47,6 +47,8 @@ dates:
 names:
   schema_rules:
     LegalEntity:
+      # Catch cases like "Name (Russian: Name) or other additional things like this."
+      reject_chars: "(:"
       reject_strings: [" and ", " or ", " et "]
   suggest_abbreviation_non_person_single_token_shorter_than: 5
   suggest_weak_alias_person_single_token: true

--- a/datasets/ca/sema_sanctions_news/ca_sema_sanctions_news.yml
+++ b/datasets/ca/sema_sanctions_news/ca_sema_sanctions_news.yml
@@ -45,6 +45,9 @@ dates:
     - "on %B %d, %Y"
     - "in %B %Y"
 names:
+  schema_rules:
+    LegalEntity:
+      reject_strings: [" and ", " or ", " et "]
   suggest_abbreviation_non_person_single_token_shorter_than: 5
   suggest_weak_alias_person_single_token: true
 

--- a/datasets/ca/sema_sanctions_news/crawler.py
+++ b/datasets/ca/sema_sanctions_news/crawler.py
@@ -8,21 +8,6 @@ from zavod.stateful.review import assert_all_accepted
 PROGRAM_KEY = "CA-SEMA"
 
 
-def split_names(name: str) -> h.Names:
-    """Split out aliases embedded in the name string."""
-    aliases = []
-
-    if "(also known as" in name.lower():
-        name, aka = name.split("(also known as", 1)
-        aliases.extend([a.strip().rstrip(")") for a in aka.split(",")])
-
-    if "(également connue sous le nom" in name.lower():
-        name, aka = name.split("(également connue sous le nom de ", 1)
-        aliases.extend([a.strip().rstrip(")") for a in aka.split(",")])
-
-    return h.Names(name=name.strip(), alias=aliases)
-
-
 def crawl_entity_notice(context: Context, row: Dict[str, _Element]) -> None:
     str_row = h.cells_to_str(row)
     country = str_row.pop("country")
@@ -64,27 +49,32 @@ def crawl_entity_notice(context: Context, row: Dict[str, _Element]) -> None:
         listing_date,
     )
 
-    for name in chain(persons, oranizations):
+    for raw_name in chain(persons, oranizations):
         entity = context.make(schema)
-        entity.id = context.make_id(name, country)
+        entity.id = context.make_id(raw_name, country)
 
-        born_patterns = ["(born ", "(bornon "]
+        born_patterns = [" (born ", " (bornon "]
         for born in born_patterns:
-            if born in name.lower():
-                name, dob = name.split(born, 1)
+            if born in raw_name.lower():
+                name, dob = raw_name.split(born, 1)
                 dob = dob.strip(")")
                 h.apply_date(entity, "birthDate", dob)
+                break
+            else:
+                name = raw_name
 
-        # TODO: Add once LangText is merged
-        # https://github.com/opensanctions/opensanctions/pull/3770
-        if "(russian:" in name.lower():
+        original = h.Names(name=name)
+        is_irregular = False
+        suggested = None
+
+        # TODO: Remove after initial import
+        if "(Russian:" in name:
             name, name_ru = name.split("(Russian:", 1)
             name_ru = name_ru.strip().rstrip(")")
-            h.apply_reviewed_name_string(context, entity, string=name_ru, lang="rus")
-
-        original = h.Names(name=name.strip())
-        suggested = split_names(name)
-        is_irregular, suggested = h.check_names_regularity(entity, suggested)
+            suggested = h.Names()
+            suggested.add("name", name.strip())
+            suggested.add("name", name_ru.strip(), lang="rus")
+            is_irregular, suggested = h.check_names_regularity(entity, suggested)
 
         h.apply_reviewed_names(
             context,
@@ -92,6 +82,7 @@ def crawl_entity_notice(context: Context, row: Dict[str, _Element]) -> None:
             original=original,
             suggested=suggested,
             is_irregular=is_irregular,
+            default_accepted=True,  # TODO: Remove after one run
         )
         entity.add("topics", "sanction")
 

--- a/datasets/ca/sema_sanctions_news/crawler.py
+++ b/datasets/ca/sema_sanctions_news/crawler.py
@@ -10,14 +10,9 @@ from zavod.stateful.review import assert_all_accepted
 PROGRAM_KEY = "CA-SEMA"
 
 
-def split_names(name: str) -> tuple[bool, h.Names]:
-    """
-    Returns:
-    - True if any name or alias contains a conjunction (or, and, et), otherwise False
-    - categorised and cleaned Names instance
-    """
+def split_names(name: str) -> h.Names:
+    """Split out aliases embedded in the name string."""
     aliases = []
-    is_irregular = False
 
     if "(also known as" in name.lower():
         name, aka = name.split("(also known as", 1)
@@ -30,15 +25,7 @@ def split_names(name: str) -> tuple[bool, h.Names]:
     # some names contain digits at the beginning of the string
     name = re.sub(r"^\d+\s*", "", name)
 
-    suggested = h.Names(name=name.strip(), alias=aliases)
-
-    for _prop_name, values in suggested.nonempty_item_lists():
-        for value in values:
-            if re.search(r"\b(or|and|et)\b", value, flags=re.I):
-                is_irregular = True
-                return is_irregular, suggested
-
-    return is_irregular, suggested
+    return h.Names(name=name.strip(), alias=aliases)
 
 
 def crawl_entity_notice(context: Context, row: Dict[str, _Element]) -> None:
@@ -101,15 +88,15 @@ def crawl_entity_notice(context: Context, row: Dict[str, _Element]) -> None:
             h.apply_reviewed_name_string(context, entity, string=name_ru, lang="rus")
 
         original = h.Names(name=name.strip())
-        crawler_is_irregular, suggested = split_names(name)
-        helper_is_irregular, suggested = h.check_names_regularity(entity, suggested)
+        suggested = split_names(name)
+        is_irregular, suggested = h.check_names_regularity(entity, suggested)
 
         h.apply_reviewed_names(
             context,
             entity,
             original=original,
             suggested=suggested,
-            is_irregular=crawler_is_irregular or helper_is_irregular,
+            is_irregular=is_irregular,
         )
         entity.add("topics", "sanction")
 

--- a/datasets/ca/sema_sanctions_news/crawler.py
+++ b/datasets/ca/sema_sanctions_news/crawler.py
@@ -1,5 +1,3 @@
-import re
-
 from itertools import chain
 from lxml.etree import _Element
 from typing import Dict
@@ -21,9 +19,6 @@ def split_names(name: str) -> h.Names:
     if "(également connue sous le nom" in name.lower():
         name, aka = name.split("(également connue sous le nom de ", 1)
         aliases.extend([a.strip().rstrip(")") for a in aka.split(",")])
-
-    # some names contain digits at the beginning of the string
-    name = re.sub(r"^\d+\s*", "", name)
 
     return h.Names(name=name.strip(), alias=aliases)
 

--- a/zavod/docs/extract/names.md
+++ b/zavod/docs/extract/names.md
@@ -206,6 +206,7 @@ names:
   schema_rules:
     Company:
       reject_chars: ","
+      reject_strings: [" and ", " or ", " et "]
       allow_chars: "/"
   suggest_weak_alias_person_single_token: true
   suggest_abbreviation_uppercase_org_single_token_shorter_than: 8

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -330,6 +330,11 @@ def _check_schema_name_specs(string: str, spec: CleaningSpec) -> Optional[Regula
         if char in string:
             return Regularity(is_irregular=True)
 
+    string_lower = string.lower()
+    for phrase in spec.reject_strings:
+        if phrase.lower() in string_lower:
+            return Regularity(is_irregular=True)
+
     # spec.allow_nullwords
     if not spec.allow_nullwords and is_nullword(string, normalize=True):
         return Regularity(is_irregular=True)

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -379,6 +379,9 @@ def check_name_regularity(entity: Entity, string: Optional[str]) -> Regularity:
     if contains_split_phrase(string):
         return Regularity(is_irregular=True)
 
+    if string[0].isdigit():
+        return Regularity(is_irregular=True)
+
     return Regularity(is_irregular=False)
 
 

--- a/zavod/zavod/meta/names.py
+++ b/zavod/zavod/meta/names.py
@@ -21,6 +21,14 @@ class CleaningSpec(BaseModel):
     Use this to define characters in dataset-specific config. Adds to the baseline
     characters for default specs.
     """
+    reject_strings: list[str] = []
+    """
+    Substrings that, if present in a name string, flag it as irregular.
+
+    Use this to define phrases in dataset-specific config that suggest a name string
+    is unsuitable as-is (e.g. " and ", " or ", " et " indicating multiple names, or
+    other superfluous strings). Matching is case-insensitive.
+    """
     allow_chars: str = ""
     """
     Characters that would otherwise trigger cleaning but are allowed for this schema.

--- a/zavod/zavod/tests/fixtures/testdataset1/testdataset1.yml
+++ b/zavod/zavod/tests/fixtures/testdataset1/testdataset1.yml
@@ -34,6 +34,7 @@ names:
   schema_rules:
     Organization:
       reject_chars: ","
+      reject_strings: [" and ", " or "]
       min_length: 3
       single_token_min_length: 4
   suggest_weak_alias_person_single_token: true

--- a/zavod/zavod/tests/helpers/names/test_regularity.py
+++ b/zavod/zavod/tests/helpers/names/test_regularity.py
@@ -23,6 +23,10 @@ def test_is_name_irregular(testdataset1: Dataset):
     assert is_name_irregular(org, "Company Alpha OR Company Beta")  # case-insensitive
     assert not is_name_irregular(org, "Org NPO")
 
+    # Leading digit
+    assert is_name_irregular(org, "1 Some Organization")
+    assert not is_name_irregular(org, "Some Organization 1")
+
     # Nullwords
     assert is_name_irregular(org, "Unknown")
 

--- a/zavod/zavod/tests/helpers/names/test_regularity.py
+++ b/zavod/zavod/tests/helpers/names/test_regularity.py
@@ -18,6 +18,11 @@ def test_is_name_irregular(testdataset1: Dataset):
     # Rejected chars
     assert is_name_irregular(org, "Org NPO, Org Charitable")
 
+    # Rejected strings
+    assert is_name_irregular(org, "Company Alpha and Company Beta")
+    assert is_name_irregular(org, "Company Alpha OR Company Beta")  # case-insensitive
+    assert not is_name_irregular(org, "Org NPO")
+
     # Nullwords
     assert is_name_irregular(org, "Unknown")
 


### PR DESCRIPTION
- anything starting with a digit is possibly irregular - there are a few handfuls of companies truly starting with a number. Usually it's numbering
- allow crawler-specific strings like ` et ` and ` and a` to flag as irregular, calling it `reject_strings` because it's not always gonna be splitters - it might be prefixes, but it's easy to rename this if we want.
- import and accept current cleaning which missed reviews

final step is https://github.com/opensanctions/opensanctions/pull/4229