### PR TITLE
Use h.xpath_element in afdb_sanctions

### DIFF
--- a/datasets/_global/afdb_sanctions/crawler.py
+++ b/datasets/_global/afdb_sanctions/crawler.py
@@ -9,9 +9,7 @@ def crawl(context: Context) -> None:
     doc = fetch_html(
         context, context.data_url, tables_xpath, html_source="httpResponseBody"
     )
-    tables = doc.xpath(tables_xpath)
-    assert len(tables) == 1
-    table = tables[0]
+    table = h.xpath_element(doc, tables_xpath)
     for row in h.parse_html_table(table):
         cells = h.cells_to_str(row)
         if not any(cells.values()):  # Skip empty rows


### PR DESCRIPTION
## Summary

- Replaces the manual `tables = doc.xpath(...); assert len(tables) == 1; table = tables[0]` pattern in `datasets/_global/afdb_sanctions/crawler.py` with a single call to [`h.xpath_element`][zavod.helpers.xpath_element].
- Behaviour is preserved: the helper raises if the AfDB sanctions page ever returns zero or multiple matching datatables, which is exactly what the previous assertion did. The error message also names the offending XPath, so the failure is easier to debug at the call site.
- Companion to #4280, which introduces the typed-helpers guidance in the docs.

## Test plan

- [ ] Run the crawler locally (`zavod crawl datasets/_global/afdb_sanctions/_global_afdb_sanctions.yml`) and confirm entities are emitted as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)