### PR TITLE
Add new roles to wd_peps.yml

### DIFF
--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -229,6 +229,7 @@ lookups:
           - "Q7315432" # Resident Commissioner
           - "Q7494991" # Sheriff of Kolkata
           - "Q7574852" # special prosecutor
+          - "Q3368517" # public prosecutor general
           - "Q7603902" # state treasurer
           - "Q8135012" # Chief Minister of Gilgit-Baltistan
           - "Q9200127" # member
@@ -438,6 +439,8 @@ lookups:
           - "Q135842653" # directeur de cabinet du ministre des Outre-mer
           - "Q8349973" # insular council
           - "Q108466181" # judicial position
+          - "Q107363151" # central bank governor
+          - "Q5785176" # auditor general
       - maybe_pep: false
         match:
           - "Q8191099" # affiliate


### PR DESCRIPTION
Three prominent positions added: central bank governor, auditor general and public prosecutor general.

Note: Within the file, central bank governors are in the list of posts that are prioritised.

