### PR TITLE
[tj_companies] Fix DevExpress `\/` escape that broke pagination parsing

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -103,7 +103,6 @@ repos:
           datasets/si|
           datasets/sk/rpvs|
           datasets/th/designated_person|
-          datasets/tj|
           datasets/tw|
           datasets/ua|
           datasets/us/cia_world_leaders|

--- a/datasets/tj/companies/crawler.py
+++ b/datasets/tj/companies/crawler.py
@@ -138,8 +138,17 @@ def crawl_page(
     _, raw_payload = response.split("(", 1)
     raw_payload = raw_payload.strip("()")
     matches = re.search(r"'result':'(.*)'", raw_payload, re.M | re.S)
+    assert matches is not None, raw_payload
 
-    dom = html.fromstring(matches.group(1))
+    # The DevExpress callback wraps the HTML in a JSON-style escaped string
+    # literal (escaping `\'`, `\n`, `\/`, etc.). There's no clean stdlib way
+    # to fully unescape it. But the only escape that actually breaks
+    # downstream parsing is `\/` inside `<\/script>`: lxml doesn't recognize
+    # that as a closing tag, so the <script> swallows the rest of the document
+    # and our pagination xpath finds nothing. Targeted unescape is sufficient —
+    # the remaining escapes live inside attribute values and script bodies,
+    # where they don't affect our queries.
+    dom = html.fromstring(matches.group(1).replace("\\/", "/"))
     pages = [
         el.text
         for el in dom.xpath(".//td[contains(@class, 'dxpPageNumber_Office2003Blue')]")

--- a/datasets/tj/companies/crawler.py
+++ b/datasets/tj/companies/crawler.py
@@ -127,6 +127,8 @@ def crawl_page(
         entity_type = "LegalEntity"
     elif section == "legal":
         entity_type = "Company"
+    else:
+        raise ValueError(f"Unknown section: {section}")
 
     local_params = params.copy()
     local_params["__CALLBACKPARAM"] = get_callback_pagination_params(page_number)
@@ -135,6 +137,7 @@ def crawl_page(
         url=url, method="POST", data=local_params, cache_days=CACHE_DAYS
     )
 
+    assert response is not None
     _, raw_payload = response.split("(", 1)
     raw_payload = raw_payload.strip("()")
     matches = re.search(r"'result':'(.*)'", raw_payload, re.M | re.S)
@@ -149,10 +152,9 @@ def crawl_page(
     # the remaining escapes live inside attribute values and script bodies,
     # where they don't affect our queries.
     dom = html.fromstring(matches.group(1).replace("\\/", "/"))
-    pages = [
-        el.text
-        for el in dom.xpath(".//td[contains(@class, 'dxpPageNumber_Office2003Blue')]")
-    ]
+    pages = h.xpath_strings(
+        dom, ".//td[contains(@class, 'dxpPageNumber_Office2003Blue')]/text()"
+    )
 
     try:
         max_page = max(map(lambda x: int(x.strip("[]")), pages))
@@ -185,18 +187,19 @@ def crawl_page(
             context.log.error("Exceeded retries.", url=url, payload=raw_payload)
             raise
 
-    headers = []
+    headers: list[str | None] = []
 
-    for cell in dom.xpath('//tr[@id="ASPxGridView1_DXHeadersRow0"]/td'):
-        value = cell.text_content()
+    for cell in h.xpath_elements(dom, '//tr[@id="ASPxGridView1_DXHeadersRow0"]/td'):
+        value = h.element_text(cell, squash=False)
         value = re.sub(r"\\[rnt]", "", value)
         headers.append(context.lookup_value("headers", value))
     if not all(headers):
         raise ValueError("Failed to translate some header: %s" % headers)
-    data_rows = dom.xpath(
+    data_rows = h.xpath_elements(
+        dom,
         "descendant-or-self::*[@id = 'ASPxGridView1_DXMainTable']/"
         "descendant-or-self::*/tr[@class and contains(concat(' ', "
-        "normalize-space(@class), ' '), ' dxgvDataRow_Office2003Blue')]"
+        "normalize-space(@class), ' '), ' dxgvDataRow_Office2003Blue')]",
     )
     if len(data_rows) == 0:
         if retries > 0:
@@ -214,9 +217,12 @@ def crawl_page(
             raise RuntimeError("No data rows found")
 
     for tr in data_rows:
-        cells = tr.xpath("td")
+        cells = h.xpath_elements(tr, "td")
 
-        values = [cell.text.strip() for cell in cells]
+        values: list[str] = []
+        for cell in cells:
+            assert cell.text is not None
+            values.append(cell.text.strip())
         item = dict(zip(headers, values))
 
         entity = context.make(entity_type)

--- a/datasets/tj/companies/tj_companies.yml
+++ b/datasets/tj/companies/tj_companies.yml
@@ -24,7 +24,7 @@ http:
 summary: |
   Legal and natural entities in the Unified State Register of taxpayers of the Republic of Tajikistan.
 description: |
-  The registry has 3 sections for taxpayers: legal entities, representatives of branches and foreign 
+  The registry has 3 sections for taxpayers: legal entities, representatives of branches and foreign
   organizations and individual entrepreneurs.
   legal entities has two identification numbers: EIN (РЯМ) and INN (РМА), date of registration,
   status and the name of the organization.
@@ -35,14 +35,29 @@ publisher:
   url: https://andoz.tj/
   description: |
     The tax committee under the Government of the Republic of Tajikistan is a holder of the company registry.
-    It carries out state registration of legal entities, individual entrepreneurs branches and 
-    representative offices foreign legal entities, ensures maintenance of the Unified State 
+    It carries out state registration of legal entities, individual entrepreneurs branches and
+    representative offices foreign legal entities, ensures maintenance of the Unified State
     Register and access to its information State Register and access to its information
   official: true
 data:
   url: https://andoz.tj/ForTaxpayer/UnifiedStateRegister
   format: HTML
   lang: rus
+
+assertions:
+  min:
+    schema_entities:
+      Company: 45000
+      Person: 900
+      LegalEntity: 600
+    country_entities:
+      tj: 45000
+    countries: 1
+  max:
+    schema_entities:
+      Company: 100000
+      Person: 2000
+      LegalEntity: 1500
 
 dates:
   formats: ["%d.%m.%Y"]


### PR DESCRIPTION
The `tj_companies` crawler stopped completing because the andoz.tj DevExpress
backend started JSON-escaping forward slashes in the callback `result` field,
so `</script>` arrives as `<\/script>`. lxml doesn't recognize that as a closing
tag — the `<script>` swallows the rest of the document and our pagination
xpath returns `[]`. That manifested as `Failed to parse max page` and
eventually `max() arg is empty` once retries ran out.

Fix: unescape `\/` → `/` in the extracted result string before handing it to
lxml. There's no clean stdlib way to fully unescape the JS-style string
(`json.loads` rejects `\'` / `\-`, `codecs.unicode_escape` / `ast.literal_eval`
don't recognize `\/`), but `\/` is the only escape that actually breaks
parsing here — the rest live in attribute values / script bodies that don't
affect our queries.

Also threw in mypy-strict fixes for the crawler (typed `h.xpath_*` helpers,
non-None asserts, explicit error on unknown section) and removed
`datasets/tj` from the mypy exclusion list.

Closes #4402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)