### PR TITLE
Issues 2026-06-02

### DIFF
--- a/datasets/_externals/ext_gleif.yml
+++ b/datasets/_externals/ext_gleif.yml
@@ -99,10 +99,10 @@ assertions:
   min:
     schema_entities:
       Security: 184000
-      Organization: 1000
-      Company: 1250
+      Organization: 8000
+      Company: 4000
   max:
     schema_entities:
       Security: 433000
-      Organization: 3000
-      Company: 4000
+      Organization: 14000
+      Company: 8000

--- a/datasets/ch/seco_sanctions/ch_seco_sanctions.yml
+++ b/datasets/ch/seco_sanctions/ch_seco_sanctions.yml
@@ -67,7 +67,9 @@ lookups:
         value: SECO-IRAN
       - match: "Ordinance of 2 October 2000 on measures against individuals and entities associated with Usama bin Laden, the group «Al-Qaïda» or the Taliban (SR 946.203), annex 2"
         value: SECO-AFGH
-      - match: "Ordinance of 4 March 2022 on measures related to the situation in Ukraine (RS 946.231.176.72), annexes 2, 8, 9, 10, 11, 12,13, 14, 14a, 15, 15a, 15b, 25 and 33"
+      - match:
+          - "Ordinance of 4 March 2022 on measures related to the situation in Ukraine (RS 946.231.176.72), annexes 2, 8, 9, 10, 11, 12,13, 14, 14a, 15, 15a, 15b, 25 and 33"
+          - "Ordinance of 4 March 2022 on measures related to the situation in Ukraine (RS 946.231.176.72), annexes 2, 8, 9, 10, 11, 12,13, 14, 14a, 15, 15a, 15b, 15c, 25 and 33"
         value: SECO-UKRAINE
       - match: "Ordinance of 14 March 2014  on measures against the Central African Republic (RS 946.231.123.6), annex"
         value: SECO-CAR

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -188,7 +188,9 @@ lookups:
         value: EU-TERR
       - match: 1210/2003
         value: EU-IRQ
-      - match: 2013/255
+      - match:
+          - 2013/255
+          - 36/2012
         value: EU-SYR
       - match:
           - 2024/254

--- a/datasets/md/companies/parse.py
+++ b/datasets/md/companies/parse.py
@@ -139,7 +139,7 @@ def parse_company(context: Context, data: Dict[str, Any]) -> None:
     name = data.pop("Denumirea completă")
     address = data.pop("Adresa")
     company = context.make("Company")
-    if idno is not None:
+    if idno is not None and str(idno).strip():
         company.id = f"oc-companies-md-{idno}"
     else:
         company.id = context.make_id(name, address)
@@ -153,8 +153,8 @@ def parse_company(context: Context, data: Dict[str, Any]) -> None:
         return
     company.add("name", name)
     company.add("taxNumber", idno)
-    company.add("incorporationDate", data.pop("Data înregistrării"))
-    company.add("dissolutionDate", data.pop("Data lichidării"))
+    h.apply_date(company, "incorporationDate", data.pop("Data înregistrării"))
+    h.apply_date(company, "dissolutionDate", data.pop("Data lichidării"))
     company.add("jurisdiction", "md")
     company.add("address", address)
     company.add("legalForm", data.pop("Forma org./jurid."))


### PR DESCRIPTION
- **[ext_gleif] up assertions, auto-resolve is working**
  

- **[ch_seco_sanctions] datapatch**
  

- **[md_companies] fix date parsing and empty-IDNO entity ID collision**
  Use h.apply_date for incorporation/dissolution dates so the configured
  DD.MM.YYYY format gets applied. Fall through to make_id(name, address)
  for empty-string IDNOs to avoid colliding all empty-IDNO rows onto the
  same `oc-companies-md-` id (which was also being rejected when
  referenced from Directorships/Ownerships).
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  

- **[eu_journal_sanctions] datapatch**
  