### PR TITLE
[li_landtag] Add Liechtenstein Landtag PEP crawler

### DIFF
--- a/datasets/li/landtag/crawler.py
+++ b/datasets/li/landtag/crawler.py
@@ -1,0 +1,183 @@
+from datetime import datetime
+from urllib.parse import urlparse
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+MEMBER_NAME = "Member of the Landtag of Liechtenstein"
+SUBSTITUTE_NAME = "Substitute member of the Landtag of Liechtenstein"
+
+# The roster's "Legislaturperiode" dropdown carries one option per legislative term,
+# its value being the term's start date (e.g. "25.03.2021") and the path it links to
+# being /abgeordnete/<year>. We iterate those pages so that members of past terms (no
+# longer in office) are retained, bounded by earliest_term_start so we don't reach
+# further back than positions are still considered PEP-relevant.
+PERIOD_VALUE_FORMAT = "%d.%m.%Y"
+
+
+def make_member_position(context: Context, substitute: bool) -> Entity:
+    return h.make_position(
+        context,
+        name=SUBSTITUTE_NAME if substitute else MEMBER_NAME,
+        country="li",
+        topics=["gov.national", "gov.legislative"],
+        # Only the full member position has a dedicated Wikidata item.
+        wikidata_id=None if substitute else "Q21328607",
+    )
+
+
+def parse_terms(index: Element) -> list[tuple[str, str, str | None]]:
+    """Return the legislative terms to crawl as ``(year, period_start, period_end)``.
+
+    Terms are read newest-first from the period dropdown. ``period_start`` is the term's
+    own start date; ``period_end`` is the start date of the next (newer) term, i.e. when
+    this term ended — ``None`` for the current term. Terms whose end falls before
+    ``earliest_term_start`` are dropped, so the reach into the past tracks the PEP
+    after-office window rather than a hard-coded year.
+    """
+    cutoff = h.earliest_term_start(["gov.national"])
+    options = h.xpath_elements(index, '//select[@id="main_ddYears"]/option')
+    starts = [h.xpath_strings(o, "./@value", expect_exactly=1)[0] for o in options]
+
+    terms: list[tuple[str, str, str | None]] = []
+    for i, start in enumerate(starts):
+        # The dropdown JS navigates to /abgeordnete/<year> using the value's year part.
+        year = start.split(".")[-1]
+        period_end = starts[i - 1] if i > 0 else None
+        if period_end is not None:
+            end_iso = datetime.strptime(period_end, PERIOD_VALUE_FORMAT).date()
+            if end_iso.isoformat() < cutoff:
+                continue
+        terms.append((year, start, period_end))
+    return terms
+
+
+def crawl_detail(context: Context, person: Entity, url: str) -> None:
+    """Set the fields only carried on the member detail page: birth date and profession.
+
+    Date of birth is given either as a full ``Geburtsdatum`` (DD.MM.YYYY) or, for members
+    who only disclose the year, as ``Jahrgang`` (YYYY). We deliberately ignore the other
+    detail-page fields (previous functions, e-mail, marital status, residence).
+    """
+    doc = context.fetch_html(url, cache_days=6)
+    # Scope to the "Persönliche Informationen" table (table--attr); the page also has a
+    # "Bisherige Funktionen" table (table--period) whose roles we deliberately skip.
+    info_table = h.xpath_element(doc, '//table[contains(@class,"table--attr")]')
+    bio: dict[str, str] = {}
+    for row in h.xpath_elements(info_table, ".//tr"):
+        cells = h.xpath_elements(row, "./td")
+        if len(cells) != 2:
+            continue
+        bio[h.element_text(cells[0])] = h.element_text(cells[1])
+
+    h.apply_date(
+        person, "birthDate", bio.pop("Geburtsdatum", None) or bio.pop("Jahrgang", None)
+    )
+    person.add("profession", bio.pop("Beruf", None))
+    context.audit_data(bio, ignore=["Partei", "Wohnort", "Familienstand", "E-Mail"])
+
+
+def get_person(context: Context, cache: dict[str, Entity], card: Element) -> Entity:
+    """Build (once per source id) the Person for a roster card.
+
+    A member recurs across the term pages we crawl; we key on the source's person id so
+    the detail page is fetched only once and the per-term occupancies all attach to the
+    same entity.
+    """
+    link = h.xpath_strings(
+        card, './/div[contains(@class,"member__name")]/a/@href', expect_exactly=1
+    )[0]
+    source_id = urlparse(link).path.rstrip("/").split("/")[-1]
+    if source_id in cache:
+        return cache[source_id]
+
+    # The roster lists members surname-first, e.g. "Bühler-Nigsch Dagmar". We keep the
+    # full string as the name regardless, and only split into surname/given name in the
+    # unambiguous single-space case — multi-token names are left unsplit rather than
+    # guessed at.
+    name = h.element_text(
+        h.xpath_element(card, './/*[contains(@class,"member__name2")]')
+    )
+    first_name = last_name = None
+    if name.count(" ") == 1:
+        last_name, first_name = name.split(" ")
+
+    person = context.make("Person")
+    person.id = context.make_slug("person", source_id)
+    h.apply_name(person, full=name, first_name=first_name, last_name=last_name)
+    # Standing for the Landtag requires Liechtenstein citizenship (political rights in
+    # national matters): Verfassung des Fürstentums Liechtenstein, Art. 29(2).
+    # https://www.gesetze.li/konso/pdf/1921.015
+    person.add("citizenship", "li")
+    party = h.xpath_element(card, './/*[contains(@class,"member__party")]')
+    person.add("political", h.element_text(party))
+    crawl_detail(context, person, link)
+
+    cache[source_id] = person
+    return person
+
+
+def crawl_term(
+    context: Context,
+    year: str,
+    period_start: str,
+    period_end: str | None,
+    positions: dict[bool, Entity],
+    cats: dict[bool, PositionCategorisation],
+    persons: dict[str, Entity],
+    emitted: set[str],
+) -> None:
+    doc = context.fetch_html(
+        f"{context.data_url}/{year}", absolute_links=True, cache_days=1
+    )
+    for card in h.xpath_elements(doc, '//div[@class="abglist__member member"]'):
+        card_id = card.get("id") or ""
+        # The leadership highlight block ("Leaders") duplicates members listed below.
+        if "Leaders" in card_id:
+            continue
+        # Substitutes ("Deputy"); full members are in the Members and Resigned
+        # ("Ausgeschieden", i.e. left mid-term) sections.
+        is_substitute = "Deputy" in card_id
+        person = get_person(context, persons, card)
+        assert person.id is not None
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            positions[is_substitute],
+            categorisation=cats[is_substitute],
+            period_start=period_start,
+            period_end=period_end,
+        )
+        if occupancy is not None:
+            context.emit(occupancy)
+            emitted.add(person.id)
+
+
+def crawl(context: Context) -> None:
+    index = context.fetch_html(context.data_url, cache_days=1)
+    terms = parse_terms(index)
+
+    positions = {
+        False: make_member_position(context, substitute=False),
+        True: make_member_position(context, substitute=True),
+    }
+    cats = {}
+    for substitute, position in positions.items():
+        context.emit(position)
+        cats[substitute] = categorise(context, position, default_is_pep=True)
+
+    persons: dict[str, Entity] = {}
+    emitted: set[str] = set()
+    for year, period_start, period_end in terms:
+        crawl_term(
+            context, year, period_start, period_end, positions, cats, persons, emitted
+        )
+
+    if not emitted:
+        raise ValueError("No members found across any term; the roster layout changed.")
+    for source_id, person in persons.items():
+        if person.id in emitted:
+            context.emit(person)

--- a/datasets/li/landtag/li_landtag.yml
+++ b/datasets/li/landtag/li_landtag.yml
@@ -1,0 +1,55 @@
+title: Liechtenstein Members of the Landtag
+prefix: li-landtag
+coverage:
+  frequency: monthly
+  start: 2025-06-05
+load_statements: true
+entry_point: crawler.py
+ci_test: false
+summary: >-
+  Members and substitute members of the Landtag, the national parliament of the
+  Principality of Liechtenstein
+description: |
+  The Landtag is the unicameral parliament of the Principality of Liechtenstein.
+  It is composed of 25 members, elected for a four-year legislative period from the
+  two electoral districts (Wahlkreise) Oberland and Unterland. In addition to the full
+  members (Abgeordnete), the source also lists substitute members (Stellvertreter) who
+  stand in for members of their party when needed.
+
+  This dataset is sourced from the official roster published by the Landtag. The roster
+  is available per legislative period, and the crawler iterates over the published
+  periods so that members of recent past terms remain in the dataset after they leave
+  office.
+url: https://www.landtag.li/abgeordnete
+tags:
+  - list.pep
+publisher:
+  name: Landtag des Fürstentums Liechtenstein
+  name_en: Parliament of the Principality of Liechtenstein
+  acronym: Landtag
+  description: |
+    The Landtag is the legislative body of the Principality of Liechtenstein. It
+    passes laws, approves the budget and oversees the government. It publishes a
+    roster of its current members and substitute members on its official website.
+  url: https://www.landtag.li/
+  country: li
+  official: true
+data:
+  url: https://www.landtag.li/abgeordnete
+  format: HTML
+  lang: deu
+
+dates:
+  formats: ["%d.%m.%Y", "%Y"]
+
+assertions:
+  min:
+    schema_entities:
+      Person: 24
+      Position: 2
+    country_entities:
+      li: 24
+  max:
+    schema_entities:
+      Person: 120
+      Position: 2


### PR DESCRIPTION
Adds a PEP crawler for the **Liechtenstein Landtag** (national parliament).

Closes opensanctions/crawler-planning#704

## What it crawls
- **Members** (Abgeordnete) and **substitute members** (Stellvertreter), modelled as two separate positions: `Member of the Landtag of Liechtenstein` (Wikidata `Q21328607`) and `Substitute member of the Landtag of Liechtenstein`.
- Iterates the published legislative periods from the roster's period dropdown (`/abgeordnete/<year>`), so members of recent past terms are retained after they leave office. Reach into the past is bounded by `h.earliest_term_start("gov.national")` rather than a hard-coded year.
- Occupancy `periodStart`/`periodEnd` are taken from the term bounds, giving correct `current`/`ended` status.
- Resigned mid-term members (`Ausgeschieden`) are captured as full members.

## Per-person data
- Name (full string preserved; split into first/last only in the unambiguous single-space case), party (`political`), profession (`Beruf`), and birth date — handling both full `Geburtsdatum` and year-only `Jahrgang`.
- Citizenship `li` (required to stand for the Landtag — Verfassung Art. 29(2), cited in code).
- Detail pages cached 6 days; fetched once per person even across terms.

## Deliberately excluded
Committee/function history, e-mail, and marital status (`Familienstand`).

## Validation
~54 persons, 69 occupancies, 2 positions. `zavod validate` passes, no issues, `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
