### PR TITLE
Tidy PEP crawler docs and skill

### DIFF
--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -24,11 +24,11 @@ context about the dataset.
 
 **Prefer section reads over full reads.** All of these docs are well-headered — use `Grep` to find the symbol/topic you need (`make_occupancy`, `apply_date`, `coverage.start`, etc.) and `Read` with `offset`/`limit` instead of reading the whole file.
 
-**Do NOT search the repo for similar crawlers.** The codebase is large and old, so many
-crawlers predate current best practice — "looks similar" and "is correct" have drifted
-apart, and copying one propagates outdated patterns. The docs above are the curated,
-current source of truth; `examples.md` is where to find worked code. Use only the files
-listed above.
+**Ground the crawler in the files listed above — they are the only source you need.**
+They are the curated, current best practice, and `examples.md` is the maintained version
+of "show me a crawler like this one." The wider crawler codebase is large and old, so many
+crawlers have drifted from current practice — which is exactly why the docs, not the
+corpus, are authoritative here.
 
 ## Step 1: Understand the source
 

--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -24,7 +24,11 @@ context about the dataset.
 
 **Prefer section reads over full reads.** All of these docs are well-headered — use `Grep` to find the symbol/topic you need (`make_occupancy`, `apply_date`, `coverage.start`, etc.) and `Read` with `offset`/`limit` instead of reading the whole file.
 
-**Do NOT search the repo for similar crawlers.** Use only the files listed above.
+**Do NOT search the repo for similar crawlers.** The codebase is large and old, so many
+crawlers predate current best practice — "looks similar" and "is correct" have drifted
+apart, and copying one propagates outdated patterns. The docs above are the curated,
+current source of truth; `examples.md` is where to find worked code. Use only the files
+listed above.
 
 ## Step 1: Understand the source
 
@@ -87,13 +91,12 @@ Depth on edge cases: `zavod/docs/peps.md` → "Selecting a position name".
 
 Full reference: `zavod/docs/peps.md`. `categorise()` is a stateful DB operation; `is_pep`/`topics` only matter on first insertion — subsequent crawls return DB values (including UI edits).
 
-**Three `is_pep` calling patterns:**
+**`default_is_pep` calling patterns:**
 
-| `is_pep` arg | When to use | Example datasets |
-|---|---|---|
-| `True` | Source definitionally contains PEPs (parliament, cabinet, judges) | fr_assemblee, ie_parliament, ky_judicial |
-| `None` | Mixed dataset, or per-locality positions where UI decides PEP status | fr_hatvp_declarations, lu_bourgmestres |
-| `False` | Explicitly not PEP (rare in PEP crawlers) | — |
+| `default_is_pep` arg | When to use |
+|---|---|
+| `True` | Source definitionally contains PEPs (parliament, cabinet, judges) |
+| `None` | Mixed dataset, or per-locality positions where the UI decides PEP status |
 
 Pass the returned `categorisation` to `make_occupancy()`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,4 +49,4 @@ Use search (grep/glob/find) to find the most relevant starting document. Once yo
 * When adding type hints, use the container types such as `set`, `tuple` or `dict` instead of the now-deprecated `typing.Set`, `typing.Tuple` or `typing.Dict`.
 * All new crawlers should be written using typed Python. Suggest adding types to existing ones.
 * We use `lxml` for parsing HTML/XML, and `context.fetch_` functions the retrieve online data. Other libraries are listed in `zavod/pyproject.toml`. NEVER use beautifulsoup, or the Python stdlib xml modules.
-* For crawlers that traverse HTML using XPath expressions, use the sensibly-typed helpers in `zavod.helpers.html` if possible.
+* For crawlers that traverse HTML using XPath expressions, use the sensibly-typed helpers in `zavod.helpers.html` (`h.xpath_element(s)`, `h.element_text`). Raw `.xpath()` returns `Any` and fails the `mypy --strict` check enforced on datasets by the `mypy-datasets` pre-commit hook — run `mypy --strict` on a new crawler before committing.

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -97,7 +97,7 @@ a PEP position, and the PEP duration of its scope.
 To allow newly discovered positions to be added to the database, and to use the
 `is_pep` value from the database, call `zavod.stateful.positions:categorise` with the Position.
 If the data source is known to only include PEP positions, or if the crawler only
-attempts to create positions known to be PEPs, the `is_pep` argument should be `True`.
+attempts to create positions known to be PEPs, the `default_is_pep` argument should be `True`.
 Otherwise it should be `None`, denoting that it should be manually categorised
 in the database.
 **Only make occupancies and emit entities for which the returned `categorisation.is_pep` is `True`**.
@@ -131,6 +131,12 @@ a position is currently held or not, we consider someone a PEP if they have not
 passed away, and they entered the position within the past 40 years. In this
 case the occupancy status should be `unknown`.
 
+When the source records that a person has died or left office mid-term, set their
+`deathDate` (on the person) and the occupancy `endDate`, rather than skipping them.
+`make_occupancy` applies the thresholds above and returns `None` once the person no
+longer qualifies — so a recently-deceased or recently-removed office holder is still
+emitted with an `ended` occupancy, while one who left long ago is dropped automatically.
+
 ### Only emit if the person is a PEP
 
 Occupancies and positions should only be emitted for instances where these
@@ -147,12 +153,12 @@ and determine whether the occupancy meets our criteria and should be emitted.
 
 ```python
 # ... looping over people in a province ...
-if person_data.pop("death_date", None):
-    return
 person = context.make("Person")
 source_id = person_data.pop("id")
 person.add("country", "us")
 person.add("name", person_data.pop("name"))
+# Set deathDate rather than skipping the person; make_occupancy decides PEP status.
+h.apply_date(person, "deathDate", person_data.pop("death_date", None))
 # ... more person properties ...
 
 pep_entities = []
@@ -164,7 +170,7 @@ for role in person_data.pop("roles"):
         country="us",
         subnational_area=province
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         continue
     occupancy = h.make_occupancy(


### PR DESCRIPTION
Documentation and skill cleanups prompted by writing two new PEP crawlers (AZ #4383, VN #4385). No code or crawler-behaviour changes.

### `zavod/docs/peps.md`
- **`categorise()` argument name.** The example called `categorise(context, position, is_pep=True)`, but the keyword-only argument is `default_is_pep`; following the doc verbatim raised `TypeError`. Fixed in the example and the prose.
- **Mid-term departures.** The example dropped anyone with a death date outright. It now sets `deathDate` (and, for the occupancy, `endDate`) and lets `make_occupancy` apply the after-death / after-office thresholds — a recently-deceased or recently-removed office holder is still emitted with an `ended` occupancy, while one who left long ago is dropped automatically. Added a short note explaining this.

### `CLAUDE.md`
- **Typed XPath helpers / mypy.** Strengthened the existing hint to note that datasets are `mypy --strict` checked by the `mypy-datasets` pre-commit hook, so raw `.xpath()` (typed `Any`) won't pass — use the `zavod.helpers.html` wrappers and run `mypy --strict` before committing.

### `.claude/skills/crawler-pep/SKILL.md`
- **Reframed the source-of-truth rule as a positive instruction** ("Ground the crawler in the files listed above…") with its rationale, instead of a bare "Do NOT search the repo for similar crawlers."
- **Trimmed the categorise table**: dropped the "Example datasets" column (it named specific crawlers, inviting exactly the corpus-copying the rule discourages, with no curation to keep it honest) and the unused `False` row, and corrected its arg name to `default_is_pep`. Net length-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)