### PR TITLE
Add Azerbaijan National Assembly (Milli Majlis) PEP crawler

### DIFF
--- a/datasets/az/parliament/az_parliament.yml
+++ b/datasets/az/parliament/az_parliament.yml
@@ -1,0 +1,49 @@
+title: Azerbaijan National Assembly (Milli Majlis)
+entry_point: crawler.py
+prefix: az-parl
+coverage:
+  frequency: weekly
+  start: 2026-06-04
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the National Assembly of Azerbaijan (Milli Majlis), the country's
+  unicameral parliament, with biographical and contact details from their profile pages.
+description: |
+  The Milli Majlis is the unicameral national legislature of the Republic of Azerbaijan,
+  composed of 125 deputies elected from single-mandate constituencies.
+
+  This dataset captures the current sitting members listed on the parliament's official
+  website. For each deputy it collects the name, constituency, party affiliation and,
+  where the profile page provides them, date and place of birth, education, the date they
+  were elected, and official contact details. The roster is updated after elections and
+  by-elections; not every member's profile carries the full set of biographical fields.
+url: https://meclis.gov.az/cat-dep.php?cat=51&lang=en
+publisher:
+  name: National Assembly of the Republic of Azerbaijan
+  acronym: Milli Majlis
+  description: >
+    The Milli Majlis is the unicameral parliament of Azerbaijan, exercising legislative
+    power under the Constitution. Its 125 deputies are elected for five-year terms.
+  url: https://meclis.gov.az/
+  country: az
+  official: true
+data:
+  url: https://meclis.gov.az/cat-dep.php?cat=51&lang=az
+  format: HTML
+  lang: aze
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 100
+      Position: 1
+    country_entities:
+      az: 100
+  max:
+    schema_entities:
+      Person: 200
+      Position: 1

--- a/datasets/az/parliament/crawler.py
+++ b/datasets/az/parliament/crawler.py
@@ -1,0 +1,197 @@
+import re
+from urllib.parse import urljoin
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.constants import ORIGIN_INFERRED
+from zavod.stateful.positions import categorise
+from zavod.util import Element
+
+# The Milli Majlis has 125 single-mandate seats. The listing occasionally drops to ~124
+# when a seat is vacant. If the count leaves this band, the site structure or the
+# convocation (pinned via cat=51 in data.url) has likely changed and the crawler should
+# be revisited rather than silently emit a stale or truncated roster.
+MIN_MEMBERS = 100
+MAX_MEMBERS = 130
+
+# Azerbaijani month names -> month number, for dates like "24 may 1967-ci il".
+AZ_MONTHS = {
+    "yanvar": 1,
+    "fevral": 2,
+    "mart": 3,
+    "aprel": 4,
+    "may": 5,
+    "iyun": 6,
+    "iyul": 7,
+    "avqust": 8,
+    "sentyabr": 9,
+    "oktyabr": 10,
+    "noyabr": 11,
+    "dekabr": 12,
+}
+DATE_RE = re.compile(r"(\d{1,2})\s+([a-zçğıişöü]+)\s+(\d{4})", re.IGNORECASE)
+
+# Patronymic suffix -> inferred gender. Azerbaijani full names end in a patronymic
+# "<father> oğlu" (son of) or "<father> qızı" (daughter of).
+GENDERS = {"oğlu": "male", "qızı": "female"}
+
+# Bio table (table.dep_stil) labels.
+BIRTH_DATE = "Doğulduğu tarixi"
+BIRTH_PLACE = "Doğulduğu yer"
+EDU_INSTITUTION = "Bitirdiyi təhsil müəssisəsinin adı"
+SPECIALTY = "İxtisası"
+ELECTED_DATE = "Deputat seçildiyi tarix"
+# Bio fields we deliberately do not emit (no clean FTM target).
+BIO_IGNORE = [
+    "Təhsili",  # education level ("Ali" = higher)
+    "Elmi dərəcəsi və elmi adı",  # academic degree / title
+    "Bildiyi xarici dillər",  # foreign languages
+    "Ailə vəziyyəti",  # family status
+]
+
+# Affiliation block (div.deputat-da / div.deputat-kom) labels.
+PARTY = "Partiya mənsubiyyəti:"
+PHONE = "Telefon:"
+EMAIL = "E-mail:"
+
+
+def parse_az_date(value: str) -> str | None:
+    """Convert an Azerbaijani long-form date to ISO, or None if it doesn't match.
+
+    Source values look like "24 may 1967-ci il"; the "-ci il" ordinal/year suffix is
+    discarded once the day, month name and year have been pulled out.
+    """
+    match = DATE_RE.search(value)
+    if match is None:
+        return None
+    day, month_name, year = match.groups()
+    month = AZ_MONTHS.get(month_name.lower())
+    if month is None:
+        return None
+    return f"{int(year):04d}-{month:02d}-{int(day):02d}"
+
+
+def parse_bio_table(table: Element) -> dict[str, list[str]]:
+    """Parse the label/value bio table into {label: [value lines]}.
+
+    Multi-line cells (e.g. several universities) are split into separate values.
+    """
+    bio: dict[str, list[str]] = {}
+    for row in h.xpath_elements(table, "./tbody/tr | ./tr"):
+        cells = row.findall("./td")
+        if len(cells) != 2:
+            continue
+        label = h.element_text(cells[0])
+        lines = [s for s in (str(t).strip() for t in cells[1].itertext()) if s]
+        if label and lines:
+            bio[label] = lines
+    return bio
+
+
+def crawl_member(context: Context, url: str, name: str) -> None:
+    doc = context.fetch_html(url, cache_days=6)
+
+    person = context.make("Person")
+    # The numeric profile id is an opaque source identifier (no PII).
+    member_id = url.split("id=")[1].split("&")[0]
+    person.id = context.make_slug(member_id)
+    person.add("name", name)
+    person.add("sourceUrl", url)
+    # National parliament: deputies must be citizens of Azerbaijan per the Constitution
+    # of the Republic of Azerbaijan, Article 85(I).
+    # https://president.az/en/pages/view/azerbaijan/constitution
+    person.add("citizenship", "az")
+
+    # Infer gender from the patronymic suffix; record the suffix as the original value.
+    suffix = name.strip().split()[-1].lower()
+    gender = GENDERS.get(suffix)
+    if gender is not None:
+        person.add("gender", gender, origin=ORIGIN_INFERRED, original_value=suffix)
+
+    tables = h.xpath_elements(doc, ".//table[contains(@class, 'dep_stil')]")
+    bio: dict[str, list[str]] = {}
+    if len(tables) > 0:
+        bio = parse_bio_table(tables[0])
+
+    birth_date = bio.pop(BIRTH_DATE, [])
+    if len(birth_date) > 0:
+        h.apply_date(person, "birthDate", parse_az_date(birth_date[0]))
+    for place in bio.pop(BIRTH_PLACE, []):
+        person.add("birthPlace", place, lang="aze")
+    for institution in bio.pop(EDU_INSTITUTION, []):
+        person.add("education", institution, lang="aze")
+    for specialty in bio.pop(SPECIALTY, []):
+        person.add("education", specialty, lang="aze")
+    elected = bio.pop(ELECTED_DATE, [])
+    start_date = parse_az_date(elected[0]) if len(elected) > 0 else None
+
+    context.audit_data(bio, ignore=BIO_IGNORE)
+
+    affiliations = h.xpath_elements(
+        doc, ".//div[contains(@class, 'deputat-da') or contains(@class, 'deputat-kom')]"
+    )
+    for div in affiliations:
+        strong = div.find("strong")
+        if strong is None:
+            continue
+        label = h.element_text(strong)
+        value = (strong.tail or "").strip()
+        if not value:
+            continue
+        if label == PARTY:
+            person.add("political", value, lang="aze")
+        elif label == PHONE:
+            person.add("phone", value)
+        elif label == EMAIL:
+            person.add("email", value)
+
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of Azerbaijan",
+        country="az",
+        wikidata_id="Q21269547",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        start_date=start_date,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    context.emit(person)
+    context.emit(position)
+    context.emit(occupancy)
+
+
+def crawl(context: Context) -> None:
+    doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=6)
+    anchors = h.xpath_elements(doc, ".//a[contains(@href, 'news-dep.php')]")
+
+    members: dict[str, str] = {}
+    for anchor in anchors:
+        href = anchor.get("href")
+        if href is None:
+            continue
+        url = urljoin(context.data_url, href)
+        name_el = h.xpath_elements(anchor, ".//div[contains(@class, 'author-name')]")
+        if len(name_el) == 0:
+            continue
+        name = h.element_text(name_el[0])
+        if name:
+            members[url] = name
+
+    count = len(members)
+    if not (MIN_MEMBERS <= count <= MAX_MEMBERS):
+        context.log.error(
+            "Unexpected number of parliament members; site or term may have changed",
+            count=count,
+        )
+        raise ValueError(f"Expected {MIN_MEMBERS}-{MAX_MEMBERS} members, found {count}")
+
+    for url, name in members.items():
+        crawl_member(context, url, name)


### PR DESCRIPTION
Closes opensanctions/crawler-planning#703

Adds a PEP crawler for the current members of the **Milli Majlis**, the unicameral parliament of Azerbaijan, sourced from the official site `meclis.gov.az`.

## Source
- Listing: `cat-dep.php?cat=51&lang=az` — single non-paginated page, no JS/anti-bot. The `lang=az` variant gives source-of-truth diacritic names (Ə Ö Ü Ç Ş Ğ İ).
- Per-MP profile pages (`news-dep.php?id=…&lang=az`) carry an optional bio table and affiliation block.

## What it extracts
- **Person**: name, `citizenship=az` (Constitution Art. 85(I)), inferred gender (from the `oğlu`/`qızı` patronymic suffix, tagged `origin=inferred` with the suffix as `original_value`), birth date, birth place, education (institutions + specialty), party, phone, email, sourceUrl.
- **Position**: *Member of the National Assembly of Azerbaijan* (`Q21269547`), categorised as PEP.
- **Occupancy**: current, with start date from "Deputat seçildiyi tarix" where present.

Every profile field is treated as optional. A freshness guard raises if the member count leaves the 100–130 band, flagging a new convocation or structural change on the pinned `cat=51`.

## Verification
- 124 Person, 1 Position, 124 Occupancy; no issues in `issues.json`.
- Referential integrity holds (all occupancy holders/posts resolve; every person has an occupancy).
- `mypy --strict`, `ruff`, `black` clean; `zavod validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)