### PR TITLE
[docs] Document historical and multi-term PEP crawling

### DIFF
--- a/zavod/docs/best_practices/priorities.md
+++ b/zavod/docs/best_practices/priorities.md
@@ -42,7 +42,7 @@ See also: [guide for building PEP data crawlers](../peps.md)
 
 - `country` (occasionally multiple apply to one position, e.g. *Ambassador of Palestine to Germany*)
 - `position` (of a person)
-- `occupancy` (relating a person to the position(s) they hold/held) - focus on current positions before worrying about historical.
+- `occupancy` (relating a person to the position(s) they hold/held) - focus on current position-holders. When a legislature exposes past terms cheaply, see [Historical and multi-term sources](../peps.md#historical-and-multi-term-sources).
 
 **Could**
 

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -192,3 +192,33 @@ if pep_entities:
 for entity in pep_entities:
     context.emit(entity)
 ```
+
+## Historical and multi-term sources
+
+Current office holders are the priority, but when a source also exposes past terms
+cheaply — the same table, or a per-term archive — it is worth crawling them. A national
+legislator remains politically exposed for years after leaving office, so several terms
+still matter.
+
+Two mechanisms divide the labour:
+
+- [`earliest_term_start`][zavod.helpers.earliest_term_start] bounds how far back you
+  **crawl**: skip fetching whole terms or archive pages older than the PEP-relevance
+  window. The only thing it buys you is the crawl you avoid, so there is no point
+  applying it to terms you would fetch anyway — [`make_occupancy`][zavod.helpers.make_occupancy]
+  gates those records more precisely. Log a skipped term at `info`; it is a deliberate
+  gap, not something the crawler team can fix.
+- [`make_occupancy`][zavod.helpers.make_occupancy] is the decider on whether political
+  exposure still applies, per occupancy. The cutoff is deliberately more generous than
+  this window, so it never skips a term whose members would still qualify.
+
+Date each occupancy. Use `startDate`/`endDate` for a person's own mandate (a member who
+left mid-term, or any source giving per-person dates); use `periodStart`/`periodEnd` for
+whole-term membership, where you only know the term's bounds and they are identical for
+everyone who served that term. The two can coexist, and `make_occupancy` treats an
+individual end date as the more specific signal. If neither is known, `electionDate` can
+stand in as a fallback for inferring exposure.
+
+Let `make_occupancy` derive the `status` from these dates — do not pass `status="ended"`
+yourself when you have an end date. Override `status` only when the source states that a
+mandate is current or ended but gives no date to derive it from.


### PR DESCRIPTION
Adds a **"Historical and multi-term sources"** section to the PEP guide (`zavod/docs/peps.md`), and links to it from `best_practices/priorities.md`.

### Why
`h.earliest_term_start` is used by several crawlers (`be/chamber`, `ky/parliament`, `rs/national_assembly`) but appears in no documentation — a crawler author would never discover it. The guide also said nothing about crawling past terms, and the `periodStart`/`periodEnd` vs `startDate`/`endDate` distinction was undocumented.

### What the new section says
- **When** to crawl past terms: current office holders are the priority, but past terms are worth it when the source exposes them cheaply (preserves the existing "current first" stance in `priorities.md`, now linked).
- **`earliest_term_start` bounds how far back you *crawl*** — its only payoff is the fetch you avoid, so there's no point applying it to terms you'd download anyway; **`make_occupancy` is the decider on whether political exposure applies**, more precisely, per occupancy. The cutoff is deliberately more generous than the relevance window. Skipped terms are logged at `info`, not `warning`.
- **Which dates**: `startDate`/`endDate` for an individual's mandate, `periodStart`/`periodEnd` for whole-term membership (identical for everyone who served the term); they can coexist and `make_occupancy` prefers the individual end. `electionDate` is a fallback when neither is known.
- **Status**: let `make_occupancy` derive it from the dates; only override `status=` when the source asserts a mandate's state but gives no date.

No hard-coded threshold numbers in the prose (they live in the code and can shift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
