### PR TITLE
Document why zavod-ui deploy uses image digest

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -113,6 +113,11 @@ jobs:
           owner: opensanctions
           repositories: operations
       - name: Trigger ETL deploy
+        # Cloud Run pulls zavod-ui via Google Artifact Registry (GAR),
+        # specifically the remote repository `opensanctions-ghcr` that
+        # mirrors ghcr.io. Something on the Google side caches it in a
+        # way that makes tag-based deploys unreliable, so we pass the
+        # resolved digest to force a fresh pull.
         run: |
           curl --fail --silent --show-error --location -X POST \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary
- Captures the reason we pass `@<digest>` rather than the `:prod`/`:test` tag to the deploy: something on the Google side caches the image via the GAR remote repo mirroring ghcr.io and tag deploys aren't reliable
- Matching `ignore_changes` on the Terraform side: opensanctions/operations#2595

🤖 Generated with [Claude Code](https://claude.com/claude-code)