### PR TITLE
dataset: dynamically generate children in catalog building

### DIFF
--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -144,6 +144,7 @@ class Dataset(FollowTheMoneyDataset):
         for resource in data.get("resources", []):
             resource["path"] = resource["name"]
         if self.is_collection:
+            data["children"] = [d.name for d in self.children]
             # As of mid-2025, the same is now in `children`, but we keep it in `datasets` for backward compatibility.
             data["datasets"] = [d.name for d in self.datasets]
             data["datasets"].remove(self.name)


### PR DESCRIPTION
This fixes a bug where for a collection containing a collection, `dataset.children` would temporarily be out of sync with `datasets` because `dataset.datasets` gets built from the latest exported sub-collection `index.json`.

https://github.com/opensanctions/operations/issues/2517
