### PR TITLE
Update source value in review when it changes

### DIFF
--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -437,6 +437,10 @@ def review_extraction(
                 context.log.debug(
                     "Source value changed. Resetting review.", key=key_slug
                 )
+            review.source_value = source_value.value_string
+            review.source_mime_type = source_value.mime_type
+            review.source_label = source_value.label
+            review.source_url = source_value.url
             review.crawler_version = crawler_version
             review.data_model = data_model
             review.extraction_schema = schema

--- a/zavod/zavod/tests/stateful/test_review.py
+++ b/zavod/zavod/tests/stateful/test_review.py
@@ -320,6 +320,49 @@ def test_text_source_comparison(testdataset1: Dataset):
     assert not source_value2.matches(review)
 
 
+def test_source_changed_updates_source_fields(testdataset1: Dataset):
+    #   preconditions:
+    #     - there is an existing review
+    #     - the source value has changed
+    #   postconditions:
+    #     - source_value, source_mime_type, source_label, source_url are all
+    #       updated to reflect the new source
+    context1 = Context(testdataset1)
+    source_value1 = TextSourceValue(
+        key_parts="key8", label="label-old", url="http://s/old", text="old text"
+    )
+    review_extraction(
+        context1,
+        crawler_version=1,
+        source_value=source_value1,
+        original_extraction=DummyModel(foo="old"),
+        origin="test data",
+        default_accepted=True,
+    )
+
+    context2 = Context(testdataset1)
+    source_value2 = TextSourceValue(
+        key_parts="key8", label="label-new", url="http://s/new", text="new text"
+    )
+    review_extraction(
+        context2,
+        crawler_version=1,
+        source_value=source_value2,
+        original_extraction=DummyModel(foo="new"),
+        origin="test data",
+    )
+
+    key8 = review_key("key8")
+    row = get_row(context2.conn, key8)
+    assert row is not None
+    assert row["source_value"] == source_value2.value_string
+    assert row["source_mime_type"] == source_value2.mime_type
+    assert row["source_label"] == source_value2.label
+    assert row["source_url"] == source_value2.url
+    context1.close()
+    context2.close()
+
+
 def test_review_key():
     # Returns a 40-char hex SHA1
     assert len(review_key("key1")) == 40


### PR DESCRIPTION
The source value here changed, and that resulted in a change to the extracted value, so the review was invalidated.

But the source value doesn't contain the new address - we're not saving the new source value. Let's do that.

```
etlprod=> select last_seen_version, modified_at, modified_by, deleted_at from review where key = 'a7122721adb744a31190ae78846b94223d5694c9';
 last_seen_version  |        modified_at         |         modified_by         |         deleted_at
--------------------+----------------------------+-----------------------------+----------------------------
 20260514123511-hvp | 2026-05-14 12:35:16.972972 | zavod                       | 2026-05-14 12:37:34
 20260519163959-euc | 2026-05-14 12:37:34        | friedrich@opensanctions.org | 2026-05-20 12:35:00.098869
 20260520123453-bev | 2026-05-20 12:35:00.093062 | zavod                       |
(3 rows)
```

<img width="1920" height="1080" alt="Screenshot 2026-05-20 at 15 33 59" src="https://github.com/user-attachments/assets/2b92c82f-829d-4b29-b31f-ef195298da44" />
