### PR TITLE
Issues 2026-05-28

### DIFF
--- a/datasets/_externals/ext_us_ofac_press_releases.yml
+++ b/datasets/_externals/ext_us_ofac_press_releases.yml
@@ -72,7 +72,7 @@ assertions:
   max:
     schema_entities:
       Company: 6000
-      Person: 3400
+      Person: 4500
       Article: 1330
       Organization: 930
       Vessel: 540

--- a/datasets/_global/abuja_mou/psc/abuja_mou_psc.yml
+++ b/datasets/_global/abuja_mou/psc/abuja_mou_psc.yml
@@ -53,6 +53,8 @@ assertions:
 lookups:
   type.identifier:
     options:
+      - match: 936016647
+        prop: registrationNumber
       - match: 636019170
         prop: mmsi
       - match: 91764126

--- a/datasets/ba/companies/crawler.py
+++ b/datasets/ba/companies/crawler.py
@@ -405,7 +405,9 @@ def crawl_details(context: Context, record: Dict[str, str]) -> bool:
         entity.add("status", record.get("status_bankruptcy", None), lang="bos")
 
         entity.add("country", "ba")
-        entity.add("address", record["address"], lang="bos")
+        address = record["address"]
+        if address != "-":
+            entity.add("address", address, lang="bos")
         entity.add("address", record.get("address_additional", None), lang="bos")
 
         entity.add("legalForm", record.get("legal_form", None), lang="bos")
@@ -455,7 +457,7 @@ def crawl_details(context: Context, record: Dict[str, str]) -> bool:
             if comp.get("country"):
                 founder_company.add("country", comp["country"], lang="bos")
 
-            if comp.get("address"):
+            if comp.get("address") and comp["address"] != "-":
                 founder_company.add("address", comp["address"], lang="bos")
 
             if comp.get("registration_number"):

--- a/datasets/eu/journal_sanctions/crawler.py
+++ b/datasets/eu/journal_sanctions/crawler.py
@@ -105,16 +105,13 @@ def get_consolidated_url(context: Context, source_url: str) -> str | None:
             parent = select.getparent()
             assert parent is not None
             parent.remove(select)
-        modify_rows = [
-            h.cells_to_str(row)
-            for row in h.parse_html_table(table)
-            if row.get("relation") not in ("Repeal",)
-        ]
-        act_values = {r.get("act") for r in modify_rows if r.get("act")}
+        rows = [h.cells_to_str(row) for row in h.parse_html_table(table)]
+        rows = [r for r in rows if r.get("relation") != "Repeal"]
+        act_values = {r.get("act") for r in rows if r.get("act")}
         assert len(act_values) <= 1, (
             f"Multiple CELEX numbers in amendments table for {source_url}: {act_values}"
         )
-        for row_strs in modify_rows:
+        for row_strs in rows:
             if row_strs.get("relation") in ("Modifies", "Extended validity"):
                 original_celex = row_strs.get("act")
                 break

--- a/datasets/tj/companies/crawler.py
+++ b/datasets/tj/companies/crawler.py
@@ -173,7 +173,7 @@ def crawl_page(
                 retries=retries - 1,
             )
         else:
-            context.log.error("Exceeded retries.")
+            context.log.error("Exceeded retries.", url=url, payload=raw_payload)
             raise
 
     headers = []


### PR DESCRIPTION
- **[ext_us_ofac_press_releases] bump Person max assertion to 4500**
  The threshold was 3400 but we're at ~3433 and climbing. There are roughly
  4.2k Person entities in the underlying non-enrichment dataset, and in a
  world with perfect deduplication we'd end up pulling in more or less all of
  them — 4500 gives headroom for that without being completely unbounded.
  
  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
  

- **[abuja_mou_psc] datapatch**
  

- **[ba_companies] skip address == "-"**
  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
  

- **[tj_companies] better debug logging**
  

- **[eu_journal_sanctions] fix for real now**
  