### PR TITLE
Use h.xpath_elements in br_ceis

### DIFF
--- a/datasets/br/ceis/crawler.py
+++ b/datasets/br/ceis/crawler.py
@@ -20,7 +20,7 @@ def get_csv_url(context: Context) -> str:
     date_pattern = re.compile(
         r'"ano"\s*:\s*"(\d+)",\s*"mes"\s*:\s*"(\d+)",\s*"dia"\s*:\s*"(\d+)"'
     )
-    for script in doc.xpath("//script"):
+    for script in h.xpath_elements(doc, "//script"):
         if script.text:
             match = date_pattern.search(script.text)
             if match:


### PR DESCRIPTION
## Summary

- Replaces the untyped `doc.xpath("//script")` iteration in `datasets/br/ceis/crawler.py` with [`h.xpath_elements`][zavod.helpers.xpath_elements] so the loop variable is statically `Element` rather than `Any`.
- No behavioural change; the helper still returns every matching `<script>` and the existing `script.text` access continues to work.
- Companion to #4280, which introduces the typed-helpers guidance in the docs.

## Test plan

- [ ] Run the crawler locally (`zavod crawl datasets/br/ceis/br_ceis.yml`) and confirm the CSV URL is still resolved correctly from the page's embedded date script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)