### PR TITLE
Feature/topic gated enrichment

### DIFF
--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -29,10 +29,11 @@ def emit_patch(
         existing_topics=list(existing_topics),
     )
 
-    patch = context.make(related_entity.schema)
+    has_internal = any(not s.external for s in related_entity.statements)
+    patch = context.make("Thing")
     patch.id = related_entity.id
     patch.add("topics", topic)
-    context.emit(patch)
+    context.emit(patch, external=not has_internal)
 
 
 def analyze_entity(context: Context, view: View, entity: Entity) -> None:
@@ -120,7 +121,7 @@ def crawl(context: Context) -> None:
     linker = get_dataset_linker(scope)
     store = get_store(scope, linker)
     store.sync()
-    view = store.view(scope)
+    view = store.view(scope, external=True)
 
     for entity_idx, entity in enumerate(view.entities()):
         if entity_idx > 0 and entity_idx % 1000 == 0:

--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -29,11 +29,10 @@ def emit_patch(
         existing_topics=list(existing_topics),
     )
 
-    has_internal = any(not s.external for s in related_entity.statements)
     patch = context.make("Thing")
     patch.id = related_entity.id
     patch.add("topics", topic)
-    context.emit(patch, external=not has_internal)
+    context.emit(patch, external=related_entity.external)
 
 
 def analyze_entity(context: Context, view: View, entity: Entity) -> None:

--- a/datasets/_externals/ext_icij_offshoreleaks.yml
+++ b/datasets/_externals/ext_icij_offshoreleaks.yml
@@ -69,6 +69,7 @@ inputs:
   - sanctions
 
 config:
+  topic_gated: true
   index_options:
     match_batch: 300
     memory: 4000

--- a/zavod/zavod/entity.py
+++ b/zavod/zavod/entity.py
@@ -171,6 +171,11 @@ class Entity(StatementEntity):
         """Return whether the entity has any statements."""
         return len(self._statements) > 0
 
+    @property
+    def external(self) -> bool:
+        """Return whether the entity is completely composed of external statements."""
+        return all(s.external for s in self.statements)
+
     def _to_nested_dict(
         self: Self, view: "View[Dataset, Entity]", depth: int, path: List[str]
     ) -> Dict[str, Any]:

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -169,17 +169,17 @@ class LocalEnricher(BaseEnricher[Dataset]):
         yield from self.expand(match)
 
 
-def has_risk_topic(entity_id: str, view: View) -> bool:
-    """Return True if and only if the entity exists in the view and carries a risk topic."""
+def has_enrich_topic(entity_id: str, view: View, enrich_topics: frozenset[str]) -> bool:
+    """True only if the entity exists in the view and carries one of the enrich topics."""
     canonical_id = view.store.linker.get_canonical(entity_id)
     entity = view.get_entity(canonical_id)
     if entity is None:
         return False
-    return len(registry.topic.RISKS.intersection(entity.get("topics"))) > 0
+    return bool(enrich_topics.intersection(entity.get("topics")))
 
 
-def is_edge_internal(entity: Entity, view: View) -> bool:
-    """For an edge entity, return True if and only if every endpoint has a risk topic."""
+def is_edge_internal(entity: Entity, view: View, enrich_topics: frozenset[str]) -> bool:
+    """For an edge entity, return True only if every endpoint carries an enrich topic."""
     endpoint_ids: set[str] = set()
     if entity.schema.source_prop is not None:
         endpoint_ids.update(entity.get(entity.schema.source_prop.name))
@@ -187,7 +187,7 @@ def is_edge_internal(entity: Entity, view: View) -> bool:
         endpoint_ids.update(entity.get(entity.schema.target_prop.name))
     if not endpoint_ids:
         return False
-    return all(has_risk_topic(eid, view) for eid in endpoint_ids)
+    return all(has_enrich_topic(eid, view, enrich_topics) for eid in endpoint_ids)
 
 
 def save_match(
@@ -198,6 +198,7 @@ def save_match(
     match: Entity,
     subject_view: View,
     topic_gated: bool,
+    enrich_topics: frozenset[str],
 ) -> None:
     if match.id is None or entity.id is None:
         return None
@@ -217,11 +218,11 @@ def save_match(
                 continue
             if topic_gated:
                 if adjacent.schema.edge:
-                    ext = not is_edge_internal(adjacent, subject_view)
+                    ext = not is_edge_internal(adjacent, subject_view, enrich_topics)
                 elif adjacent.id is None:
                     ext = True
                 else:
-                    ext = not has_risk_topic(adjacent.id, subject_view)
+                    ext = not has_enrich_topic(adjacent.id, subject_view, enrich_topics)
             else:
                 ext = False
             context.emit(adjacent, external=ext)
@@ -237,10 +238,17 @@ def enrich(context: Context) -> None:
     subject_store = get_store(scope, resolver)
     subject_store.sync()
     subject_view = subject_store.view(scope)
+
     config = dict(context.dataset.config)
     topic_gated: bool = bool(config.get("topic_gated", False))
     enricher = LocalEnricher(context.dataset, context.cache, config)
+    enrich_topics: frozenset[str] = frozenset(enricher._filter_topics)
+    if topic_gated and not enrich_topics:
+        context.log.warning(
+            "topic_gated=True but no topics configured; all expanded entities will be external"
+        )
     reset_caches()
+
     try:
         context.log.info("Matching candidates...")
         schemata = list(model.matchable_schemata())
@@ -265,6 +273,7 @@ def enrich(context: Context) -> None:
                         match,
                         subject_view,
                         topic_gated,
+                        enrich_topics,
                     )
             except EnrichmentException as exc:
                 context.log.error(

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -186,14 +186,6 @@ def has_enrich_topic(entity_id: str, view: View, enrich_topics: frozenset[str]) 
     return bool(enrich_topics.intersection(entity.get("topics")))
 
 
-def is_edge_internal(entity: Entity, view: View, enrich_topics: frozenset[str]) -> bool:
-    """For an edge entity, return True only if every endpoint carries an enrich topic."""
-    endpoint_ids = _endpoint_ids(entity)
-    if not endpoint_ids:
-        return False
-    return all(has_enrich_topic(eid, view, enrich_topics) for eid in endpoint_ids)
-
-
 def check_enrich_topics(
     expanded: Iterable[Entity], view: View, enrich_topics: frozenset[str]
 ) -> Dict[str, bool]:
@@ -212,9 +204,9 @@ def check_enrich_topics(
     return {eid: has_enrich_topic(eid, view, enrich_topics) for eid in ids_to_check}
 
 
-def promote(entity: Entity, topic_matches: Dict[str, bool]) -> bool:
-    """Decide whether an expanded entity should be emitted as internal,
-    using a precomputed map of entity-id → has_enrich_topic."""
+def should_promote(entity: Entity, topic_matches: Dict[str, bool]) -> bool:
+    """Decide whether an entity should be emitted as internal,
+    based on a precomputed map of entity-id → has_enrich_topic."""
     if entity.schema.edge:
         endpoint_ids = _endpoint_ids(entity)
         if not endpoint_ids:
@@ -253,7 +245,7 @@ def save_match(
         if topic_gated:
             topic_matches = check_enrich_topics(expanded, subject_view, enrich_topics)
             for adj in expanded:
-                context.emit(adj, external=not promote(adj, topic_matches))
+                context.emit(adj, external=not should_promote(adj, topic_matches))
         else:
             for adj in expanded:
                 context.emit(adj, external=False)

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -190,6 +190,18 @@ def is_edge_internal(entity: Entity, view: View, enrich_topics: frozenset[str]) 
     return all(has_enrich_topic(eid, view, enrich_topics) for eid in endpoint_ids)
 
 
+def promote(
+    entity: Entity, view: View, topic_gated: bool, enrich_topics: frozenset[str]
+) -> bool:
+    if not topic_gated:
+        return True
+    if entity.schema.edge:
+        return is_edge_internal(entity, view, enrich_topics)
+    else:
+        assert entity.id is not None
+        return has_enrich_topic(entity.id, view, enrich_topics)
+
+
 def save_match(
     context: Context,
     resolver: Resolver[Entity],
@@ -216,16 +228,8 @@ def save_match(
         for adjacent in enricher.expand_wrapped(entity, match):
             if check_person_cutoff(adjacent):
                 continue
-            if topic_gated:
-                if adjacent.schema.edge:
-                    ext = not is_edge_internal(adjacent, subject_view, enrich_topics)
-                elif adjacent.id is None:
-                    ext = True
-                else:
-                    ext = not has_enrich_topic(adjacent.id, subject_view, enrich_topics)
-            else:
-                ext = False
-            context.emit(adjacent, external=ext)
+            external = not promote(adjacent, subject_view, topic_gated, enrich_topics)
+            context.emit(adjacent, external=external)
 
 
 def enrich(context: Context) -> None:

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -21,7 +21,6 @@ from zavod.meta import Dataset, get_multi_dataset, get_catalog
 from zavod.store import get_store, View
 from zavod.reset import reset_caches
 
-
 log = logging.getLogger(__name__)
 
 
@@ -170,17 +169,17 @@ class LocalEnricher(BaseEnricher[Dataset]):
         yield from self.expand(match)
 
 
-def has_topic(entity_id: str, view: View) -> bool:
-    """Return True iff the entity exists in the view and carries a risk topic."""
+def has_risk_topic(entity_id: str, view: View) -> bool:
+    """Return True if and only if the entity exists in the view and carries a risk topic."""
     canonical_id = view.store.linker.get_canonical(entity_id)
     entity = view.get_entity(canonical_id)
     if entity is None:
         return False
-    return bool(entity.get("topics"))
+    return len(registry.topic.RISKS.intersection(entity.get("topics"))) > 0
 
 
 def is_edge_internal(entity: Entity, view: View) -> bool:
-    """For an edge entity, return True iff every endpoint has a risk topic."""
+    """For an edge entity, return True if and only if every endpoint has a risk topic."""
     endpoint_ids: set[str] = set()
     if entity.schema.source_prop is not None:
         endpoint_ids.update(entity.get(entity.schema.source_prop.name))
@@ -188,7 +187,7 @@ def is_edge_internal(entity: Entity, view: View) -> bool:
         endpoint_ids.update(entity.get(entity.schema.target_prop.name))
     if not endpoint_ids:
         return False
-    return all(has_topic(eid, view) for eid in endpoint_ids)
+    return all(has_risk_topic(eid, view) for eid in endpoint_ids)
 
 
 def save_match(
@@ -222,7 +221,7 @@ def save_match(
                 elif adjacent.id is None:
                     ext = True
                 else:
-                    ext = not has_topic(adjacent.id, subject_view)
+                    ext = not has_risk_topic(adjacent.id, subject_view)
             else:
                 ext = False
             context.emit(adjacent, external=ext)

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -1,6 +1,6 @@
 import logging
 from decimal import Decimal
-from typing import Generator, Iterator, List, Tuple
+from typing import Dict, Generator, Iterable, Iterator, List, Tuple
 from followthemoney import registry, model
 from followthemoney.helpers import check_person_cutoff
 
@@ -100,10 +100,10 @@ class LocalEnricher(BaseEnricher[Dataset]):
     ) -> Generator[Entity, None, None]:
         # Make sure an entity with the same ID is yielded. E.g. a QID or ID scheme
         # intentionally consistent between datasets.
-        if entity.id is not None:
-            same_id_match = self.target_view.get_entity(entity.id)
-            if same_id_match is not None:
-                yield same_id_match
+        assert entity.id is not None
+        same_id_match = self.target_view.get_entity(entity.id)
+        if same_id_match is not None:
+            yield same_id_match
 
         scores: List[Tuple[float, Entity]] = []
         last_rounded_score = None
@@ -138,8 +138,7 @@ class LocalEnricher(BaseEnricher[Dataset]):
         self, entity: Entity, path: List[str] = []
     ) -> Generator[Entity, None, None]:
         """Expand starting from a match, recursing to related non-edge entities"""
-        if entity.id is None:
-            return
+        assert entity.id is not None
 
         yield entity
 
@@ -169,6 +168,15 @@ class LocalEnricher(BaseEnricher[Dataset]):
         yield from self.expand(match)
 
 
+def _endpoint_ids(entity: Entity) -> set[str]:
+    endpoint_ids: set[str] = set()
+    if entity.schema.source_prop is not None:
+        endpoint_ids.update(entity.get(entity.schema.source_prop.name))
+    if entity.schema.target_prop is not None:
+        endpoint_ids.update(entity.get(entity.schema.target_prop.name))
+    return endpoint_ids
+
+
 def has_enrich_topic(entity_id: str, view: View, enrich_topics: frozenset[str]) -> bool:
     """True only if the entity exists in the view and carries one of the enrich topics."""
     canonical_id = view.store.linker.get_canonical(entity_id)
@@ -180,26 +188,40 @@ def has_enrich_topic(entity_id: str, view: View, enrich_topics: frozenset[str]) 
 
 def is_edge_internal(entity: Entity, view: View, enrich_topics: frozenset[str]) -> bool:
     """For an edge entity, return True only if every endpoint carries an enrich topic."""
-    endpoint_ids: set[str] = set()
-    if entity.schema.source_prop is not None:
-        endpoint_ids.update(entity.get(entity.schema.source_prop.name))
-    if entity.schema.target_prop is not None:
-        endpoint_ids.update(entity.get(entity.schema.target_prop.name))
+    endpoint_ids = _endpoint_ids(entity)
     if not endpoint_ids:
         return False
     return all(has_enrich_topic(eid, view, enrich_topics) for eid in endpoint_ids)
 
 
-def promote(
-    entity: Entity, view: View, topic_gated: bool, enrich_topics: frozenset[str]
-) -> bool:
-    if not topic_gated:
-        return True
+def check_enrich_topics(
+    expanded: Iterable[Entity], view: View, enrich_topics: frozenset[str]
+) -> Dict[str, bool]:
+    """Resolve has_enrich_topic exactly once per ID across an entire expansion.
+
+    Edges and non-edges in a single expansion  reference the same handful of IDs.
+    This avoids repeat entity lookups.
+    """
+    ids_to_check: set[str] = set()
+    for entity in expanded:
+        if entity.schema.edge:
+            ids_to_check.update(_endpoint_ids(entity))
+        else:
+            assert entity.id is not None
+            ids_to_check.add(entity.id)
+    return {eid: has_enrich_topic(eid, view, enrich_topics) for eid in ids_to_check}
+
+
+def promote(entity: Entity, topic_matches: Dict[str, bool]) -> bool:
+    """Decide whether an expanded entity should be emitted as internal,
+    using a precomputed map of entity-id → has_enrich_topic."""
     if entity.schema.edge:
-        return is_edge_internal(entity, view, enrich_topics)
-    else:
-        assert entity.id is not None
-        return has_enrich_topic(entity.id, view, enrich_topics)
+        endpoint_ids = _endpoint_ids(entity)
+        if not endpoint_ids:
+            return False
+        return all(topic_matches.get(eid, False) for eid in endpoint_ids)
+    assert entity.id is not None
+    return topic_matches.get(entity.id, False)
 
 
 def save_match(
@@ -212,8 +234,8 @@ def save_match(
     topic_gated: bool,
     enrich_topics: frozenset[str],
 ) -> None:
-    if match.id is None or entity.id is None:
-        return None
+    assert match.id is not None
+    assert entity.id is not None
     if not entity.schema.can_match(match.schema):
         return None
     judgement = resolver.get_judgement(match.id, entity.id)
@@ -225,11 +247,16 @@ def save_match(
     # them visible:
     if judgement == Judgement.POSITIVE:
         context.log.info("Enrich [%s]: %r" % (entity, match))
-        for adjacent in enricher.expand_wrapped(entity, match):
-            if check_person_cutoff(adjacent):
-                continue
-            external = not promote(adjacent, subject_view, topic_gated, enrich_topics)
-            context.emit(adjacent, external=external)
+        expanded = list(enricher.expand_wrapped(entity, match))
+        expanded = [adj for adj in expanded if not check_person_cutoff(adj)]
+
+        if topic_gated:
+            topic_matches = check_enrich_topics(expanded, subject_view, enrich_topics)
+            for adj in expanded:
+                context.emit(adj, external=not promote(adj, topic_matches))
+        else:
+            for adj in expanded:
+                context.emit(adj, external=False)
 
 
 def enrich(context: Context) -> None:

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -172,7 +172,8 @@ class LocalEnricher(BaseEnricher[Dataset]):
 
 def has_topic(entity_id: str, view: View) -> bool:
     """Return True iff the entity exists in the view and carries a risk topic."""
-    entity = view.get_entity(entity_id)
+    canonical_id = view.store.linker.get_canonical(entity_id)
+    entity = view.get_entity(canonical_id)
     if entity is None:
         return False
     return bool(entity.get("topics"))
@@ -216,13 +217,12 @@ def save_match(
             if check_person_cutoff(adjacent):
                 continue
             if topic_gated:
-                adj_id = adjacent.id
                 if adjacent.schema.edge:
                     ext = not is_edge_internal(adjacent, subject_view)
-                elif adj_id is None:
+                elif adjacent.id is None:
                     ext = True
                 else:
-                    ext = not has_topic(adj_id, subject_view)
+                    ext = not has_topic(adjacent.id, subject_view)
             else:
                 ext = False
             context.emit(adjacent, external=ext)

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -18,7 +18,7 @@ from zavod.context import Context
 from zavod.integration.dedupe import get_dataset_linker, get_resolver
 from zavod.entity import Entity
 from zavod.meta import Dataset, get_multi_dataset, get_catalog
-from zavod.store import get_store
+from zavod.store import get_store, View
 from zavod.reset import reset_caches
 
 
@@ -170,12 +170,34 @@ class LocalEnricher(BaseEnricher[Dataset]):
         yield from self.expand(match)
 
 
+def has_topic(entity_id: str, view: View) -> bool:
+    """Return True iff the entity exists in the view and carries a risk topic."""
+    entity = view.get_entity(entity_id)
+    if entity is None:
+        return False
+    return bool(entity.get("topics"))
+
+
+def is_edge_internal(entity: Entity, view: View) -> bool:
+    """For an edge entity, return True iff every endpoint has a risk topic."""
+    endpoint_ids: set[str] = set()
+    if entity.schema.source_prop is not None:
+        endpoint_ids.update(entity.get(entity.schema.source_prop.name))
+    if entity.schema.target_prop is not None:
+        endpoint_ids.update(entity.get(entity.schema.target_prop.name))
+    if not endpoint_ids:
+        return False
+    return all(has_topic(eid, view) for eid in endpoint_ids)
+
+
 def save_match(
     context: Context,
     resolver: Resolver[Entity],
     enricher: LocalEnricher,
     entity: Entity,
     match: Entity,
+    subject_view: View,
+    topic_gated: bool,
 ) -> None:
     if match.id is None or entity.id is None:
         return None
@@ -193,7 +215,17 @@ def save_match(
         for adjacent in enricher.expand_wrapped(entity, match):
             if check_person_cutoff(adjacent):
                 continue
-            context.emit(adjacent)
+            if topic_gated:
+                adj_id = adjacent.id
+                if adjacent.schema.edge:
+                    ext = not is_edge_internal(adjacent, subject_view)
+                elif adj_id is None:
+                    ext = True
+                else:
+                    ext = not has_topic(adj_id, subject_view)
+            else:
+                ext = False
+            context.emit(adjacent, external=ext)
 
 
 def enrich(context: Context) -> None:
@@ -207,6 +239,7 @@ def enrich(context: Context) -> None:
     subject_store.sync()
     subject_view = subject_store.view(scope)
     config = dict(context.dataset.config)
+    topic_gated: bool = bool(config.get("topic_gated", False))
     enricher = LocalEnricher(context.dataset, context.cache, config)
     reset_caches()
     try:
@@ -225,7 +258,15 @@ def enrich(context: Context) -> None:
                 continue
             try:
                 for match in enricher.match_candidates(subject_entity, candidate_set):
-                    save_match(context, resolver, enricher, subject_entity, match)
+                    save_match(
+                        context,
+                        resolver,
+                        enricher,
+                        subject_entity,
+                        match,
+                        subject_view,
+                        topic_gated,
+                    )
             except EnrichmentException as exc:
                 context.log.error(
                     "Enrichment error %r: %s" % (subject_entity, str(exc))

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -258,9 +258,6 @@ def enrich(context: Context) -> None:
     context.log.info(
         "Enriching %s (%s)" % (scope.name, [d.name for d in scope.datasets])
     )
-    subject_store = get_store(scope, resolver)
-    subject_store.sync()
-    subject_view = subject_store.view(scope)
 
     config = dict(context.dataset.config)
     topic_gated: bool = bool(config.get("topic_gated", False))
@@ -270,6 +267,11 @@ def enrich(context: Context) -> None:
         context.log.warning(
             "topic_gated=True but no topics configured; all expanded entities will be external"
         )
+
+    subject_store = get_store(scope, resolver)
+    subject_store.sync()
+    subject_view = subject_store.view(scope, external=topic_gated)
+
     reset_caches()
 
     try:

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -8,9 +8,10 @@ from zavod.entity import Entity
 from zavod.archive import clear_data_path
 from zavod.context import Context
 from zavod.crawl import crawl_dataset
+from zavod.integration import get_dataset_linker
 from zavod.integration.dedupe import get_resolver
 from zavod.meta import Dataset
-from zavod.runner.local_enricher import LocalEnricher
+from zavod.runner.local_enricher import LocalEnricher, is_edge_internal
 from zavod.store import get_store
 
 DATASET_DATA = {
@@ -209,4 +210,98 @@ def test_limit(vcontext: Context):
     results = list(enricher.match_candidates(entity, candidates[entity.id]))
     assert len(results) == 0, results
 
+    shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
+
+
+def test_is_edge_internal(testdataset1: Dataset):
+    """is_edge_internal returns True iff every edge endpoint has a risk topic."""
+    linker = get_dataset_linker(testdataset1)
+    crawl_dataset(testdataset1)
+    store = get_store(testdataset1, linker)
+    store.sync()
+    view = store.view(testdataset1, external=False)
+
+    # Ownership: oswell-spencer (crime.boss) → umbrella-corp (reg.warn) — both have topics
+    ownership = Entity.from_data(
+        testdataset1,
+        {
+            "schema": "Ownership",
+            "id": "test-ownership",
+            "properties": {
+                "owner": ["osv-oswell-spencer"],
+                "asset": ["osv-umbrella-corp"],
+            },
+        },
+    )
+    assert is_edge_internal(ownership, view)
+
+    # Family: johnny-does (no topics) → oswell-spencer (crime.boss) — one endpoint missing topic
+    family_no_topic = Entity.from_data(
+        testdataset1,
+        {
+            "schema": "Family",
+            "id": "test-family-no-topic",
+            "properties": {
+                "person": ["osv-johnny-does"],
+                "relative": ["osv-oswell-spencer"],
+            },
+        },
+    )
+    assert not is_edge_internal(family_no_topic, view)
+
+    # Family: one endpoint not in view at all
+    family_missing = Entity.from_data(
+        testdataset1,
+        {
+            "schema": "Family",
+            "id": "test-family-missing",
+            "properties": {
+                "person": ["osv-john-doe"],
+                "relative": ["nonexistent-id"],
+            },
+        },
+    )
+    assert not is_edge_internal(family_missing, view)
+
+    store.close()
+    shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
+
+
+def test_enrich_topic_gated(testdataset1: Dataset, testdataset_enrich_subject: Dataset):
+    """With topic_gated=True, expanded entities without topics are emitted external."""
+    resolver = get_resolver()
+    crawl_dataset(testdataset_enrich_subject)
+    crawl_dataset(testdataset1)
+
+    dataset_data = deepcopy(DATASET_DATA)
+    dataset_data["config"]["topic_gated"] = True
+    enricher_ds = make_enricher_dataset(dataset_data, testdataset1.name)
+    crawl_dataset(enricher_ds)
+
+    # Confirm the match (decide requires an active transaction)
+    resolver.begin()
+    canon_id = resolver.decide("osv-umbrella-corp", "xxx", Judgement.POSITIVE)
+    resolver.commit()
+
+    clear_data_path(enricher_ds.name)
+    crawl_dataset(enricher_ds)
+
+    resolver.begin()
+    store = get_store(enricher_ds, resolver)
+    store.sync(clear=True)
+
+    # The subject entity (Umbrella Corp.) has no topics in the subject store,
+    # so all expanded entities should be emitted as external.
+    internals = list(store.view(enricher_ds, external=False).entities())
+    assert len(internals) == 0, internals
+
+    all_entities = list(store.view(enricher_ds, external=True).entities())
+    assert len(all_entities) > 0, all_entities
+
+    # Canonical entity exists in the combined view
+    canon_entity = store.view(enricher_ds, external=True).get_entity(canon_id)
+    assert canon_entity is not None
+
+    resolver.rollback()
+    store.close()
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -5,7 +5,7 @@ from nomenklatura.judgement import Judgement
 
 from zavod import settings
 from zavod.entity import Entity
-from zavod.archive import clear_data_path
+from zavod.archive import clear_data_path, dataset_state_path
 from zavod.context import Context
 from zavod.crawl import crawl_dataset
 from zavod.integration import get_dataset_linker
@@ -300,18 +300,66 @@ def test_enrich_topic_gated(testdataset1: Dataset, testdataset_enrich_subject: D
     # oswell-spencer is reachable from the match but absent from the subject store
     # (only the enrich subject is in scope), so it must be external only.
     assert view_all.get_entity("osv-oswell-spencer") is not None
-    assert view_internal.get_entity("osv-oswell-spencer") is None, (
-        "oswell-spencer has no topic in the subject store → must be external"
-    )
+    # oswell-spencer has no topic in the subject store → must be external
+    assert view_internal.get_entity("osv-oswell-spencer") is None, ""
 
     # Ownership edge: oswell-spencer endpoint has no topic → external.
     inverted = list(view_all.get_inverted(canon_id))
     ownership_entities = [e for _, e in inverted if e.schema.edge]
     assert len(ownership_entities) == 1, ownership_entities
     ownership_id = ownership_entities[0].id
-    assert view_internal.get_entity(ownership_id) is None, (
-        "ownership edge has an untagged endpoint → must be external"
+    # ownership edge has an untagged endpoint → must be external
+    assert view_internal.get_entity(ownership_id) is None
+
+    resolver.rollback()
+    store.close()
+
+    # --- Round 2: give oswell-spencer a risk topic in the subject store ---
+    # Simulate what the graph analyzer would do after the first enricher run:
+    # tag an adjacent entity with a topic. We re-emit the full subject dataset
+    # so that the subject LevelDB rebuilds with an internal topic for oswell-spencer.
+    subject_ctx = Context(testdataset_enrich_subject)
+    subject_ctx.emit(Entity.from_data(testdataset_enrich_subject, UMBRELLA_CORP))
+    subject_ctx.emit(
+        Entity.from_data(
+            testdataset_enrich_subject,
+            {
+                "schema": "Person",
+                "id": "osv-oswell-spencer",
+                "properties": {"name": ["Oswell Spencer"], "topics": ["crime.boss"]},
+            },
+        )
     )
+    subject_ctx.close()
+
+    shutil.rmtree(
+        dataset_state_path(testdataset_enrich_subject.name) / "store",
+        ignore_errors=True,
+    )
+    clear_data_path(enricher_ds.name)
+    crawl_dataset(enricher_ds)
+
+    resolver.begin()
+    store = get_store(enricher_ds, resolver)
+    store.sync(clear=True)
+    view_internal = store.view(enricher_ds, external=False)
+    view_all = store.view(enricher_ds, external=True)
+
+    # Both endpoints of the ownership now carry risk topics → all three emitted internal.
+    internals = list(view_internal.entities())
+    # umbrella-corp, oswell-spencer, ownership edge
+    assert len(internals) == 3, internals
+
+    assert view_internal.get_entity(canon_id) is not None
+    # oswell-spencer now has a risk topic in the subject store → must be internal
+    assert view_internal.get_entity("osv-oswell-spencer") is not None
+
+    inverted = list(view_all.get_inverted(canon_id))
+    ownership_entities = [e for _, e in inverted if e.schema.edge]
+    assert len(ownership_entities) == 1, ownership_entities
+    ownership_id = ownership_entities[0].id
+    # ownership edge: both endpoints now have topics → must be internal
+    assert view_internal.get_entity(ownership_id) is not None
 
     resolver.rollback()
     store.close()

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -8,10 +8,9 @@ from zavod.entity import Entity
 from zavod.archive import clear_data_path, dataset_state_path
 from zavod.context import Context
 from zavod.crawl import crawl_dataset
-from zavod.integration import get_dataset_linker
 from zavod.integration.dedupe import get_resolver
 from zavod.meta import Dataset
-from zavod.runner.local_enricher import LocalEnricher, is_edge_internal
+from zavod.runner.local_enricher import LocalEnricher
 from zavod.store import get_store
 
 DATASET_DATA = {
@@ -210,61 +209,6 @@ def test_limit(vcontext: Context):
     results = list(enricher.match_candidates(entity, candidates[entity.id]))
     assert len(results) == 0, results
 
-    shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
-
-
-def test_is_edge_internal(testdataset1: Dataset):
-    """is_edge_internal returns True iff every edge endpoint has a risk topic."""
-    linker = get_dataset_linker(testdataset1)
-    crawl_dataset(testdataset1)
-    store = get_store(testdataset1, linker)
-    store.sync()
-    view = store.view(testdataset1, external=False)
-
-    # Ownership: oswell-spencer (crime.boss) → umbrella-corp (reg.warn) — both have topics
-    ownership = Entity.from_data(
-        testdataset1,
-        {
-            "schema": "Ownership",
-            "id": "test-ownership",
-            "properties": {
-                "owner": ["osv-oswell-spencer"],
-                "asset": ["osv-umbrella-corp"],
-            },
-        },
-    )
-    topics = frozenset(["reg.warn", "crime.boss"])
-    assert is_edge_internal(ownership, view, topics)
-
-    # Family: johnny-does (no topics) → oswell-spencer (crime.boss) — one endpoint missing topic
-    family_no_topic = Entity.from_data(
-        testdataset1,
-        {
-            "schema": "Family",
-            "id": "test-family-no-topic",
-            "properties": {
-                "person": ["osv-johnny-does"],
-                "relative": ["osv-oswell-spencer"],
-            },
-        },
-    )
-    assert not is_edge_internal(family_no_topic, view, topics)
-
-    # Family: one endpoint not in view at all
-    family_missing = Entity.from_data(
-        testdataset1,
-        {
-            "schema": "Family",
-            "id": "test-family-missing",
-            "properties": {
-                "person": ["osv-john-doe"],
-                "relative": ["nonexistent-id"],
-            },
-        },
-    )
-    assert not is_edge_internal(family_missing, view, topics)
-
-    store.close()
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
 
 

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -24,7 +24,7 @@ DATASET_DATA = {
 UMBRELLA_CORP = {
     "schema": "LegalEntity",
     "id": "xxx",
-    "properties": {"name": ["Umbrella Corp."]},
+    "properties": {"name": ["Umbrella Corp."], "topics": ["reg.warn"]},
 }
 JON_DOVER = {
     "schema": "Person",
@@ -268,39 +268,50 @@ def test_is_edge_internal(testdataset1: Dataset):
 
 
 def test_enrich_topic_gated(testdataset1: Dataset, testdataset_enrich_subject: Dataset):
-    """With topic_gated=True, expanded entities without topics are emitted external."""
-    resolver = get_resolver()
-    crawl_dataset(testdataset_enrich_subject)
-    crawl_dataset(testdataset1)
-
-    dataset_data = deepcopy(DATASET_DATA)
-    dataset_data["config"]["topic_gated"] = True
-    enricher_ds = make_enricher_dataset(dataset_data, testdataset1.name)
-    crawl_dataset(enricher_ds)
+    """With topic_gated=True, the matched entity (which has a topic) is emitted
+    internal; adjacent entities not in the subject store are emitted external."""
+    clear_data_path(testdataset_enrich_subject.name)
+    crawl_dataset(testdataset_enrich_subject)  # enriching this
+    crawl_dataset(testdataset1)  # enriching against this
 
     # Confirm the match (decide requires an active transaction)
+    resolver = get_resolver()
     resolver.begin()
     canon_id = resolver.decide("osv-umbrella-corp", "xxx", Judgement.POSITIVE)
     resolver.commit()
 
+    dataset_data = deepcopy(DATASET_DATA)
+    dataset_data["config"]["topic_gated"] = True
+    enricher_ds = make_enricher_dataset(dataset_data, testdataset1.name)
     clear_data_path(enricher_ds.name)
     crawl_dataset(enricher_ds)
 
     resolver.begin()
     store = get_store(enricher_ds, resolver)
     store.sync(clear=True)
+    view_internal = store.view(enricher_ds, external=False)
+    view_all = store.view(enricher_ds, external=True)
 
-    # The subject entity (Umbrella Corp.) has no topics in the subject store,
-    # so all expanded entities should be emitted as external.
-    internals = list(store.view(enricher_ds, external=False).entities())
-    assert len(internals) == 0, internals
+    # The matched entity has topic "reg.warn" in the subject store → emitted internal.
+    internals = list(view_internal.entities())
+    assert len(internals) == 1, internals
+    assert internals[0].id == canon_id
 
-    all_entities = list(store.view(enricher_ds, external=True).entities())
-    assert len(all_entities) > 0, all_entities
+    # oswell-spencer is reachable from the match but absent from the subject store
+    # (only the enrich subject is in scope), so it must be external only.
+    assert view_all.get_entity("osv-oswell-spencer") is not None
+    assert view_internal.get_entity("osv-oswell-spencer") is None, (
+        "oswell-spencer has no topic in the subject store → must be external"
+    )
 
-    # Canonical entity exists in the combined view
-    canon_entity = store.view(enricher_ds, external=True).get_entity(canon_id)
-    assert canon_entity is not None
+    # Ownership edge: oswell-spencer endpoint has no topic → external.
+    inverted = list(view_all.get_inverted(canon_id))
+    ownership_entities = [e for _, e in inverted if e.schema.edge]
+    assert len(ownership_entities) == 1, ownership_entities
+    ownership_id = ownership_entities[0].id
+    assert view_internal.get_entity(ownership_id) is None, (
+        "ownership edge has an untagged endpoint → must be external"
+    )
 
     resolver.rollback()
     store.close()

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -262,20 +262,18 @@ def test_enrich_topic_gated(testdataset1: Dataset, testdataset_enrich_subject: D
 
     # --- Round 2: give oswell-spencer a risk topic in the subject store ---
     # Simulate what the graph analyzer would do after the first enricher run:
-    # tag an adjacent entity with a topic. We re-emit the full subject dataset
-    # so that the subject LevelDB rebuilds with an internal topic for oswell-spencer.
+    # tag an adjacent (currently external) entity with a topic and emit external.
     subject_ctx = Context(testdataset_enrich_subject)
     subject_ctx.emit(Entity.from_data(testdataset_enrich_subject, UMBRELLA_CORP))
-    subject_ctx.emit(
-        Entity.from_data(
-            testdataset_enrich_subject,
-            {
-                "schema": "Person",
-                "id": "osv-oswell-spencer",
-                "properties": {"name": ["Oswell Spencer"], "topics": ["crime.boss"]},
-            },
-        )
+    oswell_patch = Entity.from_data(
+        testdataset_enrich_subject,
+        {
+            "schema": "Person",
+            "id": "osv-oswell-spencer",
+            "properties": {"topics": ["crime.boss"]},
+        },
     )
+    subject_ctx.emit(oswell_patch, external=True)
     subject_ctx.close()
 
     shutil.rmtree(

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -233,7 +233,8 @@ def test_is_edge_internal(testdataset1: Dataset):
             },
         },
     )
-    assert is_edge_internal(ownership, view)
+    topics = frozenset(["reg.warn", "crime.boss"])
+    assert is_edge_internal(ownership, view, topics)
 
     # Family: johnny-does (no topics) → oswell-spencer (crime.boss) — one endpoint missing topic
     family_no_topic = Entity.from_data(
@@ -247,7 +248,7 @@ def test_is_edge_internal(testdataset1: Dataset):
             },
         },
     )
-    assert not is_edge_internal(family_no_topic, view)
+    assert not is_edge_internal(family_no_topic, view, topics)
 
     # Family: one endpoint not in view at all
     family_missing = Entity.from_data(
@@ -261,7 +262,7 @@ def test_is_edge_internal(testdataset1: Dataset):
             },
         },
     )
-    assert not is_edge_internal(family_missing, view)
+    assert not is_edge_internal(family_missing, view, topics)
 
     store.close()
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
@@ -282,6 +283,7 @@ def test_enrich_topic_gated(testdataset1: Dataset, testdataset_enrich_subject: D
 
     dataset_data = deepcopy(DATASET_DATA)
     dataset_data["config"]["topic_gated"] = True
+    dataset_data["config"]["topics"] = ["reg.warn", "crime.boss"]
     enricher_ds = make_enricher_dataset(dataset_data, testdataset1.name)
     clear_data_path(enricher_ds.name)
     crawl_dataset(enricher_ds)


### PR DESCRIPTION
https://github.com/opensanctions/operations/issues/2583

The delta looks good other than the entire entity add/removes which I think are due to https://github.com/opensanctions/opensanctions/issues/4399 rather than this

<img width="1872" height="934" alt="image" src="https://github.com/user-attachments/assets/25091b42-ab00-4aa6-8f5d-3be9f0bde66b" />

The change to external is what we're hoping to see here, and covers the risk-topic-less entities while leaving the risky entities

```
 (feature/topic-gated-enrichment) $ grep 'CNOOC INTERNATIONAL LIMITED' ext_icij_offshoreleaks-ofac-gated-2026-06-05t1541/statements.pack ext_icij_offshoreleaks-ofac-not-gated-2026-06-05t1433/statements.pack
ext_icij_offshoreleaks-ofac-gated-2026-06-05t1541/statements.pack:icijol-129829,Company:name,CNOOC INTERNATIONAL LIMITED,ext_icij_offshoreleaks,,,,,2025-12-30T13:13:05,2026-06-05T14:33:49,aa20e6bc7799145a30ee529176acfb8966090e2a
ext_icij_offshoreleaks-ofac-not-gated-2026-06-05t1433/statements.pack:icijol-129829,Company:name,CNOOC INTERNATIONAL LIMITED,ext_icij_offshoreleaks,,,,,2025-12-30T13:13:05,2026-06-05T13:07:11,aa20e6bc7799145a30ee529176acfb8966090e2a
```