### PR TITLE
tn_cnlct: switch to French consolidated list

### DIFF
--- a/datasets/tn/cnlct/crawler.py
+++ b/datasets/tn/cnlct/crawler.py
@@ -8,35 +8,61 @@ from rigour.mime.types import XLSX
 
 from zavod import Context
 from zavod import helpers as h
+from zavod.entity import Entity
 
-# Matches YYYY/MM/DD or YYYY-MM-DD embedded in combined DOB+place field
-DOB_DATE_RE = re.compile(r"(\d{4}[/-]\d{2}[/-]\d{2})")
-# Matches the date substring following Arabic "مؤرخ في" (dated on)
-DECISION_DATE_RE = re.compile(r"مؤرخ في\s+(.+?)(?:\s{3,}|قرار|$)", re.DOTALL)
-# Matches decision numbers: "عدد 01 لسنة 2026"
-DECISION_NUM_RE = re.compile(r"عدد\s+0*(\d+)\s+لسنة\s+(\d{4})")
+# Birth date written day-first inside the combined "DOB + place" field,
+# e.g. "16/04/1972 à Tunis".
+DOB_DMY_RE = re.compile(r"\b(\d{1,2}/\d{1,2}/\d{4})\b")
+# Cells that openpyxl read as real dates arrive as ISO strings ("1972-02-21").
+DOB_ISO_RE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
+# A listing/renewal decree: "Arrêté n° 01 du 9 novembre 2018". Captures the
+# decree number and the date that follows "du".
+DECISION_RE = re.compile(r"n°\s*0*(\d+)\s*du\s+(\d{1,2}\s+\S+\s+\d{4})", re.IGNORECASE)
+# A date introduced by "du" with a day number, used for the modification field.
+MOD_DATE_RE = re.compile(r"du\s+(\d{1,2}\s+\S+\s+\d{4})", re.IGNORECASE)
 
 
-def extract_decision_dates(text: str) -> list[str]:
-    """Return all date strings following 'مؤرخ في' in a decision field."""
-    return [m.group(1).strip() for m in DECISION_DATE_RE.finditer(text)]
+def parse_birth(entity: Entity, dob_place: str) -> None:
+    """Split the combined "date and place of birth" cell onto an entity.
+
+    The field mixes a day-first date with a free-text place ("16/04/1972 à
+    Tunis"), is sometimes a bare place ("Le Kef"), and is sometimes a date the
+    spreadsheet stored as a real date (arriving as an ISO string). The date is
+    applied to ``birthDate`` and the remainder, stripped of the French
+    preposition "à", to ``birthPlace``.
+    """
+    dmy = DOB_DMY_RE.search(dob_place)
+    iso = DOB_ISO_RE.search(dob_place)
+    if dmy is not None:
+        h.apply_date(entity, "birthDate", dmy.group(1))
+        rest = DOB_DMY_RE.sub("", dob_place)
+    elif iso is not None:
+        h.apply_date(entity, "birthDate", iso.group(1))
+        rest = DOB_ISO_RE.sub("", dob_place)
+    else:
+        rest = dob_place
+    place = squash_spaces(re.sub(r"^\s*à\s+", "", rest.strip()))
+    if place:
+        entity.add("birthPlace", place)
 
 
 def crawl_row(context: Context, row: dict[str, Any]) -> None:
     seq_num = row.pop("seq_num")
     if seq_num is None:
         return
-    full_name = squash_spaces(row.pop("full_name") or "")
+    given_names = squash_spaces(row.pop("given_names") or "")
     surname = squash_spaces(row.pop("surname") or "")
-    dob_place = row.pop("dob_place")
+    dob_place = squash_spaces(row.pop("dob_place") or "")
     address = squash_spaces(row.pop("address") or "")
-    nationality = row.pop("nationality")
-
+    nationality = squash_spaces(row.pop("nationality") or "")
+    reason = (row.pop("reason") or "").strip()
+    decision = squash_spaces(row.pop("decision") or "")
     last_modified = squash_spaces(row.pop("last_modified") or "")
     row.pop("extra")
 
-    # Determine entity type: Person if DOB field is present, Organization otherwise
-    is_person = dob_place is not None and len(str(dob_place))
+    # The sheet has no type column: rows with a date/place of birth are people,
+    # the rest (with an empty birth field) are organizations.
+    is_person = len(dob_place) > 0
 
     if is_person:
         entity = context.make("Person")
@@ -45,78 +71,69 @@ def crawl_row(context: Context, row: dict[str, Any]) -> None:
         entity = context.make("Organization")
         entity.id = context.make_slug("org", seq_num)
 
-    if not full_name and not surname:
+    if not given_names and not surname:
         context.log.warning("Row with no name", seq_num=seq_num)
         return
     entity.add("topics", "sanction")
     entity.add("address", address)
 
     if is_person:
-        # الإسم الثلاثي = 3-part given-name chain; اللقب = family surname
-        h.apply_name(entity, first_name=full_name, last_name=surname)
+        # Prenom is a chain of given names, Nom the family name.
+        h.apply_name(entity, first_name=given_names, last_name=surname, lang="fra")
         entity.add("nationality", nationality)
-        # Parse DOB from combined "YYYY/MM/DD ب[city]" field
-        dob_str = str(dob_place).strip()
-        dob_m = DOB_DATE_RE.search(dob_str)
-        if dob_m:
-            # Normalise YYYY-MM-DD → YYYY/MM/DD for h.apply_date format matching
-            date_str = dob_m.group(1).replace("-", "/")
-            h.apply_date(entity, "birthDate", date_str)
-        # Birth place: remove the date and leading Arabic preposition "ب" (meaning
-        # "in"/"at").  Only the single preposition letter is stripped so that the
-        # definite article "ال" stays attached to place names that carry it
-        # (e.g. "بالمنستير" → "المنستير", not "منستير").
-        birth_place = DOB_DATE_RE.sub("", dob_str).strip()
-        birth_place = re.sub(r"^ب", "", birth_place).strip()
-        if birth_place:
-            entity.add("birthPlace", birth_place)
+        parse_birth(entity, dob_place)
     else:
-        name = " ".join(p for p in [full_name, surname] if p)
+        name = " ".join(p for p in [given_names, surname] if p)
         entity.add("name", name)
         entity.add("country", nationality)
 
     sanction = h.make_sanction(context, entity)
-    sanction.add("reason", row.pop("reason"))
+    sanction.add("reason", reason)
 
-    decision = squash_spaces(row.pop("decision") or "")
-    # Authority IDs from listing decision(s)
-    if len(decision):
-        for m in DECISION_NUM_RE.finditer(decision):
-            sanction.add("authorityId", f"{m.group(1)}/{m.group(2)}")
-        listing_dates = extract_decision_dates(decision)
+    # Listing decree(s): "Arrêté n° 01 du 9 novembre 2018". The decree number
+    # is unique per year, so we key authorityId as "<number>/<year>" and take
+    # the earliest decree date as the listing date.
+    if decision:
+        listing_dates = []
+        for m in DECISION_RE.finditer(decision):
+            date_str = m.group(2)
+            year = date_str.rsplit(" ", 1)[-1]
+            sanction.add("authorityId", f"{int(m.group(1))}/{year}")
+            listing_dates.append(date_str)
         if listing_dates:
             h.apply_date(sanction, "listingDate", listing_dates[0])
+        else:
+            context.log.warning("Could not parse listing decree", decision=decision)
 
-    # Last modification date
-    if len(last_modified):
-        mod_dates = extract_decision_dates(last_modified)
-        if mod_dates:
-            h.apply_date(sanction, "modifiedAt", mod_dates[0])
+    # Most recent renewal/modification decree carries the modification date.
+    if last_modified:
+        mod = MOD_DATE_RE.search(last_modified)
+        if mod is not None:
+            h.apply_date(sanction, "modifiedAt", mod.group(1))
 
     context.emit(entity)
     context.emit(sanction)
-    context.audit_data(row, ignore=["pub_date", "extra"])
+    context.audit_data(row, ignore=["pub_date"])
+
+
+def find_list_url(context: Context) -> str:
+    """Return the URL of the consolidated list XLSX on the CNLCT page.
+
+    The page leads with the current consolidated list, followed by an archive
+    of per-date update decrees (``MAJ_*`` files). The consolidated list is
+    therefore the first XLSX link in the content body.
+    """
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    content = h.xpath_element(doc, ".//div[@class='entry-content entry clearfix']")
+    for a in content.findall(".//a[@href]"):
+        href = a.get("href", "")
+        if href.lower().endswith(".xlsx"):
+            return urljoin(context.data_url, href)
+    raise ValueError("No consolidated list XLSX found on the CNLCT page")
 
 
 def crawl(context: Context) -> None:
-    # Scrape landing page to find the most recent complete list XLSX.
-    # Full list URLs never contain "تحيين" (update) or "حذف" (deletion).
-    doc = context.fetch_html(context.data_url, cache_days=1)
-    data_url: str | None = None
-    for a in doc.findall(".//a[@href]"):
-        href = a.get("href", "")
-        if not href.lower().endswith(".xlsx"):
-            continue
-        filename = href.rsplit("/", 1)[-1]
-        # Skip if filename contains "تحيين" (update) or "حذف" (deletion): not full lists
-        if "تحيين" in filename or "حذف" in filename:
-            continue
-        data_url = urljoin(context.data_url, href)
-        break
-
-    if data_url is None:
-        raise ValueError("No full-list XLSX found on the CNLCT page")
-
+    data_url = find_list_url(context)
     path = context.fetch_resource("source.xlsx", data_url)
     context.export_resource(path, XLSX, title=context.SOURCE_TITLE)
 
@@ -124,10 +141,24 @@ def crawl(context: Context) -> None:
     ws = wb.active
     assert ws is not None, "No active worksheet in workbook"
 
-    for item in h.parse_xlsx_sheet(
-        context,
-        ws,
-        skiprows=1,  # skip merged title row before the header row
-        header_lookup=context.get_lookup("columns"),
-    ):
-        crawl_row(context, item)
+    rows = list(
+        h.parse_xlsx_sheet(
+            context,
+            ws,
+            skiprows=1,  # skip the merged title row before the header row
+            header_lookup=context.get_lookup("columns"),
+        )
+    )
+
+    # Guard: the consolidated list is numbered contiguously from 1; the update
+    # decrees carry only the sequence numbers of the entries they touch. A
+    # non-contiguous sequence means we fetched an update file, not the full list.
+    seqs = sorted(int(r["seq_num"]) for r in rows if r["seq_num"] is not None)
+    if seqs != list(range(1, len(seqs) + 1)):
+        raise ValueError(
+            "Sequence numbers are not contiguous from 1 "
+            f"({len(seqs)} rows) — fetched file is likely not the full list"
+        )
+
+    for row in rows:
+        crawl_row(context, row)

--- a/datasets/tn/cnlct/tn_cnlct.yml
+++ b/datasets/tn/cnlct/tn_cnlct.yml
@@ -14,7 +14,7 @@ description: |
   published by the National Commission for Combating Terrorism (CNLCT) of Tunisia under
   Law No. 2015-26 of August 7, 2015 on counter-terrorism and the prevention of money
   laundering. Listed individuals and entities are subject to asset freezing.
-url: http://www.cnlct.tn/?page_id=2559
+url: http://www.cnlct.tn/fr/?page_id=1684
 tags:
   - list.sanction
 publisher:
@@ -29,28 +29,27 @@ publisher:
   country: tn
   official: true
 data:
-  url: http://www.cnlct.tn/?page_id=2559
+  url: http://www.cnlct.tn/fr/?page_id=1684
   format: HTML
-  lang: ara
+  lang: fra
 
 dates:
   formats:
-    - "%Y/%m/%d"
     - "%d/%m/%Y"
     - "%d %B %Y"
   months:
-    january: جانفي
-    february: فيفري
-    march: مارس
-    april: أفريل
-    may: ماي
-    june: جوان
-    july: جويلية
-    august: أوت
-    september: سبتمبر
-    october: أكتوبر
-    november: نوفمبر
-    december: ديسمبر
+    january: janvier
+    february: [février, fevrier]
+    march: mars
+    april: avril
+    may: mai
+    june: juin
+    july: juillet
+    august: [août, aout]
+    september: septembre
+    october: octobre
+    november: novembre
+    december: [décembre, decembre]
 
 assertions:
   min:
@@ -64,50 +63,51 @@ assertions:
 
 lookups:
   columns:
+    normalize: true
     options:
-      - match: م/ع
+      # The sequence-number column carries no header on the French sheet, so
+      # parse_xlsx_sheet falls back to the positional name "column_0".
+      - match: column_0
         value: seq_num
-      - match: الإسم الثلاثي
-        value: full_name
-      - match: اللقب
+      - match: Prenom
+        value: given_names
+      - match: Nom
         value: surname
-      - match: تاريخ الولادة ومكانها
+      - match: Date et Lieu de naissance
         value: dob_place
-      - match: العنوان
+      - match: Adresse
         value: address
-      - match: الجنسية
+      - match: Nationalité
         value: nationality
-      - match: مبررات الإدراج
+      - match: Justification d'Insertion
         value: reason
-      - match: قرار وتاريخ الإدراج
+      - match: Décision et Date d'Inscription
         value: decision
-      - match: آخر تعديل
+      - match: Dernière Modification
         value: last_modified
-      - match: تاريخ وساعة النشر بموقع اللجنة
+      - match: Date et heure de publication sur le site Web de la Commission
         value: pub_date
-      - match: معطيات إضافية
+      - match: Divers
         value: extra
 
   type.country:
     lowercase: true
     options:
-      - match: تونسية
+      - match: Tunisienne
         value: tn
-      - match: تونسي
-        value: tn
-      - match: إيطالية
+      - match: Italienne
         value: it
-      - match: مغربية
+      - match: Marocaine
         value: ma
-      - match: تونسية/بلجيكية
+      - match: Tunisienne/Belge
         values:
           - tn
           - be
-      - match: تونسية/إيرلندية
+      - match: Tunisienne/ Irlandaise
         values:
           - tn
           - ie
-      - match: تونسية/فرنسية
+      - match: Tunisienne/Française
         values:
           - tn
           - fr


### PR DESCRIPTION
## Problem

`tn_cnlct` was publishing empty — `https://www.opensanctions.org/issues/tn_cnlct/` showed the dataset missing all its data.

The source (CNLCT) is healthy and online, but its **Arabic** page stopped republishing a consolidated list around 2022 and now only posts dated update/deletion deltas (`تحيين`/`حذف`). The crawler's "first XLSX that isn't an update" heuristic therefore landed on an 8-row 2023 supplement, which fails the min-100-persons assertion, so the export was rejected.

## Fix

The **French** page still publishes a full consolidated list (163 entries) at the top of the content body, followed by the per-date update archive (`MAJ_*`). This PR:

- Repoints the crawler at the French page (`/fr/?page_id=1684`, `lang: fra`).
- Selects the first XLSX in `div.entry-content` (positional — the consolidated list always leads the page).
- Reworks the column/date/country/decree parsing for French (French headers, day-first `DD/MM/YYYY à <place>` birth fields, `Arrêté n° X du <date>` decrees → `authorityId` `<number>/<year>` + `listingDate`, renewal date → `modifiedAt`).
- Adds a **guard** asserting the sheet's sequence numbers are contiguous from 1. The consolidated list is numbered 1→163; update files carry only scattered seq numbers. So if the page layout ever shifts and a delta file gets selected, the crawler fails loudly instead of publishing a partial list.

## Local run

- 156 Persons, 7 Organizations, 163 Sanctions — both assertions pass.
- No warnings/errors in `issues.log`.
- `mypy --strict` clean.

## Note

Names are now Latin-script (as published in the French list); the original Arabic-script names are not in this source. Recovering them would require cross-referencing the Arabic delta files by sequence number — a larger, separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)