### PR TITLE
[lu_chamber] adapt to migrated source export

### DIFF
--- a/datasets/lu/chamber/crawler.py
+++ b/datasets/lu/chamber/crawler.py
@@ -1,5 +1,4 @@
 import csv
-import re
 
 from rigour.mime.types import CSV
 from urllib.parse import urljoin
@@ -7,29 +6,22 @@ from urllib.parse import urljoin
 from zavod import Context, helpers as h, Entity
 from zavod.stateful.positions import categorise
 
-ENDPOINTS = {
-    "current": "la-liste-des-deputes-actifs-a-la-chambre-des-deputes-du-luxembourg/",
-    "historical": "la-liste-des-anciens-deputes-de-la-chambre-des-deputes-du-luxembourg/",
-}
-# Matches placeholder names like "CSV 15" or "déi gréng 02" used when the
-# source lacks the actual candidate name for a historical seat.
-PLACEHOLDER_RE = re.compile(r"\d+$")
+# data.public.lu dataset slug for the active deputies list. The catalog republishes
+# the CSV daily under a new timestamped URL, so we resolve the current resource via
+# the metadata API on every run rather than hard-coding a download link.
+DATASET_SLUG = "la-liste-des-deputes-actifs-a-la-chambre-des-deputes-du-luxembourg/"
 
 
 def crawl_row(context: Context, row: dict[str, str], position: Entity) -> None:
-    first_name = row.pop("FIRSTNAME")
-    last_name = row.pop("NAME")
-    # Skip placeholder entries for historical seats that lack the actual member name.
-    if "Siège" in first_name and PLACEHOLDER_RE.search(last_name):
-        return
-    dob = row.pop("BIRTH_DATE")
+    first_name = row.pop("pph_prenom")
+    last_name = row.pop("pph_nom")
+    dob = row.pop("pph_date_naissance")
 
     entity = context.make("Person")
     entity.id = context.make_id(first_name, last_name, dob)
     h.apply_name(entity, first_name=first_name, last_name=last_name)
-    entity.add("gender", row.pop("PERSON_TITLE"))
-    entity.add("political", row.pop("POLITICAL_GROUP"))
-    entity.add("political", row.pop("POLITICAL_PARTY"))
+    entity.add("gender", row.pop("per_titre"))
+    entity.add("political", row.pop("rattachement_abrv"))
     entity.add("citizenship", "lu")
     h.apply_date(entity, "birthDate", dob)
 
@@ -37,20 +29,33 @@ def crawl_row(context: Context, row: dict[str, str], position: Entity) -> None:
     if not categorisation.is_pep:
         return
 
+    constituency = row.pop("derniere_circonscription")
     occupancy = h.make_occupancy(
         context,
         person=entity,
         position=position,
-        start_date=row.pop("START_DATE"),
-        end_date=row.pop("END_DATE", None),
+        start_date=row.pop("date_debut_depute"),
         categorisation=categorisation,
     )
     if occupancy is not None:
+        occupancy.add("constituency", constituency)
         context.emit(occupancy)
         context.emit(position)
         context.emit(entity)
 
-    context.audit_data(row, ["PHONE_EXT", "MOBILE", "EMAIL", "ADDRESS"])
+    # rattachement_type ("Groupe politique"/"Sensibilité politique") describes the
+    # group's parliamentary standing, which has no FollowTheMoney property, so it is
+    # audited but not emitted.
+    context.audit_data(
+        row,
+        [
+            "rattachement_type",
+            "address",
+            "phone_ext",
+            "phone_mobile",
+            "email",
+        ],
+    )
 
 
 def crawl(context: Context) -> None:
@@ -64,23 +69,22 @@ def crawl(context: Context) -> None:
     )
     context.emit(position)
 
-    for resource_name, endpoint in ENDPOINTS.items():
-        # data.public.lu per-dataset metadata endpoint; "resources" lists downloadable files.
-        data = context.fetch_json(urljoin(context.data_url, endpoint), cache_days=5)
-        csv_resources = [
-            r for r in data.get("resources", []) if r.get("format") == "csv"
-        ]
-        assert len(csv_resources) == 1, (endpoint, len(csv_resources))
-        csv_resource = csv_resources[0]
+    # The per-dataset metadata endpoint; "resources" lists the downloadable files.
+    # Not cached: the catalog republishes the CSV daily under a new timestamped URL
+    # and deletes the old one, so a stale resource URL would 404 on the next download.
+    data = context.fetch_json(urljoin(context.data_url, DATASET_SLUG))
+    csv_resources = [r for r in data.get("resources", []) if r.get("format") == "csv"]
+    assert len(csv_resources) == 1, len(csv_resources)
+    csv_resource = csv_resources[0]
 
-        path = context.fetch_resource(
-            f"{resource_name}_deputies.csv", csv_resource["url"]
-        )
-        context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-        with open(path, "r", encoding="utf-8-sig") as fh:
-            rows = list(csv.DictReader(fh))
-            if "current" in resource_name:
-                # The Chamber is made up of 60 seats.
-                assert len(rows) >= 55, len(rows)
-            for row in rows:
-                crawl_row(context, row, position)
+    path = context.fetch_resource("deputies.csv", csv_resource["url"])
+    context.export_resource(path, CSV, title=context.SOURCE_TITLE)
+    # The source exports as Windows-1252, not UTF-8. Automatic detection is unreliable
+    # here: byte 0xe8 is valid in several single-byte codepages, so a detector mistakes
+    # the French/Luxembourgish text for cp1250 and yields mojibake.
+    with open(path, "r", encoding="cp1252") as fh:
+        rows = list(csv.DictReader(fh))
+        # The Chamber has 60 seats.
+        assert len(rows) >= 55, len(rows)
+        for row in rows:
+            crawl_row(context, row, position)

--- a/datasets/lu/chamber/lu_chamber.yml
+++ b/datasets/lu/chamber/lu_chamber.yml
@@ -30,12 +30,12 @@ data:
   url: https://data.public.lu/api/1/datasets/
   format: CSV
 dates:
-  formats: ["%d/%m/%Y"]
+  formats: ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d"]
 
 assertions:
   min:
     schema_entities:
-      Person: 60  # The Chamber is made up of 60 seats. Some previous members may be included.
+      Person: 55  # The Chamber is made up of 60 seats.
       Position: 1
     country_entities:
       lu: 1


### PR DESCRIPTION
The `lu_chamber` crawler was failing with a 404 ([issue](https://www.opensanctions.org/issues/lu_chamber/)). Investigating revealed data.public.lu has migrated the active deputies list to a new export, changing it on every axis:

| Aspect | Before | After |
|---|---|---|
| Resource URL | stable | republished **daily** under a new timestamp; old one deleted |
| Encoding | UTF-8 | **Windows-1252** |
| Columns | `FIRSTNAME`, `NAME`, … | French lowercase (`pph_prenom`, `pph_nom`, …) |
| Dates | `%d/%m/%Y` | ISO (`2023-10-24 00:00:00`) |

### Changes
- **Don't cache the metadata lookup.** The crawler already resolves the resource URL from the catalog API, but cached it for 5 days — so it kept pointing at a deleted timestamped file and 404'd. The lookup now runs fresh each crawl.
- **Hardcode `cp1252`.** The source is Windows-1252. `normality`'s encoding detection mis-guesses it as cp1250 (`Cimetičre` instead of `Cimetière`), so auto-detection is not safe here.
- **Rewrite `crawl_row`** for the new French column names and ISO date formats.
- **Drop the historical endpoint.** The "anciens députés" export is frozen since 2025-03-28 and still on the old format/encoding; it would need separate handling and is out of scope here.
- **Map the new electoral-district column** (`derniere_circonscription`) to `Occupancy:constituency`. The `rattachement_type` column (Groupe politique / Sensibilité politique) is audited but not emitted — no matching FtM property.

### Verification
Clean run: 60 Person / 60 Occupancy / 1 Position, no issues, accents correct, `mypy --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)