### PR TITLE
Issues 2026-06-05

### DIFF
--- a/.claude/skills/typechecker-fixes/SKILL.md
+++ b/.claude/skills/typechecker-fixes/SKILL.md
@@ -129,6 +129,8 @@ content = h.xpath_element(doc, divs_xpath)
 
 `h.element_text()` calls `text_content()` internally and applies `collapse_spaces` + `strip`. If the original code was calling `squash_spaces` or `collapse_spaces` on the result, that's now redundant and should be removed. If the extracted text is used for lookups (check the `lookups:` section in the crawler's `.yml` file) or exact comparisons, pass `squash=False` to preserve the original whitespace.
 
+**Watch out for code that splits the text on `\n`** (or otherwise relies on line breaks) — the default `squash=True` collapses newlines into spaces, which silently breaks the splitting and merges all rows into one. Always pass `squash=False` in that case.
+
 ```python
 # Before
 name_info = summary.text.strip()

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -121,7 +121,6 @@ repos:
           datasets/us/occ_enfact|
           datasets/us/ddtc_enforcements|
           datasets/us/ddtc_debarred|
-          datasets/us/fbi_most_wanted|
           datasets/us/sam_exclusions|
           datasets/us/nk_jointventures|
           datasets/us/cia_world_factbook|

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -79,7 +79,6 @@ repos:
           datasets/bg/jud_declarations|
           datasets/bh|
           datasets/br|
-          datasets/cl|
           datasets/cn|
           datasets/co|
           datasets/ee|

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -77,7 +77,6 @@ repos:
           datasets/_wikidata|
           datasets/ae|
           datasets/bg/jud_declarations|
-          datasets/bh|
           datasets/br|
           datasets/cn|
           datasets/co|

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -79,14 +79,12 @@ repos:
           datasets/bg/jud_declarations|
           datasets/br|
           datasets/cn|
-          datasets/co|
           datasets/ee|
           datasets/eu|
           datasets/gb/coh|
           datasets/gb/fca_firds|
           datasets/gb/nca_most_wanted|
           datasets/gb/nca_press_releases|
-          datasets/hk|
           datasets/id|
           datasets/in|
           datasets/ky/judicial|

--- a/datasets/cl/info_probidad/crawler.py
+++ b/datasets/cl/info_probidad/crawler.py
@@ -147,12 +147,15 @@ def crawl_row(context: Context, declaration_id: int) -> None:
 
 
 def crawl(context: Context) -> None:
+    assert context.dataset.data is not None
     path = context.fetch_resource("source.html", context.dataset.data.url)
     json_path = dataset_data_path(context.dataset.name) / "source.json"
 
     with open(path, "r") as fh:
         html = fh.read()
-    json = REGEX_JSON.search(html).group(1)
+    json_match = REGEX_JSON.search(html)
+    assert json_match is not None
+    json = json_match.group(1)
     with open(json_path, "w") as fh:
         fh.write(json)
     context.export_resource(json_path, JSON, title=context.SOURCE_TITLE)

--- a/datasets/cl/info_probidad/crawler.py
+++ b/datasets/cl/info_probidad/crawler.py
@@ -1,13 +1,22 @@
 """
 # Occasional issues:
 
-## 500 Server Error: SPARQL Request Failed for url: https://datos.cplt.cl/catalogos/infoprobidad/csvdeclaraciones
+## Listing page renders `var datos = null;`
 
-This happens for a few days, then it goes away again for a few weeks.
+The listing page is server-rendered from an upstream SPARQL endpoint at
+https://datos.cplt.cl/catalogos/infoprobidad/csvdeclaraciones. We've seen this
+endpoint fail in a few different ways — sometimes a 500 ("SPARQL Request
+Failed"), sometimes HTTP/2 framing errors, sometimes an empty reply with no
+response body at all.
 
-We've emailed them about it, but since it comes back from time to time, it's probably
-related to how their data grows, and who knows whether someone takes action or it
-just fixes itself. Give it a few days.
+The frontend swallows whichever flavor of failure happens upstream and renders
+the listing page with `var datos = null;` instead of the expected JSON array,
+so the page itself still responds with a happy 200.
+
+This happens for a few days, then it goes away again for a few weeks. We've
+emailed them about it, but since it comes back from time to time, it's probably
+related to how their data grows, and who knows whether someone takes action or
+it just fixes itself. Give it a few days.
 """
 
 import re
@@ -20,7 +29,7 @@ from zavod import helpers as h
 from zavod.archive import dataset_data_path
 from zavod.stateful.positions import categorise
 
-REGEX_JSON = re.compile(r"var datos =(.+?}]);")
+REGEX_DATOS = re.compile(r"var datos =\s*(null|\[.+?}\]);")
 DECLARATION_URL = "https://www.infoprobidad.cl/Declaracion/descargarDeclaracionJSon"
 
 
@@ -153,9 +162,16 @@ def crawl(context: Context) -> None:
 
     with open(path, "r") as fh:
         html = fh.read()
-    json_match = REGEX_JSON.search(html)
-    assert json_match is not None
-    json = json_match.group(1)
+    match = REGEX_DATOS.search(html)
+    assert match is not None, "Could not find `var datos = ...` in source HTML"
+    json = match.group(1)
+    # The listing page server-renders `var datos = null;` when its upstream
+    # SPARQL endpoint is failing. we catch this here to have a more informative
+    # error than just failing to parse the JSON.
+    # See the module docstring; this typically self-heals in a few days.
+    assert json != "null", (
+        "Source listing page returned `var datos = null` — upstream backend is likely failing."
+    )
     with open(json_path, "w") as fh:
         fh.write(json)
     context.export_resource(json_path, JSON, title=context.SOURCE_TITLE)

--- a/datasets/co/funcion_publica/crawler.py
+++ b/datasets/co/funcion_publica/crawler.py
@@ -1,14 +1,13 @@
 from datetime import timedelta
 from normality import slugify
 from rigour.mime.types import CSV
-from typing import Dict
 import csv
-from lxml.html import HtmlElement
 import re
 
 from zavod import helpers as h
 from zavod.context import Context
 from zavod.entity import Entity
+from zavod.util import Element
 from zavod.stateful.positions import YEAR_DAYS, OccupancyStatus, categorise
 from zavod import settings
 
@@ -76,7 +75,7 @@ def build_position(context: Context, *, role: str, entity_name: str) -> Entity:
     return position
 
 
-def crawl_sheet_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_sheet_row(context: Context, row: dict[str, str]) -> str | None:
     person = context.make("Person")
     id_number = row.pop("NUMERO_DOCUMENTO")
     person.id = context.make_slug(id_number, prefix="co-cedula")
@@ -105,7 +104,7 @@ def crawl_sheet_row(context: Context, row: Dict[str, str]) -> None:
     position = build_position(context, role=role, entity_name=entity_name)
     categorisation = categorise(context, position)
     if not categorisation.is_pep:
-        return
+        return None
 
     occupancy = h.make_occupancy(
         context,
@@ -123,6 +122,8 @@ def crawl_sheet_row(context: Context, row: Dict[str, str]) -> None:
         end_date=row.pop("FECHA_DESVINCULACION"),
         categorisation=categorisation,
     )
+    # assert added during typechecker fixes to not change behavior; may not reflect reality
+    assert occupancy is not None
     context.emit(person)
     context.emit(position)
     context.emit(occupancy)
@@ -132,11 +133,12 @@ def crawl_sheet_row(context: Context, row: Dict[str, str]) -> None:
 
 def crawl_table_row(
     context: Context,
-    seen: set,
-    row: Dict[str, HtmlElement],
+    seen: set[str | None],
+    row: dict[str, Element],
 ) -> None:
     str_row = h.cells_to_str(row)
     name_id = str_row.pop("declarante")
+    assert name_id is not None
     person = context.make("Person")
     match = REGEX_ID.search(name_id)
     if match is None:
@@ -174,9 +176,9 @@ def crawl_table_row(
     if key in seen:
         return
 
-    if str_row.pop("fecha_publicacion") < h.backdate(
-        settings.RUN_TIME, timedelta(days=YEAR_DAYS * 5)
-    ):
+    fecha_publicacion = str_row.pop("fecha_publicacion")
+    assert fecha_publicacion is not None
+    if fecha_publicacion < h.backdate(settings.RUN_TIME, timedelta(days=YEAR_DAYS * 5)):
         context.log.warning("Skipping potentially too old position", key=key)
         return
 
@@ -210,6 +212,8 @@ def crawl_table_row(
         status=OccupancyStatus.UNKNOWN,
         categorisation=categorisation,
     )
+    # assert added during typechecker fixes to not change behavior; may not reflect reality
+    assert occupancy is not None
     context.emit(person)
     context.emit(position)
     context.emit(occupancy)
@@ -217,26 +221,30 @@ def crawl_table_row(
 
 
 def crawl(context: Context) -> None:
-    seen = set()
+    seen: set[str | None] = set()
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
     with open(path, "r") as fh:
         for row in csv.DictReader(fh):
             seen.add(crawl_sheet_row(context, row))
 
-    next_link = "https://www.funcionpublica.gov.co/fdci/consultaCiudadana/consultaPEP?find=FindNext&tipoRegistro=4&offset=0&max=50"
+    next_link: str | None = (
+        "https://www.funcionpublica.gov.co/fdci/consultaCiudadana/consultaPEP?find=FindNext&tipoRegistro=4&offset=0&max=50"
+    )
     while next_link:
         context.log.info("Fetching page", url=next_link)
         doc = context.fetch_html(next_link, cache_days=1, absolute_links=True)
-        step_anchors = doc.xpath("//a[contains(@class, 'step')]")
-        context.log.info("Pages", pagenums=[a.text_content() for a in step_anchors])
+        step_anchors = h.xpath_elements(doc, "//a[contains(@class, 'step')]")
+        context.log.info("Pages", pagenums=[h.element_text(a) for a in step_anchors])
         if not step_anchors:
             context.log.warning("No pagination found", url=next_link)
-        next_anchors = doc.xpath("//a[contains(@class, 'nextLink')]")
+        next_anchors = h.xpath_elements(doc, "//a[contains(@class, 'nextLink')]")
         if next_anchors:
-            next_link = next_anchors[0].get("href")
+            href = next_anchors[0].get("href")
+            assert href is not None
+            next_link = href
         else:
             next_link = None
 
-        for row in h.parse_html_table(doc.find(".//table")):
-            crawl_table_row(context, seen, row)
+        for html_row in h.parse_html_table(h.xpath_element(doc, ".//table")):
+            crawl_table_row(context, seen, html_row)

--- a/datasets/co/join_dots/crawler.py
+++ b/datasets/co/join_dots/crawler.py
@@ -1,7 +1,6 @@
 from followthemoney.util import join_text
-from normality import collapse_spaces, slugify
+from normality import slugify, squash_spaces
 from rigour.mime.types import CSV
-from typing import Dict
 import csv
 from lxml import html
 
@@ -33,7 +32,7 @@ from zavod.stateful.positions import OccupancyStatus, categorise
 GRAPH_URL = "https://peps.directoriolegislativo.org/json/graph.json"
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> tuple[str, Entity]:
+def crawl_row(context: Context, row: dict[str, str]) -> tuple[str, Entity]:
     entity = context.make("Person")
     id_number = row.pop("ID / CC")
     entity.id = context.make_slug(id_number, prefix="co-cedula")
@@ -51,7 +50,9 @@ def crawl_row(context: Context, row: Dict[str, str]) -> tuple[str, Entity]:
         ),
     )
     entity.add("idNumber", id_number)
-    return slugify(entity.get("name")), entity
+    name_slug = slugify(entity.get("name"))
+    assert name_slug is not None
+    return name_slug, entity
 
 
 def parse_node(context: Context, node: dict[str, str]) -> dict[str, str] | None:
@@ -59,16 +60,21 @@ def parse_node(context: Context, node: dict[str, str]) -> dict[str, str] | None:
     if description.strip() == "":
         return None
     doc = html.fromstring(description)
-    text: str = doc.text_content()
+    # squash=False to preserve newlines — we split rows on \n below
+    text = h.element_text(doc, squash=False)
     data: dict[str, str] = {}
     for row in text.split("\n"):
         if row:
             key, value = row.split(":", 1)
-            data[slugify(key, "_")] = collapse_spaces(value)
+            slug_key = slugify(key, "_")
+            assert slug_key is not None
+            data[slug_key] = squash_spaces(value)
 
     links = doc.findall(".//a")
     if len(links) == 1:
-        data["link"] = links[0].get("href")
+        href = links[0].get("href")
+        assert href is not None
+        data["link"] = href
     else:
         context.log.warning(
             "Expected exactly one link for node", id=node["ID"], count=len(links)
@@ -83,6 +89,7 @@ def crawl_node(context: Context, peps: dict[str, Entity], node: dict[str, str]) 
 
     name = data["politically_exposed_person"]
     name_slug = slugify(name)
+    assert name_slug is not None
     entity = peps.get(name_slug, None)
     if entity:
         position_slug = slugify(data.pop("position"))

--- a/datasets/hk/principal_officials/crawler.py
+++ b/datasets/hk/principal_officials/crawler.py
@@ -1,17 +1,17 @@
 import re
 from normality import collapse_spaces
-from xml.etree import ElementTree
 
 from zavod import Context
 from zavod import helpers as h
 from zavod.stateful.positions import categorise
+from zavod.util import Element
 
 
 def get_element_text(
-    doc: ElementTree, xpath_value: str, to_remove: list[str] = [], position: int = 0
+    doc: Element, xpath_value: str, to_remove: list[str] = [], position: int = 0
 ) -> str | None:
-    element_tag = doc.xpath(xpath_value)
-    element_text = element_tag[position].text_content() if element_tag else ""
+    elements = h.xpath_elements(doc, xpath_value)
+    element_text = h.element_text(elements[position]) if elements else ""
 
     for string in to_remove:
         element_text = element_text.replace(string, "")
@@ -19,12 +19,14 @@ def get_element_text(
     return collapse_spaces(element_text.strip())
 
 
-def crawl_members(context: Context, section: str, elem: ElementTree) -> None:
+def crawl_members(context: Context, section: str, elem: Element) -> None:
     url = elem.get("href")
+    assert url is not None
 
     doc = context.fetch_html(url, cache_days=1)
 
     member_header = get_element_text(doc, '//h1[contains(@class,"title")]')
+    assert member_header is not None
     member_desc = get_element_text(doc, '//section[@class="blockItem"]')
 
     person_name = member_header.split(",")[0]
@@ -62,6 +64,8 @@ def crawl_members(context: Context, section: str, elem: ElementTree) -> None:
         no_end_implies_current=True,
     )
 
+    # assert added during typechecker fixes to not change behavior; may not reflect reality
+    assert occupancy is not None
     context.emit(person)
     context.emit(position)
     context.emit(occupancy)
@@ -69,9 +73,7 @@ def crawl_members(context: Context, section: str, elem: ElementTree) -> None:
 
 def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url, cache_days=1, absolute_links=True)
-    for section in doc.xpath('//section[@class="blockItem"]'):
-        section_name = section.xpath("./h3")[0].text_content()
-        officials = section.xpath(".//p//a")
-
-        for elem in officials:
+    for section in h.xpath_elements(doc, '//section[@class="blockItem"]'):
+        section_name = h.element_text(h.xpath_element(section, "./h3"))
+        for elem in h.xpath_elements(section, ".//p//a"):
             crawl_members(context, section_name, elem)

--- a/datasets/ru/egrul/crawler.py
+++ b/datasets/ru/egrul/crawler.py
@@ -10,7 +10,7 @@ from zavod import helpers as h
 from zavod.shed.internal_data import fetch_internal_data, list_internal_data
 
 LOCAL_BUCKET_PATH = "/Users/leon/internal-data/"
-PROCESSED_EGRUL_PREFIX = "ru_egrul/processed_2026-03-07/"
+PROCESSED_EGRUL_PREFIX = "ru_egrul/processed_2026-06-04/"
 
 
 def substitute_abbreviations(name: str | None) -> str | None:

--- a/datasets/tr/fcib/crawler.py
+++ b/datasets/tr/fcib/crawler.py
@@ -73,8 +73,8 @@ def crawl_row(
     if not name:
         return  # in the XLSX file, there are empty rows
 
-    pass_no = row.pop("passport_number") or ""  # Person
-    passport_other = row.pop("passport_number_other_info") or ""  # LegalEntity
+    pass_no = row.pop("passport_number", None) or ""  # Person
+    passport_other = row.pop("passport_number_other_info", None) or ""  # LegalEntity
     birth_establishment_date = split(row.pop("date_of_birth_establishment", ""))
     birth_place = row.pop("birth_place", "")
     birth_dates = split(row.pop("birth_date"))

--- a/datasets/us/fbi_most_wanted/crawler.py
+++ b/datasets/us/fbi_most_wanted/crawler.py
@@ -110,7 +110,7 @@ def crawl_person(context: Context, url: str) -> None:
     context.emit(person)
 
 
-def crawl_type(context: Context, type: str, query_id: str) -> None:
+def crawl_type(context: Context, *, query_type: str, query_id: str) -> None:
     total_pages: Optional[int] = None
     total_xpath = './/div[@class="row top-total"]//p'
     for page in count(1):
@@ -149,18 +149,32 @@ def crawl_type(context: Context, type: str, query_id: str) -> None:
 
 
 def crawl(context: Context) -> None:
-    # Check if new menu items have been added that we potentially want to crawl.
-    # Expected items listed below.
+    # Check dataset URL (you will need to have a US IP).
+    # Check top row menu. If new menu items have been added, add them here, either
+    # to crawl or to ignore.
+    # To find query_id, press the "Filter" button once on the listing page and look
+    # at the console of network requests in the browser devtools.
     menu_xpath = ".//ul[contains(@class, 'section-menu')]"
     doc = fetch_html(context, context.dataset.model.url, menu_xpath)
     [menu] = doc.xpath(menu_xpath)
-    h.assert_dom_hash(menu, "8c4476503900c45adeb407a980cbc7663688aa1f")
+    h.assert_dom_hash(menu, "d5a637f3eb32e7f0e46cb0d9a99682620e4793df")
 
-    crawl_type(context, "topten", "0f737222c5054a81a120bce207b0446a")
-    crawl_type(context, "fugitives", "f7f80a1681ac41a08266bd0920c9d9d8")
-    crawl_type(context, "terrorism", "55d8265003c84ff2a7688d7acd8ebd5a")
+    crawl_type(
+        context, query_type="topten", query_id="0f737222c5054a81a120bce207b0446a"
+    )
+    crawl_type(
+        context, query_type="fugitives", query_id="f7f80a1681ac41a08266bd0920c9d9d8"
+    )
+    crawl_type(
+        context, query_type="terrorism", query_id="55d8265003c84ff2a7688d7acd8ebd5a"
+    )
+    crawl_type(
+        context,
+        query_type="most-wanted-fraudsters",
+        query_id="2dc632f7086346c992ce8fee76a98886",
+    )
     # kidnap - these are the victims, not wanted criminals.
-    crawl_type(context, "parental-kidnappings", "querylisting-1")
+    crawl_type(context, query_type="parental-kidnappings", query_id="querylisting-1")
     # seeking-information - some of these are victims, some name unknown criminals
     # ecap - name unknown, not all suspects
     # indian-country - some victims

--- a/datasets/us/fbi_most_wanted/crawler.py
+++ b/datasets/us/fbi_most_wanted/crawler.py
@@ -155,8 +155,10 @@ def crawl(context: Context) -> None:
     # To find query_id, press the "Filter" button once on the listing page and look
     # at the console of network requests in the browser devtools.
     menu_xpath = ".//ul[contains(@class, 'section-menu')]"
-    doc = fetch_html(context, context.dataset.model.url, menu_xpath)
-    [menu] = doc.xpath(menu_xpath)
+    url = context.dataset.model.url
+    assert url is not None
+    doc = fetch_html(context, url, menu_xpath)
+    menu = h.xpath_element(doc, menu_xpath)
     h.assert_dom_hash(menu, "d5a637f3eb32e7f0e46cb0d9a99682620e4793df")
 
     crawl_type(


### PR DESCRIPTION
- **[cl] fix mypy strict errors**
  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
  

- **pre-commit: remove bh, it no longer exists**
  

- **[co] fix mypy --strict errors; remove co from pre-commit exclude list**
  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
  

- **[hk] fix mypy --strict errors; remove hk from pre-commit exclude list**
  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
  

- **[tr_fcib] restore default in row.pop for optional passport columns**
  Regression from ca7f06477 — switching to `row.pop(k) or ""` dropped the
  default and started raising KeyError when the column is missing.
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  

- **[us_fbi_most_wanted] Update with new section**
  

- **[us_fbi_most_wanted] fix mypy --strict errors; remove from pre-commit exclude list**
  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
  

- **[cl_info_probidad] detect upstream failure rendered as `var datos = null`**
  When the SPARQL backend is unhealthy the listing page still returns 200
  but renders `var datos = null;`. Detect that explicitly with an assert
  so we get a useful error instead of a regex-doesn't-match crash, and
  update the module docstring to describe the actual symptom.
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  