### PR TITLE
docs: make PEP property priorities findable in peps.md and the crawler-pep skill

### DIFF
--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -18,7 +18,7 @@ context about the dataset.
 **Consult on demand** (open only when you actually need the section — don't pre-load):
 
 - `.claude/skills/crawler-pep/examples.md` — full code examples (Patterns A/B/C, subnational variant, freshness check, qsv recipes). Open when you're stuck on a pattern or want a worked example.
-- `zavod/docs/peps.md` — depth on Position naming, `categorise()`, Occupancy duration rules. Open if you need more than the summary in this skill.
+- `zavod/docs/peps.md` — depth on Position naming, `categorise()`, Occupancy duration rules, and which person/PEP properties to capture (its "Properties to capture" section). Open if you need more than the summary in this skill.
 - `zavod/docs/metadata.md` — full YAML field reference. Open if you're using a field not covered by the template in `crawler-guide.md`.
 - `zavod/docs/extract/names.md` — open only if you're doing LLM-assisted or reviewed name cleaning.
 
@@ -75,6 +75,14 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 ```
+
+### Person properties
+
+Capture properties by priority — don't chase every field. For people, capture when
+available: name(s), date/place/country of birth, citizenship/nationality, and ID
+numbers. Don't extract private addresses or phone numbers. Full PEP property ladder
+(Must/Could/Won't) and the generic framing: `zavod/docs/peps.md` → "Properties to
+capture".
 
 ### Position naming
 

--- a/zavod/docs/best_practices/priorities.md
+++ b/zavod/docs/best_practices/priorities.md
@@ -36,23 +36,6 @@ Aim for **complete coverage** - make sure all risk-associated entities (people, 
 
 ## Politically-exposed persons
 
-See also: [guide for building PEP data crawlers](../peps.md)
-
-**Must**
-
-- `country` (occasionally multiple apply to one position, e.g. *Ambassador of Palestine to Germany*)
-- `position` (of a person)
-- `occupancy` (relating a person to the position(s) they hold/held) - focus on current position-holders. When a legislature exposes past terms cheaply, see [Historical and multi-term sources](../peps.md#historical-and-multi-term-sources).
-
-**Could**
-
-- `citizenship` - safe to assume over `country` for most elected officials
-- `biography`
-- [Occupancy:constituency](https://www.opensanctions.org/reference/#schema.Occupancy)
-- [Position:subnationalArea](https://www.opensanctions.org/reference/#schema.Position)
-- [Occupancy:politicalGroup](https://www.opensanctions.org/reference/#schema.Occupancy)
-
-**Won't - don't extract**
-
-- private individual addresses (not needed, and privacy concern)
-- phone numbers (not needed, more sensitive than emails)
+The PEP-specific property priorities (Must / Could / Won't) live with the rest of the
+PEP guidance: see [Properties to capture](../peps.md#properties-to-capture) in the
+[guide for building PEP data crawlers](../peps.md).

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -17,6 +17,48 @@ In addition to capturing general information about PEPs, a PEP crawler must
 - Add the `role.pep` [topic](https://www.opensanctions.org/reference/#type.topic) to each PEP Person entity.
 - Add the `role.rca` [topic](https://www.opensanctions.org/reference/#type.topic) to each relative or close associate, as well as the most appropriate entity to represent the relationship, e.g. [Family](https://www.opensanctions.org/reference/#schema.Family), [Associate](https://www.opensanctions.org/reference/#schema.Associate), or [UnknownLink](https://www.opensanctions.org/reference/#schema.UnknownLink).
 
+## Properties to capture
+
+Not every attribute is worth the same effort. Time-box the work and capture
+properties by priority, aiming for complete coverage of the people who qualify
+while not wrongly marking someone as a PEP.
+
+**People — capture when available:**
+
+- Name(s) (see: [name cleaning and review framework](extract/names.md))
+- Date of birth, place of birth, country of birth
+- Citizenship or nationality
+- Official ID numbers and other identifiers (e.g. National ID, `wikidataId`)
+
+This is the people-relevant subset of the general [data collection
+priorities](best_practices/priorities.md) — see there for the full
+Essential / Should / Could / Won't framing and for company/vessel attributes.
+
+**PEP-specific:**
+
+*Must:*
+
+- `country` (occasionally multiple apply to one position, e.g. *Ambassador of Palestine to Germany*)
+- `position` (of a person)
+- `occupancy` (relating a person to the position(s) they hold/held) — focus on current
+  position-holders. When a legislature exposes past terms cheaply, see
+  [Historical and multi-term sources](#historical-and-multi-term-sources).
+
+*Could:*
+
+- `citizenship` — safe to assume over `country` for most elected officials
+- `biography`
+- [`Occupancy:constituency`](https://www.opensanctions.org/reference/#schema.Occupancy)
+- [`Position:subnationalArea`](https://www.opensanctions.org/reference/#schema.Position)
+- [`Occupancy:politicalGroup`](https://www.opensanctions.org/reference/#schema.Occupancy) —
+  the parliamentary faction/group held within the body, distinct from a person's general
+  party membership (`Person:political`)
+
+*Won't — don't extract:*
+
+- private individual addresses (not needed, and a privacy concern)
+- phone numbers (not needed, more sensitive than emails)
+
 ## Creating Positions
 
 The [Position](https://www.opensanctions.org/reference/#schema.Position) `name` property should ideally capture the position and its jurisdiction, but be no more specific than that.


### PR DESCRIPTION
## Problem

The data-collection property priority ladder (which person/PEP properties to capture, Essential/Should/Could/Won't) lived only in `best_practices/priorities.md`. Nothing on the PEP-crawler path linked to it: the `crawler-pep` skill never referenced it, and `peps.md` — the doc the skill routes authors to for PEP depth — didn't link it either. The only inbound link was a footer "see also" in `crawler-guide.md`. So when scaffolding a PEP crawler, the agent got position/occupancy mechanics but no prompt about which person properties to set.

## Change

- **`peps.md`**: new `## Properties to capture` section up front. The PEP-specific Must/Could/Won't block is **moved** here from `priorities.md`; the people-relevant generic essentials (names, DOB/POB, citizenship, IDs) are **copied**, explicitly marked as a subset of the authoritative `priorities.md` so a reader knows which to trust if they diverge. Also spells out that `Occupancy:politicalGroup` (in-chamber faction) is distinct from `Person:political` (general party membership).
- **`priorities.md`**: the "Politically-exposed persons" block is replaced by a one-line pointer to the new `peps.md` section. The generic "Generally" section stays — still authoritative for the cross-entity framing and for sanctions crawlers.
- **`crawler-pep` SKILL**: the `peps.md` entry in "Consult on demand" now names the new section, and Step 3 gains a short "Person properties" subsection with the essentials inline plus a link.

Net effect: a PEP author reading `peps.md` (where the skill already sends them) now sees the property guidance inline; sanctions authors still get it via `priorities.md`. The only duplication — the generic people essentials — is marked as a convenience subset to limit drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)