### PR TITLE
cz_pep_declarations: fetch per-person detail so positions are emitted

### DIFF
--- a/datasets/cz/pep_declarations/crawler.py
+++ b/datasets/cz/pep_declarations/crawler.py
@@ -5,20 +5,29 @@ from zavod.stateful.positions import categorise
 
 
 IGNORE = [
+    # Name composed from the parts above.
     "fullName",
+    # Declaration-filing records (private, canOpen=false) and metadata about
+    # them - not biographical data about the official.
+    "statements",
+    "hasPoint3",
+    "hasRequestStatement",
+    "hasSecretStatement",
+    # Whether the person currently holds any registered position.
     "active",
+    # Flattened, human-readable duplicates of workingPositions[].
     "concatenatedWorkingPositions",
     "concatenatedWorkingPositionDates",
     "concatenatedWorkingPositionOrganizations",
+    "workingFrom",
+    "workingTo",
+    # Person-level summary flags; the per-position deputy/senator flags inside
+    # workingPositions[].workingPosition are used instead.
     "deputy",
     "senator",
     "deputyAndOthers",
     "senatorAndOthers",
-    "workingFrom",
-    "workingTo",
     "judge",
-    "visibility",
-    "government",
 ]
 
 
@@ -102,6 +111,11 @@ def crawl(context: Context) -> None:
             break
 
         for item in items:
-            crawl_person(context, item)
+            # The list endpoint only returns flattened summary fields; the
+            # structured workingPositions array lives on the detail endpoint.
+            detail_url = f"{context.data_url}/{item['id']}"
+            detail = context.fetch_json(detail_url, cache_days=14)
+            assert detail is not None, "Expected JSON response"
+            crawl_person(context, detail)
 
         page += 1

--- a/datasets/cz/pep_declarations/cz_pep_declarations.yml
+++ b/datasets/cz/pep_declarations/cz_pep_declarations.yml
@@ -1,11 +1,12 @@
 title: Czech Republic PEPs from the Central Register of Declarations
 prefix: cz-pep
-url: https://cro.justice.cz/verejnost/funkcionari
+url: https://cro.gov.cz/verejnost/funkcionari
 coverage:
   frequency: monthly
   start: 2026-03-17
 load_statements: true
 entry_point: crawler.py
+ci_test: false  # ~39k per-person detail fetches is too slow for CI
 summary: >-
   Czech public officials registered in the Central Register of Declarations
   (Centrální registr oznámení), covering parliament, judiciary, and local
@@ -26,10 +27,10 @@ publisher:
     courts, and public registers, including the Central Register of Declarations
     (CRO) for public officials.
   country: cz
-  url: https://cro.justice.cz
+  url: https://cro.gov.cz
   official: true
 data:
-  url: https://cro.justice.cz/verejnost/api/funkcionari
+  url: https://cro.gov.cz/verejnost/api/funkcionari
 dates:
   formats: ["%d.%m.%Y"]
   lang: ces


### PR DESCRIPTION
## Problem

`cz_pep_declarations` was emitting **0 entities**. The crawler iterates `item["workingPositions"]`, but the list endpoint (`/api/funkcionari?page=…`) only returns flattened summary fields (`concatenatedWorkingPositions`, `concatenatedWorkingPositionDates`, …) — never the structured `workingPositions` array. With `item.pop("workingPositions", [])` defaulting to `[]`, the loop body never ran and nothing was emitted. The crawl still took ~12 min because it paginated through all ~394 pages doing nothing per record.

## Fix

- Fetch the **per-person detail** endpoint (`/api/funkcionari/{id}`) for each list item, which contains the structured `workingPositions` array, and crawl that.
- Cache detail responses for **14 days** (`cache_days=14`) — this is the expensive part (~39k requests).
- Reconcile the `IGNORE` list with the real detail schema: add `statements`, `hasPoint3`, `hasRequestStatement`, `hasSecretStatement`; drop the stale `visibility`/`government` entries that never existed at the top level. `fullName` stays ignored — it bundles academic titles into the name string and carries no name info beyond the parts we already use.
- Point the host at **`cro.gov.cz`** (`cro.justice.cz` now 301-redirects there permanently).
- Set **`ci_test: false`** — ~39k detail fetches are too slow for CI.

## Verification

Confirmed `crawl_person` against a real deputy record emits `Person` / `Position` / `Occupancy`, with no `audit_data` warnings.

## Note

`categorise` returns `default_is_pep` for unreviewed positions, and only deputies/senators default to `True`. On a fresh DB that's ~280 people (below the `min Person: 500` assertion) until more positions are classified through the review UI — which the existing `# TODO: update after full classification of positions` note already anticipates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)