### PR TITLE
[ext_ua_edr] Bump runtime memory by 50%

### DIFF
--- a/datasets/_externals/ext_ua_edr.yml
+++ b/datasets/_externals/ext_ua_edr.yml
@@ -13,7 +13,7 @@ exports:
 deploy:
   schedule: "@monthly"
   cpu: "2000m"
-  memory: "6000Mi"
+  memory: "9000Mi"
   disk: "100Gi"
 load_statements: true
 ci_test: false


### PR DESCRIPTION
Hasn't run successfully since 2026-01-24 and we've been ignoring it. Bumping `memory` from `6000Mi` to `9000Mi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)