### PR TITLE
Friday afternoon type clauding

### DIFF
--- a/datasets/_global/everypolitician/crawler.py
+++ b/datasets/_global/everypolitician/crawler.py
@@ -1,6 +1,6 @@
 import re
+from typing import Any, Dict, Optional, Set
 from urllib.parse import urljoin, unquote
-from typing import Dict, Optional, Set
 from followthemoney.helpers import post_summary
 
 from zavod import Context
@@ -12,7 +12,7 @@ PHONE_SPLITS = [",", "/", "(1)", "(2)", "(3)", "(4)", "(5)", "(6)", "(7)", "(8)"
 PHONE_REMOVE = re.compile(r"(ex|ext|extension|fax|tel|\:|\-)", re.IGNORECASE)
 
 
-def clean_emails(emails):
+def clean_emails(emails: str | None) -> list[str] | None:
     out = []
     for email in h.multi_split(emails, ["/", ","]):
         if email is None:
@@ -24,7 +24,7 @@ def clean_emails(emails):
     return out
 
 
-def clean_phones(phones):
+def clean_phones(phones: str | None) -> list[str]:
     out = []
     for phone in h.multi_split(phones, PHONE_SPLITS):
         phone = PHONE_REMOVE.sub("", phone)
@@ -42,7 +42,9 @@ def crawl(context: Context) -> None:
             crawl_legislature(context, code, legislature)
 
 
-def crawl_legislature(context: Context, country: str, legislature) -> None:
+def crawl_legislature(
+    context: Context, country: str, legislature: dict[str, Any]
+) -> None:
     url = urljoin(context.data_url, legislature.get("popolo"))
     # print(url)
     # this isn't being updated, hence long interval:
@@ -90,11 +92,11 @@ def crawl_legislature(context: Context, country: str, legislature) -> None:
             parse_person(context, person, country)
 
 
-def person_entity_id(context, person_id: str) -> str:
+def person_entity_id(context: Context, person_id: str) -> str:
     return context.make_slug(person_id)
 
 
-def parse_person(context: Context, data, country) -> None:
+def parse_person(context: Context, data: dict[str, Any], country: str) -> None:
     person_id = data.pop("id", None)
     person = context.make("Person")
     person.id = person_entity_id(context, person_id)
@@ -154,10 +156,10 @@ def parse_person(context: Context, data, country) -> None:
 
 def parse_membership(
     context: Context,
-    country,
-    data,
-    organizations,
-    events,
+    country: str,
+    data: dict[str, Any],
+    organizations: Dict[str, Optional[str]],
+    events: dict[str | None, Any],
     birth_dates: Dict[str, str],
     death_dates: Dict[str, str],
 ) -> Optional[str]:

--- a/datasets/_global/iadb_sanctions/crawler.py
+++ b/datasets/_global/iadb_sanctions/crawler.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from typing import Optional, List
+from pathlib import Path
+from typing import Any, Iterator, Optional, List
 
 from normality import slugify, stringify
 from openpyxl import load_workbook
@@ -28,7 +29,7 @@ def parse_countries(countries: Optional[str]) -> List[str]:
     return parsed
 
 
-def header_names(cells):
+def header_names(cells: list[Any]) -> list[str]:
     headers = []
     for idx, cell in enumerate(cells):
         if cell is None:
@@ -37,7 +38,7 @@ def header_names(cells):
     return headers
 
 
-def excel_records(path):
+def excel_records(path: Path) -> Iterator[dict[str, str]]:
     wb = load_workbook(filename=path, read_only=True)
     for sheet in wb.worksheets:
         headers = None

--- a/datasets/_global/icij_offshoreleaks/crawler.py
+++ b/datasets/_global/icij_offshoreleaks/crawler.py
@@ -14,7 +14,7 @@ ADDRESSES_FULL: Dict[str, List[str]] = {}
 ADDRESSES_COUNTRIES: Dict[str, List[str]] = {}
 
 
-def parse_countries(text):
+def parse_countries(text: str | None) -> list[str] | None:
     return h.multi_split(text, [";"])
 
 
@@ -49,7 +49,7 @@ def read_rows(
                 #     context.log.info("Read %d rows..." % idx, file_name=file_name)
 
 
-def make_row_entity(context: Context, row: Dict[str, str], schema) -> None:
+def make_row_entity(context: Context, row: Dict[str, str], schema: str) -> None:
     # node_id = row.pop("id", row.pop("_id", row.pop("node_id", None)))
     node_id = row.pop("node_id", None)
     proxy = context.make(schema)

--- a/datasets/_global/research/crawler.py
+++ b/datasets/_global/research/crawler.py
@@ -40,7 +40,7 @@ def crawl_sec_row(context: Context, row: Dict[str, str]) -> None:
     context.audit_data(row)
 
 
-def crawl_sec(context: Context):
+def crawl_sec(context: Context) -> None:
     path = context.fetch_resource("sec-source.csv", SECURITIES_STATEMENTS_CSV)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
     with open(path, "r") as fh:
@@ -77,7 +77,7 @@ def crawl_sec(context: Context):
             crawl_sec_row(context, row)
 
 
-def crawl_sanction_ownership_row(context: Context, row: Dict):
+def crawl_sanction_ownership_row(context: Context, row: Dict) -> None:
     # source link to prove the relationships when a link exists
     source_link = stringify(row.pop("Source Link"))
     owner_schema = stringify(row.pop("Owner Schema"))
@@ -147,7 +147,7 @@ def crawl_sanction_ownership_row(context: Context, row: Dict):
         context.emit(ubo_ownership)
 
 
-def crawl_sanction_ownership(context: Context):
+def crawl_sanction_ownership(context: Context) -> None:
     path = context.fetch_resource(
         "sanction-ownership-source.csv", SANCTION_OWNERSHIP_CSV
     )
@@ -157,6 +157,6 @@ def crawl_sanction_ownership(context: Context):
             crawl_sanction_ownership_row(context, row)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     crawl_sec(context)
     crawl_sanction_ownership(context)

--- a/datasets/_global/shu_uyghur_companies/crawler.py
+++ b/datasets/_global/shu_uyghur_companies/crawler.py
@@ -1,6 +1,7 @@
 import openpyxl
 
 from zavod import Context, helpers as h
+from zavod.entity import Entity
 
 OPERATING_URL = "https://data.opensanctions.org/contrib/shu_uyghur_companies/Companies%20Operating%20in%20XUAR-web.archive.org-20240331100003.xlsx"
 LABOUR_TRANSFERS_URL = "https://data.opensanctions.org/contrib/shu_uyghur_companies/2023-07-03%20Companies%20Named%20in%20Reports%20v2-web.archive.org-20250102144725.xlsx"
@@ -22,7 +23,14 @@ OPERATING_SHEETS = {
 }
 
 
-def apply_addresses(context, entity, addr, addr_en, city, city_en) -> None:
+def apply_addresses(
+    context: Context,
+    entity: Entity,
+    addr: str | None,
+    addr_en: str | None,
+    city: str | None,
+    city_en: str | None,
+) -> None:
     """Create and apply addresses to an entity."""
     if addr:
         address_ent = h.make_address(context, full=addr, city=city, lang="zhu")
@@ -32,7 +40,7 @@ def apply_addresses(context, entity, addr, addr_en, city, city_en) -> None:
         h.copy_address(entity, address_en_ent)
 
 
-def crawl_labour_transfers(context: Context, labour_transfers_url) -> None:
+def crawl_labour_transfers(context: Context, labour_transfers_url: str) -> None:
     path = context.fetch_resource("labour_transfers.xlsx", labour_transfers_url)
     workbook: openpyxl.Workbook = openpyxl.load_workbook(path, read_only=True)
     assert set(workbook.sheetnames) == set(APP_LABOUR_SHEETS)
@@ -133,7 +141,7 @@ def crawl_labour_transfers(context: Context, labour_transfers_url) -> None:
         )
 
 
-def crawl_operating(context: Context, companies_url) -> None:
+def crawl_operating(context: Context, companies_url: str) -> None:
     path = context.fetch_resource("companies_registry.xlsx", companies_url)
     workbook: openpyxl.Workbook = openpyxl.load_workbook(path, read_only=True)
     assert set(workbook.sheetnames) == OPERATING_SHEETS

--- a/datasets/_global/worldbank/crawler.py
+++ b/datasets/_global/worldbank/crawler.py
@@ -6,7 +6,7 @@ from zavod import helpers as h
 SPLITS = r"(a\.k\.a\.?|aka|f/k/a|also known as|\(formerly |, also d\.b\.a\.|\(currently (d/b/a)?|d/b/a|\(name change from|, as the successor or assign to)"  # noqa
 
 
-def clean_name(text):
+def clean_name(text: str) -> list[str]:
     text = text.replace("M/S", "MS")
     parts = re.split(SPLITS, text, re.I)
     names = []

--- a/datasets/at/meine_abgeordneten/crawler.py
+++ b/datasets/at/meine_abgeordneten/crawler.py
@@ -7,14 +7,18 @@ from normality import collapse_spaces
 from requests import HTTPError
 
 from zavod import Context, helpers as h
+from zavod.entity import Entity
 from zavod.stateful.positions import OccupancyStatus, categorise
+from zavod.util import Element
 
 PARTY_NAMES = defaultdict(int)
 PARTY_REGEX = re.compile(r"(\([\w ]+\)|, [\w ]+$)")
 MAX_POSITION_NAME_LENGTH = 120
 
 
-def extract_dates(context: Context, url, el):
+def extract_dates(
+    context: Context, url: str, el: Element
+) -> tuple[str | None, str | None, bool]:
     active_date_el = el.find('.//span[@class="aktiv"]')
     inactive_dates_el = el.find('.//span[@class="inaktiv"]')
     start_date = None
@@ -69,7 +73,7 @@ def extract_dates(context: Context, url, el):
     return start_date, end_date, assume_current
 
 
-def strip_party_name(position_name):
+def strip_party_name(position_name: str) -> str:
     party_match = PARTY_REGEX.search(position_name)
     if party_match:
         party_name = party_match.group(0).strip()
@@ -83,7 +87,7 @@ def strip_party_name(position_name):
     return collapse_spaces(position_name)
 
 
-def crawl_sources(context, entity, el):
+def crawl_sources(context: Context, entity: Entity, el: Element) -> None:
     for source_el in el.xpath('.//p[contains(@class, "source")]'):
         text = collapse_spaces(source_el.text_content())
         entity.add("description", text)
@@ -91,7 +95,9 @@ def crawl_sources(context, entity, el):
             entity.add("sourceUrl", link.get("href"))
 
 
-def crawl_mandate(context, url, person, el):
+def crawl_mandate(
+    context: Context, url: str, person: Entity, el: Element
+) -> str | None:
     """Returns true if dates could be parsed for a PEP position."""
     start_date, end_date, assume_current = extract_dates(context, url, el)
 
@@ -150,7 +156,7 @@ def crawl_mandate(context, url, person, el):
         return start_date or end_date
 
 
-def crawl_title(context, url, person, el):
+def crawl_title(context: Context, url: str, person: Entity, el: Element) -> None:
     h1 = el.find(".//h1")
     position_name = h1.getnext().text_content().strip()
     position = h.make_position(context, position_name, country="at", lang="deu")
@@ -176,7 +182,7 @@ def crawl_title(context, url, person, el):
         context.emit(occupancy)
 
 
-def crawl_item(url_info_page: str, context: Context):
+def crawl_item(url_info_page: str, context: Context) -> None:
     try:
         info_page = context.fetch_html(url_info_page, cache_days=1, absolute_links=True)
     except HTTPError as e:
@@ -222,7 +228,7 @@ def crawl_item(url_info_page: str, context: Context):
         crawl_title(context, url_info_page, person, header_el)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     response = context.fetch_html(context.data_url)
 
     # XPath to the url for the pages of each politician

--- a/datasets/at/nbter_sanctions/crawler.py
+++ b/datasets/at/nbter_sanctions/crawler.py
@@ -1,11 +1,10 @@
 import csv
-from typing import Dict
 
 from zavod import Context
 from zavod import helpers as h
 
 
-def crawl_row(context: Context, row: Dict[str, str]):
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     full_name = row.pop("name")
     # Split `other_name` on `/` and trim any extra whitespace
     other_names = row.pop("other name").split("/")
@@ -58,7 +57,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
             context.emit(entity)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     doc = context.fetch_html(
         context.dataset.model.url, cache_days=1, absolute_links=True
     )

--- a/datasets/lt/fiu_freezes/crawler.py
+++ b/datasets/lt/fiu_freezes/crawler.py
@@ -4,6 +4,7 @@ from normality import slugify
 from zavod import Context
 from zavod import helpers as h
 from zavod.extract.zyte_api import fetch_html
+from zavod.util import ElementOrTree
 
 
 def crawl_page(
@@ -12,7 +13,7 @@ def crawl_page(
     unblock_validator: str,
     program_key: str,
     required: bool = True,
-):
+) -> ElementOrTree:
     doc = fetch_html(context, link, unblock_validator, cache_days=3)
     for p in h.xpath_elements(doc, ".//p"):
         p.tail = p.tail + "\n" if p.tail else "\n"
@@ -84,7 +85,7 @@ def crawl_page(
     return doc
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     assert context.dataset.model.url
     # Detect if new sanctions programs are added
     index_doc = fetch_html(

--- a/datasets/lt/illegal_gambling/crawler.py
+++ b/datasets/lt/illegal_gambling/crawler.py
@@ -1,9 +1,10 @@
 import re
-from typing import Generator, Dict, Tuple
+from typing import Iterator
 
 from normality import squash_spaces
 from zavod import Context
 from zavod import helpers as h
+from zavod.util import Element
 
 EXPECTED_HEADERS = [
     [
@@ -32,8 +33,8 @@ NAME_SPLITS = [
 
 
 def parse_table(
-    table,
-) -> Generator[Dict[str, str | Tuple[str]], None, None]:
+    table: Element,
+) -> Iterator[dict[str, str]]:
     """
     The first two rows of the table represent the headers, but we're not going to
     try and parse colspan and rowspan.
@@ -54,7 +55,7 @@ def parse_table(
         yield {hdr: c for hdr, c in zip(HEADERS, cells, strict=True)}
 
 
-def crawl_item(item, context: Context):
+def crawl_item(item: dict[str, str], context: Context) -> None:
     raw_names = item.pop("Name")
     domain = item.pop("Domain")
     contacts = item.pop("Contacts")
@@ -92,7 +93,7 @@ def crawl_item(item, context: Context):
     context.emit(entity)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     response = context.fetch_html(context.data_url)
     tables = response.findall(".//table")
     for table in tables:

--- a/datasets/lt/illegal_websites/crawler.py
+++ b/datasets/lt/illegal_websites/crawler.py
@@ -1,12 +1,11 @@
 import csv
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod import Context
 from zavod.extract.zyte_api import fetch_resource
 
 
-def crawl_row(context: Context, row: Dict[str, str]):
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     domain = row.pop("\ufeffDomenas")
     company_name = row.pop("Bendrovės pavadinimas")
     brand_name = row.pop("Prekės ženklas")
@@ -23,7 +22,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
     context.audit_data(row)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     _, _, _, path = fetch_resource(
         context,
         "source.csv",

--- a/datasets/lt/magnitsky_amendments/crawler.py
+++ b/datasets/lt/magnitsky_amendments/crawler.py
@@ -1,9 +1,11 @@
 import json
+from typing import Any
+
 from zavod import Context
 from zavod import helpers as h
 
 
-def map_gender(gender_code):
+def map_gender(gender_code: str) -> str | None:
     gender_map = {
         "V": "male",
         "M": "female",  # Assuming "M" stands for female in Lithuanian
@@ -11,7 +13,7 @@ def map_gender(gender_code):
     return gender_map.get(gender_code)
 
 
-def crawl_page(context: Context, entry):
+def crawl_page(context: Context, entry: dict[str, Any]) -> None:
     person = context.make("Person")
     # ID based on the person's first and last name
     person_id = context.make_id(entry.get("vardas"), entry.get("pavarde"))
@@ -42,7 +44,7 @@ def crawl_page(context: Context, entry):
     context.emit(sanction)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     page = 0
     while True:
         url = f"https://www.migracija.lt/external/nam/search?pageNo={page}&pageSize=100&language=lt"

--- a/datasets/md/companies/parse.py
+++ b/datasets/md/companies/parse.py
@@ -24,7 +24,7 @@ LEGAL_ENTITIES_URL = "https://dataset.gov.md/ro/dataset/11736-date-din-registrul
 REGEX_CONTAINS_WORDS = re.compile(r"\w{2}")
 
 
-def read_ckan(context: Context, source_url, label) -> str:
+def read_ckan(context: Context, source_url: str, label: str) -> str:
     resource_list_doc = context.fetch_html(source_url)
 
     resource_item_els = list(
@@ -183,7 +183,7 @@ def parse_companies(context: Context, book: Workbook) -> None:
             context.log.info("Read %d companies..." % idx)
 
 
-def parse_nonprofits(context, wb):
+def parse_nonprofits(context: Context, wb: Workbook) -> None:
     assert set(wb.sheetnames) == {wb.active.title}
     for row in h.parse_xlsx_sheet(
         context,

--- a/datasets/md/interdictie/crawler.py
+++ b/datasets/md/interdictie/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import Iterator, List
 from lxml import html
 from rigour.mime.types import HTML
 
@@ -37,7 +37,7 @@ ROLES = {
 }
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(path, HTML, title=context.SOURCE_TITLE)
     with open(path, "r") as fh:
@@ -93,7 +93,7 @@ def crawl(context: Context):
         context.emit(sanction)
 
 
-def parse_date(text: str, context: Context):
+def parse_date(text: str, context: Context) -> str | None:
     segments = text.split(", ")
     if len(segments) == 3:
         text = " ".join(segments[1:])
@@ -105,12 +105,14 @@ def parse_date(text: str, context: Context):
     return None
 
 
-def parse_sanction_decision(context, text):
+def parse_sanction_decision(
+    context: Context, text: str
+) -> tuple[str | None, str | None]:
     match = REGEX_SANCTION_NUMBER.match(text)
     if match:
         return match.group(1), parse_date(match.group(2), context)
     else:
-        context.log.warn(f'Failed to parse saction number and date from "{ text }"')
+        context.log.warn(f'Failed to parse saction number and date from "{text}"')
         return None, None
 
 
@@ -124,7 +126,9 @@ def clean_control_string(text: str) -> str:
     return text
 
 
-def crawl_control(context: Context, entity: Entity, date, text: str):
+def crawl_control(
+    context: Context, entity: Entity, date: str | None, text: str
+) -> None:
     entities = []
     text = clean_control_string(text)
     match = re.match(REGEX_MEMBER_GROUPS, text)
@@ -164,7 +168,9 @@ def crawl_control(context: Context, entity: Entity, date, text: str):
         context.emit(entity)
 
 
-def make_ownerships(context, company: Entity, date, owners: List[str]) -> Entity:
+def make_ownerships(
+    context: Context, company: Entity, date: str | None, owners: List[str]
+) -> Iterator[Entity]:
     for name in owners:
         name = name.strip()
         match = re.match(r"^([^\d\.\()]+)(\(?(\d+\.?\d*) ?%\)?)?$", name)
@@ -188,7 +194,9 @@ def make_ownerships(context, company: Entity, date, owners: List[str]) -> Entity
             yield ownership
 
 
-def make_members(context, company: Entity, date, members: List[str]):
+def make_members(
+    context: Context, company: Entity, date: str | None, members: List[str]
+) -> Iterator[Entity]:
     for name in members:
         name = name.strip()
         if name:

--- a/datasets/md/rise_profiles/crawler.py
+++ b/datasets/md/rise_profiles/crawler.py
@@ -1,7 +1,7 @@
 from urllib.parse import urljoin, urlencode
 from normality import collapse_spaces, slugify
 
-from zavod import Context
+from zavod import Context, Entity
 from zavod import helpers as h
 
 CACHE_DAYS = 14
@@ -10,7 +10,9 @@ COUNTRY = "md"
 relationships = dict()
 
 
-def crawl_entity(context: Context, relative_url: str, follow_relations: bool = True):
+def crawl_entity(
+    context: Context, relative_url: str, follow_relations: bool = True
+) -> Entity | None:
     url = urljoin(context.data_url, relative_url)
     doc = context.fetch_html(url, cache_days=CACHE_DAYS)
     name_el = doc.find('.//span[@class="name"]')
@@ -78,7 +80,7 @@ def crawl_entity(context: Context, relative_url: str, follow_relations: bool = T
 
 def make_person(
     context: Context, url: str, name: str, position: str | None, attributes: dict
-):
+) -> Entity:
     person = context.make("Person")
     identification = [COUNTRY, name]
     birth_date = attributes.pop("data-nasterii", None)
@@ -98,7 +100,7 @@ def make_person(
     return person
 
 
-def make_company(context: Context, url: str, name: str, attributes: dict):
+def make_company(context: Context, url: str, name: str, attributes: dict) -> Entity:
     company = context.make("Company")
     identification = [COUNTRY, name]
     founded = attributes.pop("data-inregistrarii", None)
@@ -120,7 +122,9 @@ def make_company(context: Context, url: str, name: str, attributes: dict):
     return company
 
 
-def make_legal_entity(context: Context, url: str, name: str, attributes: dict):
+def make_legal_entity(
+    context: Context, url: str, name: str, attributes: dict
+) -> Entity:
     entity = context.make("LegalEntity")
     identification = [COUNTRY, name]
     # founded = parse_date(attributes.get("data-fondarii"))
@@ -159,7 +163,13 @@ def make_legal_entity(context: Context, url: str, name: str, attributes: dict):
     return entity
 
 
-def make_relation(context, source, description, dest_name, dest_url):
+def make_relation(
+    context: Context,
+    source: Entity,
+    description: str | None,
+    dest_name: str | None,
+    dest_url: str | None,
+) -> None:
     res = context.lookup("relations", description)
     dest = None
     if dest_url:
@@ -186,11 +196,11 @@ def make_relation(context, source, description, dest_name, dest_url):
     context.emit(relation)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     query = {"br": 0, "lang": "rom"}
     while True:
         context.log.debug("Crawling index offset ", query)
-        url = f"{ context.data_url }?{ urlencode(query) }"
+        url = f"{context.data_url}?{urlencode(query)}"
         doc = context.fetch_html(url)
         profiles = doc.findall('.//div[@class="profileWindow"]//a')
 

--- a/datasets/md/terror_sanctions/crawler.py
+++ b/datasets/md/terror_sanctions/crawler.py
@@ -24,7 +24,7 @@ SPLITS = [
 ]
 
 
-def clean_name(string: str):
+def clean_name(string: str) -> str:
     name = re.sub(r"^[\]\), ]+", "", string)
     name = re.sub(r"[\[\(\., ]+$", "", string)
     return name
@@ -38,7 +38,7 @@ def parse_names(string: str) -> Tuple[str, List[str]]:
     return name, aliases
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(path, HTML, title=context.SOURCE_TITLE)
     with open(path, "r") as fh:

--- a/datasets/ng/chipper_peps/crawler.py
+++ b/datasets/ng/chipper_peps/crawler.py
@@ -34,13 +34,13 @@ REGEX_HOUSE_REP = re.compile(
 # House of Representatives Deputy Chairman Army
 
 
-def has_length(name: Optional[str], length: int):
+def has_length(name: Optional[str], length: int) -> bool:
     if name is None:
         return False
     return len(name.strip().strip(".")) >= length
 
 
-def crawl_position(context: Context, entity: Entity, name: str):
+def crawl_position(context: Context, entity: Entity, name: str) -> None:
     name = REGEX_FIX_COMMA.sub(r"\1, \2", name)
     name_lower = name.lower()
 
@@ -79,7 +79,7 @@ def crawl_position(context: Context, entity: Entity, name: str):
         entity.add("topics", "poi")
 
 
-def crawl_row(context: Context, row: Dict[str, str]):
+def crawl_row(context: Context, row: Dict[str, str]) -> None:
     entity = context.make("Person")
     identifier = row.pop("Unique Identifier")
     if not identifier:
@@ -135,7 +135,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
     context.emit(entity)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
     with open(path, "r") as fh:

--- a/datasets/ng/join_dots/crawler.py
+++ b/datasets/ng/join_dots/crawler.py
@@ -1,5 +1,5 @@
 import openpyxl
-from typing import Any, Dict, Generator, List, Optional, Tuple
+from typing import Any, Iterator, Optional, Tuple
 from normality import collapse_spaces, slugify
 from rigour.mime.types import XLSX
 import re
@@ -59,7 +59,7 @@ def clean_position(
         return res.name
 
 
-def position_topics(position):
+def position_topics(position: str) -> list[str]:
     if "President Federal Republic Of Nigeria" in position:
         return ["gov.national", "gov.head"]
     if position.startswith("Minister"):
@@ -83,7 +83,9 @@ def parse_position_dates(string: Optional[str]) -> Tuple[Optional[str], Optional
     return start, end
 
 
-def crawl_pep(context: Context, row) -> Tuple[Optional[str], Optional[str]]:
+def crawl_pep(
+    context: Context, row: dict[str, Any]
+) -> Tuple[Optional[str], Optional[str]]:
     name = row.pop("name")
     birth_date = row.pop("date_of_birth", None)
     birth_date = birth_date.isoformat()[:10] if birth_date else None
@@ -132,7 +134,9 @@ def crawl_pep(context: Context, row) -> Tuple[Optional[str], Optional[str]]:
     return None, None
 
 
-def crawl_relative(context: Context, row, pep_ids):
+def crawl_relative(
+    context: Context, row: dict[str, Any], pep_ids: dict[str | None, str | None]
+) -> None:
     name = row.pop("name")
     pep_name = row.pop("pep_name")
     pep_id = pep_ids.get(slugify(pep_name), None)
@@ -158,8 +162,8 @@ def crawl_relative(context: Context, row, pep_ids):
     context.emit(rel)
 
 
-def worksheet_rows(sheet) -> Generator[Dict[str, Any], None, None]:
-    headers: Optional[List[str]] = None
+def worksheet_rows(sheet: Any) -> Iterator[dict[str, Any]]:
+    headers: list[str] | None = None
     for row in sheet.rows:
         cells = [c.value for c in row]
         if headers is None:
@@ -168,7 +172,7 @@ def worksheet_rows(sheet) -> Generator[Dict[str, Any], None, None]:
         yield dict(zip(headers, cells))
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     pep_ids = {}
     dupes = set()
 

--- a/datasets/ng/nigsac_sanctions/crawler.py
+++ b/datasets/ng/nigsac_sanctions/crawler.py
@@ -1,5 +1,4 @@
 from lxml import html
-from typing import Dict
 from rigour.mime.types import HTML
 from normality import collapse_spaces, slugify
 
@@ -8,7 +7,7 @@ from zavod import helpers as h
 from zavod.entity import Entity
 
 
-def format_birth_place(city, country):
+def format_birth_place(city: str | None, country: str | None) -> str | None:
     if city and country:
         return f"{city}, {country}"
     if city:
@@ -18,7 +17,7 @@ def format_birth_place(city, country):
     return None
 
 
-def parse_page(context: Context, url) -> Dict[str, str]:
+def parse_page(context: Context, url: str) -> dict[str, str | None]:
     doc = context.fetch_html(url, cache_days=1)
     data = dict()
     for dt in doc.findall(".//dt"):
@@ -37,7 +36,13 @@ def parse_page(context: Context, url) -> Dict[str, str]:
     return data
 
 
-def crawl_common(context: Context, url: str, entity: Entity, sanction: Entity, data):
+def crawl_common(
+    context: Context,
+    url: str,
+    entity: Entity,
+    sanction: Entity,
+    data: dict[str, str | None],
+) -> None:
     entity.add("sourceUrl", url)
     entity.add("topics", "sanction")
     entity.add("notes", data.pop("narrative-summary"))
@@ -51,7 +56,7 @@ def crawl_common(context: Context, url: str, entity: Entity, sanction: Entity, d
     context.audit_data(data, ["phone-numbers"])
 
 
-def crawl_individual(context: Context, url: str, data: Dict[str, str]):
+def crawl_individual(context: Context, url: str, data: dict[str, str | None]) -> None:
     first_name = data.pop("first-name")
     middle_name = data.pop("middlename")
     last_name = data.pop("surname")
@@ -93,7 +98,7 @@ def crawl_individual(context: Context, url: str, data: Dict[str, str]):
     crawl_common(context, url, entity, sanction, data)
 
 
-def crawl_entity(context: Context, url: str, data: Dict[str, str]):
+def crawl_entity(context: Context, url: str, data: dict[str, str | None]) -> None:
     entity = context.make("LegalEntity")
     name = data.pop("entity-name")
     entity.id = context.make_id(name)
@@ -109,7 +114,7 @@ def crawl_entity(context: Context, url: str, data: Dict[str, str]):
     crawl_common(context, url, entity, sanction, data)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(path, HTML, title=context.SOURCE_TITLE)
     with open(path, "r") as fh:

--- a/datasets/sg/gov_dir/crawler.py
+++ b/datasets/sg/gov_dir/crawler.py
@@ -87,7 +87,13 @@ class CrawlState(object):
     uncategorised = set()
 
 
-def make_position_name(rank, public_body, agency, section_name, hierarchy):
+def make_position_name(
+    rank: str,
+    public_body: str,
+    agency: str,
+    section_name: str,
+    hierarchy: str | None,
+) -> str:
     if agency:
         position = f"{rank}, {section_name}, {agency}"
     else:
@@ -130,7 +136,13 @@ def make_hierarchy(breadcrumbs: HtmlElement) -> Optional[str]:
     return None
 
 
-def check_expectations(context: Context, link, official_count, pep_count, expectations):
+def check_expectations(
+    context: Context,
+    link: str,
+    official_count: int,
+    pep_count: int,
+    expectations: dict[str, int] | None,
+) -> None:
     if expectations:
         if official_count < expectations["officials"]:
             context.log.warning(
@@ -153,9 +165,9 @@ def crawl_person(
     state: CrawlState,
     official: HtmlElement,
     link: str,
-    public_body,
-    agency,
-    section_name,
+    public_body: str,
+    agency: str,
+    section_name: str,
     hierarchy: Optional[str],
 ) -> bool:
     """Returns true if the crawled person is a PEP based on the provided position info"""
@@ -224,7 +236,7 @@ def crawl_person(
     return False
 
 
-def crawl_body(context: Context, state: CrawlState, link) -> None:
+def crawl_body(context: Context, state: CrawlState, link: str) -> None:
     """Crawl a government body page"""
     if link in state.seen_urls:
         return
@@ -298,7 +310,7 @@ def crawl_body(context: Context, state: CrawlState, link) -> None:
         crawl_body(context, state, subdivision_link.get("href"))
 
 
-def crawl_spokespersons(context: Context, state: CrawlState):
+def crawl_spokespersons(context: Context, state: CrawlState) -> None:
     """Crawl the root page to find all spokesperson links and process them."""
     main_doc = context.fetch_html(SPOKEPERSONS_URL, cache_days=1)
 
@@ -310,8 +322,12 @@ def crawl_spokespersons(context: Context, state: CrawlState):
 
 
 def crawl_subpage(
-    context: Context, state: CrawlState, link: str, public_body, agency=None
-):
+    context: Context,
+    state: CrawlState,
+    link: str,
+    public_body: str,
+    agency: str | None = None,
+) -> None:
     """Crawls a spokesperson page to extract spokesperson details and visit subdivision links."""
     if link in state.seen_urls:
         return
@@ -330,7 +346,7 @@ def crawl_subpage(
             crawl_subpage(context, state, sub_link, public_body, agency)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     assert is_pep(context, "Director of this") is True
     assert is_pep(context, "Deputy director") is True
     assert is_pep(context, "DEADBEEF") is None

--- a/datasets/sg/gov_dir/crawler.py
+++ b/datasets/sg/gov_dir/crawler.py
@@ -88,6 +88,7 @@ class CrawlState(object):
 
 
 def make_position_name(
+    *,
     rank: str,
     public_body: str,
     agency: str,
@@ -138,7 +139,8 @@ def make_hierarchy(breadcrumbs: HtmlElement) -> Optional[str]:
 
 def check_expectations(
     context: Context,
-    link: str,
+    url: str,
+    *,
     official_count: int,
     pep_count: int,
     expectations: dict[str, int] | None,
@@ -149,14 +151,14 @@ def check_expectations(
                 "Insufficient officials",
                 expected=expectations["officials"],
                 actual=official_count,
-                url=link,
+                url=url,
             )
         if pep_count < expectations["peps"]:
             context.log.warning(
                 "Insufficient PEPs",
                 expected=expectations["peps"],
                 actual=pep_count,
-                url=link,
+                url=url,
             )
 
 
@@ -164,7 +166,8 @@ def crawl_person(
     context: Context,
     state: CrawlState,
     official: HtmlElement,
-    link: str,
+    url: str,
+    *,
     public_body: str,
     agency: str,
     section_name: str,
@@ -188,7 +191,11 @@ def crawl_person(
 
     pep_status = is_pep(context, rank)
     position_name = make_position_name(
-        rank, public_body, agency, section_name, hierarchy
+        rank=rank,
+        public_body=public_body,
+        agency=agency,
+        section_name=section_name,
+        hierarchy=hierarchy,
     )
     # Override status and position name for MPs
     if collapse_spaces(section_name.lower()) == "members of parliament":
@@ -205,7 +212,7 @@ def crawl_person(
     # contains roles (scientists, clinical stuff, etc) that don't require citizenship
     person.add("country", "sg")
     person.add("name", full_name)
-    person.add("sourceUrl", link)
+    person.add("sourceUrl", url)
     person.add("position", rank)
     if title is not None:
         person.add("title", title)
@@ -231,26 +238,26 @@ def crawl_person(
             context.emit(occupancy)
             return True
     elif categorisation.is_pep is None:
-        context.log.info("Uncategorised position", position=position_name, url=link)
+        context.log.info("Uncategorised position", position=position_name, url=url)
         state.uncategorised.add(position_name)
     return False
 
 
-def crawl_body(context: Context, state: CrawlState, link: str) -> None:
+def crawl_body(context: Context, state: CrawlState, url: str) -> None:
     """Crawl a government body page"""
-    if link in state.seen_urls:
+    if url in state.seen_urls:
         return
-    state.seen_urls.add(link)
-    expectations = PAGE_EXPECTATIONS.get(link, None)
+    state.seen_urls.add(url)
+    expectations = PAGE_EXPECTATIONS.get(url, None)
     official_count = 0
     pep_count = 0
     try:
-        board_doc = context.fetch_html(link, cache_days=1)
+        board_doc = context.fetch_html(url, cache_days=1)
     except HTTPError as e:
         if e.response.status_code == 403:
             # We see one 403 right now - maybe it's in a "draft" state or something?
             # https://www.sgdi.gov.sg/ministries/mnd/statutory-boards/bca/departments/p--c/departments/wppd
-            context.log.info("Access denied for body page", url=link)
+            context.log.info("Access denied for body page", url=url)
             return
         raise
 
@@ -285,11 +292,11 @@ def crawl_body(context: Context, state: CrawlState, link: str) -> None:
                 context,
                 state,
                 official,
-                link,
-                public_body,
-                agency,
-                section_name,
-                hierarchy,
+                url,
+                public_body=public_body,
+                agency=agency,
+                section_name=section_name,
+                hierarchy=hierarchy,
             )
             if is_pep:
                 pep_count += 1
@@ -299,12 +306,25 @@ def crawl_body(context: Context, state: CrawlState, link: str) -> None:
         for official in section.findall(".//li[@id]"):
             official_count += 1
             is_pep = crawl_person(
-                context, state, official, link, public_body, agency, "", hierarchy
+                context,
+                state,
+                official,
+                url,
+                public_body=public_body,
+                agency=agency,
+                section_name="",
+                hierarchy=hierarchy,
             )
             if is_pep:
                 pep_count += 1
 
-    check_expectations(context, link, official_count, pep_count, expectations)
+    check_expectations(
+        context,
+        url,
+        official_count=official_count,
+        pep_count=pep_count,
+        expectations=expectations,
+    )
     subdivision_links = board_doc.xpath(".//div[contains(@class, 'tab-content')]//a")
     for subdivision_link in subdivision_links:
         crawl_body(context, state, subdivision_link.get("href"))
@@ -316,34 +336,46 @@ def crawl_spokespersons(context: Context, state: CrawlState) -> None:
 
     for list_item in main_doc.xpath(".//ul[@class='contact-list']//a"):
         # Extract the public body from the text within an <a> element
-        link_url = list_item.get("href")
+        url = list_item.get("href")
         public_body = list_item.text_content().strip()
-        crawl_subpage(context, state, link_url, public_body)
+        crawl_subpage(context, state, url, public_body=public_body)
 
 
 def crawl_subpage(
     context: Context,
     state: CrawlState,
-    link: str,
+    url: str,
+    *,
     public_body: str,
     agency: str | None = None,
 ) -> None:
     """Crawls a spokesperson page to extract spokesperson details and visit subdivision links."""
-    if link in state.seen_urls:
+    if url in state.seen_urls:
         return
-    state.seen_urls.add(link)
-    subpage_doc = context.fetch_html(link)
+    state.seen_urls.add(url)
+    subpage_doc = context.fetch_html(url)
     # Main subpage
     for person in subpage_doc.xpath("//div[@class='section-info']//li"):
-        crawl_person(context, state, person, link, public_body, agency, "", None)
+        crawl_person(
+            context,
+            state,
+            person,
+            url,
+            public_body=public_body,
+            agency=agency or "",
+            section_name="",
+            hierarchy=None,
+        )
     # Subsections
     for subsection_el in subpage_doc.xpath(
         ".//div[@class='tab-content']//ul[@class='section-listing']//a"
     ):
-        sub_link = subsection_el.get("href")
+        sub_url = subsection_el.get("href")
         agency = subsection_el.text_content().strip()
-        if sub_link:
-            crawl_subpage(context, state, sub_link, public_body, agency)
+        if sub_url:
+            crawl_subpage(
+                context, state, sub_url, public_body=public_body, agency=agency
+            )
 
 
 def crawl(context: Context) -> None:
@@ -362,15 +394,15 @@ def crawl(context: Context) -> None:
             ".//div[@class='directory-list']//ul[@class='ministries']//li//a"
         )
         for board in bodies:
-            link = board.get("href")
+            url = board.get("href")
             org_name = board.text_content().strip()
-            if link is None:
+            if url is None:
                 context.log.warning("No link found", org_name=org_name)
                 continue
             if org_name == "":
-                context.log.warning("No org name found", link=link)
+                context.log.warning("No org name found", url=url)
                 continue
-            crawl_body(context, state, link)
+            crawl_body(context, state, url)
     # Crawl spokespersons pages
     crawl_spokespersons(context, state)
     expected = set(PAGE_EXPECTATIONS.keys())

--- a/datasets/sg/mas_investor_alert/crawler.py
+++ b/datasets/sg/mas_investor_alert/crawler.py
@@ -1,11 +1,13 @@
 import itertools
 import json
 from collections import namedtuple
+from typing import Any
 
 from rigour.mime.types import JSON
 from followthemoney.types import registry
 
 from zavod import Context, helpers as h
+from zavod.entity import Entity
 
 
 IGNORE = [
@@ -17,7 +19,7 @@ OWNERSHIP_KEYWORDS = ["owned ", "managed ", "operates ", "operated "]
 WEBSITE_KEYWORDS = [".com", ".net", ".org", "https:", "http:", "www.", ".sg", ".co"]
 
 
-def check_num_found(context, data):
+def check_num_found(context: Context, data: dict[str, Any]) -> None:
     num_found = data.get("response").get("numFound")
     if num_found is None:
         context.log.warn("Response doesn't contain numFound field")
@@ -28,7 +30,9 @@ def check_num_found(context, data):
             )
 
 
-def emit_ownership(context, entity, owner_name, name):
+def emit_ownership(
+    context: Context, entity: Entity, owner_name: str, name: str
+) -> None:
     result = context.lookup("ownership", name)
     if result is not None:
         entity.add("name", result.entity_name)
@@ -49,7 +53,9 @@ def emit_ownership(context, entity, owner_name, name):
         context.log.warning(f'Name "{name}" needs to be remapped', value=name)
 
 
-def emit_relationship(context, entity, related_ids, root_seen_ids):
+def emit_relationship(
+    context: Context, entity: Entity, related_ids: list[str], root_seen_ids: set[str]
+) -> None:
     for rel_id in related_ids:
         if rel_id not in root_seen_ids:
             # The relations described here should have a peer at the root level, otherwise they are dangling.
@@ -67,7 +73,7 @@ def emit_relationship(context, entity, related_ids, root_seen_ids):
         context.emit(rel)
 
 
-def add_lookup_items(context, entity, name):
+def add_lookup_items(context: Context, entity: Entity, name: str) -> None:
     res = context.lookup("names", name)
     if res:
         # This lookup may return either a 'name', a 'website', or both.
@@ -125,7 +131,7 @@ def crawl_item(context: Context, item: dict) -> CrawlItemResult:
     return CrawlItemResult(entity=entity, source_id=id, related_source_ids=related_ids)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
     with open(path, "r", encoding="utf-8") as fh:

--- a/datasets/ua/edr/parse.py
+++ b/datasets/ua/edr/parse.py
@@ -23,7 +23,7 @@ def tag_text(el: Element) -> str:
     return tostring(el, encoding="utf-8").decode("utf-8")
 
 
-def parse_owner(context: Context, company_id: str, unique_id: str, el: Element):
+def parse_owner(context: Context, company_id: str, unique_id: str, el: Element) -> None:
     if el.text is None:
         return
     if "причина відсутності:" in el.text:
@@ -64,7 +64,7 @@ def parse_owner(context: Context, company_id: str, unique_id: str, el: Element):
         context.emit(ownership)
 
 
-def parse_uo(context: Context, fh: IO[bytes]):
+def parse_uo(context: Context, fh: IO[bytes]) -> None:
     for idx, (_, el) in enumerate(etree.iterparse(fh, tag="RECORD")):
         if idx > 0 and idx % 10000 == 0:
             context.log.info("Parse UO records: %d..." % idx)
@@ -140,7 +140,7 @@ def parse_uo(context: Context, fh: IO[bytes]):
 #         el.clear()
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     path = context.get_resource_path("source.zip")
     fetch_internal_data("ua_edr/23022022.zip", path)
     context.log.info("Parsing: %s" % path)

--- a/datasets/ua/war_sanctions/crawler.py
+++ b/datasets/ua/war_sanctions/crawler.py
@@ -208,17 +208,17 @@ def generate_token(context: Context, cid: str, pkey: str) -> str:
     return token
 
 
-def apply_names(context: Context, person: Entity, person_data: Dict[str, str]):
+def apply_names(context: Context, person: Entity, person_data: Dict[str, str]) -> None:
     for key, lang in NAMES_LANG_MAP.items():
         raw_name = person_data.pop(key)
         h.apply_reviewed_name_string(context, person, string=raw_name, lang=lang)
 
 
-def make_id(context: Context, entity_type: str, raw_id: str):
+def make_id(context: Context, entity_type: str, raw_id: str) -> str | None:
     return context.make_slug(entity_type, raw_id)
 
 
-def split_dob_dod(raw_date):
+def split_dob_dod(raw_date: str) -> tuple[str | None, str | None]:
     parts = [p.strip() for p in raw_date.split("-")]
     dob = parts[0] if parts and parts[0] else None
     dod = parts[1] if len(parts) > 1 and parts[1] else None
@@ -274,13 +274,13 @@ def load_managers(context: Context, program_key: str) -> Dict[str, Dict]:
 
 def crawl_ship_relation(
     context: Context,
-    party_info,
-    vessel_id_slug,
+    party_info: Dict[str, Any],
+    vessel_id_slug: str | None,
     managers_lookup: Dict[str, Dict],
     program_key: str,
     source_url: str,
     rel_role: Optional[str] = None,
-):
+) -> None:
     company_id_raw = party_info.pop("id")
     start_date = party_info.pop("date")
     # Note: We intentionally skip "c/o" (care of) relationships between companies.
@@ -326,14 +326,14 @@ def crawl_ship_relation(
 def emit_relation(
     context: Context,
     *,
-    subject_id,
-    object_id,
+    subject_id: str | None,
+    object_id: str | None,
     rel_schema: str = "UnknownLink",
     rel_role: Optional[str] = None,
     from_prop: str = "subject",
     to_prop: str = "object",
     start_date: Optional[str] = None,
-):
+) -> None:
     relation = context.make(rel_schema)
     relation.id = context.make_id(
         object_id, rel_role, subject_id, start_date, rel_schema
@@ -348,13 +348,13 @@ def emit_relation(
 
 def crawl_person(
     context: Context,
-    person_data,
-    program_key,
-    endpoint,
-    source_url,
+    person_data: Dict[str, Any],
+    program_key: str,
+    endpoint: str,
+    source_url: str,
     topic: Optional[str] = "poi",
     known_vessel_ids: set[str] | None = None,
-):
+) -> None:
     birth_date = person_data.pop("date_bd")
     death_date = person_data.pop("date_death", None)
     if "- " in birth_date:
@@ -441,7 +441,7 @@ def crawl_legal_entity(
     topic: Optional[str] = "poi",
     reg_prop: str = "ogrnCode",
     itn_prop: str = "innCode",
-):
+) -> None:
     legal_entity = context.make("LegalEntity")
     legal_entity.id = make_id(context, WSAPIDataType.ENTITY, company_data.pop("id"))
     legal_entity.add("name", h.multi_split(company_data.pop("name"), [" / "]))
@@ -495,7 +495,7 @@ def emit_manager(
     management_data: Dict,
     program_key: str,
     source_url: str,
-):
+) -> None:
     """Emit a manager entity. Call only when manager is referenced by a ship."""
     # Make a copy to avoid mutating the cached lookup dict
     management_data = management_data.copy()
@@ -524,11 +524,11 @@ def emit_manager(
 
 def crawl_vessel(
     context: Context,
-    vessel_data,
-    program_key,
+    vessel_data: Dict[str, Any],
+    program_key: str,
     managers_lookup: Dict[str, Dict],
     source_url: str,
-):
+) -> None:
     raw_vessel_id = vessel_data.pop("id")
     vessel = context.make("Vessel")
     vessel.id = make_id(context, WSAPIDataType.VESSEL, raw_vessel_id)
@@ -616,7 +616,7 @@ def crawl_vessel(
     )
 
 
-def crawl_rostec_structure(context: Context, structure_data):
+def crawl_rostec_structure(context: Context, structure_data: Dict[str, Any]) -> None:
     company_id = structure_data.pop("company_id")
     parent_id = structure_data.pop("parent_id")
     if parent_id and company_id:
@@ -631,7 +631,7 @@ def crawl_rostec_structure(context: Context, structure_data):
         )
 
 
-def check_updates(context: Context):
+def check_updates(context: Context) -> None:
     # NOTE: When debugging, uncomment the logging below ONLY in local development.
     # Do not enable in production or commit uncommented to avoid leaking
     # the API docs key in the logs.
@@ -702,7 +702,7 @@ def check_updates(context: Context):
     # - structure
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     check_updates(context)
 
     # Load all managers once upfront from the /transport/management endpoint

--- a/datasets/ua/war_sanctions/crawler.py
+++ b/datasets/ua/war_sanctions/crawler.py
@@ -277,6 +277,7 @@ def crawl_ship_relation(
     party_info: Dict[str, Any],
     vessel_id_slug: str | None,
     managers_lookup: Dict[str, Dict],
+    *,
     program_key: str,
     source_url: str,
     rel_role: Optional[str] = None,
@@ -292,7 +293,12 @@ def crawl_ship_relation(
     # Convert to string to match the string keys in managers_lookup
     company_id_str = str(company_id_raw)
     if company_id_str in managers_lookup:
-        emit_manager(context, managers_lookup[company_id_str], program_key, source_url)
+        emit_manager(
+            context,
+            managers_lookup[company_id_str],
+            program_key=program_key,
+            source_url=source_url,
+        )
     else:
         context.log.warn(
             "company_id not found in the managers_lookup", company_id=company_id_str
@@ -349,6 +355,7 @@ def emit_relation(
 def crawl_person(
     context: Context,
     person_data: Dict[str, Any],
+    *,
     program_key: str,
     endpoint: str,
     source_url: str,
@@ -436,6 +443,7 @@ def crawl_person(
 def crawl_legal_entity(
     context: Context,
     company_data: Dict[str, str],
+    *,
     program_key: Optional[str],
     source_url: str,
     topic: Optional[str] = "poi",
@@ -493,6 +501,7 @@ def crawl_legal_entity(
 def emit_manager(
     context: Context,
     management_data: Dict,
+    *,
     program_key: str,
     source_url: str,
 ) -> None:
@@ -525,8 +534,9 @@ def emit_manager(
 def crawl_vessel(
     context: Context,
     vessel_data: Dict[str, Any],
-    program_key: str,
     managers_lookup: Dict[str, Dict],
+    *,
+    program_key: str,
     source_url: str,
 ) -> None:
     raw_vessel_id = vessel_data.pop("id")
@@ -577,9 +587,9 @@ def crawl_vessel(
             party_info,
             vessel.id,
             managers_lookup,
-            program_key,
-            source_url,
-            role,
+            program_key=program_key,
+            source_url=source_url,
+            rel_role=role,
         )
 
     pi_club_info = vessel_data.pop("pi_club", None)
@@ -729,9 +739,9 @@ def crawl(context: Context) -> None:
                 crawl_person(
                     context,
                     entity_details,
-                    link.program_key,
-                    link.endpoint,
-                    source_url,
+                    program_key=link.program_key,
+                    endpoint=link.endpoint,
+                    source_url=source_url,
                     topic=link.topic,
                     known_vessel_ids=vessel_ids,
                 )
@@ -739,8 +749,8 @@ def crawl(context: Context) -> None:
                 crawl_legal_entity(
                     context,
                     entity_details,
-                    link.program_key,
-                    source_url,
+                    program_key=link.program_key,
+                    source_url=source_url,
                     topic=link.topic,
                     reg_prop=link.reg_prop,
                     itn_prop=link.itn_prop,
@@ -750,9 +760,9 @@ def crawl(context: Context) -> None:
                 crawl_vessel(
                     context,
                     entity_details,
-                    link.program_key,
                     managers_lookup,
-                    source_url,
+                    program_key=link.program_key,
+                    source_url=source_url,
                 )
             elif link.type is WSAPIDataType.MANAGER:
                 continue

--- a/datasets/za/fic_sanctions/crawler.py
+++ b/datasets/za/fic_sanctions/crawler.py
@@ -66,7 +66,7 @@ def clean_passports(context: Context, text: str) -> List[str]:
     return passports, ids
 
 
-def crawl_row(context: Context, data: Dict[str, str]):
+def crawl_row(context: Context, data: Dict[str, str]) -> None:
     full_name = data.pop("FullName", None)
     if full_name is not None:
         ent_id = data.pop("IndividualID")
@@ -127,7 +127,7 @@ def crawl_row(context: Context, data: Dict[str, str]):
     context.emit(sanction)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     path = context.fetch_resource(
         "source.xml",
         context.data_url,

--- a/datasets/za/mm_officials/crawler.py
+++ b/datasets/za/mm_officials/crawler.py
@@ -32,7 +32,7 @@ REGEX_NAME_CLEAN = re.compile(
 )
 
 
-def clean_emails(emails):
+def clean_emails(emails: str | None) -> list[str]:
     out = []
     for email in h.multi_split(emails, ["/", ",", " or "]):
         if email is None:
@@ -42,7 +42,7 @@ def clean_emails(emails):
     return out
 
 
-def clean_phones(phones):
+def clean_phones(phones: str | None) -> list[str]:
     out = []
     for phone in h.multi_split(
         phones, [",", "/", "(1)", "(2)", "(3)", "(4)", "(5)", "(6)", "(7)", "(8)"]
@@ -54,11 +54,11 @@ def clean_phones(phones):
     return out
 
 
-def clean_name(name):
+def clean_name(name: str) -> str:
     return REGEX_NAME_CLEAN.sub("", name).strip()
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     officials = context.fetch_json(context.data_url, cache_days=1).get("data")
 
     # All munis

--- a/datasets/za/pmg_legislators/crawler.py
+++ b/datasets/za/pmg_legislators/crawler.py
@@ -31,7 +31,7 @@ POSITIONS_OF_INTEREST = [
 ]
 
 
-def clean_emails(emails):
+def clean_emails(emails: str | None) -> list[str] | None:
     out = []
     for email in h.multi_split(emails, ["/", ",", " or "]):
         if email is None:
@@ -43,7 +43,7 @@ def clean_emails(emails):
     return out
 
 
-def clean_phones(phones):
+def clean_phones(phones: str | None) -> list[str]:
     out = []
     for phone in h.multi_split(phones, PHONE_SPLITS):
         phone = PHONE_REMOVE.sub("", phone)
@@ -51,7 +51,9 @@ def clean_phones(phones):
     return out
 
 
-def crawl_person(context: Context, person_data: dict, organizations):
+def crawl_person(
+    context: Context, person_data: dict[str, str], organizations: dict[str, str]
+) -> None:
     person_id = person_data.get("id")
 
     person_qid = None
@@ -176,7 +178,7 @@ def crawl_membership(
         context.emit(occupancy)
 
 
-def crawl(context: Context):
+def crawl(context: Context) -> None:
     path = context.fetch_resource("pombola.json", context.data_url)
     context.export_resource(path, JSON, context.SOURCE_TITLE)
     with open(path, "r") as f:

--- a/datasets/za/wanted/crawler.py
+++ b/datasets/za/wanted/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from urllib.parse import parse_qs, urlparse
 
 from lxml import html
@@ -16,7 +15,7 @@ UNKNOWNS = {"unknown", "uknown"}
 CACHE_DAYS = 1
 
 
-def crawl_detail_page(context: Context, person: Entity, source_url: str):
+def crawl_detail_page(context: Context, person: Entity, source_url: str) -> None:
     """Fetch and parse detailed information from a person's detail page."""
     doc = fetch_html(
         context,
@@ -71,7 +70,7 @@ def crawl_detail_page(context: Context, person: Entity, source_url: str):
     context.emit(person)
 
 
-def crawl_person(context: Context, row: Dict[str, html.HtmlElement]):
+def crawl_person(context: Context, row: dict[str, html.HtmlElement]) -> None:
     detail_url = row["Surname"].xpath(".//a/@href")[0]
 
     # There can be additional text outside the link, e.g. "international sought"
@@ -114,7 +113,7 @@ def crawl_person(context: Context, row: Dict[str, html.HtmlElement]):
     crawl_detail_page(context, person, detail_url)
 
 
-def crawl(context):
+def crawl(context: Context) -> None:
     doc = fetch_html(
         context,
         context.data_url,


### PR DESCRIPTION
Worked down `mypy --strict --explicit-package-bases datasets/ | grep "Function is missing"` from 123 to 0, country by country.

Fixes across `at`, `lt`, `sg`, `za`, `ng`, `_global`, `md`, `ua`. Mostly `-> None` return types and missing parameter annotations. A couple of extras:

- `sg/gov_dir`: keyword-only args for functions with many ambiguous `str` params (`make_position_name`, `crawl_person`, `check_expectations`, `crawl_subpage`); renamed `link` → `url` throughout
- `ua/war_sanctions`: keyword-only args for `crawl_ship_relation`, `crawl_person`, `crawl_legal_entity`, `crawl_vessel`, `emit_manager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)