### PR TITLE
Release five more PEP datasets to peps collection

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -37,6 +37,7 @@ children:
   - at_parlament
   - az_parliament
   - be_chamber
+  - be_flemish_parliament
   - be_walloon_parliament
   - bg_jud_declarations
   - br_pep
@@ -50,6 +51,7 @@ children:
   - co_join_dots
   - cu_inventario_legislatura
   - cy_parliament
+  - cz_pep_declarations
   - de_abgeordnetenwatch
   - de_bundesrat
   - de_bundestag
@@ -89,6 +91,7 @@ children:
   - lu_chamber
   - lv_saeima
   - me_acp_peps
+  - me_skupstina
   - mk_officials
   - mt_parlament
   - mx_deputies
@@ -105,6 +108,7 @@ children:
   - pt_parliament
   - ro_fiu_declarations
   - rs_national_assembly
+  - se_riksdag
   - se_soe
   - sg_gov_dir
   - si_dz_rs
@@ -121,6 +125,7 @@ children:
   - us_state_dept
   - uy_pep
   - ve_asamblea_nacional
+  - vn_national_assembly
   - wd_categories
   - wd_peps
   - za_mm_officials

--- a/datasets/be/flemish_parliament/be_flemish_parliament.yml
+++ b/datasets/be/flemish_parliament/be_flemish_parliament.yml
@@ -3,7 +3,7 @@ prefix: be-vla-parl
 url: https://www.vlaamsparlement.be
 coverage:
   frequency: monthly
-  start: 2026-04-15
+  start: "2026-06-08"
 load_statements: true
 entry_point: crawler.py
 summary: >-

--- a/datasets/be/flemish_parliament/be_flemish_parliament.yml
+++ b/datasets/be/flemish_parliament/be_flemish_parliament.yml
@@ -3,7 +3,7 @@ prefix: be-vla-parl
 url: https://www.vlaamsparlement.be
 coverage:
   frequency: monthly
-  start: "2026-06-08"
+  start: "2026-06-09"
 load_statements: true
 entry_point: crawler.py
 summary: >-

--- a/datasets/cz/pep_declarations/cz_pep_declarations.yml
+++ b/datasets/cz/pep_declarations/cz_pep_declarations.yml
@@ -3,7 +3,7 @@ prefix: cz-pep
 url: https://cro.gov.cz/verejnost/funkcionari
 coverage:
   frequency: monthly
-  start: 2026-03-17
+  start: "2026-06-08"
 load_statements: true
 entry_point: crawler.py
 ci_test: false  # ~39k per-person detail fetches is too slow for CI

--- a/datasets/cz/pep_declarations/cz_pep_declarations.yml
+++ b/datasets/cz/pep_declarations/cz_pep_declarations.yml
@@ -3,7 +3,7 @@ prefix: cz-pep
 url: https://cro.gov.cz/verejnost/funkcionari
 coverage:
   frequency: monthly
-  start: "2026-06-08"
+  start: "2026-06-09"
 load_statements: true
 entry_point: crawler.py
 ci_test: false  # ~39k per-person detail fetches is too slow for CI

--- a/datasets/me/skupstina/me_skupstina.yml
+++ b/datasets/me/skupstina/me_skupstina.yml
@@ -2,7 +2,7 @@ title: Montenegro Members of Parliament (Skupština)
 prefix: me-skup
 coverage:
   frequency: monthly
-  start: 2026-06-05
+  start: "2026-06-08"
 load_statements: true
 entry_point: crawler.py
 ci_test: false

--- a/datasets/me/skupstina/me_skupstina.yml
+++ b/datasets/me/skupstina/me_skupstina.yml
@@ -2,7 +2,7 @@ title: Montenegro Members of Parliament (Skupština)
 prefix: me-skup
 coverage:
   frequency: monthly
-  start: "2026-06-08"
+  start: "2026-06-09"
 load_statements: true
 entry_point: crawler.py
 ci_test: false

--- a/datasets/se/riksdag/se_riksdag.yml
+++ b/datasets/se/riksdag/se_riksdag.yml
@@ -3,7 +3,7 @@ prefix: se-riksdag
 url: https://www.riksdagen.se/en/members-and-parties/members/
 coverage:
   frequency: monthly
-  start: "2026-06-08"
+  start: "2026-06-09"
 load_statements: true
 entry_point: crawler.py
 summary: >-

--- a/datasets/se/riksdag/se_riksdag.yml
+++ b/datasets/se/riksdag/se_riksdag.yml
@@ -3,7 +3,7 @@ prefix: se-riksdag
 url: https://www.riksdagen.se/en/members-and-parties/members/
 coverage:
   frequency: monthly
-  start: 2025-11-19
+  start: "2026-06-08"
 load_statements: true
 entry_point: crawler.py
 summary: >-

--- a/datasets/vn/national_assembly/vn_national_assembly.yml
+++ b/datasets/vn/national_assembly/vn_national_assembly.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: vn-na
 coverage:
   frequency: weekly
-  start: 2021-07-20
+  start: "2026-06-08"
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/vn/national_assembly/vn_national_assembly.yml
+++ b/datasets/vn/national_assembly/vn_national_assembly.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: vn-na
 coverage:
   frequency: weekly
-  start: "2026-06-08"
+  start: "2026-06-09"
 load_statements: true
 ci_test: false
 summary: >-


### PR DESCRIPTION
Releases five previously-unreleased PEP datasets by adding them to the `peps` collection:

- `be_flemish_parliament` — Belgium Flemish Parliament
- `cz_pep_declarations` — Czech Republic Central Register of Declarations
- `me_skupstina` — Montenegro Members of Parliament (Skupština)
- `se_riksdag` — Sweden Members of Riksdag
- `vn_national_assembly` — Vietnam National Assembly (Quốc hội)

`coverage.start` set to `2026-06-08` on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)