### PR TITLE
Invalidate cache with async=false

### DIFF
--- a/zavod/zavod/archive/cdn.py
+++ b/zavod/zavod/archive/cdn.py
@@ -19,7 +19,7 @@ def invalidate_archive_cache(path: str) -> None:
     purge_url = "https://api.bunny.net/purge"
     headers = {"AccessKey": bunnynet_api_key}
     archive_url = f"{settings.ARCHIVE_SITE}/{path}"
-    params = {"url": archive_url, "async": "true"}
+    params = {"url": archive_url, "async": "false"}
 
     try:
         response = requests.post(purge_url, headers=headers, params=params)


### PR DESCRIPTION
So there's less surprise about what's been invalidated, when.

Fixes https://github.com/opensanctions/operations/issues/2585