### PR TITLE
[_global_afdb_sanctions] name migration step 3

### DIFF
--- a/datasets/_global/afdb_sanctions/afdb_sanctions.yml
+++ b/datasets/_global/afdb_sanctions/afdb_sanctions.yml
@@ -60,6 +60,11 @@ assertions:
       LegalEntity: 1400
       Person: 500
 
+names:
+  schema_rules:
+    LegalEntity:
+      reject_strings: ["aka", "d.b.a.", " or ", "operating", "previously"]
+
 lookups:
   names:
     options:

--- a/datasets/_global/afdb_sanctions/crawler.py
+++ b/datasets/_global/afdb_sanctions/crawler.py
@@ -1,52 +1,7 @@
-import re
-
 from zavod.extract.zyte_api import fetch_html
 
 from zavod import Context
 from zavod import helpers as h
-
-NAME_SPLITS = [
-    "doing business as",
-    "also known as",
-    " or ",
-    "a.k.a.",
-    "aka ",
-    "f/k/a",
-    "d/b/a",
-    "dba",
-    "d.b.a.",
-    "a/k/a",
-    "operating",
-    "formerly",
-    "previously",
-]
-DETECT_ALIAS_RE = re.compile("|".join(re.escape(s) for s in NAME_SPLITS), re.IGNORECASE)
-NAME_REGEX = re.compile(r"^(?P<name>[^()]+?)\s*\(\s*(?P<alias>[^()]+?)\s*\)$")
-
-
-def apply_clean_name(context: Context, entity, name) -> None:
-    names_lookup_result = context.lookup("names", name)
-    if names_lookup_result is not None:
-        details = names_lookup_result.names[0]
-        entity.add("name", details.get("name"))
-        entity.add("alias", details.get("alias"))
-        entity.add("weakAlias", details.get("weak_alias"))
-        entity.add("previousName", details.get("previous_name"))
-        entity.add("abbreviation", details.get("abbreviation"))
-    # Only allow the normal "Name (Alias)" format if no alias-y terms were found
-    elif NAME_REGEX.match(name) and not DETECT_ALIAS_RE.search(name):
-        match = NAME_REGEX.match(name)
-        entity.add("name", match.group("name").strip())
-        entity.add("alias", match.group("alias").strip('“”"'))
-    # If the name looks like it might contain an alias, log a warning
-    elif "(" in name or DETECT_ALIAS_RE.search(name):
-        context.log.warn(
-            "Name looks like it might contain an alias, but no lookup found", name=name
-        )
-        # We apply the name anyway in this case not to lose it until it's fixed
-        entity.add("name", name)
-    else:
-        entity.add("name", name)
 
 
 def crawl(context: Context) -> None:
@@ -74,9 +29,7 @@ def crawl(context: Context) -> None:
         country = cells.pop("nationality")
         entity = context.make(schema)
         entity.id = context.make_id(name, country)
-        original = h.Names(name=name)
-        apply_clean_name(context, entity, name)
-        h.review_names(context, entity, original=original, llm_cleaning=True)
+        h.apply_reviewed_name_string(context, entity, string=name, llm_cleaning=True)
         entity.add("topics", "debarment")
         entity.add("country", country)
 


### PR DESCRIPTION
## Summary

- Step 3 of the name framework migration for the AFDB sanctions crawler
- Removes the old apply_clean_name function (regex splits, alias detection, lookup logic) and all supporting constants
- Replaces with h.apply_reviewed_name_string(..., llm_cleaning=True)
- Adds reject_strings to the dataset names spec for split-phrase variants not covered by rigour: aka, d.b.a., ' or ', operating, previously

Depends on #4240 (step 1).

## Test plan

- [x] Verify crawler runs and entities are emitted correctly
- [x] Confirm names with the added reject_strings phrases are flagged for LLM review

Generated with [Claude Code](https://claude.com/claude-code)