### PR TITLE
Document typed XPath helpers in zavod.helpers.html

### DIFF
--- a/zavod/docs/best_practices/xpath_and_html.md
+++ b/zavod/docs/best_practices/xpath_and_html.md
@@ -1,48 +1,96 @@
 # XPath and HTML
 
-## Selector Design
-Try to make the selectors specific enough to reliably select the correct content (to avoid e.g. the wrong thing being stuffed in a person's `name` property) while making them as semantic, concise, and general as possible to be maintainable and resillient against irrelevant changes in the HTML.
+XPath selectors are a common source of brittle, hard-to-debug crawlers; the helpers in `zavod.helpers.html` add typed return values and explicit count guards on top of `lxml`.
+
+## Use the typed helpers in `zavod.helpers.html`
+
+`lxml`'s `Element.xpath()` has a loose return type. The same call can return a list of elements, a list of strings, a single string, a number, or a boolean, depending on the expression. The type stubs reflect this by typing the result as `Any`. A typo in the expression or an upstream HTML change can therefore produce a result of the wrong type, with the failure surfacing far away from the offending line.
+
+The helpers in `zavod.helpers.html` wrap `.xpath()` with concrete return types and runtime checks. Prefer them over calling `.xpath()` directly:
+
+| Helper | Returns | Use for |
+| --- | --- | --- |
+| [`h.xpath_elements`][zavod.helpers.xpath_elements] | `list[Element]` | Any element-returning expression. |
+| [`h.xpath_element`][zavod.helpers.xpath_element] | `Element` | Exactly one element; raises on zero or multiple matches. |
+| [`h.xpath_strings`][zavod.helpers.xpath_strings] | `list[str]` | Text-returning expressions (`.../text()`, `string(...)`). |
+| [`h.xpath_string`][zavod.helpers.xpath_string] | `str` | Exactly one string result. |
+| [`h.element_text`][zavod.helpers.element_text] | `str` | Concatenated text content, whitespace-squashed by default. |
+
+```python
+from zavod import helpers as h
+
+# Typed result; raises if the table is not unique.
+table = h.xpath_element(doc, './/div[@id="block-content"]//table')
+
+# Typed list of rows with a count guard.
+rows = h.xpath_elements(table, "./tbody/tr", expect_exactly=12)
+
+# Clean string extraction with whitespace squashing.
+title = h.element_text(h.xpath_element(doc, ".//h1"))
+```
+
+For tabular content, use [`h.parse_html_table`][zavod.helpers.parse_html_table] rather than walking rows by hand. It yields one `dict[str, Element]` per row, keyed by slugified header text; pair it with [`h.cells_to_str`][zavod.helpers.cells_to_str] when string values are enough:
+
+```python
+for row in h.parse_html_table(table):
+    cells = h.cells_to_str(row)
+    name = cells["full_name"]
+    # ... or reach into row["full_name"] when the cell contains links or markup
+```
+
+[`h.links_to_dict`][zavod.helpers.links_to_dict] is occasionally useful when a cell contains labelled anchor elements that should become a `{label: href}` mapping.
+
+`lxml`'s own `.findall()` is typed and a fine choice for trivial relative selectors (`row.findall("./td")`, `el.findall(".//a")`); reach for the `xpath_*` helpers when the selector actually needs XPath predicates, axes, or `contains(...)`.
+
+## Write specific but semantic selectors
+
+Selectors need to be specific enough to pick out the intended content, but semantic and concise enough to survive irrelevant HTML changes. A selector that is too loose can put the wrong text into a person's `name` property. A selector pinned to layout details breaks on the next restyle.
 
 ```python
 # Good:
-table = doc.xpath('.//div[@id="block-content"]//table')
+table = h.xpath_element(doc, './/div[@id="block-content"]//table')
 
 # Avoid:
-table = doc.xpath('.//div[@id="block-content"]//div[3]//table')
+table = h.xpath_element(doc, './/div[@id="block-content"]//div[3]//table')
 ```
-Prefer `.//div[contains(@class, 'abc')]` over `.//div[@class='abc']` because classes can contain multiple values, but beware of conflicting class names like `abc-footer`.
 
-## Fail loudly if the selection is different from what was expected
+Prefer `.//div[contains(@class, 'abc')]` over `.//div[@class='abc']` because the `class` attribute can hold multiple whitespace-separated values. Watch for conflicting class names like `abc-footer`, which also match `contains(@class, 'abc')`.
 
-Beware of selections being different from what you intend. Common issues are:
+## Fail loudly when a selection does not match expectations
 
-* missing a bunch of entities because we're looping over a selection which turned out to be empty;
-* emitting garbage because content was added to the page which matched unintentionally;
-* cryptic errors because the wrong table is selected.
+Selections often turn out to be different from what was intended. Common symptoms:
 
-    It's ideal for an error to occur as close as possible to the offending code.
+- the loop runs over an empty selection and the crawler silently produces no entities;
+- content added to the page matches the expression unintentionally and ends up in entity properties;
+- the wrong table is selected, and the failure surfaces several function calls later.
 
-One way to guard against these issues is assertions on the number of matches:
+Errors should surface as close to the offending code as possible. The typed helpers above enforce shape (list vs. single, element vs. string). For count expectations, pass `expect_exactly` or assert on the returned list:
 
 ```python
-items = doc.xpath(".//h2[@text()='The Section']/following-sibling::ul/li)
+# Exactly one match expected; raises on zero or many.
+table = h.xpath_element(doc, ".//table")
+
+# Known fixed count.
+rows = h.xpath_elements(table, "./tbody/tr", expect_exactly=12)
+
+# Open-ended but must not be empty.
+items = h.xpath_elements(doc, ".//h2[text()='The Section']/following-sibling::ul/li")
 assert len(items) > 0, items
 ```
 
-```python
-table = doc.xpath(".//table")
-assert len(table) == 1, table
-```
+## Use content hashes to flag silent changes
 
-## Get notified of changes to content
+To get a warning when page content changes from a previously hardcoded hash, use [`h.assert_dom_hash`][zavod.helpers.assert_dom_hash]. This catches drift that would otherwise need to be noticed manually: data extracted by hand, or a new section that should trigger a review of the parser. Scope the hash to a specific block of content, not the whole document, so frequently changing parts of the site (headers, footers, ads) do not trigger spurious warnings.
 
-Use `h.assert_*_hash` to get a warning when the content has changed from when you last hardcoded the hash. We usually use this when we want to be notified of changes to the page - either because we manually extracted the data and need to update it manually, or if we want to be notified when new sections are added to the page.
-
-`assert_dom_hash` is useful for focusing on a specific block of content, excluding more frequently changing parts of the site like headers, footers, etc.
+By default, `h.assert_dom_hash` logs a warning and returns `False` when the hash does not match, allowing the crawler to continue. Use the return value to log a maintainer-facing message that explains what to recheck before updating the hash:
 
 ```python
-# Use a hash to ensure the element’s content is correct and hasn't changed unexpectedly.
-h.assert_dom_hash(table[0], "26de80467eb7b4a93c0ad5c5c5b8cd75b07a38e0")
+expected = "30aca6ba4b245649db4bee16e0798d661080bd9a"
+if not h.assert_dom_hash(article, expected, text_only=True):
+    context.log.warning(
+        "Page hash changed: confirm the referenced lists are still the "
+        "UNSC Taliban and Al-Qaida lists before updating the hash."
+    )
 ```
 
-
+Pass `text_only=True` to ignore markup churn (class renames, added wrappers) and hash only the visible text. Pass `raise_exc=True` to turn the check into a hard failure when continuing past a change is unacceptable. For checking a whole page by URL rather than a sub-tree, use [`h.assert_html_url_hash`][zavod.helpers.assert_html_url_hash].

--- a/zavod/zavod/helpers/html.py
+++ b/zavod/zavod/helpers/html.py
@@ -139,7 +139,17 @@ def xpath_elements(
     el: Element, xpath: str, *, expect_exactly: Optional[int] = None
 ) -> List[Element]:
     """
-    Return a list of HtmlElement objects that match the given XPath expression.
+    Evaluate an XPath expression and return matching elements as a typed list.
+
+    Prefer this over `el.xpath(...)` when the expression returns elements:
+    `lxml`'s `.xpath()` is typed as `Any` because a single call can return
+    elements, strings, numbers, or booleans depending on the expression. This
+    helper asserts the result is a list of elements, so a mismatched expression
+    or upstream HTML change fails at the call site rather than further down
+    the crawler.
+
+    Args:
+        expect_exactly: If set, raise unless exactly this many elements match.
     """
     result = el.xpath(xpath)
     assert isinstance(result, list), (
@@ -159,7 +169,11 @@ def xpath_elements(
 
 def xpath_element(el: Element, xpath: str) -> Element:
     """
-    Return the only element that matches the given XPath expression (and complain if there are multiple)
+    Evaluate an XPath expression and return the single matching element.
+
+    Use this when exactly one match is expected — e.g. selecting the main
+    content table on a page. Raises if there are zero or more than one matches,
+    catching unexpected duplication or removal at the call site.
     """
     return xpath_elements(el, xpath, expect_exactly=1)[0]
 
@@ -168,7 +182,15 @@ def xpath_strings(
     el: Element, xpath: str, *, expect_exactly: Optional[int] = None
 ) -> List[str]:
     """
-    Return a list of strings that match the given XPath expression.
+    Evaluate an XPath expression and return matching strings as a typed list.
+
+    Use this for expressions that return text rather than elements, such as
+    `.//td/text()` or attribute selectors like `.//@href`. Like `xpath_elements`,
+    this guards against `.xpath()`'s `Any` return type by asserting the result
+    is a list of strings.
+
+    Args:
+        expect_exactly: If set, raise unless exactly this many strings match.
     """
     result = el.xpath(xpath)
     if not isinstance(result, list) or not all(isinstance(r, str) for r in result):
@@ -181,6 +203,13 @@ def xpath_strings(
 
 
 def xpath_string(el: Element, xpath: str) -> str:
+    """
+    Evaluate an XPath expression and return the single matching string.
+
+    Use for text-returning expressions where exactly one result is expected,
+    such as `string(.//h1)` or `.//meta[@name='title']/@content`. Raises if
+    there are zero or more than one matches.
+    """
     return xpath_strings(el, xpath, expect_exactly=1)[0]
 
 


### PR DESCRIPTION
## Summary

- Rewrites `zavod/docs/best_practices/xpath_and_html.md` to lead with the typed XPath helpers (`xpath_element`, `xpath_elements`, `xpath_strings`, `xpath_string`, `element_text`) and explain *why* they exist: `lxml`'s `.xpath()` is typed `Any`, so a typo or upstream HTML change fails far from the offending line.
- Corrects the `assert_dom_hash` section to match the actual API — it warns by default and returns `bool`; `raise_exc=True` is opt-in. Adds the `parse_html_table` + `cells_to_str` pairing and places `.findall()` alongside the xpath helpers for trivial relative selectors.
- Expands the docstrings on `xpath_element` / `xpath_elements` / `xpath_string` / `xpath_strings` so the mkdocstrings-generated helpers reference carries the same framing.
- Prose is brought in line with the [FollowTheMoney documentation styleguide](https://github.com/opensanctions/followthemoney/blob/main/docs/styleguide.md): sentence-case headers, no first-person "we", split em-dash interjections, present-tense system behavior, opening summary sentence.

## Test plan

- [ ] `mkdocs serve` in `zavod/` and confirm the page renders, the autorefs links (`[h.xpath_element][zavod.helpers.xpath_element]` etc.) resolve to anchors on `helpers.md`, and the code blocks are syntax-highlighted.
- [ ] Spot-check the rendered helpers reference page to confirm the expanded `xpath_*` docstrings appear correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)