### PR TITLE
Port simplify_dates / simplify_undirected from nomenklatura.publish

### DIFF
--- a/zavod/zavod/exporters/consolidate.py
+++ b/zavod/zavod/exporters/consolidate.py
@@ -1,10 +1,16 @@
+from functools import lru_cache
+from typing import List, Tuple
+
 from normality import WS
+from followthemoney import registry
 from rigour.names import reduce_names
-from nomenklatura.resolver import Linker
-from nomenklatura.publish.dates import simplify_dates
-from nomenklatura.publish.edges import simplify_undirected
+from nomenklatura.resolver import Identifier, Linker
 
 from zavod.entity import Entity
+
+
+PROV_MIN_DATES = ("createdAt", "authoredAt", "publishedAt")
+PROV_MAX_DATES = ("modifiedAt", "retrievedAt")
 
 
 NAME_PROPS = (
@@ -38,6 +44,81 @@ NEVER_REMOVE_NAMES_DATASETS = {
     "ca_dfatd_sema_sanctions",
     "au_dfat_sanctions",
 }
+
+
+@lru_cache(maxsize=10000)
+def _remove_prefix_date_values(values: Tuple[str, ...]) -> Tuple[str, ...]:
+    """See ``_simplify_dates``."""
+    kept: List[str] = []
+    values_list = sorted(values, reverse=True)
+    for index, value in enumerate(values_list):
+        if index > 0:
+            longer = values_list[index - 1]
+            if longer.startswith(value):
+                continue
+        kept.append(value)
+    return tuple(kept)
+
+
+def _simplify_dates(entity: Entity) -> Entity:
+    """If an entity has multiple values for a date field, you may
+    want to remove all those that are prefixes of others. For example,
+    if a Person has both a birthDate of 1990 and of 1990-05-01, we'd
+    want to drop the mention of 1990."""
+    for prop in entity.iterprops():
+        if prop.type == registry.date:
+            # Unrolled hot path: called for every entity in every export.
+            stmts = entity._statements[prop.name]
+            if len(stmts) < 2:
+                continue
+            values_in = tuple({s.value for s in stmts})
+            if len(values_in) < 2:
+                continue
+            values = _remove_prefix_date_values(values_in)
+            if prop.name in PROV_MAX_DATES:
+                values = (max(values),)
+            elif prop.name in PROV_MIN_DATES:
+                values = (min(values),)
+
+            # If the sentinel HISTORIC is present, remove it during entity
+            # consolidation.
+            if registry.date.HISTORIC in values:
+                values = tuple(v for v in values if v != registry.date.HISTORIC)
+
+            for stmt in list(stmts):
+                if stmt.value not in values:
+                    entity._statements[prop.name].remove(stmt)
+    return entity
+
+
+def _simplify_undirected(entity: Entity) -> Entity:
+    """Simplify undirected edges by removing duplicate entity IDs on both
+    ends."""
+    # Problem: undirected relationships in which both
+    # entities are given as the source AND the target
+    if (
+        not entity.schema.edge
+        or entity.schema.edge_directed
+        or not entity.schema.edge_source
+        or not entity.schema.edge_target
+    ):
+        return entity
+    sources = entity.get_statements(entity.schema.edge_source)
+    targets = entity.get_statements(entity.schema.edge_target)
+    source_ids = set((s.value for s in sources))
+    target_ids = set((t.value for t in targets))
+    common = source_ids.intersection(target_ids)
+    if len(common) != 2:
+        return entity
+    identifiers = [Identifier.get(s) for s in common]
+    source_id, target_id = max(identifiers), min(identifiers)
+    for stmt in sources:
+        if stmt.value == target_id:
+            entity._statements[entity.schema.edge_source].remove(stmt)
+    for stmt in targets:
+        if stmt.value == source_id:
+            entity._statements[entity.schema.edge_target].remove(stmt)
+    return entity
 
 
 def simplify_names(entity: Entity) -> Entity:
@@ -94,7 +175,7 @@ def consolidate_entity(linker: Linker[Entity], entity: Entity) -> Entity:
     """Consolidate an entity by simplifying some of its properties."""
     if entity.id is not None:
         entity.extra_referents.update(linker.get_referents(entity.id))
-    entity = simplify_dates(entity)
+    entity = _simplify_dates(entity)
     entity = simplify_names(entity)
-    entity = simplify_undirected(entity)
+    entity = _simplify_undirected(entity)
     return entity

--- a/zavod/zavod/tests/exporters/test_consolidate_dates.py
+++ b/zavod/zavod/tests/exporters/test_consolidate_dates.py
@@ -1,0 +1,20 @@
+from followthemoney import StatementEntity
+from zavod.exporters.consolidate import _simplify_dates
+
+ENTITY = {
+    "id": "demo",
+    "schema": "Person",
+    "properties": {
+        "birthDate": ["1972", "1972-04", "1972-04-12"],
+        "createdAt": ["2023-01-01", "2023-03-03"],
+    },
+}
+
+
+def test_simplify_dates():
+    entity = StatementEntity.from_dict(ENTITY)
+    assert len(entity.get("birthDate")) == 3
+    assert len(entity.get("createdAt")) == 2
+    simple = _simplify_dates(entity)
+    assert simple.get("birthDate") == ["1972-04-12"]
+    assert simple.get("createdAt") == ["2023-01-01"]

--- a/zavod/zavod/tests/exporters/test_consolidate_edges.py
+++ b/zavod/zavod/tests/exporters/test_consolidate_edges.py
@@ -1,0 +1,34 @@
+from typing import Dict, Any
+from followthemoney import StatementEntity
+from zavod.exporters.consolidate import _simplify_undirected
+
+
+def _e(schema: str, **props: Dict[str, Any]) -> StatementEntity:
+    data = {"schema": schema, "properties": props, "id": "test"}
+    return StatementEntity.from_dict(data)
+
+
+def test_family_simplified():
+    ent = _e("Family", person=["Q7747", "ofac-2332"], relative=["Q7747", "ofac-2332"])
+    assert len(ent.get("person")) == 2, ent.to_dict()
+    simp = _simplify_undirected(ent)
+    assert simp.schema.name == "Family"
+    assert simp.get("person") == ["Q7747"], simp.to_dict()
+    assert simp.get("relative") == ["ofac-2332"], simp.to_dict()
+
+    ent = _e("Family", person=["ofac-2332"], relative=["Q7747"])
+    simp = _simplify_undirected(ent)
+    assert simp.get("person") == ["ofac-2332"], simp.to_dict()
+    assert simp.get("relative") == ["Q7747"], simp.to_dict()
+
+
+def test_payment_simplified():
+    ent = _e(
+        "Payment",
+        payer=["Q7747", "ofac-2332"],
+        beneficiary=["Q7747", "ofac-2332"],
+    )
+    assert len(ent.get("payer")) == 2, ent.to_dict()
+    simp = _simplify_undirected(ent)
+    assert simp.schema.name == "Payment"
+    assert sorted(simp.get("payer")) == sorted(["Q7747", "ofac-2332"])


### PR DESCRIPTION
## Summary

- Move `simplify_dates`, `simplify_undirected`, and the prefix-date helper from `nomenklatura.publish` into `zavod.exporters.consolidate`, which is their only consumer.
- Bound the prefix-date dedup cache (`@cache` → `@lru_cache(maxsize=10000)`) so long-running exports don't grow it without bound.
- Tighten `_remove_prefix_date_values` to return `Tuple[str, ...]` (matches use, immutable for cache safety).
- Underscore-prefix the helpers since they're module-internal.

## Follow-up

After this lands, the `nomenklatura.publish` module can be removed in a `nomenklatura` release. zavod will need its `nomenklatura` pin bumped at that point.

## Test plan

- [x] `pytest zavod/tests/exporters/` (21 passed, including the 3 ported tests)
- [x] `mypy --strict zavod/exporters/consolidate.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)