### PR TITLE
[au_dfat_sanctions] Fix crash on integer listing_information

### DIFF
--- a/datasets/au/dfat_sanctions/crawler.py
+++ b/datasets/au/dfat_sanctions/crawler.py
@@ -171,7 +171,8 @@ def parse_reference(
             sanction.add("listingDate", listing_info)
         else:
             sanction.add(
-                "summary", listing_info.replace("_x000D_", "") if listing_info else None
+                "summary",
+                str(listing_info).replace("_x000D_", "") if listing_info else None,
             )
         designation_instrument = row.pop("instrument_of_designation")
         # designation instrument is very often the same as listing info


### PR DESCRIPTION
Source sheet sometimes has integer values in the listing information column, which crashed on `.replace()`. Coerce to str first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)