### PR TITLE
eu_esma_saris: retry export fetch and validate it is CSV

### DIFF
--- a/datasets/eu/esma_saris/crawler.py
+++ b/datasets/eu/esma_saris/crawler.py
@@ -1,13 +1,28 @@
 import csv
+import time
+from pathlib import Path
 
 from zavod import Context
 from zavod import helpers as h
 
 PROGRAM_KEY = "EU-ESMA"
 
+SEARCH_URL = "https://registers.esma.europa.eu/publication/searchRegister/doMainSearch"
+# The export endpoint requires a server-side session that is established by the
+# search POST below. Without it, the endpoint returns an HTML page with a 200
+# status, which would otherwise be silently parsed as CSV.
+FETCH_ATTEMPTS = 3
+FETCH_SLEEP = 10
 
-def crawl(context: Context) -> None:
-    # Set the initial cookie
+
+def fetch_source(context: Context) -> Path:
+    """Establish the ESMA search session and download the export CSV.
+
+    The export only returns CSV once the ``doMainSearch`` POST has set a session
+    cookie; otherwise it serves an HTML landing page with a 200 status. ESMA
+    occasionally drops the handshake on a given run, so retry a few times and
+    validate that what we fetched is actually the CSV before handing it on.
+    """
     data = {
         "core": "esma_registers_saris_new",
         "pagingSize": "10",
@@ -17,11 +32,32 @@ def crawl(context: Context) -> None:
         "criteria": [],
         "wt": "json",
     }
-    context.http.post(
-        "https://registers.esma.europa.eu/publication/searchRegister/doMainSearch",
-        json=data,
+    for attempt in range(1, FETCH_ATTEMPTS + 1):
+        # Set the session cookie used by the export endpoint.
+        context.http.post(SEARCH_URL, json=data)
+        source_file = context.fetch_resource("source.csv", context.data_url)
+        with open(source_file, "r") as f:
+            header = f.readline()
+        if "instrumentIdentifier" in header:
+            return source_file
+        # We got the HTML landing page (or some other non-CSV response).
+        # Drop the cached file so the next attempt re-fetches.
+        context.log.warn(
+            "ESMA export did not return CSV, session handshake likely failed",
+            attempt=attempt,
+            header=header[:200],
+        )
+        source_file.unlink(missing_ok=True)
+        if attempt < FETCH_ATTEMPTS:
+            time.sleep(FETCH_SLEEP)
+    raise RuntimeError(
+        "ESMA export returned HTML, not CSV, after "
+        f"{FETCH_ATTEMPTS} attempts (session handshake failed)"
     )
-    source_file = context.fetch_resource("source.csv", context.data_url)
+
+
+def crawl(context: Context) -> None:
+    source_file = fetch_source(context)
     with open(source_file, "r") as f:
         reader = csv.DictReader(f)
         for row in reader:


### PR DESCRIPTION
## Problem

The `eu_esma_saris` crawler failed with a cryptic `KeyError: 'instrumentIdentifier'`. The ESMA data structure has **not** changed — the CSV header is intact.

The export endpoint requires a server-side session established by the `doMainSearch` POST. Without that session cookie, the endpoint returns an HTML landing page **with a 200 status**, which `fetch_resource` silently saved as `source.csv`. `csv.DictReader` then read `<!DOCTYPE html>` as the header row, and `row.pop("instrumentIdentifier")` raised `KeyError` — three steps removed from the actual cause. ESMA occasionally drops the handshake on a given daily run, which is why it ran fine for months and then failed.

## Fix

- Extract a `fetch_source()` helper that runs the handshake + fetch, then validates the first line contains `instrumentIdentifier` before parsing.
- On a non-CSV response, log a warning, delete the cached `source.csv` (so `fetch_resource` re-fetches rather than returning the stale HTML), and retry — up to 3 attempts with a 10s sleep.
- If all attempts fail, raise a clear `RuntimeError` naming the real cause (session handshake failed) instead of the opaque downstream `KeyError`.

## Verification

Ran the crawler end-to-end: 13,827 entities emitted, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)