### PR TITLE
nz_parliament: PEP crawler for New Zealand members of parliament

### DIFF
--- a/datasets/nz/parliament/crawler.py
+++ b/datasets/nz/parliament/crawler.py
@@ -7,21 +7,47 @@ from zavod.entity import Entity
 from zavod.extract import zyte_api
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# CKAN datastore resources in the data.govt.nz "Members of Parliament" dataset, joined
-# on the stable integer MemberID. The "Basic List of Current Members" resource is
-# deliberately not used: it lacks MemberID and stores Māori macrons as "?", so it can
-# neither be joined reliably nor trusted for names.
-API = "https://catalogue.data.govt.nz/api/3/action/datastore_search"
-ROSTER = "11b77d31-e8cb-46e6-8924-aabfbb9136ad"  # name, year of birth/death, gender
-TERMS = "9767376e-ead0-468d-8b55-a65dfb629b54"  # one row per parliamentary term
+# The data.govt.nz "Members of Parliament" dataset. Resource IDs are resolved by name at
+# runtime rather than hardcoded: CKAN mints a new resource_id whenever a resource is
+# re-uploaded, so a hardcoded ID would silently 404 after a routine refresh.
+#
+# Two resources are joined on the integer MemberID. The "Basic List of Current Members"
+# resource is deliberately unused: it lacks MemberID and stores Māori macrons as "?", so
+# it can be neither joined reliably nor trusted for names.
+DATASET = "members-of-parliament"
+ROSTER_NAME = (
+    "Members of Parliament - full list"  # name, birth/death year, gender, ethnicity
+)
+TERMS_NAME = "Members of Parliament - Member Terms"  # one row per parliamentary term
+API = "https://catalogue.data.govt.nz/api/3/action"
 # Above the current row counts (1.5k roster, 5.3k terms); a truncated read fails loudly.
 LIMIT = 20000
 
 
-def fetch_records(context: Context, resource_id: str) -> list[dict[str, Any]]:
-    url = f"{API}?resource_id={resource_id}&limit={LIMIT}"
+def fetch_action(context: Context, action: str, query: str) -> Any:
+    url = f"{API}/{action}?{query}"
     data = zyte_api.fetch_json(context, url, geolocation="nz", cache_days=1)
-    result = data["result"]
+    if not data.get("success"):
+        raise ValueError(f"CKAN {action} request was not successful: {url}")
+    return data["result"]
+
+
+def resolve_resource_id(resources: list[dict[str, Any]], name: str) -> str:
+    matches = [
+        r for r in resources if r.get("name") == name and r.get("datastore_active")
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"Expected exactly one active datastore resource named {name!r}, "
+            f"found {len(matches)}"
+        )
+    return str(matches[0]["id"])
+
+
+def fetch_records(context: Context, resource_id: str) -> list[dict[str, Any]]:
+    result = fetch_action(
+        context, "datastore_search", f"resource_id={resource_id}&limit={LIMIT}"
+    )
     records: list[dict[str, Any]] = result["records"]
     if len(records) != result["total"]:
         raise ValueError(
@@ -60,19 +86,23 @@ def crawl_member(
     # s 47(3). https://www.legislation.govt.nz/act/public/1993/0087/latest/DLM308516.html
     person.add("citizenship", "nz")
     if record is not None:
-        person.add("gender", record.pop("Gender", None))
-        year_of_birth = record.pop("Year_of_Birth", None)
+        # pop without a default: a renamed/removed column crashes here rather than
+        # silently dropping data, and audit_data surfaces any newly added column.
+        person.add("gender", record.pop("Gender"))
+        year_of_birth = record.pop("Year_of_Birth")
         h.apply_date(person, "birthDate", str(year_of_birth) if year_of_birth else None)
-        year_of_death = record.pop("Year_of_Death", None)
+        year_of_death = record.pop("Year_of_Death")
         h.apply_date(person, "deathDate", str(year_of_death) if year_of_death else None)
         # Multiple ethnicities are comma-separated ("Māori, European"); a slash denotes a
-        # single Stats NZ category ("Middle Eastern/Latin American/African"), so only split
-        # on commas.
-        person.add("ethnicity", h.multi_split(record.pop("Ethnicity", None), [","]))
+        # single Stats NZ category ("Middle Eastern/Latin American/African"), so only
+        # split on commas.
+        person.add("ethnicity", h.multi_split(record.pop("Ethnicity"), [","]))
+        context.audit_data(record, ignore=["_id", "MemberID"])
 
     has_occupancy = False
     for term in terms:
-        person.add("political", term.get("Party") or None)
+        person.add("political", term.pop("Party") or None)
+        constituency = term.pop("Electorate_List") or None
         # make_occupancy gates each term on PEP duration, so old terms drop out and only
         # current or recently-ended ones survive — the historical multi-term pattern.
         occupancy = h.make_occupancy(
@@ -80,18 +110,27 @@ def crawl_member(
             person,
             position,
             categorisation=categorisation,
-            start_date=iso_date(term.get("Date_Elected")),
-            end_date=iso_date(term.get("Date_Vacated")),
+            start_date=iso_date(term.pop("Date_Elected")),
+            end_date=iso_date(term.pop("Date_Vacated")),
         )
         if occupancy is not None:
-            occupancy.add("constituency", term.get("Electorate_List") or None)
+            occupancy.add("constituency", constituency)
             context.emit(occupancy)
             has_occupancy = True
+        context.audit_data(
+            term,
+            ignore=[
+                "_id",
+                "MemberID",
+                "Name",
+                "Parliament",
+                "Method_of_Election",
+                "Reason_for_Leaving",
+            ],
+        )
 
     if has_occupancy:
         context.emit(person)
-    if record is not None:
-        context.audit_data(record, ignore=["_id", "MemberID"])
 
 
 def crawl(context: Context) -> None:
@@ -105,14 +144,18 @@ def crawl(context: Context) -> None:
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)
 
+    resources = fetch_action(context, "package_show", f"id={DATASET}")["resources"]
+    roster_id = resolve_resource_id(resources, ROSTER_NAME)
+    terms_id = resolve_resource_id(resources, TERMS_NAME)
+
     terms_by_member: dict[int, list[dict[str, Any]]] = defaultdict(list)
-    for term in fetch_records(context, TERMS):
+    for term in fetch_records(context, terms_id):
         terms_by_member[term["MemberID"]].append(term)
 
     sitting = {
         mid
         for mid, terms in terms_by_member.items()
-        if any(not t.get("Date_Vacated") for t in terms)
+        if any(not t["Date_Vacated"] for t in terms)
     }
     if not (115 <= len(sitting) <= 130):
         context.log.warning(
@@ -120,7 +163,7 @@ def crawl(context: Context) -> None:
             count=len(sitting),
         )
 
-    roster = {r["MemberID"]: r for r in fetch_records(context, ROSTER)}
+    roster = {r["MemberID"]: r for r in fetch_records(context, roster_id)}
     # Iterate by member terms: a member with no term cannot hold a qualifying occupancy,
     # and a member present in terms but not yet in the roster must still be emitted.
     for member_id, terms in terms_by_member.items():

--- a/datasets/nz/parliament/crawler.py
+++ b/datasets/nz/parliament/crawler.py
@@ -1,0 +1,129 @@
+from collections import defaultdict
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.extract import zyte_api
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# CKAN datastore resources in the data.govt.nz "Members of Parliament" dataset, joined
+# on the stable integer MemberID. The "Basic List of Current Members" resource is
+# deliberately not used: it lacks MemberID and stores Māori macrons as "?", so it can
+# neither be joined reliably nor trusted for names.
+API = "https://catalogue.data.govt.nz/api/3/action/datastore_search"
+ROSTER = "11b77d31-e8cb-46e6-8924-aabfbb9136ad"  # name, year of birth/death, gender
+TERMS = "9767376e-ead0-468d-8b55-a65dfb629b54"  # one row per parliamentary term
+# Above the current row counts (1.5k roster, 5.3k terms); a truncated read fails loudly.
+LIMIT = 20000
+
+
+def fetch_records(context: Context, resource_id: str) -> list[dict[str, Any]]:
+    url = f"{API}?resource_id={resource_id}&limit={LIMIT}"
+    data = zyte_api.fetch_json(context, url, geolocation="nz", cache_days=1)
+    result = data["result"]
+    records: list[dict[str, Any]] = result["records"]
+    if len(records) != result["total"]:
+        raise ValueError(
+            f"Datastore read truncated for {resource_id}: "
+            f"{len(records)} of {result['total']}"
+        )
+    return records
+
+
+def iso_date(value: str | None) -> str | None:
+    # Datastore dates look like "2023-10-14T00:00:00"; keep the calendar day.
+    return value[:10] if value else None
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    member_id: int,
+    record: dict[str, Any] | None,
+    terms: list[dict[str, Any]],
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug("member", str(member_id))
+
+    # The biographical roster occasionally lags the terms list for new members, so fall
+    # back to the name carried on the term rows when a member is missing from it.
+    name = record.pop("Name") if record is not None else terms[0]["Name"]
+    last, _, first = name.partition(",")  # source format is "LASTNAME, First Middle"
+    if first.strip():
+        h.apply_name(person, first_name=first.strip(), last_name=last.strip())
+    else:
+        person.add("name", name.strip())
+
+    # New Zealand citizenship is a legal requirement to be elected: Electoral Act 1993
+    # s 47(3). https://www.legislation.govt.nz/act/public/1993/0087/latest/DLM308516.html
+    person.add("citizenship", "nz")
+    if record is not None:
+        person.add("gender", record.pop("Gender", None))
+        year_of_birth = record.pop("Year_of_Birth", None)
+        h.apply_date(person, "birthDate", str(year_of_birth) if year_of_birth else None)
+        year_of_death = record.pop("Year_of_Death", None)
+        h.apply_date(person, "deathDate", str(year_of_death) if year_of_death else None)
+        # Multiple ethnicities are comma-separated ("Māori, European"); a slash denotes a
+        # single Stats NZ category ("Middle Eastern/Latin American/African"), so only split
+        # on commas.
+        person.add("ethnicity", h.multi_split(record.pop("Ethnicity", None), [","]))
+
+    has_occupancy = False
+    for term in terms:
+        person.add("political", term.get("Party") or None)
+        # make_occupancy gates each term on PEP duration, so old terms drop out and only
+        # current or recently-ended ones survive — the historical multi-term pattern.
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            categorisation=categorisation,
+            start_date=iso_date(term.get("Date_Elected")),
+            end_date=iso_date(term.get("Date_Vacated")),
+        )
+        if occupancy is not None:
+            occupancy.add("constituency", term.get("Electorate_List") or None)
+            context.emit(occupancy)
+            has_occupancy = True
+
+    if has_occupancy:
+        context.emit(person)
+    if record is not None:
+        context.audit_data(record, ignore=["_id", "MemberID"])
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the New Zealand House of Representatives",
+        country="nz",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q19899675",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    terms_by_member: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for term in fetch_records(context, TERMS):
+        terms_by_member[term["MemberID"]].append(term)
+
+    sitting = {
+        mid
+        for mid, terms in terms_by_member.items()
+        if any(not t.get("Date_Vacated") for t in terms)
+    }
+    if not (115 <= len(sitting) <= 130):
+        context.log.warning(
+            "Sitting member count outside the expected ~120-123 range",
+            count=len(sitting),
+        )
+
+    roster = {r["MemberID"]: r for r in fetch_records(context, ROSTER)}
+    # Iterate by member terms: a member with no term cannot hold a qualifying occupancy,
+    # and a member present in terms but not yet in the roster must still be emitted.
+    for member_id, terms in terms_by_member.items():
+        crawl_member(
+            context, position, categorisation, member_id, roster.get(member_id), terms
+        )

--- a/datasets/nz/parliament/nz_parliament.yml
+++ b/datasets/nz/parliament/nz_parliament.yml
@@ -1,0 +1,58 @@
+title: New Zealand Members of Parliament
+entry_point: crawler.py
+prefix: nz-parl
+coverage:
+  frequency: weekly
+  start: 2026-06-08
+load_statements: true
+ci_test: false  # fetched via the Zyte API (catalogue.data.govt.nz is anti-bot protected)
+summary: >-
+  Current and recent members of the New Zealand House of Representatives
+description: |
+  Members of the House of Representatives, the unicameral parliament of New Zealand
+  (120–123 seats, elected under a mixed-member proportional system).
+
+  The data is sourced from the official "Members of Parliament" open dataset published
+  on data.govt.nz by the Parliamentary Service / Department of Internal Affairs. Two
+  resources are combined on a stable member identifier: a biographical roster (name,
+  year of birth and death, gender) covering all members since 1854, and a list of
+  parliamentary terms (electorate, party, dates elected and vacated). A person is
+  emitted when at least one of their terms still qualifies them as a politically
+  exposed person.
+url: https://catalogue.data.govt.nz/dataset/members-of-parliament
+publisher:
+  name: New Zealand Parliament
+  description: |
+    Te Pāremata o Aotearoa, the New Zealand Parliament, is the unicameral legislature
+    of New Zealand, consisting of the Sovereign and the House of Representatives. The
+    member data is maintained by the Parliamentary Service and published via the
+    Department of Internal Affairs on the data.govt.nz open data catalogue.
+  country: nz
+  url: https://www.parliament.nz/
+  official: true
+data:
+  url: https://catalogue.data.govt.nz/dataset/members-of-parliament
+  format: JSON
+  lang: eng
+
+assertions:
+  min:
+    schema_entities:
+      Person: 110
+      Position: 1
+    country_entities:
+      nz: 110
+  max:
+    schema_entities:
+      Person: 400
+
+lookups:
+  type.gender:
+    normalize: true
+    options:
+      - match: Male
+        value: male
+      - match: Female
+        value: female
+      - match: Other
+        value: other


### PR DESCRIPTION
Adds a PEP crawler for current and recent members of the New Zealand House of Representatives. Closes opensanctions/crawler-planning#646.

## Source

The issue preferred scraping parliament.nz, but that site is a **Blazor Server SPA** — a rendered fetch returns only the app shell, with no scrapeable list or JSON endpoint. The same data is published as clean **CKAN datastore resources on data.govt.nz** (CC-BY-4.0, updated quarterly), covering current *and* historical members with more fields than the website. Both sources sit behind anti-bot protection (Radware / Imperva), so the crawler fetches through **Zyte** either way (`ci_test: false`); given that, the structured API is the clear choice.

Two datastore resources are joined on the stable integer `MemberID`:
- **roster** (1,555) — name, year of birth/death, gender, ethnicity
- **terms** (5,266) — one row per parliamentary term: electorate, party, elected/vacated dates

The "Basic List of Current Members" resource is deliberately not used — it lacks `MemberID` and stores Māori macrons as `?` (e.g. `T?kuta`), so it joins only 84/122 by name and is less current than the terms list.

## Modelling

- One Position: "Member of the New Zealand House of Representatives" (`country=nz`, `gov.national` + `gov.legislative`, Wikidata Q19899675), `categorise(default_is_pep=True)`.
- Person per `MemberID` (`make_slug` on the opaque integer — no PII): name parsed from "LASTNAME, First" and emitted verbatim, `citizenship=nz`, gender, birthDate/deathDate (year precision), ethnicity (comma-multiples split; the slash-delimited "Middle Eastern/Latin American/African" Stats NZ category kept intact), party → `political`.
- Occupancy per term: `Date_Elected`/`Date_Vacated` → start/end, `Electorate_List` → `Occupancy:constituency`. `make_occupancy` applies the 20-year national after-office window, so output is current + recently-departed members; a person is emitted only if at least one term still qualifies.
- **Iterates by term-holder, not the roster** — a sitting member can lag the biographical roster (e.g. Vanushi Walters), and iterating terms guarantees they are still emitted, with the name falling back to the term rows.
- `citizenship=nz` is grounded in Electoral Act 1993 s 47(3) (cited in a code comment).

## Output (verified)

- 354 Person, 899 Occupancy, 1 Position; 0 issues; `zavod validate` and `mypy --strict` pass.
- **124 current** occupancies (matches the sitting count), 775 ended.
- Full Person↔Occupancy referential integrity; citizenship 100% `nz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)