### PR TITLE
[am_national_assembly] Add Armenia National Assembly PEP crawler

### DIFF
--- a/datasets/am/national_assembly/am_national_assembly.yml
+++ b/datasets/am/national_assembly/am_national_assembly.yml
@@ -1,0 +1,53 @@
+title: Armenia National Assembly Members
+entry_point: crawler.py
+prefix: am-natassembly
+coverage:
+  frequency: weekly
+  start: 2021-08-02
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the National Assembly of Armenia, the country's unicameral
+  parliament, as published on the official parliament website.
+description: |
+  The National Assembly (Azgayin Zhoghov) is the unicameral parliament of
+  the Republic of Armenia. Its members are elected via party lists and
+  organised into parliamentary factions.
+
+  This dataset is crawled from the official roster of sitting members
+  published on parliament.am. Each member's detail page provides their
+  birth date, party affiliation, faction membership (with a start date),
+  committee assignments and a biographical note. The roster is refreshed
+  as the composition of the assembly changes.
+url: https://www.parliament.am/deputies.php?sel=factions&lang=eng
+publisher:
+  name: National Assembly of the Republic of Armenia
+  acronym: NA
+  description: >
+    The National Assembly is the legislative branch of the Republic of
+    Armenia. Its official website publishes the roster of sitting members
+    of parliament.
+  url: https://www.parliament.am/
+  country: am
+  official: true
+data:
+  url: https://www.parliament.am/deputies.php?sel=factions&lang=eng
+  format: HTML
+  lang: eng
+tags:
+  - list.pep
+
+dates:
+  formats: ["%d.%m.%Y"]
+
+assertions:
+  min:
+    schema_entities:
+      Person: 90
+      Position: 1
+    country_entities:
+      am: 90
+  max:
+    schema_entities:
+      Person: 160
+      Position: 1

--- a/datasets/am/national_assembly/crawler.py
+++ b/datasets/am/national_assembly/crawler.py
@@ -1,0 +1,167 @@
+from zavod import Context, helpers as h
+from zavod.util import Element
+from zavod.stateful.positions import categorise
+from zavod.extract import zyte_api
+
+# parliament.am refuses connections from non-Armenian networks, so all requests
+# are routed through Zyte with an Armenian exit point. The pages are static
+# server-rendered PHP, so the cheaper httpResponseBody source is sufficient.
+GEOLOCATION = "am"
+
+# The roster URL implicitly serves the current convocation. The 8th convocation
+# convened on 2021-08-02; faction links carry show_session=8. When a new
+# convocation is seated, a higher session number appears and we want the crawler
+# to fail loudly so a maintainer reviews the new term rather than silently
+# emitting a changed roster.
+EXPECTED_SESSION = 8
+
+DETAIL_LINK_XPATH = ".//a[contains(@href, 'sel=details')]"
+NAME_XPATH = ".//div[@class='dep_name']"
+
+# Fields we read from the detail-page key/value table. Any label we don't
+# recognise is surfaced via audit_data() so the crawler breaks on new data.
+F_DISTRICT = "Sequential number"
+F_BIRTH_DATE = "Birth date"
+F_PARTY = "Party"
+F_FACTION = "Faction"
+F_COMMITTEE = "Committee"
+F_MEMBERSHIP = "Membership"
+F_EMAIL = "E-mail"
+
+
+def parse_fields(doc: Element) -> dict[str, Element]:
+    """Map each detail-page row label to its value element.
+
+    The detail page renders attributes as <div class=description_1>LABEL</div>
+    paired with <div class=description_2>VALUE</div> inside the same table row.
+    Returning the value element (not text) lets callers reach into structured
+    cells such as the faction block, which nests a membership start date.
+    """
+    fields: dict[str, Element] = {}
+    for label_div in h.xpath_elements(doc, ".//div[@class='description_1']"):
+        label = h.element_text(label_div)
+        rows = h.xpath_elements(label_div, "./ancestor::tr[1]")
+        if not rows:
+            continue
+        values = h.xpath_elements(rows[0], ".//div[contains(@class, 'description_2')]")
+        if not values:
+            continue
+        if label in fields:
+            raise ValueError(f"Duplicate detail field: {label!r}")
+        fields[label] = values[0]
+    return fields
+
+
+def crawl_person(context: Context, url: str, member_id: str) -> None:
+    doc = zyte_api.fetch_html(
+        context,
+        url,
+        unblock_validator=NAME_XPATH,
+        html_source="httpResponseBody",
+        cache_days=7,
+        geolocation=GEOLOCATION,
+        absolute_links=True,
+    )
+    name = h.xpath_string(doc, NAME_XPATH + "/text()")
+    if not name:
+        context.log.warning("Member without a name", url=url)
+        return
+
+    fields = parse_fields(doc)
+    birth_date = (
+        h.element_text(fields.pop(F_BIRTH_DATE)) if F_BIRTH_DATE in fields else None
+    )
+    party = h.element_text(fields.pop(F_PARTY)) if F_PARTY in fields else None
+    email = h.element_text(fields.pop(F_EMAIL)) if F_EMAIL in fields else None
+
+    # The faction cell lists each membership as a grey <span> start date (e.g.
+    # "02.08.2021") followed by the faction name. The first is the term start.
+    start_date = None
+    if F_FACTION in fields:
+        spans = h.xpath_strings(fields.pop(F_FACTION), ".//span/text()")
+        if spans:
+            start_date = spans[0].strip()
+
+    # The remaining fields are informational and intentionally not modelled:
+    # the electoral "Sequential number", committee and interparliamentary
+    # memberships. Surface them through audit so new labels break the crawler.
+    context.audit_data(
+        {k: h.element_text(v) for k, v in fields.items()},
+        ignore=[F_DISTRICT, F_COMMITTEE, F_MEMBERSHIP],
+    )
+
+    entity = context.make("Person")
+    # The numeric member ID is an opaque, stable source identifier.
+    entity.id = context.make_slug(member_id)
+    h.apply_name(entity, full=name)
+    entity.add("sourceUrl", url)
+    entity.add("political", party)
+    entity.add("email", email)
+    # The Electoral Code of the Republic of Armenia requires deputies to hold
+    # only Armenian citizenship (no dual nationals); see Article 48 of the
+    # Constitution and the Electoral Code:
+    # http://www.parliament.am/legislation.php?sel=show&ID=2020&lang=eng
+    entity.add("citizenship", "am")
+    h.apply_date(entity, "birthDate", birth_date)
+
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of Armenia",
+        wikidata_id="Q17277248",
+        country="am",
+        topics=["gov.legislative", "gov.national"],
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+
+    occupancy = h.make_occupancy(
+        context,
+        person=entity,
+        position=position,
+        start_date=start_date,
+        categorisation=categorisation,
+    )
+    if occupancy is not None:
+        context.emit(occupancy)
+        context.emit(position)
+        context.emit(entity)
+
+
+def crawl(context: Context) -> None:
+    doc = zyte_api.fetch_html(
+        context,
+        context.data_url,
+        unblock_validator=DETAIL_LINK_XPATH,
+        html_source="httpResponseBody",
+        cache_days=1,
+        geolocation=GEOLOCATION,
+        absolute_links=True,
+    )
+
+    sessions: set[int] = set()
+    for link in h.xpath_elements(doc, ".//a[contains(@href, 'show_session=')]"):
+        href = link.get("href")
+        if href is None:
+            continue
+        sessions.add(int(href.split("show_session=")[1].split("&")[0]))
+    if sessions and max(sessions) != EXPECTED_SESSION:
+        raise ValueError(
+            f"Unexpected convocation on the roster: found sessions {sorted(sessions)}, "
+            f"expected {EXPECTED_SESSION}. A new term may have been seated; review the source."
+        )
+
+    seen: set[str] = set()
+    for link in h.xpath_elements(doc, DETAIL_LINK_XPATH):
+        url = link.get("href")
+        if url is None or "ID=" not in url:
+            continue
+        member_id = url.split("ID=")[1].split("&")[0]
+        if member_id in seen:
+            continue
+        seen.add(member_id)
+        crawl_person(context, url, member_id)
+
+    if len(seen) < 90:
+        raise ValueError(f"Only found {len(seen)} members; expected ~107.")


### PR DESCRIPTION
Adds a PEP crawler for sitting members of the **National Assembly of Armenia** (8th convocation, 107 members).

Implements opensanctions/crawler-planning#698

## Source
- Roster: `deputies.php?sel=factions&lang=eng`; per-member detail at `deputies.php?sel=details&ID=<N>`.
- Server-rendered PHP (no JS). Clean `description_1`/`description_2` key-value rows yield birth date, party, faction (+ membership start date), committee, email.
- Position: `Member of the National Assembly of Armenia` (Wikidata `Q17277248`).
- Citizenship `am`: the Armenian Electoral Code requires deputies to hold only Armenian citizenship (cited in a code comment).

## Fetching — Zyte required
parliament.am refuses connections from non-Armenian networks, so all requests go through **Zyte with `geolocation=am`** (`httpResponseBody`, modelled on `pl/sejm`).

## Freshness
The roster URL serves the *current* convocation. The crawler asserts the page's `show_session` is `8` and raises otherwise, so a new term forces maintainer review instead of silently changing the roster. Also fails if fewer than ~90 members are found.

## Validation status — why draft
- ✅ `mypy --strict` passes; ruff clean; field extraction verified offline against the archived detail-page HTML (name, birth date, party, email, faction start all parse correctly).
- ⚠️ **Not yet run end-to-end via `zavod crawl`/`zavod validate`** — Zyte was unreachable from the dev sandbox during development (repeated 520s / timeouts to the Zyte API). Needs a real crawl + assertion tuning, and confirmation that the live page still matches the structure (built against a Nov-2025 snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)