### PR TITLE
us_state_terrorist_orgs: follow source date column renames

### DIFF
--- a/datasets/us/state_terrorist_orgs/crawler.py
+++ b/datasets/us/state_terrorist_orgs/crawler.py
@@ -37,22 +37,24 @@ def split_clean_name(
 
 def crawl_row(context: Context, row: dict[str, str]) -> None:
     name = row.pop("name")
-    start_date = row.pop("date_designated", None) or row.pop(
-        "date_originally_designated", None
-    )
+    # The designated table records the date the designation took effect; the
+    # delisted table only carries the original listing date.
+    start_date = row.pop("date_implemented", None)
+    listing_date = row.pop("date_originally_listed", None)
     # Rely on auditing rows to be sure the default of None doesn't mean we miss these
     # if the column name changes.
     end_date = row.pop("date_removed", None)
 
     name_clean, name_former, alias = split_clean_name(context, name)
     entity = context.make("Organization")
-    entity.id = context.make_id(name, start_date)
+    entity.id = context.make_id(name, start_date or listing_date)
     entity.add("name", name_clean)
     entity.add("alias", alias)
     entity.add("previousName", name_former)
 
     sanction = h.make_sanction(context, entity, program_key=PROGRAM_KEY)
     h.apply_date(sanction, "startDate", start_date)
+    h.apply_date(sanction, "listingDate", listing_date)
     if end_date:
         h.apply_date(sanction, "endDate", end_date)
     if h.is_active(sanction):


### PR DESCRIPTION
## What

The U.S. State Department renamed the date columns on the [FTO page](https://www.state.gov/foreign-terrorist-organizations/):

| Table | Old column | New column |
|---|---|---|
| Designated FTOs | Date Designated / Date Originally Designated | **Date Implemented** |
| Delisted FTOs | Date Originally Designated | **Date Originally Listed** |

The crawler popped the old column names, so neither matched and `startDate` was silently dropped on every sanction — surfaced as `audit_data` warnings (`date_implemented` ×96, `date_originally_listed` ×21).

## Changes

- Map **Date Implemented** → `startDate` (designated table).
- Map **Date Originally Listed** → `listingDate` (delisted table) — FTM defines `listingDate` as "the date on which the designation is listed; distinct from `startDate`", which fits the delisted table that publishes no effective date.
- **Date Removed** → `endDate` (unchanged).
- Entity IDs preserved by hashing `start_date or listing_date` (same date values as before, just renamed columns).

## Verification

Local crawl: 234 entities, **0 audit warnings**. 96 sanctions with `startDate` (active, `crime.terror`), 21 with `listingDate` + `endDate` (delisted, inactive) — matching the two source tables exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)