### PR TITLE
[me_skupstina] Add Montenegro Parliament (Skupština) PEP crawler

### DIFF
--- a/datasets/me/skupstina/crawler.py
+++ b/datasets/me/skupstina/crawler.py
@@ -1,0 +1,157 @@
+import re
+from typing import Any
+
+from lxml.html import HtmlElement, fromstring
+from normality import squash_spaces
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import OccupancyStatus, PositionCategorisation, categorise
+
+# Deep link to a member's profile on the official site, built from the API `slug`.
+PROFILE_URL = "https://www.skupstina.me/me/clanovi-parlamenta/%s"
+
+
+def clean_date(value: str | None) -> str | None:
+    """Tidy the source's free-text date of birth before date parsing.
+
+    The ``date_of_birth`` field mixes numeric and Montenegrin-month-name forms and
+    sometimes carries a trailing "godine" ("of the year") or stray double spaces; we
+    normalise whitespace and drop the suffix so the dataset date formats can match.
+    """
+    if value is None:
+        return None
+    value = squash_spaces(value)
+    if value.lower().endswith("godine"):
+        value = value[: -len("godine")].strip()
+    return value or None
+
+
+# Block-level tags that should become line breaks when flattening the biography HTML,
+# so paragraphs don't run together (e.g. "2020.IZBORNA LISTA").
+BLOCK_BREAK = re.compile(r"</(p|div|li|h[1-6]|tr|ul|ol)>|<br\s*/?>", re.IGNORECASE)
+
+
+def html_to_text(value: str | None) -> str | None:
+    """Flatten an HTML biography snippet to readable plain text.
+
+    Block boundaries are turned into line breaks before tags are stripped, then each
+    line is whitespace-squashed and empty lines dropped.
+    """
+    if value is None or not value.strip():
+        return None
+    element: HtmlElement = fromstring(BLOCK_BREAK.sub("\n", value))
+    lines = [squash_spaces(line) for line in element.text_content().split("\n")]
+    return "\n".join(line for line in lines if line) or None
+
+
+def make_member_position(context: Context) -> Entity:
+    return h.make_position(
+        context,
+        name="Member of the Parliament of Montenegro",
+        country="me",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21328576",
+    )
+
+
+def crawl_member(
+    context: Context,
+    member: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    translation = member.pop("translation")
+    person = context.make("Person")
+    person.id = context.make_slug("person", member.pop("id"))
+    h.apply_name(person, full=translation.pop("name"), lang="cnr")
+    h.apply_date(person, "birthDate", clean_date(translation.pop("date_of_birth")))
+    person.add("birthPlace", translation.pop("place_of_birth"), lang="cnr")
+    person.add("biography", html_to_text(translation.pop("biography")), lang="cnr")
+    # Standing for the Skupština requires Montenegrin citizenship: Constitution of
+    # Montenegro Art. 45, implemented by the Law on Election of Councillors and MPs
+    # Art. 2. https://www.constituteproject.org/constitution/Montenegro_2013
+    person.add("citizenship", "me")
+
+    party = member.pop("political_party", None)
+    if party is not None:
+        person.add("political", party["translation"]["name"], lang="cnr")
+
+    # term_of_office_ceased is currently always 0; treat either flag as "no longer in
+    # office" so the crawler keeps working if the source starts using it.
+    term_expired = member.pop("term_expired")
+    term_ceased = member.pop("term_of_office_ceased")
+    is_former = term_expired == 1 or term_ceased == 1
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+        no_end_implies_current=not is_former,
+        status=OccupancyStatus.ENDED if is_former else None,
+    )
+    if occupancy is None:
+        return
+
+    group = member.pop("parliamentary_group", None)
+    if group is not None:
+        occupancy.add("politicalGroup", group["translation"]["name"], lang="cnr")
+    occupancy.add("sourceUrl", PROFILE_URL % translation.pop("slug"))
+
+    context.audit_data(
+        member,
+        ignore=[
+            "image_id",
+            "featured_image_id",
+            "image",
+            # Leadership flags: we model everyone as a plain member.
+            "president",
+            "vice_president",
+            "seat_number",
+            "political_party_id",
+            "parliamentary_group_id",
+            "creator_id",
+            "created_at",
+            "updated_at",
+        ],
+    )
+    context.audit_data(
+        translation,
+        ignore=[
+            "id",
+            "parliament_member_id",
+            "locale",
+            "status",
+            "electoral_list",
+            # Contact and committee-membership detail we deliberately drop.
+            "email",
+            "phone",
+            "fax",
+            "address",
+            "parliamentary_function",
+            "seo_title",
+            "seo_keywords",
+            "seo_description",
+            "editor_id",
+            "created_at",
+            "updated_at",
+        ],
+    )
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    data = context.fetch_json(context.data_url, cache_days=1)
+    members = data["data"]["data"]
+    # The API returns everything in one page; guard against silent truncation if the
+    # roster ever grows past the limit set in the data URL.
+    assert 0 < len(members) < 500, len(members)
+
+    position = make_member_position(context)
+    context.emit(position)
+    categorisation = categorise(context, position, default_is_pep=True)
+
+    for member in members:
+        crawl_member(context, member, position, categorisation)

--- a/datasets/me/skupstina/me_skupstina.yml
+++ b/datasets/me/skupstina/me_skupstina.yml
@@ -1,0 +1,65 @@
+title: Montenegro Members of Parliament (Skupština)
+prefix: me-skup
+coverage:
+  frequency: monthly
+  start: 2026-06-05
+load_statements: true
+entry_point: crawler.py
+ci_test: false
+summary: >-
+  Members of the Skupština, the unicameral parliament of Montenegro, including former
+  members of the current convocation
+description: |
+  The Skupština Crne Gore is the unicameral parliament of Montenegro. Its members
+  (poslanici) are elected for a four-year term.
+
+  This dataset is sourced from the JSON API backing the official Skupština website.
+  It covers the sitting members as well as members whose term has expired, the latter
+  emitted with an ended occupancy. For each member the source provides the name, date
+  and place of birth, political party, parliamentary group and a biography.
+url: https://www.skupstina.me/
+publisher:
+  name: Skupština Crne Gore
+  name_en: Parliament of Montenegro
+  description: |
+    The Skupština is the legislative body of Montenegro. It passes laws, adopts the
+    budget, elects and oversees the government, and ratifies international treaties.
+    It publishes data on its members through its official website.
+  url: https://www.skupstina.me/
+  country: me
+  official: true
+data:
+  url: https://api.skupstina.me/v1/parliament-members?limit=500&extended_fields=translation,image,political_party.translation,parliamentary_group.translation
+  format: JSON
+  lang: cnr
+
+dates:
+  formats: ["%d. %m. %Y.", "%d. %B %Y.", "%Y."]
+  months:
+    january: [januar]
+    february: [februar]
+    march: [mart, marta]
+    april: [april, aprila]
+    may: [maj, maja]
+    june: [jun, juna]
+    july: [jul, jula]
+    august: [avgust, avgusta]
+    september: [septembar, septembra]
+    october: [oktobar, oktobra]
+    november: [novembar, novembra]
+    december: [decembar, decembra]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 90
+      Position: 1
+    country_entities:
+      me: 90
+  max:
+    schema_entities:
+      Person: 250
+      Position: 1

--- a/zavod/zavod/runtime/safety.py
+++ b/zavod/zavod/runtime/safety.py
@@ -26,7 +26,8 @@ HTML_ENTITY_PATTERN = re.compile(
 
 XSS_SUSPECT_PATTERN = re.compile(
     r"<[^>]*>|"  # Tags
-    r"javascript:|data:|vbscript:|"  # URI schemes
+    r"\b(?:javascript|data|vbscript):|"  # URI schemes (require a boundary before the
+    # scheme so words like "MANDATA:" don't match the "data:" alternative)
     r"(\b)on\w+\s*=|"  # Event handlers
     # Disabled for now because it produces too many false positives
     # r"&#|&[a-zA-Z]",  # Entity references

--- a/zavod/zavod/tests/runtime/test_safety.py
+++ b/zavod/zavod/tests/runtime/test_safety.py
@@ -1,0 +1,33 @@
+import pytest
+
+from zavod.runtime.safety import XSS_SUSPECT_PATTERN
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "<script>alert(1)</script>",
+        "click <a href='x'>here</a>",
+        'href="javascript:alert(1)"',
+        "src=data:text/html;base64,AAAA",
+        " data:text/html",
+        "onload=alert(1)",
+        "&#x41;",
+    ],
+)
+def test_xss_pattern_matches(value: str) -> None:
+    assert XSS_SUSPECT_PATTERN.search(value) is not None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # "data:", "javascript:" etc. embedded in a longer word must not match: the
+        # scheme alternatives require a word boundary before them.
+        "POSLANIČKOG MANDATA: 2. Decembar 2020.",
+        "ERRATA: see footnote",
+        "plain biography text without markup",
+    ],
+)
+def test_xss_pattern_ignores_words_ending_in_scheme(value: str) -> None:
+    assert XSS_SUSPECT_PATTERN.search(value) is None


### PR DESCRIPTION
Adds a PEP crawler for the **Skupština Crne Gore** (Parliament of Montenegro), sourced from the JSON API behind the official website.

Closes opensanctions/crawler-planning#697

## What it crawls
- All members from `api.skupstina.me/v1/parliament-members`. Sitting members (`term_expired==0`) get a **current** occupancy; former members of the convocation get an **ended** one — 81 current + 36 ended.
- Single position: `Member of the Parliament of Montenegro` (Wikidata `Q21328576`), `gov.national` + `gov.legislative`.
- Per member: name, **birth date** (parsed from mixed Montenegrin formats — numeric, month-name incl. genitive forms, year-only, with a `" godine"` suffix — via `dates.formats` + a `dates.months` map), birth place, party (`political`), and **biography** (`Person:biography`, HTML flattened with block tags → line breaks).
- **`parliamentary_group`** → `Occupancy.politicalGroup`.
- **Deep link** to each member's profile (`/me/clanovi-parlamenta/{slug}`) → `Occupancy.sourceUrl`.
- Citizenship `me` — legally required to stand (Constitution Art. 45 + electoral law Art. 2, cited in code).

Dropped (via `audit_data` ignore): contact details, committee `parliamentary_function`, images, SEO/timestamps. President/Vice-President flags are not modelled separately — everyone is a plain member.

## Framework fix
The XSS/HTML smell check (`zavod/runtime/safety.py`) matched the `data:` URI-scheme alternative inside ordinary words like "MAN**DATA:**" (Montenegrin "MANDATA:"), producing false-positive warnings on legitimate biography text. Tightened the `javascript|data|vbscript` alternatives to require a **word boundary** before the scheme — real payloads are always boundary-preceded (start, quote, `=`, space). Added `zavod/tests/runtime/test_safety.py` (none existed before) covering both true matches and the suffix false-negatives.

## Validation
235 entities (117 persons, 117 occupancies, 1 position). `zavod validate` passes, **`issues.json` empty**, `mypy --strict` clean across zavod and the dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
