### PR TITLE
Issues 2026-05-27

### DIFF
--- a/datasets/eu/journal_sanctions/crawler.py
+++ b/datasets/eu/journal_sanctions/crawler.py
@@ -97,18 +97,24 @@ def get_consolidated_url(context: Context, source_url: str) -> str | None:
         absolute_links=True,
     )
     original_celex: str | None = None
-    for table in doc.xpath(".//table[@id='relatedDocsTbMS']"):
+    for table in h.xpath_element(doc, ".//table[@id='relatedDocsTbMS']"):
         # The <th> header cells embed <select> filter widgets whose text corrupts
         # parse_html_table's slugified keys (e.g. "relation_all_modifies" instead
         # of "relation").  Strip them before parsing.
-        for select in table.xpath(".//thead//th/select"):
-            select.getparent().remove(select)
-        rows = [h.cells_to_str(row) for row in h.parse_html_table(table)]
-        act_values = {r.get("act") for r in rows if r.get("act")}
+        for select in h.xpath_element(table, ".//thead//th/select"):
+            parent = select.getparent()
+            assert parent is not None
+            parent.remove(select)
+        modify_rows = [
+            h.cells_to_str(row)
+            for row in h.parse_html_table(table)
+            if row.get("relation") not in ("Repeal",)
+        ]
+        act_values = {r.get("act") for r in modify_rows if r.get("act")}
         assert len(act_values) <= 1, (
             f"Multiple CELEX numbers in amendments table for {source_url}: {act_values}"
         )
-        for row_strs in rows:
+        for row_strs in modify_rows:
             if row_strs.get("relation") in ("Modifies", "Extended validity"):
                 original_celex = row_strs.get("act")
                 break

--- a/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
+++ b/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
@@ -1510,6 +1510,55 @@ lookups:
       - match: "7709473987 (Russia TIN)"
         props:
           innCode: "7709473987"
+      - match: "Russia INN – 7704817031"
+        props:
+          innCode: "7704817031"
+      - match: "Russia INN: 9909674370"
+        props:
+          innCode: "9909674370"
+      - match: "Marshall Islands Entity Number - 117922"
+        props:
+          registrationNumber: "117922"
+      - match: "Panama Folio Number - Folio Nº 155737650"
+        props:
+          registrationNumber: "155737650"
+      - match: "Georgia MyGov Legal Code - 10756093Georgia Identification Code - 400361559"
+        props:
+          registrationNumber: ["10756093", "400361559"]
+      - match: "Georgia MyGov Legal Code – 10783789 Georgia Identification Code - 405655143 "
+        props:
+          registrationNumber: ["10783789", "405655143"]
+      - match: "Georgia MyGov Legal Code – 10703969 Georgia Identification Code - 412771852  "
+        props:
+          registrationNumber: ["10703969", "412771852"]
+      - match: "Kyrgyzstan INN - 01211202510014Kyrgyzstan Company Registration Number - 322290-3301-ОАО"
+        props:
+          taxNumber: "01211202510014"  # remapping to taxNumber because of validation failure
+          registrationNumber: "322290-3301-ОАО"
+      - match: "Kyrgyzstan INN - 02512202410270Kyrgyzstan Company Registration Number - 311855-3301-ОАО"
+        props:
+          taxNumber: "02512202410270"  # remapping to taxNumber because of validation failure
+          registrationNumber: "311855-3301-ОАО"
+      - match: "OGRN 1247700271829TIN 9710131220 (TIN region – Moscow)Checkpoint 773001001"
+        props:
+          ogrnCode: "1247700271829"
+          innCode: "9710131220"
+          kppCode: "773001001"
+      - match: "OKPO of a legal entity: 20205649TIN of a legal entity: 02903199310045Registration number: 5275-3301-OJSCRegistration number: KG0110104013"
+        props:
+          okpoCode: "20205649"
+          taxNumber: "02903199310045"  # remapping to taxNumber because of validation failure
+          registrationNumber: ["5275-3301-OJSC", "KG0110104013"]
+      - match: "Registration Number 5069 (United Arab Emirates)Economic Register Number (CBLS) 11874154 (United Arab Emirates)Alt. Registration Number RA000693_172229 (Belize)"
+        props:
+          registrationNumber: ["5069", "11874154", "RA000693_172229"]
+      - match: "Seat number 2025074769 Management No. SF2025008950 "
+        props:
+          registrationNumber: ["2025074769", "SF2025008950"]
+      - match: "UK Company number - 11655602EVA ID (IP Identification) - EEA90DD050C635EC8F637E8DB2F69969Legal Entity Identifier - 984500B899H9EED3B354 "
+        props:
+          registrationNumber: ["11655602", "EEA90DD050C635EC8F637E8DB2F69969"]
+          leiCode: "984500B899H9EED3B354"
   companies:
     normalize: true
     options:
@@ -2162,6 +2211,8 @@ lookups:
           - Zale Shipping Inc
           - Zulu Ships Management
           - Xinbi Guarantee
+          - EXMO POLAND SP Z.O.O.
+          - REPRESENATIVE OFFICE OF ALISTAIR LTD
         value: SAME
       - match: Subsidiary of the Organisation for Technological Industries (OTI) and therefore the Syrian Ministry of Defence
         values:

--- a/datasets/ru/dossier_center_poi/crawler.py
+++ b/datasets/ru/dossier_center_poi/crawler.py
@@ -8,11 +8,9 @@ ORGANIZERS_URL = "https://peps.dossier.center/types/oligarhi/"
 ACCOMPLICES_URL = "https://peps.dossier.center/types/goschinovniki/"
 
 
-def get_element_text(
-    doc: Element, xpath_value: str, to_remove: list[str] = [], position: int = 0
-) -> str:
-    el = h.xpath_element(doc, xpath_value)
-    text = h.element_text(el) or ""
+def get_element_text(doc: Element, xpath_value: str, to_remove: list[str] = []) -> str:
+    els = h.xpath_elements(doc, xpath_value)
+    text = "".join(h.element_text(el) for el in els)
     for string in to_remove:
         text = text.replace(string, "")
     return text
@@ -60,18 +58,18 @@ def crawl_person(context: Context, url: str, accomplice: bool = False) -> None:
         doc, '//div[@class="b-pr-section__field bottom-gap p-compact"]//p[2]'
     )
 
-    birth_date_n_palce = get_element_text(
+    birth_date_and_place = get_element_text(
         doc,
         '//div[@class="b-pr-section__label"][contains(.//text(), "Дата и место рождения")]//following-sibling::div[@class="b-pr-section__value"]',
     )
     date_pattern = r"\d{1,2}[./]\d{1,2}[./]\d{4}"
 
-    date_of_birth_matches = re.findall(date_pattern, birth_date_n_palce)
+    date_of_birth_matches = re.findall(date_pattern, birth_date_and_place)
     date_of_birth: str | None = (
         date_of_birth_matches[0] if date_of_birth_matches else None
     )
 
-    place_of_birth = re.sub(date_pattern, "", birth_date_n_palce)
+    place_of_birth = re.sub(date_pattern, "", birth_date_and_place)
     place_of_birth = place_of_birth.strip(", ")
 
     citizenships = get_element_text(


### PR DESCRIPTION
- **[gb_fcdo_sanctions] datapatch**
  

- **[eu_journal_sanctions] fix getting the original act for a CELEX**
  The code uses the related documents table to get at the original act that. So I think it's fine to filter the laws that it repeals, they are discarded by the code just below anyway
  