### PR TITLE
[kz_companies] Retry on 502

### DIFF
--- a/datasets/kz/companies/kz_companies.yml
+++ b/datasets/kz/companies/kz_companies.yml
@@ -17,7 +17,7 @@ ci_test: false
 http:
   total_retries: 5
   backoff_factor: 3
-  retry_statuses: [503, 429, 403]
+  retry_statuses: [502, 503, 429, 403]
 summary: >
   Companies and other entities registered in the Republic of Kazakhstan and their director.
 description: |


### PR DESCRIPTION
Add 502 to the `retry_statuses` for the `kz_companies` crawler. The runner has been dying mid-pagination with HTTPError against `data.egov.kz`, and a transient 502 is the likely culprit — worth a try before doing anything more invasive.

Refs #4400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)