### PR TITLE
Release six parliament/PEP datasets to peps collection

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -29,11 +29,13 @@ description: |
   not include some relevant information from enrichment sources. [Read the FAQ
   item](https://www.opensanctions.org/faq/165/peps-only/).**
 children:
+  - ad_consell_general
   - am_hetq_officials
   - ann_pep_positions
   - ar_parliament
   - at_meine_abgeordneten
   - at_parlament
+  - az_parliament
   - be_chamber
   - be_walloon_parliament
   - bg_jud_declarations
@@ -80,8 +82,11 @@ children:
   - jp_shugiin
   - ky_judicial
   - ky_parliament
+  - li_landtag
   - lt_pep_declarations
   - lt_seimas
+  - lu_bourgmestres
+  - lu_chamber
   - lv_saeima
   - me_acp_peps
   - mk_officials
@@ -99,6 +104,7 @@ children:
   - pl_senate
   - pt_parliament
   - ro_fiu_declarations
+  - rs_national_assembly
   - se_soe
   - sg_gov_dir
   - si_dz_rs

--- a/datasets/ad/consell_general/ad_consell_general.yml
+++ b/datasets/ad/consell_general/ad_consell_general.yml
@@ -2,7 +2,7 @@ title: Andorra General Council Members
 prefix: ad-cg
 coverage:
   frequency: monthly
-  start: 2026-06-05
+  start: "2026-06-08"
 load_statements: true
 entry_point: crawler.py
 ci_test: false

--- a/datasets/az/parliament/az_parliament.yml
+++ b/datasets/az/parliament/az_parliament.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: az-parl
 coverage:
   frequency: weekly
-  start: 2026-06-04
+  start: "2026-06-08"
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/li/landtag/li_landtag.yml
+++ b/datasets/li/landtag/li_landtag.yml
@@ -2,7 +2,7 @@ title: Liechtenstein Members of the Landtag
 prefix: li-landtag
 coverage:
   frequency: monthly
-  start: 2025-06-05
+  start: "2026-06-08"
 load_statements: true
 entry_point: crawler.py
 ci_test: false

--- a/datasets/lu/bourgmestres/lu_bourgmestres.yml
+++ b/datasets/lu/bourgmestres/lu_bourgmestres.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: lu-bourg
 coverage:
   frequency: monthly
-  start: 2026-06-03
+  start: "2026-06-08"
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/lu/chamber/lu_chamber.yml
+++ b/datasets/lu/chamber/lu_chamber.yml
@@ -3,7 +3,7 @@ prefix: lu-chamber
 url: https://data.public.lu/en/datasets/la-liste-des-deputes-actifs-a-la-chambre-des-deputes-du-luxembourg/
 coverage:
   frequency: monthly
-  start: 2025-11-26
+  start: "2026-06-08"
 load_statements: true
 entry_point: crawler.py
 summary: >-

--- a/datasets/rs/national_assembly/rs_national_assembly.yml
+++ b/datasets/rs/national_assembly/rs_national_assembly.yml
@@ -2,7 +2,7 @@ title: Serbia National Assembly Members
 prefix: rs-na
 coverage:
   frequency: monthly
-  start: 2026-06-05
+  start: "2026-06-08"
 load_statements: true
 entry_point: crawler.py
 ci_test: false


### PR DESCRIPTION
Releases six previously-unreleased PEP datasets by adding them to the `peps` collection:

- `ad_consell_general` — Andorra General Council Members
- `az_parliament` — Azerbaijan National Assembly (Milli Majlis)
- `li_landtag` — Liechtenstein Members of the Landtag
- `lu_bourgmestres` — Luxembourg Municipal Mayors and Aldermen
- `lu_chamber` — Luxembourg Members of the Chamber of Deputies
- `rs_national_assembly` — Serbia National Assembly Members

`coverage.start` set to `2026-06-08` on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)