### PR TITLE
al_kuvendi: PEP crawler for members of the Albanian parliament (Kuvendi)

### DIFF
--- a/datasets/al/kuvendi/al_kuvendi.yml
+++ b/datasets/al/kuvendi/al_kuvendi.yml
@@ -1,0 +1,47 @@
+title: Albania Members of Parliament (Kuvendi)
+entry_point: crawler.py
+prefix: al-kuvendi
+coverage:
+  frequency: weekly
+  start: 2026-06-08
+load_statements: true
+summary: >-
+  Current members of the Kuvendi, the unicameral parliament of the Republic of Albania
+description: |
+  This dataset contains the current members of the Kuvendi i Shqipërisë (Assembly of
+  the Republic of Albania), the country's unicameral legislature of 140 seats.
+
+  The data is sourced from the JSON API that backs the official parlament.al website.
+  It lists each member's name, date of birth (where available), email address and
+  political party.
+publisher:
+  name: Kuvendi i Shqipërisë
+  name_en: Assembly of the Republic of Albania
+  description: |
+    The Kuvendi is the unicameral parliament of Albania. It has 140 members elected
+    for four-year terms by proportional representation across the country's twelve
+    electoral districts (qarqe).
+  country: al
+  url: https://www.parlament.al/
+  official: true
+data:
+  # Undocumented OData API backing the parlament.al single-page app. $top is capped
+  # at 1000 by the server, returning the full member set in one request.
+  url: https://kuvendiapi.azurewebsites.net/api/Anetaret?$top=1000
+  format: JSON
+
+assertions:
+  min:
+    schema_entities:
+      Person: 125
+      Position: 1
+  max:
+    schema_entities:
+      Person: 160
+
+lookups:
+  type.email:
+    options:
+      # Domain typo in the source for a single sitting member.
+      - match: ardit.bido@parlamend.al
+        value: ardit.bido@parlament.al

--- a/datasets/al/kuvendi/al_kuvendi.yml
+++ b/datasets/al/kuvendi/al_kuvendi.yml
@@ -1,19 +1,21 @@
-title: Albania Members of Parliament (Kuvendi)
+title: Albania Members of Parliament
 entry_point: crawler.py
 prefix: al-kuv
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-08
 load_statements: true
 summary: >-
   Current members of the Kuvendi, the unicameral parliament of the Republic of Albania
 description: |
-  This dataset contains the current members of the Kuvendi i Shqipërisë (Assembly of
-  the Republic of Albania), the country's unicameral legislature of 140 seats.
+  Current members of the Kuvendi i Shqipërisë (Assembly of the Republic of Albania),
+  the unicameral parliament of Albania. Its 140 members are elected for four-year
+  terms by proportional representation across the country's twelve electoral districts
+  (qarqe), and hold the country's legislative power, including passing laws, approving
+  the budget, and electing the President and the government.
 
-  The data is sourced from the JSON API that backs the official parlament.al website.
-  It lists each member's name, date of birth (where available), email address and
-  political party.
+  This dataset records each sitting member with their name, date of birth (where
+  available), email address, and political party.
 publisher:
   name: Kuvendi i Shqipërisë
   name_en: Assembly of the Republic of Albania
@@ -42,6 +44,5 @@ assertions:
 lookups:
   type.email:
     options:
-      # Domain typo in the source for a single sitting member.
       - match: ardit.bido@parlamend.al
         value: ardit.bido@parlament.al

--- a/datasets/al/kuvendi/al_kuvendi.yml
+++ b/datasets/al/kuvendi/al_kuvendi.yml
@@ -1,6 +1,6 @@
 title: Albania Members of Parliament (Kuvendi)
 entry_point: crawler.py
-prefix: al-kuvendi
+prefix: al-kuv
 coverage:
   frequency: weekly
   start: 2026-06-08

--- a/datasets/al/kuvendi/crawler.py
+++ b/datasets/al/kuvendi/crawler.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from zavod import Context, Entity
+from zavod import helpers as h
+
+# The 2025 Kuvendi has 140 seats; the API marks sitting members with status 0.
+SITTING_STATUS = 0
+EXPECTED_SEATS = 140
+TIRANE = ZoneInfo("Europe/Tirane")
+
+
+def clean_birth_date(raw: str | None) -> str | None:
+    """Recover an MP's calendar birth date from the source `ditlindje` field.
+
+    The source stores two kinds of unusable values that must be dropped: rows where
+    the birth date was never entered default to the record's import timestamp (year
+    2022 or 2025), and a couple carry the placeholder year 0001. Since MPs must be at
+    least 18, a plausible birth year (1925–2007) cleanly separates real dates from
+    these artifacts.
+
+    Real dates are stored as local midnight expressed in UTC (e.g. a 5 July birthday
+    appears as `...-07-04T23:00:00`, or `T22:00:00` in summer), so taking the date
+    substring is off by one day. Converting to Europe/Tirane recovers the intended
+    calendar day across both standard and daylight-saving offsets.
+    """
+    if raw is None:
+        return None
+    year = int(raw[:4])
+    if year < 1925 or year > 2007:
+        return None
+    parsed = datetime.fromisoformat(raw).replace(tzinfo=timezone.utc)
+    return parsed.astimezone(TIRANE).date().isoformat()
+
+
+def crawl_member(context: Context, position: Entity, record: dict[str, Any]) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug(record.pop("id"))
+
+    # `atesi` (patronymic) is sometimes a "-" placeholder rather than a name.
+    patronymic = record.pop("atesi", None)
+    if patronymic is not None and patronymic.strip("- ") == "":
+        patronymic = None
+    h.apply_name(
+        person,
+        first_name=record.pop("emer"),
+        patronymic=patronymic,
+        last_name=record.pop("mbiemer"),
+    )
+    person.add("citizenship", "al")
+    h.apply_date(person, "birthDate", clean_birth_date(record.pop("ditlindje")))
+    person.add("birthPlace", record.pop("vendlindje", None))
+    person.add("email", record.pop("email", None))
+    person.add("political", record.pop("partia", None))
+
+    occupancy = h.make_occupancy(context, person, position)
+    if occupancy is None:
+        return
+
+    context.audit_data(
+        record,
+        # Electoral district code, profile photo, social media handles and row
+        # audit metadata are not modelled.
+        ignore=[
+            "qarku",
+            "fotoProfil",
+            "fbProfileUrl",
+            "twitterProfileUrl",
+            "linkedInPrifileUrl",
+            "status",
+            "dateKrijimi",
+            "dateModifikimi",
+            "krijuarNga",
+            "modifikuarNga",
+        ],
+    )
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    data: Any = context.fetch_json(context.data_url)
+    if not isinstance(data, list) or len(data) == 0:
+        raise ValueError("Unexpected API response: expected a non-empty list")
+
+    members = [r for r in data if r.get("status") == SITTING_STATUS]
+    if not (EXPECTED_SEATS * 0.9 <= len(members) <= EXPECTED_SEATS * 1.1):
+        context.log.warning(
+            "Sitting member count differs from the expected 140 seats",
+            count=len(members),
+        )
+
+    position = h.make_position(
+        context,
+        name="Member of the Parliament of Albania",
+        country="al",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q20177772",
+    )
+    context.emit(position)
+
+    for record in members:
+        crawl_member(context, position, record)

--- a/datasets/al/kuvendi/crawler.py
+++ b/datasets/al/kuvendi/crawler.py
@@ -34,7 +34,9 @@ def clean_birth_date(raw: str | None) -> str | None:
 
 def crawl_member(context: Context, position: Entity, record: dict[str, Any]) -> None:
     person = context.make("Person")
-    person.id = context.make_slug(record.pop("id"))
+    first_name = record.get("emer")
+    last_name = record.get("mbiemer")
+    person.id = context.make_id(first_name, last_name, record.pop("id"))
 
     # `atesi` (patronymic) is sometimes a "-" placeholder rather than a name.
     patronymic = record.pop("atesi", None)
@@ -42,9 +44,9 @@ def crawl_member(context: Context, position: Entity, record: dict[str, Any]) -> 
         patronymic = None
     h.apply_name(
         person,
-        first_name=record.pop("emer"),
+        first_name=first_name,
         patronymic=patronymic,
-        last_name=record.pop("mbiemer"),
+        last_name=last_name,
     )
     person.add("citizenship", "al")
     h.apply_date(person, "birthDate", clean_birth_date(record.pop("ditlindje")))

--- a/datasets/al/kuvendi/crawler.py
+++ b/datasets/al/kuvendi/crawler.py
@@ -5,9 +5,7 @@ from zoneinfo import ZoneInfo
 from zavod import Context, Entity
 from zavod import helpers as h
 
-# The 2025 Kuvendi has 140 seats; the API marks sitting members with status 0.
-SITTING_STATUS = 0
-EXPECTED_SEATS = 140
+
 TIRANE = ZoneInfo("Europe/Tirane")
 
 
@@ -60,10 +58,8 @@ def crawl_member(context: Context, position: Entity, record: dict[str, Any]) -> 
 
     context.audit_data(
         record,
-        # Electoral district code, profile photo, social media handles and row
-        # audit metadata are not modelled.
         ignore=[
-            "qarku",
+            "qarku",  # numerical representation of the MP's electoral district
             "fotoProfil",
             "fbProfileUrl",
             "twitterProfileUrl",
@@ -80,16 +76,10 @@ def crawl_member(context: Context, position: Entity, record: dict[str, Any]) -> 
 
 
 def crawl(context: Context) -> None:
-    data: Any = context.fetch_json(context.data_url)
-    if not isinstance(data, list) or len(data) == 0:
-        raise ValueError("Unexpected API response: expected a non-empty list")
+    data = context.fetch_json(context.data_url)
 
-    members = [r for r in data if r.get("status") == SITTING_STATUS]
-    if not (EXPECTED_SEATS * 0.9 <= len(members) <= EXPECTED_SEATS * 1.1):
-        context.log.warning(
-            "Sitting member count differs from the expected 140 seats",
-            count=len(members),
-        )
+    # the API marks sitting members with status 0
+    members = [r for r in data if r.get("status") == 0]
 
     position = h.make_position(
         context,


### PR DESCRIPTION
Adds a new PEP crawler for the 140 sitting members of the Kuvendi (Assembly of the Republic of Albania). Closes opensanctions/crawler-planning#694.

## Source

Undocumented OData API backing the parlament.al SPA: `https://kuvendiapi.azurewebsites.net/api/Anetaret?$top=1000`. `$top` is server-capped at 1000, so a single request returns the full member set (236 rows) — no pagination. `status` is a .NET enum so server-side `$filter` doesn't work; we filter client-side to `status == 0`, the 140 sitting members (matches the Kuvendi's 140 seats).

## Data cleaning

The `ditlindje` (date of birth) field needs two fixes, both handled in `clean_birth_date`:

- **Import-timestamp artifacts** — when a DOB was never entered it defaults to the row's creation timestamp (year 2022/2025), plus a couple of placeholder `0001` years. A plausible-birth-year filter (1925–2007, given MPs must be 18+) cleanly separates these from real dates. ~31% of rows are dropped this way.
- **Timezone off-by-one** — legitimate dates are stored as local midnight expressed in UTC (e.g. a 5 July birthday appears as `…-07-04T23:00:00`). Converting to `Europe/Tirane` recovers the intended calendar day across both standard and DST offsets. (Verified against Iris Luarasi: `1973-07-04T23:00:00` → 1973-07-05.)

A single source email domain typo (`parlamentd.al`) is corrected via a `type.email` lookup. `atesi` (patronymic) `"-"` placeholders are dropped. Other endpoints (`strukturat` committee/group memberships) were evaluated but carry no role information, so they add no PEP-qualifying position beyond "Member of Parliament" and are not crawled.

## Output (verified with qsv)

- 140 Person, 140 Occupancy, 1 Position — 0 issues, `mypy --strict` clean.
- citizenship 100% `al` (Albanian citizenship is a legal eligibility requirement to hold a seat); occupancy status 100% `current`.
- 96/140 birth dates emitted, range 1944–2000 (no artifacts leaked); 140 distinct person ids, no duplicate names.
- Position: "Member of the Parliament of Albania", Wikidata `Q20177772`, topics `gov.national` + `gov.legislative`.

Note: `political` (party) is left as inconsistent source free-text (`PS` / `Partia Socialiste` / `Partia Socialiste e Shqipërisë` all refer to the Socialist Party). It is source-faithful and not used for matching; canonicalizing it would be a separate optional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)