### PR TITLE
[_global_afdb_sanctions] name migration

### DIFF
--- a/datasets/_global/afdb_sanctions/afdb_sanctions.yml
+++ b/datasets/_global/afdb_sanctions/afdb_sanctions.yml
@@ -60,6 +60,11 @@ assertions:
       LegalEntity: 1400
       Person: 500
 
+names:
+  schema_rules:
+    LegalEntity:
+      reject_strings: ["aka", "d.b.a.", " or ", "operating", "previously"]
+
 lookups:
   names:
     options:

--- a/datasets/_global/afdb_sanctions/crawler.py
+++ b/datasets/_global/afdb_sanctions/crawler.py
@@ -74,7 +74,9 @@ def crawl(context: Context) -> None:
         country = cells.pop("nationality")
         entity = context.make(schema)
         entity.id = context.make_id(name, country)
+        original = h.Names(name=name)
         apply_clean_name(context, entity, name)
+        h.review_names(context, entity, original=original, llm_cleaning=True)
         entity.add("topics", "debarment")
         entity.add("country", country)
 


### PR DESCRIPTION
## Summary

- Step 1 of the name framework migration for the AFDB sanctions crawler
- Introduces `h.review_names` with `llm_cleaning=True` alongside the existing `apply_clean_name` logic
- Existing `entity.add` calls are unchanged; reviewed names are not applied until Step 3

## Test plan

- [ ] Verify crawler runs without errors
- [ ] Check that name reviews are created in the review UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)