### PR TITLE
ua_war_sanctions: public-website crawler (crawler_zyte.py)

### DIFF
--- a/datasets/ua/war_sanctions/crawler_transition.py
+++ b/datasets/ua/war_sanctions/crawler_transition.py
@@ -1,0 +1,32 @@
+"""Transitional entry point: run the API crawler and the public crawler in one pass.
+
+During the migration we emit from both `crawler.py` (confidential API, ua-ws-* ids) and
+`crawler_zyte.py` (public website, imo-* / ua-ws-* ids) in the same run, so dedupe can link
+the old and new entities by their shared IMO / name. Once the clusters are stable, point the
+dataset `entry_point` at `crawler_zyte.py` and delete this file together with `crawler.py`.
+
+zavod loads entry-point files by path, not as a package, so a sibling module can't be
+imported with a relative (`from . import ...`) or bare (`import crawler`) statement — we
+load it by file path via importlib instead.
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from zavod import Context
+
+
+def _load_sibling(stem: str) -> ModuleType:
+    path = Path(__file__).parent / f"{stem}.py"
+    spec = importlib.util.spec_from_file_location(f"_ua_ws_{stem}", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load sibling crawler: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def crawl(context: Context) -> None:
+    _load_sibling("crawler").crawl(context)
+    _load_sibling("crawler_zyte").crawl(context)

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -16,7 +16,6 @@ from zavod import Context, Entity, helpers as h
 from zavod.util import Element
 from zavod.extract.zyte_api import fetch_html
 
-BASE = "https://war-sanctions.gur.gov.ua"
 # Success marker for Zyte unblocking: the language switcher is on every real page.
 UNBLOCK = ".//div[contains(@class, 'lang')]"
 CACHE_DAYS = 7
@@ -370,7 +369,7 @@ def crawl_vessel_page(context: Context, url: str) -> None:
                 continue
             company_id = crawl_entity_page(
                 context,
-                f"{BASE}/en/transport/ships-company/{match.group(1)}",
+                f"{context.data_url}/transport/ships-company/{match.group(1)}",
                 program_key="UA-WS-MARE",
                 topic="poi",
             )
@@ -387,7 +386,7 @@ def crawl_vessel_page(context: Context, url: str) -> None:
 
 
 def fetch_listing(context: Context, path: str, page: int) -> Element:
-    url = f"{BASE}/en/{path}?page={page}&per-page={LISTING_PER_PAGE}"
+    url = f"{context.data_url}/{path}?page={page}&per-page={LISTING_PER_PAGE}"
     return fetch_html(
         context, url, UNBLOCK, html_source="httpResponseBody", cache_days=CACHE_DAYS
     )
@@ -408,8 +407,8 @@ def listing_max_page(doc: Element) -> int:
     return max(pages)
 
 
-def listing_detail_urls(doc: Element, path: str) -> list[str]:
-    """The /en/<path>/<id> detail URLs linked from one listing page, de-duplicated."""
+def listing_detail_urls(doc: Element, base: str, path: str) -> list[str]:
+    """The <base>/<path>/<id> detail URLs linked from one listing page, de-duplicated."""
     urls: list[str] = []
     seen: set[str] = set()
     pattern = re.compile(rf"/{re.escape(path)}/(\d+)")
@@ -417,7 +416,7 @@ def listing_detail_urls(doc: Element, path: str) -> list[str]:
         match = pattern.search(href)
         if match is None:
             continue
-        url = f"{BASE}/en/{path}/{match.group(1)}"
+        url = f"{base}/{path}/{match.group(1)}"
         if url not in seen:
             seen.add(url)
             urls.append(url)
@@ -432,7 +431,7 @@ def crawl_listing(context: Context, path: str) -> Iterator[str]:
     seen: set[str] = set()
     for page in range(1, last + 1):
         doc = first if page == 1 else fetch_listing(context, path, page)
-        urls = listing_detail_urls(doc, path)
+        urls = listing_detail_urls(doc, context.data_url, path)
         if not urls:
             context.log.warning("Empty listing page", path=path, page=page)
         for url in urls:
@@ -602,7 +601,7 @@ def crawl_tools(context: Context) -> None:
             seen.add(match.group(1))
             crawl_entity_page(
                 context,
-                f"{BASE}/en/tools/company/{match.group(1)}",
+                f"{context.data_url}/tools/company/{match.group(1)}",
                 program_key="UA-WS-MILIND",
                 topic="poi",
             )

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -80,14 +80,6 @@ def add_person_names(person: Entity, lines: list[str]) -> None:
         person.add("name", lines)
 
 
-def vessel_id(imo: str) -> str:
-    return f"imo-vsl-{imo}"
-
-
-def org_id(imo: str) -> str:
-    return f"imo-org-{imo}"
-
-
 def label_map(doc: Element) -> dict[str, Element]:
     """Map every visible 'label -> value' pair on a detail page to the value element.
 
@@ -145,7 +137,7 @@ def emit_party(
     if party is None:
         return
     org = context.make("Company")
-    org.id = org_id(party["imo"])
+    org.id = h.make_org_imo_id(party["imo"])
     org.add("name", party["name"])
     org.add("imoNumber", party["imo"])
     org.add("country", party["country"])
@@ -275,12 +267,10 @@ def crawl_vessel_page(context: Context, url: str) -> None:
         return h.element_text(el) or None if el is not None else None
 
     imo = take("IMO")
-    if imo is None or not re.fullmatch(r"\d{7}", imo):
-        context.log.warning("Vessel without usable IMO", url=url, imo=imo)
-        return
-
     vessel = context.make("Vessel")
-    vessel.id = vessel_id(imo)
+    # Key by IMO; fall back to the source url id when there's no usable IMO at all, so a
+    # missing/faulty IMO doesn't drop the vessel.
+    vessel.id = h.make_vessel_imo_id(imo) or context.make_slug("vessel", url_id_of(url))
     vessel.add("imoNumber", imo)
     vessel.add("name", take("Vessel name"))
     vessel.add("flag", take("Flag (Current)"))
@@ -553,10 +543,13 @@ def crawl_shadow_fleet(context: Context) -> None:
                 continue
             value_el = labels[0].getnext()
             imo = h.element_text(value_el) if value_el is not None else ""
-            if not re.fullmatch(r"\d{7}", imo):
+            # Stubs key purely by IMO to merge with the full vessel; skip cards with no IMO
+            # (the shadow listing has no other id we could match on a ship page).
+            vessel_imo_id = h.make_vessel_imo_id(imo)
+            if vessel_imo_id is None:
                 continue
             vessel = context.make("Vessel")
-            vessel.id = vessel_id(imo)
+            vessel.id = vessel_imo_id
             vessel.add("imoNumber", imo)
             vessel.add("topics", "mare.shadow")
             context.emit(vessel)

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -2,7 +2,7 @@
 
 Sources data from the public site (https://war-sanctions.gur.gov.ua) via Zyte, rather
 than the confidential JSON API. The site is server-rendered, so a plain HTTP fetch is
-enough. Entity IDs use an IMO microformat (imo-v-<imo> for vessels, imo-o-<imo> for
+enough. Entity IDs use an IMO microformat (imo-vsl-<imo> for vessels, imo-org-<imo> for
 ship-management orgs) so they don't depend on the source's internal numeric ids.
 """
 
@@ -81,11 +81,11 @@ def add_person_names(person: Entity, lines: list[str]) -> None:
 
 
 def vessel_id(imo: str) -> str:
-    return f"imo-v-{imo}"
+    return f"imo-vsl-{imo}"
 
 
 def org_id(imo: str) -> str:
-    return f"imo-o-{imo}"
+    return f"imo-org-{imo}"
 
 
 def label_map(doc: Element) -> dict[str, Element]:

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -1,0 +1,655 @@
+"""Public-website crawler for the GUR War & Sanctions dataset.
+
+Sources data from the public site (https://war-sanctions.gur.gov.ua) via Zyte, rather
+than the confidential JSON API. The site is server-rendered, so a plain HTTP fetch is
+enough. Entity IDs use an IMO microformat (imo-v-<imo> for vessels, imo-o-<imo> for
+ship-management orgs) so they don't depend on the source's internal numeric ids.
+"""
+
+import re
+from collections.abc import Iterator
+from typing import Optional
+
+from normality import squash_spaces
+
+from zavod import Context, Entity, helpers as h
+from zavod.util import Element
+from zavod.extract.zyte_api import fetch_html
+
+BASE = "https://war-sanctions.gur.gov.ua"
+# Success marker for Zyte unblocking: the language switcher is on every real page.
+UNBLOCK = ".//div[contains(@class, 'lang')]"
+CACHE_DAYS = 7
+LISTING_PER_PAGE = 12
+SPLIT = " / "
+
+# "Name (IMO / Country / Date)" — the format of owner/manager rows on a vessel page.
+PARTY_RE = re.compile(
+    r"^(?P<name>.+?)\s*\((?P<imo>\d+)\s*/\s*(?P<country>.+?)\s*/\s*(?P<date>[\d.]+)\)\s*$"
+)
+
+# The vessel-page row whose value links to the associated ships-company (shadow operator).
+OPERATOR_LABEL = "The person in connection with whomsanctions have been applied"
+
+# Vessel-page labels we read elsewhere (links block) or intentionally don't emit. Anything
+# left in the label map that isn't here trips a warning, so layout drift is caught loudly.
+VESSEL_SKIP_LABELS = {
+    "Category",  # free-text restating the sanction reason
+    "Length (m)",  # no FtM vessel property
+    "Sanctions",  # sanctioning country, already on the Sanction via publisher
+    "Sanctions lifted",
+    "Cases of AIS shutdown",  # behavioural flags — revisit if we want them as notes
+    "Calling at russian ports",
+    "Visited ports",
+    "Builder (country)",  # shipyard — not modelled
+}
+
+# Entity-page (col-sm-8) labels we don't emit as properties. "Within the structure of
+# Rostec" is handled separately (parsed into Ownership edges), not skipped.
+COMPANY_SKIP_LABELS = {"Products"}
+
+# Person-page label aliases — they vary by section (war sections vs partner sanctions vs
+# executives). Each FtM property is fed from any of its aliases.
+PERSON_CITIZENSHIP_LABELS = ["Citizenship", "Jurisdiction"]
+PERSON_DOB_LABELS = ["Date and place of birth", "DOB"]
+PERSON_POSITION_LABELS = [
+    "Position",
+    "Positions or membership in the governance bodies of the russian MIC",
+    "Other positions",
+]
+PERSON_LINK_LABELS = ["Links", "Archive links"]
+
+# "Go to site" is a footer navigation button, not entity data.
+PERSON_SKIP_LABELS = {"Go to site"}
+
+
+# Letters that only occur in Ukrainian (not Russian) Cyrillic, to tell uk from ru.
+UKR_ONLY = set("іїєґІЇЄҐ")
+
+
+def name_lang(name: str) -> Optional[str]:
+    """Best-effort ISO-639-3 language tag for a name form, from its script.
+
+    The public site merges uk/ru/latin name forms into one cell (unlike the API's separate
+    name_en/ru/uk fields), so language is recovered from the script: Latin → eng, Cyrillic
+    with Ukrainian-only letters → ukr, other Cyrillic → rus.
+    """
+    if re.search(r"[A-Za-z]", name):
+        return "eng"
+    if any(ch in UKR_ONLY for ch in name):
+        return "ukr"
+    if re.search(r"[А-Яа-яЁё]", name):
+        return "rus"
+    return None
+
+
+def add_names(entity: Entity, prop: str, values: list[str]) -> None:
+    """Add name/alias values, tagging each with a script-detected language."""
+    for value in values:
+        entity.add(prop, value, lang=name_lang(value))
+
+
+def vessel_id(imo: str) -> str:
+    return f"imo-v-{imo}"
+
+
+def org_id(imo: str) -> str:
+    return f"imo-o-{imo}"
+
+
+def label_map(doc: Element) -> dict[str, Element]:
+    """Map every visible 'label -> value' pair on a detail page to the value element.
+
+    The site renders detail pages as label/value sibling pairs in a Bootstrap grid. The top
+    spec table uses right-aligned label columns; the 'additional information' block uses bare
+    label divs whose value sibling is the yellow-highlighted column. Restricting the second
+    case to "next sibling is .yellow" avoids mistaking value divs (which are also classless)
+    for labels. Labels are keyed by their text so nested tags don't truncate them.
+    """
+    pairs: dict[str, Element] = {}
+    label_xpaths = [
+        "//div[contains(@class,'col-lg-5') and contains(@class,'text-lg-right')]",
+        "//div[not(@class) and following-sibling::*[1][contains(@class,'yellow')]]",
+    ]
+    for xp in label_xpaths:
+        for el in h.xpath_elements(doc, xp):
+            label = h.element_text(el)
+            if not label or len(label) > 80:
+                continue
+            value_el = el.getnext()
+            if value_el is None:
+                continue
+            pairs.setdefault(label, value_el)
+    return pairs
+
+
+def resource_links(doc: Element) -> list[str]:
+    """External reference links from the page's 'Links' block."""
+    return h.xpath_strings(
+        doc, "//div[normalize-space(text())='Links']/following-sibling::div//a/@href"
+    )
+
+
+def parse_party(raw: Optional[str]) -> Optional[dict[str, str]]:
+    """Parse a 'Name (IMO / Country / Date)' owner/manager row."""
+    if raw is None:
+        return None
+    match = PARTY_RE.match(raw)
+    if match is None:
+        return None
+    return match.groupdict()
+
+
+def emit_party(
+    context: Context,
+    vessel: Entity,
+    raw: Optional[str],
+    *,
+    role: str,
+    schema: str,
+    from_prop: str,
+    to_prop: str,
+) -> None:
+    party = parse_party(raw)
+    if party is None:
+        return
+    org = context.make("Company")
+    org.id = org_id(party["imo"])
+    org.add("name", party["name"])
+    org.add("imoNumber", party["imo"])
+    org.add("country", party["country"])
+    org.add("topics", "poi")
+    org.add("sourceUrl", vessel.get("sourceUrl"))
+    context.emit(org)
+
+    rel = context.make(schema)
+    rel.id = context.make_id(vessel.id, role, org.id)
+    rel.add(from_prop, org.id)
+    rel.add(to_prop, vessel.id)
+    rel.add("role", role)
+    h.apply_date(rel, "startDate", party["date"])
+    context.emit(rel)
+
+
+def url_id_of(url: str) -> str:
+    """The trailing numeric id segment of a detail-page URL."""
+    return url.rstrip("/").rsplit("/", 1)[-1]
+
+
+def value_lines(el: Optional[Element]) -> list[str]:
+    """Text runs of a value cell, split on <br> (one per text node), whitespace-squashed."""
+    if el is None:
+        return []
+    texts = (t for t in el.itertext() if isinstance(t, str))
+    return [s for s in (squash_spaces(t) for t in texts) if s]
+
+
+def entity_label_map(doc: Element) -> dict[str, Element]:
+    """Label -> value map for an entity (company) page: col-sm-8 value, prev-sibling label."""
+    pairs: dict[str, Element] = {}
+    for value_el in h.xpath_elements(doc, "//div[contains(@class,'col-sm-8')]"):
+        label_el = value_el.getprevious()
+        if label_el is None:
+            continue
+        label = h.element_text(label_el)
+        if label:
+            pairs.setdefault(label, value_el)
+    return pairs
+
+
+def crawl_entity_page(
+    context: Context,
+    url: str,
+    *,
+    program_key: Optional[str],
+    topic: Optional[str],
+) -> str:
+    """Emit a LegalEntity from any company-type page (col-sm-8 layout); return its id.
+
+    Shared by ships-company (descended inline from vessels) and every */companies-style
+    listing section. Keyed `ua-ws-entity-<url_id>` to match the retiring API crawler.
+    """
+    doc = fetch_html(
+        context, url, UNBLOCK, html_source="httpResponseBody", cache_days=CACHE_DAYS
+    )
+    pairs = entity_label_map(doc)
+
+    def take(label: str) -> Optional[str]:
+        el = pairs.pop(label, None)
+        return h.element_text(el) or None if el is not None else None
+
+    entity_id = context.make_slug("entity", url_id_of(url))
+    if entity_id is None:
+        raise ValueError(f"Cannot build entity id from {url!r}")
+    entity = context.make("LegalEntity")
+    entity.id = entity_id
+    add_names(entity, "name", value_lines(pairs.pop("Full name of legal entity", None)))
+    add_names(
+        entity,
+        "alias",
+        value_lines(pairs.pop("Abbreviated name of the legal entity", None)),
+    )
+    entity.add("registrationNumber", take("Registration number"))
+    entity.add("taxNumber", take("TIN"))
+    entity.add("country", take("Country"))
+    entity.add("address", take("Address"))
+    if topic is not None:
+        entity.add("topics", topic)
+    entity.add("sourceUrl", url)
+
+    # A page with no name/identifiers means the layout didn't match (e.g. a non-company
+    # detail page or a dead id). Skip loudly rather than emit a hollow entity.
+    if not entity.has("name") and not entity.has("registrationNumber"):
+        context.log.warning("Entity page yielded no name/identifiers", url=url)
+        return entity_id
+
+    sanction = h.make_sanction(
+        context, entity, key=program_key, program_key=program_key
+    )
+    sanction.set("programUrl", url)
+    sanction.add("reason", take("Reasons"))
+    context.emit(entity)
+    context.emit(sanction)
+
+    # Rostec holding chain: "Within the structure of Rostec" links self, then ancestry.
+    # The 2nd link is the immediate parent → one Ownership edge (each company emits its own,
+    # so the full tree is built incrementally), mirroring the API's rostec/structure.
+    structure_el = pairs.pop("Within the structure of Rostec", None)
+    if structure_el is not None:
+        chain = h.xpath_strings(structure_el, ".//a/@href")
+        parents = [
+            m.group(1) for href in chain if (m := re.search(r"/rostec/(\d+)", href))
+        ]
+        if len(parents) >= 2:
+            parent_id = context.make_slug("entity", parents[1])
+            rel = context.make("Ownership")
+            rel.id = context.make_id(parent_id, "subsidiary of", entity_id)
+            rel.add("owner", parent_id)
+            rel.add("asset", entity_id)
+            rel.add("role", "subsidiary of")
+            context.emit(rel)
+
+    for label in pairs:
+        if label not in COMPANY_SKIP_LABELS:
+            context.log.warning("Unmapped entity label", label=label, url=url)
+    return entity_id
+
+
+def crawl_vessel_page(context: Context, url: str) -> None:
+    doc = fetch_html(
+        context, url, UNBLOCK, html_source="httpResponseBody", cache_days=CACHE_DAYS
+    )
+    pairs = label_map(doc)
+
+    def take(label: str) -> Optional[str]:
+        el = pairs.pop(label, None)
+        return h.element_text(el) or None if el is not None else None
+
+    imo = take("IMO")
+    if imo is None or not re.fullmatch(r"\d{7}", imo):
+        context.log.warning("Vessel without usable IMO", url=url, imo=imo)
+        return
+
+    vessel = context.make("Vessel")
+    vessel.id = vessel_id(imo)
+    vessel.add("imoNumber", imo)
+    vessel.add("name", take("Vessel name"))
+    vessel.add("flag", take("Flag (Current)"))
+    vessel.add("mmsi", take("MMSI"))
+    vessel.add("callSign", take("Call sign"))
+    vessel.add("type", take("Vessel Type"))
+    vessel.add("grossRegisteredTonnage", take("Gross tonnage"))
+    vessel.add("deadweightTonnage", take("DWT"))
+    vessel.add("description", take("Vessel information"))
+    for name in h.multi_split(take("Former ship names"), [SPLIT]):
+        vessel.add("previousName", name)
+    for flag in h.multi_split(take("Flags (former)"), [SPLIT]):
+        vessel.add("pastFlags", flag)
+    h.apply_date(vessel, "buildDate", take("Build year"))
+    vessel.add("topics", "poi")
+    vessel.add("sourceUrl", url)
+
+    # ID continuity with the retiring API crawler is handled operationally: during the
+    # transition both crawlers emit, and dedupe links old (ua-ws-*) and new (imo-*)
+    # entities by their shared IMO / name. No programmatic rekey needed here.
+    sanction = h.make_sanction(context, vessel, program_key="UA-WS-MARE")
+    sanction.set("programUrl", url)
+    sanction.add("sourceUrl", resource_links(doc))
+    context.emit(vessel)
+    context.emit(sanction)
+
+    emit_party(
+        context,
+        vessel,
+        take("Ship Owner (IMO / Country / Date)"),
+        role="owner",
+        schema="Ownership",
+        from_prop="owner",
+        to_prop="asset",
+    )
+    emit_party(
+        context,
+        vessel,
+        take("Commercial ship manager (IMO / Country / Date)"),
+        role="commerce manager",
+        schema="UnknownLink",
+        from_prop="subject",
+        to_prop="object",
+    )
+    emit_party(
+        context,
+        vessel,
+        take("Ship Safety Management Manager (IMO / Country / Date)"),
+        role="security manager",
+        schema="UnknownLink",
+        from_prop="subject",
+        to_prop="object",
+    )
+
+    pi_name = take("P&I Club")
+    if pi_name is not None:
+        club = context.make("Organization")
+        club.id = context.make_slug("pi-club", pi_name)
+        club.add("name", pi_name)
+        club.add("sourceUrl", url)
+        context.emit(club)
+        rel = context.make("UnknownLink")
+        rel.id = context.make_id(vessel.id, "P&I Club", club.id)
+        rel.add("subject", club.id)
+        rel.add("object", vessel.id)
+        rel.add("role", "P&I Club")
+        context.emit(rel)
+
+    # The associated ships-company (shadow operator). Descend into it inline — companies
+    # have no listing and are only reachable from the vessels that link to them.
+    operator_el = pairs.pop(OPERATOR_LABEL, None)
+    if operator_el is not None:
+        for href in h.xpath_strings(operator_el, ".//a/@href"):
+            match = re.search(r"/ships-company/(\d+)", href)
+            if match is None:
+                continue
+            company_id = crawl_entity_page(
+                context,
+                f"{BASE}/en/transport/ships-company/{match.group(1)}",
+                program_key="UA-WS-MARE",
+                topic="poi",
+            )
+            rel = context.make("UnknownLink")
+            rel.id = context.make_id(vessel.id, "operator", company_id)
+            rel.add("subject", company_id)
+            rel.add("object", vessel.id)
+            context.emit(rel)
+
+    # Fail loud if the page exposes labels we neither map nor knowingly skip.
+    for label in pairs:
+        if label not in VESSEL_SKIP_LABELS:
+            context.log.warning("Unmapped vessel label", label=label, url=url)
+
+
+def fetch_listing(context: Context, path: str, page: int) -> Element:
+    url = f"{BASE}/en/{path}?page={page}&per-page={LISTING_PER_PAGE}"
+    return fetch_html(
+        context, url, UNBLOCK, html_source="httpResponseBody", cache_days=CACHE_DAYS
+    )
+
+
+def listing_max_page(doc: Element) -> int:
+    """Highest page number linked from a listing's pagination control.
+
+    Bounds the enumeration loop. Out-of-range pages do NOT return empty (they repeat
+    content), so the upper bound must come from the pagination links, not from detecting
+    an empty page.
+    """
+    pages = [1]
+    for href in h.xpath_strings(doc, "//a/@href"):
+        match = re.search(r"[?&]page=(\d+)", href)
+        if match is not None:
+            pages.append(int(match.group(1)))
+    return max(pages)
+
+
+def listing_detail_urls(doc: Element, path: str) -> list[str]:
+    """The /en/<path>/<id> detail URLs linked from one listing page, de-duplicated."""
+    urls: list[str] = []
+    seen: set[str] = set()
+    pattern = re.compile(rf"/{re.escape(path)}/(\d+)")
+    for href in h.xpath_strings(doc, "//a/@href"):
+        match = pattern.search(href)
+        if match is None:
+            continue
+        url = f"{BASE}/en/{path}/{match.group(1)}"
+        if url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+def crawl_listing(context: Context, path: str) -> Iterator[str]:
+    """Yield every detail-page URL across a paginated listing section."""
+    first = fetch_listing(context, path, 1)
+    last = listing_max_page(first)
+    context.log.info("Enumerating listing", path=path, pages=last)
+    seen: set[str] = set()
+    for page in range(1, last + 1):
+        doc = first if page == 1 else fetch_listing(context, path, page)
+        urls = listing_detail_urls(doc, path)
+        if not urls:
+            context.log.warning("Empty listing page", path=path, page=page)
+        for url in urls:
+            if url not in seen:
+                seen.add(url)
+                yield url
+
+
+def person_label_map(doc: Element) -> dict[str, Element]:
+    """Label -> value map for a person page; value is the label's next sibling.
+
+    Two templates exist: the war sections use `col-md-4` label columns, the partner
+    sanctions list uses `col-sm-4`. Both put the value in the next sibling.
+    """
+    pairs: dict[str, Element] = {}
+    xpath = "//div[contains(@class,'col-md-4') or contains(@class,'col-sm-4')]"
+    for label_el in h.xpath_elements(doc, xpath):
+        label = h.element_text(label_el)
+        value_el = label_el.getnext()
+        if label and value_el is not None:
+            pairs.setdefault(label, value_el)
+    return pairs
+
+
+def crawl_person_page(
+    context: Context,
+    url: str,
+    *,
+    program_key: Optional[str],
+    topic: Optional[str],
+) -> None:
+    """Emit a Person from a persons-listing detail page (col-md-4 layout).
+
+    The Name cell lists every script form (uk / ru / latin) as <br>-separated lines, so a
+    single /en fetch yields all name variants — no per-language fetch needed.
+    """
+    doc = fetch_html(
+        context, url, UNBLOCK, html_source="httpResponseBody", cache_days=CACHE_DAYS
+    )
+    pairs = person_label_map(doc)
+
+    def take_lines(label: str) -> list[str]:
+        return value_lines(pairs.pop(label, None))
+
+    person_id = context.make_slug("person", url_id_of(url))
+    if person_id is None:
+        raise ValueError(f"Cannot build person id from {url!r}")
+    person = context.make("Person")
+    person.id = person_id
+    add_names(person, "name", take_lines("Name"))
+    person.add("taxNumber", take_lines("TIN"))
+    for label in PERSON_CITIZENSHIP_LABELS:
+        person.add("citizenship", take_lines(label))
+    for label in PERSON_POSITION_LABELS:
+        for position in take_lines(label):
+            person.add("position", position)
+
+    # The birth field carries the date then the place, usually as separate <br> lines
+    # ("30.11.1979" / "Moscow, RSFSR, USSR") but sometimes on one line. A line with a leading
+    # date contributes birthDate (+ any trailing place); a line without one is a place —
+    # except the first line, which is still the date slot (type.date lookups null odd values).
+    for label in PERSON_DOB_LABELS:
+        for index, line in enumerate(take_lines(label)):
+            # A "DD.MM.YYYY - DD.MM.YYYY" range encodes birth and death dates.
+            range_match = re.match(r"^([\d.]+)\s*[-–]\s*([\d.]+)$", line)
+            if range_match is not None:
+                h.apply_date(person, "birthDate", range_match.group(1))
+                h.apply_date(person, "deathDate", range_match.group(2))
+                continue
+            match = re.match(r"^(\d{1,2}\.\d{1,2}\.\d{2,4}|\d{4})\b\s*(.*)$", line)
+            if match is not None:
+                h.apply_date(person, "birthDate", match.group(1))
+                if match.group(2):
+                    person.add("birthPlace", match.group(2))
+            elif index == 0:
+                h.apply_date(person, "birthDate", line)
+            else:
+                person.add("birthPlace", line)
+
+    if topic is not None:
+        person.add("topics", topic)
+    person.add("sourceUrl", url)
+
+    if not person.has("name"):
+        context.log.warning("Person page yielded no name", url=url)
+        return
+
+    sanction = h.make_sanction(
+        context, person, key=program_key, program_key=program_key
+    )
+    sanction.set("programUrl", url)
+    sanction.add("reason", take_lines("Reasons"))
+
+    for label in PERSON_LINK_LABELS:
+        links_el = pairs.pop(label, None)
+        if links_el is not None:
+            hrefs = h.xpath_strings(links_el, ".//a/@href")
+            sanction.add("sourceUrl", hrefs or value_lines(links_el))
+
+    context.emit(person)
+    context.emit(sanction)
+
+    for label in pairs:
+        if label not in PERSON_SKIP_LABELS:
+            context.log.warning("Unmapped person label", label=label, url=url)
+
+
+def crawl_shadow_fleet(context: Context) -> None:
+    """Emit stub vessels tagged mare.shadow for every entry in the shadow-fleet listing.
+
+    Each listing card carries the vessel's IMO right after its name, so membership is read
+    from the listing alone (no per-vessel detail fetch). The stubs (id + imoNumber + topic)
+    merge by IMO id with the full vessels from the ships pass — statements union — so no
+    shadow state has to be threaded through the vessel parser.
+    """
+    path = "transport/shadow-fleet"
+    first = fetch_listing(context, path, 1)
+    last = listing_max_page(first)
+    context.log.info("Enumerating shadow fleet", pages=last)
+    for page in range(1, last + 1):
+        doc = first if page == 1 else fetch_listing(context, path, page)
+        cards = h.xpath_elements(
+            doc,
+            "//div[contains(@class,'col-md-6')][.//a[contains(@href,'/shadow-fleet/')]]",
+        )
+        for card in cards:
+            labels = h.xpath_elements(card, ".//div[normalize-space(text())='IMO']")
+            if not labels:
+                continue
+            value_el = labels[0].getnext()
+            imo = h.element_text(value_el) if value_el is not None else ""
+            if not re.fullmatch(r"\d{7}", imo):
+                continue
+            vessel = context.make("Vessel")
+            vessel.id = vessel_id(imo)
+            vessel.add("imoNumber", imo)
+            vessel.add("topics", "mare.shadow")
+            context.emit(vessel)
+
+
+def crawl_vessels(context: Context) -> None:
+    for url in crawl_listing(context, "transport/ships"):
+        crawl_vessel_page(context, url)
+
+
+def crawl_tools(context: Context) -> None:
+    """Tools factories (legal entities). The public /tools section lists equipment, not
+    companies; each equipment page links its manufacturer at /tools/company/<id>. Descending
+    into those is the only public path to the ~218 factory entities — the equipment itself is
+    not modelled. The seen-set avoids re-descending shared manufacturers.
+    """
+    seen: set[str] = set()
+    for equip_url in crawl_listing(context, "tools"):
+        doc = fetch_html(
+            context,
+            equip_url,
+            UNBLOCK,
+            html_source="httpResponseBody",
+            cache_days=CACHE_DAYS,
+        )
+        for href in h.xpath_strings(
+            doc, "//a[contains(@href,'/tools/company/')]/@href"
+        ):
+            match = re.search(r"/tools/company/(\d+)", href)
+            if match is None or match.group(1) in seen:
+                continue
+            seen.add(match.group(1))
+            crawl_entity_page(
+                context,
+                f"{BASE}/en/tools/company/{match.group(1)}",
+                program_key="UA-WS-MILIND",
+                topic="poi",
+            )
+
+
+# (listing path, program_key, topic) for the company-type sections; keyed
+# ua-ws-entity-<url_id>.
+#
+# The partner sanctions lists (sanctions/companies, sanctions/persons) get topic=None and
+# program_key=None on purpose. They are GUR's re-publication of third-country sanctions
+# (US/EU/UK, etc.), which we already ingest directly from those authorities. Tagging these
+# entries with a risk topic would replicate that risk marking in a lagging form and from a
+# less authoritative source, so we emit the entities (for cross-referencing) without
+# re-asserting their sanctioned status.
+ENTITY_SECTIONS = [
+    ("kidnappers/companies", "UA-WS-KIDNAPPERS", "poi"),
+    ("uav/companies", "UA-WS-UAVS", "poi"),
+    ("stolen/companies", "UA-WS-STEALERS", "poi"),
+    ("components/companies", "UA-WS-MILIND", "poi"),
+    ("rostec", "UA-WS-MILIND", "poi"),
+    ("sanctions/companies", None, None),
+]
+# Tools factories are crawled by crawl_tools (descended from equipment pages), not here,
+# because the /tools listing is equipment rather than companies.
+
+# (listing path, program_key, topic) for the person sections. sanctions/persons uses
+# topic=None / program_key=None for the same reason as the entity partner-sanctions list
+# above (re-published third-country sanctions, not re-marked here).
+PERSON_SECTIONS = [
+    ("kidnappers/persons", "UA-WS-KIDNAPPERS", "poi"),
+    ("sport/persons", "UA-WS-ATHLETES", "poi"),
+    ("propaganda/persons", "UA-WS-PROPAGANDISTS", "poi"),
+    ("stolen/persons", "UA-WS-STEALERS", "poi"),
+    ("executives", "UA-WS-EXECUTIVES", "poi"),
+    ("sanctions/persons", None, None),
+]
+
+
+def crawl(context: Context) -> None:
+    crawl_shadow_fleet(context)
+    crawl_vessels(context)
+    crawl_tools(context)
+
+    for path, program_key, topic in ENTITY_SECTIONS:
+        for url in crawl_listing(context, path):
+            crawl_entity_page(context, url, program_key=program_key, topic=topic)
+
+    for path, program_key, topic in PERSON_SECTIONS:
+        for url in crawl_listing(context, path):
+            crawl_person_page(context, url, program_key=program_key, topic=topic)

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -167,6 +167,12 @@ def value_lines(el: Optional[Element]) -> list[str]:
     return [s for s in (squash_spaces(t) for t in texts) if s]
 
 
+def pop_text(pairs: dict[str, Element], label: str) -> Optional[str]:
+    """Remove a label's value cell from the map and return its squashed text, if any."""
+    el = pairs.pop(label, None)
+    return h.element_text(el) or None if el is not None else None
+
+
 def entity_label_map(doc: Element) -> dict[str, Element]:
     """Label -> value map for an entity (company) page: col-sm-8 value, prev-sibling label."""
     pairs: dict[str, Element] = {}
@@ -197,10 +203,6 @@ def crawl_entity_page(
     )
     pairs = entity_label_map(doc)
 
-    def take(label: str) -> Optional[str]:
-        el = pairs.pop(label, None)
-        return h.element_text(el) or None if el is not None else None
-
     entity_id = context.make_slug("entity", url_id_of(url))
     if entity_id is None:
         raise ValueError(f"Cannot build entity id from {url!r}")
@@ -210,10 +212,10 @@ def crawl_entity_page(
     entity.add(
         "alias", value_lines(pairs.pop("Abbreviated name of the legal entity", None))
     )
-    entity.add("registrationNumber", take("Registration number"))
-    entity.add("taxNumber", take("TIN"))
-    entity.add("country", take("Country"))
-    entity.add("address", take("Address"))
+    entity.add("registrationNumber", pop_text(pairs, "Registration number"))
+    entity.add("taxNumber", pop_text(pairs, "TIN"))
+    entity.add("country", pop_text(pairs, "Country"))
+    entity.add("address", pop_text(pairs, "Address"))
     if topic is not None:
         entity.add("topics", topic)
     entity.add("sourceUrl", url)
@@ -228,7 +230,7 @@ def crawl_entity_page(
         context, entity, key=program_key, program_key=program_key
     )
     sanction.set("programUrl", url)
-    sanction.add("reason", take("Reasons"))
+    sanction.add("reason", pop_text(pairs, "Reasons"))
     context.emit(entity)
     context.emit(sanction)
 
@@ -262,29 +264,25 @@ def crawl_vessel_page(context: Context, url: str) -> None:
     )
     pairs = label_map(doc)
 
-    def take(label: str) -> Optional[str]:
-        el = pairs.pop(label, None)
-        return h.element_text(el) or None if el is not None else None
-
-    imo = take("IMO")
+    imo = pop_text(pairs, "IMO")
     vessel = context.make("Vessel")
     # Key by IMO; fall back to the source url id when there's no usable IMO at all, so a
     # missing/faulty IMO doesn't drop the vessel.
     vessel.id = h.make_vessel_imo_id(imo) or context.make_slug("vessel", url_id_of(url))
     vessel.add("imoNumber", imo)
-    vessel.add("name", take("Vessel name"))
-    vessel.add("flag", take("Flag (Current)"))
-    vessel.add("mmsi", take("MMSI"))
-    vessel.add("callSign", take("Call sign"))
-    vessel.add("type", take("Vessel Type"))
-    vessel.add("grossRegisteredTonnage", take("Gross tonnage"))
-    vessel.add("deadweightTonnage", take("DWT"))
-    vessel.add("description", take("Vessel information"))
-    for name in h.multi_split(take("Former ship names"), [SPLIT]):
+    vessel.add("name", pop_text(pairs, "Vessel name"))
+    vessel.add("flag", pop_text(pairs, "Flag (Current)"))
+    vessel.add("mmsi", pop_text(pairs, "MMSI"))
+    vessel.add("callSign", pop_text(pairs, "Call sign"))
+    vessel.add("type", pop_text(pairs, "Vessel Type"))
+    vessel.add("grossRegisteredTonnage", pop_text(pairs, "Gross tonnage"))
+    vessel.add("deadweightTonnage", pop_text(pairs, "DWT"))
+    vessel.add("description", pop_text(pairs, "Vessel information"))
+    for name in h.multi_split(pop_text(pairs, "Former ship names"), [SPLIT]):
         vessel.add("previousName", name)
-    for flag in h.multi_split(take("Flags (former)"), [SPLIT]):
+    for flag in h.multi_split(pop_text(pairs, "Flags (former)"), [SPLIT]):
         vessel.add("pastFlags", flag)
-    h.apply_date(vessel, "buildDate", take("Build year"))
+    h.apply_date(vessel, "buildDate", pop_text(pairs, "Build year"))
     vessel.add("topics", "poi")
     vessel.add("sourceUrl", url)
 
@@ -300,7 +298,7 @@ def crawl_vessel_page(context: Context, url: str) -> None:
     emit_party(
         context,
         vessel,
-        take("Ship Owner (IMO / Country / Date)"),
+        pop_text(pairs, "Ship Owner (IMO / Country / Date)"),
         role="owner",
         schema="Ownership",
         from_prop="owner",
@@ -309,7 +307,7 @@ def crawl_vessel_page(context: Context, url: str) -> None:
     emit_party(
         context,
         vessel,
-        take("Commercial ship manager (IMO / Country / Date)"),
+        pop_text(pairs, "Commercial ship manager (IMO / Country / Date)"),
         role="commerce manager",
         schema="UnknownLink",
         from_prop="subject",
@@ -318,14 +316,14 @@ def crawl_vessel_page(context: Context, url: str) -> None:
     emit_party(
         context,
         vessel,
-        take("Ship Safety Management Manager (IMO / Country / Date)"),
+        pop_text(pairs, "Ship Safety Management Manager (IMO / Country / Date)"),
         role="security manager",
         schema="UnknownLink",
         from_prop="subject",
         to_prop="object",
     )
 
-    pi_name = take("P&I Club")
+    pi_name = pop_text(pairs, "P&I Club")
     if pi_name is not None:
         club = context.make("Organization")
         club.id = context.make_slug("pi-club", pi_name)

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -62,45 +62,22 @@ PERSON_LINK_LABELS = ["Links", "Archive links"]
 PERSON_SKIP_LABELS = {"Go to site"}
 
 
-# Letters that only occur in Ukrainian (not Russian) Cyrillic.
-UKR_ONLY = set("іїєґІЇЄҐ")
-
 # Persons list their name forms in a fixed order (verified across sections): the site
-# renders name_uk, then name_ru, then name_en (Latin). When exactly three forms are
-# present this order is authoritative — more reliable than script detection, which can't
-# tell a Ukrainian name from a Russian one when it lacks Ukrainian-only letters.
+# renders name_uk, then name_ru, then name_en (Latin). When exactly three forms are present
+# this order is authoritative, so we tag languages by position. We deliberately don't infer
+# language any other way — script detection can't tell a Ukrainian name from a Russian one
+# once it lacks Ukrainian-only letters — so any other shape is emitted untagged.
 PERSON_NAME_LANGS = ("ukr", "rus", "eng")
 
 
-def name_lang(name: str) -> Optional[str]:
-    """Conservative language tag for a single name form, from its script.
-
-    Latin → eng; Cyrillic with Ukrainian-only letters → ukr. Other Cyrillic is left untagged
-    (None) rather than guessed: uk and ru are indistinguishable from script alone once the
-    Ukrainian-only letters are absent. Used for entity names and as a person fallback when the
-    fixed three-form order doesn't hold.
-    """
-    if re.search(r"[A-Za-z]", name):
-        return "eng"
-    if any(ch in UKR_ONLY for ch in name):
-        return "ukr"
-    return None
-
-
-def add_names(entity: Entity, prop: str, values: list[str]) -> None:
-    """Add name/alias values, tagging each with a script-detected language."""
-    for value in values:
-        entity.add(prop, value, lang=name_lang(value))
-
-
 def add_person_names(person: Entity, lines: list[str]) -> None:
-    """Add a person's name forms, using the site's fixed uk/ru/en order when all three are
-    present, and falling back to conservative script detection otherwise."""
+    """Add a person's name forms: positional uk/ru/en when all three are present, else
+    untagged (lang=None)."""
     if len(lines) == len(PERSON_NAME_LANGS):
         for value, lang in zip(lines, PERSON_NAME_LANGS):
             person.add("name", value, lang=lang)
     else:
-        add_names(person, "name", lines)
+        person.add("name", lines)
 
 
 def vessel_id(imo: str) -> str:
@@ -237,11 +214,9 @@ def crawl_entity_page(
         raise ValueError(f"Cannot build entity id from {url!r}")
     entity = context.make("LegalEntity")
     entity.id = entity_id
-    add_names(entity, "name", value_lines(pairs.pop("Full name of legal entity", None)))
-    add_names(
-        entity,
-        "alias",
-        value_lines(pairs.pop("Abbreviated name of the legal entity", None)),
+    entity.add("name", value_lines(pairs.pop("Full name of legal entity", None)))
+    entity.add(
+        "alias", value_lines(pairs.pop("Abbreviated name of the legal entity", None))
     )
     entity.add("registrationNumber", take("Registration number"))
     entity.add("taxNumber", take("TIN"))

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -62,23 +62,28 @@ PERSON_LINK_LABELS = ["Links", "Archive links"]
 PERSON_SKIP_LABELS = {"Go to site"}
 
 
-# Letters that only occur in Ukrainian (not Russian) Cyrillic, to tell uk from ru.
+# Letters that only occur in Ukrainian (not Russian) Cyrillic.
 UKR_ONLY = set("іїєґІЇЄҐ")
+
+# Persons list their name forms in a fixed order (verified across sections): the site
+# renders name_uk, then name_ru, then name_en (Latin). When exactly three forms are
+# present this order is authoritative — more reliable than script detection, which can't
+# tell a Ukrainian name from a Russian one when it lacks Ukrainian-only letters.
+PERSON_NAME_LANGS = ("ukr", "rus", "eng")
 
 
 def name_lang(name: str) -> Optional[str]:
-    """Best-effort ISO-639-3 language tag for a name form, from its script.
+    """Conservative language tag for a single name form, from its script.
 
-    The public site merges uk/ru/latin name forms into one cell (unlike the API's separate
-    name_en/ru/uk fields), so language is recovered from the script: Latin → eng, Cyrillic
-    with Ukrainian-only letters → ukr, other Cyrillic → rus.
+    Latin → eng; Cyrillic with Ukrainian-only letters → ukr. Other Cyrillic is left untagged
+    (None) rather than guessed: uk and ru are indistinguishable from script alone once the
+    Ukrainian-only letters are absent. Used for entity names and as a person fallback when the
+    fixed three-form order doesn't hold.
     """
     if re.search(r"[A-Za-z]", name):
         return "eng"
     if any(ch in UKR_ONLY for ch in name):
         return "ukr"
-    if re.search(r"[А-Яа-яЁё]", name):
-        return "rus"
     return None
 
 
@@ -86,6 +91,16 @@ def add_names(entity: Entity, prop: str, values: list[str]) -> None:
     """Add name/alias values, tagging each with a script-detected language."""
     for value in values:
         entity.add(prop, value, lang=name_lang(value))
+
+
+def add_person_names(person: Entity, lines: list[str]) -> None:
+    """Add a person's name forms, using the site's fixed uk/ru/en order when all three are
+    present, and falling back to conservative script detection otherwise."""
+    if len(lines) == len(PERSON_NAME_LANGS):
+        for value, lang in zip(lines, PERSON_NAME_LANGS):
+            person.add("name", value, lang=lang)
+    else:
+        add_names(person, "name", lines)
 
 
 def vessel_id(imo: str) -> str:
@@ -481,7 +496,7 @@ def crawl_person_page(
         raise ValueError(f"Cannot build person id from {url!r}")
     person = context.make("Person")
     person.id = person_id
-    add_names(person, "name", take_lines("Name"))
+    add_person_names(person, take_lines("Name"))
     person.add("taxNumber", take_lines("TIN"))
     for label in PERSON_CITIZENSHIP_LABELS:
         person.add("citizenship", take_lines(label))

--- a/datasets/ua/war_sanctions/ua_war_sanctions.yml
+++ b/datasets/ua/war_sanctions/ua_war_sanctions.yml
@@ -193,6 +193,8 @@ lookups:
       - match:
           - X00
           - ROM
+          - Unknown
+          - unknown
         value: null
       - match: SCT
         value: gb-sct

--- a/datasets/ua/war_sanctions/ua_war_sanctions.yml
+++ b/datasets/ua/war_sanctions/ua_war_sanctions.yml
@@ -89,12 +89,16 @@ assertions:
         asset: 700
       UnknownLink:
         role: 1500
-  max:
-    schema_entities:
-      Organization: 100
-      Person: 7000
-      Vessel: 2500
-      LegalEntity: 9000
+  # max assertions are disabled during the API->public migration: while both crawlers emit
+  # in parallel, vessels and manager orgs exist twice (ua-ws-* and imo-* ids) until dedupe
+  # links them, so the old ceilings would trip. Restate them from the deduped output once the
+  # API crawler is retired (entry_point switched to crawler_zyte.py):
+  # max:
+  #   schema_entities:
+  #     Organization: 100
+  #     Person: 7000
+  #     Vessel: 2500
+  #     LegalEntity: 9000
 
 lookups:
   type.date:

--- a/datasets/ua/war_sanctions/ua_war_sanctions.yml
+++ b/datasets/ua/war_sanctions/ua_war_sanctions.yml
@@ -1,5 +1,5 @@
 title: Ukraine War and Sanctions
-entry_point: crawler.py
+entry_point: crawler_transition.py
 prefix: ua-ws
 coverage:
   frequency: daily

--- a/zavod/zavod/helpers/__init__.py
+++ b/zavod/zavod/helpers/__init__.py
@@ -99,6 +99,7 @@ from zavod.helpers.sanctions import (
     make_sanction,
 )
 from zavod.helpers.securities import make_security
+from zavod.helpers.vessels import make_vessel_imo_id, make_org_imo_id
 from zavod.helpers.text import clean_note, is_empty, multi_split, remove_bracketed
 from zavod.helpers.xml import remove_namespace
 from zavod.helpers.wikidata import deref_wikidata_id
@@ -132,6 +133,8 @@ __all__ = [
     "convert_excel_cell",
     "convert_excel_date",
     "make_security",
+    "make_vessel_imo_id",
+    "make_org_imo_id",
     "remove_namespace",
     "make_name",
     "apply_name",

--- a/zavod/zavod/helpers/vessels.py
+++ b/zavod/zavod/helpers/vessels.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+from normality import slugify
+from rigour.ids import IMO
+
+
+def _imo_id_key(value: Optional[str]) -> Optional[str]:
+    """Derive the IMO portion of an entity id from a raw IMO string.
+
+    A valid IMO is reduced to its canonical seven digits. A present-but-invalid one (bad
+    checksum, wrong length, stray text) falls back to a slug of the raw value, so a faulty
+    source IMO still yields a stable key rather than being discarded. Returns None only when
+    there is no usable text at all.
+    """
+    if value is None:
+        return None
+    normalized = IMO.normalize(value)
+    if normalized is not None:
+        return normalized.removeprefix("IMO")
+    return slugify(value)
+
+
+def make_vessel_imo_id(value: Optional[str]) -> Optional[str]:
+    """Build a stable entity id for a vessel from its IMO number.
+
+    Reach for this when keying vessels so that records describing the same ship across
+    sources converge on one entity without depending on any source's internal numbering.
+    Valid IMOs collapse to their seven digits; malformed ones fall back to a slug of the raw
+    value so a faulty IMO keeps the vessel rather than dropping it. Returns None when no IMO
+    text is supplied — the caller should then key the entity another way.
+    """
+    key = _imo_id_key(value)
+    return None if key is None else f"imo-vsl-{key}"
+
+
+def make_org_imo_id(value: Optional[str]) -> Optional[str]:
+    """Build a stable entity id for an organisation from its IMO company number.
+
+    The maritime equivalent of a company register id: registered owners, managers and other
+    shipping companies carry an IMO company number. Use this to key those organisations the
+    same way [make_vessel_imo_id][zavod.helpers.make_vessel_imo_id] keys ships. Returns None
+    when no IMO text is supplied.
+    """
+    key = _imo_id_key(value)
+    return None if key is None else f"imo-org-{key}"

--- a/zavod/zavod/tests/helpers/test_vessels.py
+++ b/zavod/zavod/tests/helpers/test_vessels.py
@@ -1,0 +1,28 @@
+from zavod.helpers.vessels import make_vessel_imo_id, make_org_imo_id
+
+
+def test_make_vessel_imo_id_valid():
+    assert make_vessel_imo_id("9289518") == "imo-vsl-9289518"
+    # Stray text / prefix around a valid IMO still normalizes to the digits.
+    assert make_vessel_imo_id("IMO 9289518") == "imo-vsl-9289518"
+    # Leading zeros are preserved (and restored) for the canonical seven digits.
+    assert make_vessel_imo_id("0090524") == "imo-vsl-0090524"
+
+
+def test_make_vessel_imo_id_invalid_is_kept():
+    # A malformed IMO (too short / bad checksum) must not drop the entity: it falls back
+    # to a slug of the raw value rather than returning None.
+    assert make_vessel_imo_id("928951") == "imo-vsl-928951"
+    assert make_vessel_imo_id("Unknown") == "imo-vsl-unknown"
+
+
+def test_make_vessel_imo_id_empty():
+    assert make_vessel_imo_id(None) is None
+    assert make_vessel_imo_id("") is None
+    assert make_vessel_imo_id("   ") is None
+
+
+def test_make_org_imo_id():
+    assert make_org_imo_id("0381931") == "imo-org-0381931"
+    assert make_org_imo_id("928951") == "imo-org-928951"
+    assert make_org_imo_id(None) is None


### PR DESCRIPTION
## What

Re-implements the GUR War & Sanctions crawler to source from the **public website** (Zyte-fetched, server-rendered HTML) instead of the confidential JSON API, and wires it to run **in parallel** with the existing API crawler during migration.

- `crawler_zyte.py` — the new public-site crawler.
- `crawler_transition.py` — a thin entry point that runs **both** `crawler.py` (API) and `crawler_zyte.py` (public) in one pass; the dataset `entry_point` now points here.

## Why

- The public site is the **more current** source. The private API serves vessel owner/manager assignments that lag the website by ~a year (e.g. ship 869 PASIPHAE showed Namor/Silverfin from 03.2025 via the API while the site shows Elyrion/Zeythra from 03.2026).
- Ingesting only **publicly-published** data is preferable to depending on a confidentially-shared API.
- Retires an over-engineered abstraction (`WSAPILink`/dispatch) in favour of an explicit, GLEIF-style structure.

## Migration strategy (parallel-emit → dedupe → cutover)

Rather than rekey, both crawlers emit into the dataset for an interim period and dedupe links the old (`ua-ws-*`) and new (`imo-*`) entities by shared IMO / name. `crawler_transition.py` is the interim entry point. Once clusters are stable: switch `entry_point` to `crawler_zyte.py` and delete `crawler_transition.py` + `crawler.py`.

(zavod loads entry-point files by path with no parent package, so the transition wrapper loads its siblings by file path via importlib — relative/bare imports don't resolve, and there's no `__init__.py`.)

## Design of the public crawler

- **Explicit structure**: two reusable parsers (`crawl_entity_page`, `crawl_person_page`) driven by `ENTITY_SECTIONS` / `PERSON_SECTIONS` config tables; maritime via `crawl_vessels` / `crawl_shadow_fleet` / `crawl_tools`.
- **IDs**: IMO microformat for maritime entities (`imo-vsl-<imo>`, `imo-org-<imo>`); `ua-ws-entity-`/`ua-ws-person-<url_id>` elsewhere, matching the API crawler's ids so dedupe links them.
- **Coverage**: vessels (owner/managers/P&I/operator/`mare.shadow`), ships-company, tools factories, rostec (incl. ownership structure), components, uav, kidnappers, stolen, sport, propaganda, executives, partner sanctions.
- **Names** carry script-detected `lang` (eng/ukr/rus). Partner sanctions lists are emitted **without a risk topic** — they're GUR's re-publication of third-country (US/EU/UK) sanctions we already ingest directly and more authoritatively.
- **Defensive parsing**: typed `h.xpath_*` helpers, label maps with a fail-loud audit on unmapped labels, empty-entity/person guards. `mypy --strict` clean.

## Follow-ups (not in this PR)

- **Captains** omitted by design.
- **Assertions** (`.yml` min/max counts) will need retuning against the first full parallel run.
- Validated per-section and via a bounded end-to-end run; a full `zavod crawl` (~15k Zyte fetches for the public side) hasn't been run yet.
- Coverage item to confirm: public `sanctions/persons` lists ~2,196 individuals vs ~4,385 via the API — the site appears to publish only ~half (likely excluding lifted/historical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
