### PR TITLE
se_riksdag: stop propagating MEP country onto persons

### DIFF
--- a/datasets/se/riksdag/crawler.py
+++ b/datasets/se/riksdag/crawler.py
@@ -168,6 +168,9 @@ def crawl(context: Context) -> None:
                 start_date=role.get("from"),
                 end_date=role.get("tom"),
                 categorisation=categorisation,
+                # Citizenship is set explicitly above; don't let an MEP seat
+                # (country "eu") propagate onto the person as a country.
+                propagate_country=False,
             )
             if occupancy is not None:
                 if role.get("typ") == "kammaruppdrag":


### PR DESCRIPTION
The `se_riksdag` crawler sets `citizenship="se"` explicitly, but still triggered the `make_occupancy` deprecation warning about persons "with no country affiliation".

The warning actually fires whenever a position's country isn't already among the person's country values — not only when the person has no country. Members who held a European Parliament seat get a position with `country="eu"`, which isn't part of their Swedish citizenship, so `propagate_country` added `country=eu` to the person and emitted the warning.

Passing `propagate_country=False` silences the warning and avoids tagging former MEPs with `country=eu` (holding an MEP seat doesn't make someone an EU "citizen"; their citizenship is already set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)