### PR TITLE
[ad_consell_general] Add Andorra General Council members crawler

### DIFF
--- a/datasets/ad/consell_general/ad_consell_general.yml
+++ b/datasets/ad/consell_general/ad_consell_general.yml
@@ -1,0 +1,53 @@
+title: Andorra General Council Members
+prefix: ad-cg
+coverage:
+  frequency: monthly
+  start: 2026-06-05
+load_statements: true
+entry_point: crawler.py
+ci_test: false
+summary: >-
+  Members of the General Council (Consell General), the parliament of the
+  Principality of Andorra.
+description: |
+  The General Council (Consell General) is the unicameral parliament of the
+  Principality of Andorra, with 28 members (consellers generals): 14 elected
+  from the national constituency and two from each of the seven parishes.
+
+  This dataset is scraped from the General Council's official roster of the
+  current members, following each member's profile page for their date of
+  birth, election date, parliamentary group and constituency. Leadership
+  offices (Síndic General, Subsíndic General, secretaries) are internal roles
+  and are not modelled as separate positions.
+tags:
+  - list.pep
+url: https://www.consellgeneral.ad/ca/composicio-actual/consellers-generals
+publisher:
+  name: Consell General
+  name_en: General Council of Andorra
+  description: |
+    The General Council is the parliament of the Principality of Andorra. It
+    represents the Andorran people, holds legislative power and publishes the
+    roster of its current members on its official website.
+  url: https://www.consellgeneral.ad/
+  country: ad
+  official: true
+data:
+  url: https://www.consellgeneral.ad/ca/composicio-actual/consellers-generals
+  format: HTML
+  lang: cat
+
+dates:
+  formats: ["%d/%m/%Y"]
+
+assertions:
+  min:
+    schema_entities:
+      Person: 24
+      Position: 1
+    country_entities:
+      ad: 24
+  max:
+    schema_entities:
+      Person: 40
+      Position: 1

--- a/datasets/ad/consell_general/crawler.py
+++ b/datasets/ad/consell_general/crawler.py
@@ -1,0 +1,94 @@
+from normality import squash_spaces
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+# The roster lists 28 members; the first tile on the page is the section's intro
+# (a "Consellers i conselleres generals" heading), not a person.
+INTRO_SLUG = "consellers-generals-1"
+
+
+def field(doc: Element, css_class: str) -> str | None:
+    """Return the text value of a labelled profile field, e.g. ``div.datanaixement``.
+
+    Each member profile renders its attributes as ``<div class="…"><b>Label</b>
+    <span>value</span></div>`` blocks with stable class names. Returns None when the
+    block is absent (not every member fills in every field).
+    """
+    blocks = h.xpath_elements(doc, f"//div[@class='{css_class}']")
+    if not blocks:
+        return None
+    spans = h.xpath_elements(blocks[0], ".//span")
+    if not spans:
+        return None
+    value = squash_spaces(h.element_text(spans[0]))
+    return value or None
+
+
+def crawl_member(
+    context: Context,
+    url: str,
+    name: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    doc = context.fetch_html(url, cache_days=30)
+
+    person = context.make("Person")
+    # The profile slug is the source's per-member key; hash it so the name (PII) does
+    # not leak into the entity id.
+    person.id = context.make_id(url)
+    # Names are kept as published (given-name-first, Catalan diacritics).
+    person.add("name", name, lang="cat")
+    h.apply_date(person, "birthDate", field(doc, "datanaixement"))
+    # Members must be Andorran nationals: Constitution of Andorra, Art. 25.
+    # https://www.constituteproject.org/constitution/Andorra_1993
+    person.add("citizenship", "ad")
+    group = field(doc, "grup")
+    person.add("political", group, lang="cat")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+        start_date=field(doc, "dataeleccio"),
+        no_end_implies_current=True,
+    )
+    if occupancy is None:
+        return
+    occupancy.add("politicalGroup", group, lang="cat")
+    occupancy.add("constituency", field(doc, "electe"), lang="cat")
+    occupancy.add("sourceUrl", url)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the General Council of Andorra",
+        country="ad",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q20177831",
+    )
+    context.emit(position)
+    categorisation = categorise(context, position, default_is_pep=True)
+
+    doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
+    headlines = h.xpath_elements(
+        doc, "//div[contains(@class, 'tileItem')]//h3[@class='tileHeadline']/a"
+    )
+    seen: set[str] = set()
+    for link in headlines:
+        url = link.get("href")
+        if url is None or url.rstrip("/").endswith(INTRO_SLUG) or url in seen:
+            continue
+        seen.add(url)
+        name = squash_spaces(h.element_text(link))
+        crawl_member(context, url, name, position, categorisation)
+
+    assert len(seen) >= 24, len(seen)

--- a/datasets/ad/consell_general/crawler.py
+++ b/datasets/ad/consell_general/crawler.py
@@ -82,13 +82,9 @@ def crawl(context: Context) -> None:
     headlines = h.xpath_elements(
         doc, "//div[contains(@class, 'tileItem')]//h3[@class='tileHeadline']/a"
     )
-    seen: set[str] = set()
     for link in headlines:
         url = link.get("href")
-        if url is None or url.rstrip("/").endswith(INTRO_SLUG) or url in seen:
+        if url is None or url.rstrip("/").endswith(INTRO_SLUG):
             continue
-        seen.add(url)
         name = squash_spaces(h.element_text(link))
         crawl_member(context, url, name, position, categorisation)
-
-    assert len(seen) >= 24, len(seen)


### PR DESCRIPTION
Implements opensanctions/crawler-planning#707.

Scrapes the 28 current members (consellers generals) of Andorra's unicameral parliament, the **General Council (Consell General)**, from the [official roster](https://www.consellgeneral.ad/ca/composicio-actual/consellers-generals).

## Source
HTML scraping (Plone CMS). Confirmed there is no API, RSS/JSON view, or open-data portal, and Wikidata is stale/incomplete for the current term. The roster page lists all members; each links to a profile page with stable class-named fields.

## Modelling
- One position: **Member of the General Council of Andorra** (`Q20177831`), `gov.national` + `gov.legislative`. Leadership offices (Síndic General, Subsíndic, secretaries) are internal roles, not separate positions.
- Per member: name (Catalan, as published), `birthDate`, `political` (parliamentary group), `citizenship=ad` (Constitution Art. 25, restated on the roster page).
- Occupancy: `startDate` from each member's own election date (replacements differ from the 2023 general election), `politicalGroup`, `constituency`, deep `sourceUrl`. `no_end_implies_current=True` (live official roster).
- Current members only — there is no archived roster of past convocations, so no historical-term handling.

## Results
28 Person + 28 Occupancy (all `current`) + 1 Position. `issues.json` empty; `zavod validate` passes; `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)