### PR TITLE
Fix rstrip-as-suffix bugs in pl_mswia_sanctions and jp_meti_ru

### DIFF
--- a/datasets/jp/meti_ru/crawler.py
+++ b/datasets/jp/meti_ru/crawler.py
@@ -84,7 +84,7 @@ def clean_name_en(data_string: str) -> tuple[str, list[str]]:
         # Default: Return the data string as the name with no aliases
         return data_string.strip(), []
 
-    clean_name = parts[0].strip().rstrip(",").rstrip(".").rstrip("a.k.a")
+    clean_name = parts[0].strip().rstrip(",").rstrip(".").removesuffix("a.k.a")
     aliases = []
     if len(parts) > 1:
         aliases_part = parts[1]

--- a/datasets/pl/mswia_sanctions/crawler.py
+++ b/datasets/pl/mswia_sanctions/crawler.py
@@ -112,7 +112,7 @@ def crawl_row(context: Context, row: dict[str, str | None], table_title: str) ->
 
     else:
         # "w likwidacji" = in liquidation; "w upadłości" = in bankruptcy
-        name = names[0].rstrip(" w likwidacji").rstrip(" w upadłości")
+        name = names[0].removesuffix(" w likwidacji").removesuffix(" w upadłości")
         entity.add("name", name)
 
         alias = names[1] if len(names) > 1 else ""
@@ -132,8 +132,8 @@ def crawl_row(context: Context, row: dict[str, str | None], table_title: str) ->
             aliases = h.multi_split(alias, ["lub", "obecnie:", "inaczej:"])
             # Aliases are often in quotes
             cleaned_aliases = [
-                a.rstrip(" w likwidacji")
-                .rstrip(" w upadłości")
+                a.removesuffix(" w likwidacji")
+                .removesuffix(" w upadłości")
                 .replace("„", "")
                 .replace("”", "")
                 for a in aliases


### PR DESCRIPTION
`str.rstrip(s)` treats `s` as a *set of characters*, not a suffix. Two crawlers had this bug:

- `pl_mswia_sanctions`: `rstrip(" w likwidacji")` chewed trailing chars in `{' ', 'w', 'l', 'i', 'k', 'd', 'a', 'c', 'j'}` from names — "OOO Firma Innowacyjna Mark" became "...Mar". Fixes #4344.
- `jp_meti_ru`: `rstrip("a.k.a")` stripped trailing `{a, ., k}`. Mostly masked by an earlier `split("a.k.a.")` but still wrong.

Both replaced with `removesuffix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)