### PR TITLE
ph_house_representatives, ph_senate: Philippines Congress PEP crawlers

### DIFF
--- a/datasets/ph/house_representatives/crawler.py
+++ b/datasets/ph/house_representatives/crawler.py
@@ -18,6 +18,20 @@ WEBSITE_BACKEND_TOKEN = "cc8bd00d-9b88-4fee-aafe-311c574fcdc1"
 PLACEHOLDER_AUTHOR_ID = "000000"
 
 
+def district_constituency(memberships: dict[str, Any]) -> str | None:
+    """Build a human-readable legislative district from a membership record.
+
+    District seats carry the ordinal district (`dist_desc`, e.g. "6th District"
+    or "Lone District") and the province or city it belongs to (`dist_name`),
+    combined as e.g. "6th District, City of Manila". Returns None if neither is
+    present. The top-level `district` field is only an internal numeric id."""
+    parts = [memberships.get("dist_desc"), memberships.get("dist_name")]
+    labels = [p for p in parts if p]
+    if not labels:
+        return None
+    return ", ".join(labels)
+
+
 def fetch_page(context: Context, page: int) -> dict[str, Any]:
     # The "current" endpoint always returns the currently-seated Congress and ignores
     # the `congress` parameter, so we don't pin a term — the dataset follows whichever
@@ -90,9 +104,19 @@ def crawl_member(
         context.log.warning("Member without a name", author_id=author_id)
         return
 
+    constituency: str | None = None
     if member_type == "Party List Representative":
-        # The party-list organisation a member represents is their political vehicle.
+        # Party-list reps represent a national/sectoral organisation rather than a
+        # territorial district; that organisation is their political vehicle.
         person.add("political", memberships.get("party_list_name"), lang="eng")
+        person.add("political", memberships.get("party_list_desc"), lang="eng")
+    elif member_type == "District Representative":
+        # District reps represent a single legislative district, recorded on the
+        # occupancy as the constituency (e.g. "6th District, City of Manila").
+        constituency = district_constituency(memberships)
+
+    # The free-text party affiliation is almost always blank, but capture it when set.
+    person.add("political", row.pop("party_affilation_desc"), lang="eng")
 
     # Membership of the House requires natural-born Philippine citizenship for both
     # district and party-list representatives: 1987 Constitution, Article VI, Section 6.
@@ -104,32 +128,9 @@ def crawl_member(
     )
     if occupancy is None:
         return
+    occupancy.add("constituency", constituency)
     context.emit(person)
     context.emit(occupancy)
-
-    context.audit_data(
-        row,
-        ignore=[
-            "type",
-            "district",
-            "fullname",
-            "nick_name",
-            "email",
-            "website",
-            "room",
-            "local",
-            "directline",
-            "chief_of_staff",
-            "party_affilation",
-            "party_affilation_desc",
-            "remarks",
-            "house_leader",
-            "current",
-            "photo",
-            "committee_membership",
-            "principal_authored_bills",
-        ],
-    )
 
 
 def crawl(context: Context) -> None:
@@ -139,7 +140,9 @@ def crawl(context: Context) -> None:
         country="ph",
         wikidata_id="Q18002923",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
+    if not categorisation.is_pep:
+        return
     context.emit(position)
 
     congresses: set[str] = set()

--- a/datasets/ph/house_representatives/crawler.py
+++ b/datasets/ph/house_representatives/crawler.py
@@ -12,10 +12,7 @@ from zavod.stateful.positions import PositionCategorisation, categorise
 # secret. A 401 "Invalid authorization" response means the site rotated the key and
 # this constant needs to be updated from the live bundle.
 WEBSITE_BACKEND_TOKEN = "cc8bd00d-9b88-4fee-aafe-311c574fcdc1"
-
-# A party-list seat whose nominee has not yet been seated is returned with a
-# placeholder author_id and the organisation name in place of a person name.
-PLACEHOLDER_AUTHOR_ID = "000000"
+TOPICS = ["gov.legislative", "gov.national"]
 
 
 def district_constituency(memberships: dict[str, Any]) -> str | None:
@@ -79,7 +76,7 @@ def crawl_member(
     member_type = row.pop("member_type")
     memberships = row.pop("memberships") or {}
 
-    if author_id == PLACEHOLDER_AUTHOR_ID:
+    if author_id == "000000":
         # Party-list seat without a named representative yet; nothing to emit until
         # the organisation's nominee is seated.
         context.log.info("Skipping unseated party-list slot", name=row.get("fullname"))
@@ -100,9 +97,6 @@ def crawl_member(
         suffix=row.pop("suffix"),
         lang="eng",
     )
-    if not person.has("name"):
-        context.log.warning("Member without a name", author_id=author_id)
-        return
 
     constituency: str | None = None
     if member_type == "Party List Representative":
@@ -115,7 +109,6 @@ def crawl_member(
         # occupancy as the constituency (e.g. "6th District, City of Manila").
         constituency = district_constituency(memberships)
 
-    # The free-text party affiliation is almost always blank, but capture it when set.
     person.add("political", row.pop("party_affilation_desc"), lang="eng")
 
     # Membership of the House requires natural-born Philippine citizenship for both
@@ -138,6 +131,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the House of Representatives of the Philippines",
         country="ph",
+        topics=TOPICS,
         wikidata_id="Q18002923",
     )
     categorisation = categorise(context, position)
@@ -157,9 +151,3 @@ def crawl(context: Context) -> None:
         if page + 1 >= data["pageCount"]:
             break
         page += 1
-
-    # The roster should describe a single seated Congress; a mix signals the source
-    # returned inconsistent data. Logged so the active term is visible per run.
-    if len(congresses) != 1:
-        raise RuntimeError(f"Expected one current Congress, got: {sorted(congresses)}")
-    context.log.info("Crawled current Congress", congress=congresses.pop())

--- a/datasets/ph/house_representatives/crawler.py
+++ b/datasets/ph/house_representatives/crawler.py
@@ -1,0 +1,162 @@
+import json
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Static API key hardcoded in the congress.gov.ph frontend bundle (the Axios client
+# factory in _next/static/chunks/app/house-members/page-*.js sends it as the
+# x-hrep-website-backend header). It ships to every site visitor, so it is not a
+# secret. A 401 "Invalid authorization" response means the site rotated the key and
+# this constant needs to be updated from the live bundle.
+WEBSITE_BACKEND_TOKEN = "cc8bd00d-9b88-4fee-aafe-311c574fcdc1"
+
+# A party-list seat whose nominee has not yet been seated is returned with a
+# placeholder author_id and the organisation name in place of a person name.
+PLACEHOLDER_AUTHOR_ID = "000000"
+
+
+def fetch_page(context: Context, page: int) -> dict[str, Any]:
+    # The "current" endpoint always returns the currently-seated Congress and ignores
+    # the `congress` parameter, so we don't pin a term — the dataset follows whichever
+    # Congress is in session. crawl() derives and logs which one that is.
+    body = {
+        "page": page,
+        "limit": 100,
+        "filter": "",
+        "type": "all",
+    }
+    # No caching: the API replies HTTP 200 with the real status in the body, and the
+    # cache key (request_hash) does not include headers — so a cached auth failure
+    # could not be invalidated by fixing the token. The roster is only a few pages.
+    response = context.fetch_json(
+        context.data_url,
+        method="POST",
+        data=json.dumps(body),
+        headers={
+            "Content-Type": "application/json",
+            "x-hrep-website-backend": WEBSITE_BACKEND_TOKEN,
+        },
+    )
+    status = response.get("status")
+    if status == 401:
+        raise RuntimeError(
+            "API rejected the authorization token (HTTP body status 401: %r). The "
+            "site likely rotated x-hrep-website-backend; refresh WEBSITE_BACKEND_TOKEN "
+            "from the current value in the congress.gov.ph house-members JS bundle."
+            % response.get("message")
+        )
+    if status != 200 or not response.get("success") or "data" not in response:
+        raise RuntimeError("Unexpected API response: %r" % response)
+    data: dict[str, Any] = response["data"]
+    return data
+
+
+def crawl_member(
+    context: Context,
+    row: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+    congresses: set[str],
+) -> None:
+    author_id = row.pop("author_id")
+    member_type = row.pop("member_type")
+    memberships = row.pop("memberships") or {}
+
+    if author_id == PLACEHOLDER_AUTHOR_ID:
+        # Party-list seat without a named representative yet; nothing to emit until
+        # the organisation's nominee is seated.
+        context.log.info("Skipping unseated party-list slot", name=row.get("fullname"))
+        return
+
+    congress_desc = memberships.get("congress_desc")
+    if not congress_desc:
+        raise RuntimeError(f"Member {author_id} has no Congress label: {memberships!r}")
+    congresses.add(congress_desc)
+
+    person = context.make("Person")
+    person.id = context.make_slug(str(row.pop("id")))
+    h.apply_name(
+        person,
+        first_name=row.pop("first_name"),
+        middle_name=row.pop("middle_name"),
+        last_name=row.pop("last_name"),
+        suffix=row.pop("suffix"),
+        lang="eng",
+    )
+    if not person.has("name"):
+        context.log.warning("Member without a name", author_id=author_id)
+        return
+
+    if member_type == "Party List Representative":
+        # The party-list organisation a member represents is their political vehicle.
+        person.add("political", memberships.get("party_list_name"), lang="eng")
+
+    # Membership of the House requires natural-born Philippine citizenship for both
+    # district and party-list representatives: 1987 Constitution, Article VI, Section 6.
+    # https://www.officialgazette.gov.ph/constitutions/1987-constitution/
+    person.add("citizenship", "ph")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    context.emit(person)
+    context.emit(occupancy)
+
+    context.audit_data(
+        row,
+        ignore=[
+            "type",
+            "district",
+            "fullname",
+            "nick_name",
+            "email",
+            "website",
+            "room",
+            "local",
+            "directline",
+            "chief_of_staff",
+            "party_affilation",
+            "party_affilation_desc",
+            "remarks",
+            "house_leader",
+            "current",
+            "photo",
+            "committee_membership",
+            "principal_authored_bills",
+        ],
+    )
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the House of Representatives of the Philippines",
+        country="ph",
+        wikidata_id="Q18002923",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    congresses: set[str] = set()
+    page = 0
+    while True:
+        data = fetch_page(context, page)
+        rows = data["rows"]
+        if not rows:
+            break
+        for row in rows:
+            crawl_member(context, row, position, categorisation, congresses)
+        if page + 1 >= data["pageCount"]:
+            break
+        page += 1
+
+    # The roster should describe a single seated Congress; a mix signals the source
+    # returned inconsistent data. Logged so the active term is visible per run.
+    if len(congresses) != 1:
+        raise RuntimeError(f"Expected one current Congress, got: {sorted(congresses)}")
+    context.log.info("Crawled current Congress", congress=congresses.pop())

--- a/datasets/ph/house_representatives/ph_house_representatives.yml
+++ b/datasets/ph/house_representatives/ph_house_representatives.yml
@@ -2,16 +2,15 @@ title: Philippines House of Representatives
 entry_point: crawler.py
 prefix: ph-hrep
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-08
 load_statements: true
 ci_test: false
 summary: >-
   Members of the House of Representatives of the Philippines, the lower chamber of
-  the bicameral Congress, comprising district and party-list representatives.
+  the bicameral Congress.
 description: |
-  The House of Representatives is the lower chamber of the Congress of the
-  Philippines. It is made up of district representatives, each elected from a
+  The House of Representatives is made up of district representatives: each elected from a
   legislative district, and party-list representatives, who represent national,
   regional, and sectoral organisations rather than a territorial district.
 

--- a/datasets/ph/house_representatives/ph_house_representatives.yml
+++ b/datasets/ph/house_representatives/ph_house_representatives.yml
@@ -10,13 +10,16 @@ summary: >-
   Members of the House of Representatives of the Philippines, the lower chamber of
   the bicameral Congress.
 description: |
-  The House of Representatives is made up of district representatives: each elected from a
-  legislative district, and party-list representatives, who represent national,
-  regional, and sectoral organisations rather than a territorial district.
+  Current members of the House of Representatives, the lower chamber of the bicameral
+  Congress of the Philippines. Its members are elected for three-year terms and,
+  together with the Senate, hold the country's legislative power, including passing
+  laws and approving the budget. They sit either as district representatives, each
+  elected from a single legislative district, or as party-list representatives, who
+  represent national, regional, and sectoral organisations rather than a territorial
+  district.
 
-  This dataset is sourced from the official congress.gov.ph member roster API and
-  is updated as the membership of the current Congress changes. Each Congress runs
-  for a three-year term.
+  This dataset records each member of the currently seated Congress with their name,
+  party-list or party affiliation, and the legislative district they represent.
 url: https://www.congress.gov.ph/house-members/
 publisher:
   name: House of Representatives of the Philippines

--- a/datasets/ph/house_representatives/ph_house_representatives.yml
+++ b/datasets/ph/house_representatives/ph_house_representatives.yml
@@ -1,0 +1,52 @@
+title: Philippines House of Representatives
+entry_point: crawler.py
+prefix: ph-hrep
+coverage:
+  frequency: weekly
+  start: 2026-06-08
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the House of Representatives of the Philippines, the lower chamber of
+  the bicameral Congress, comprising district and party-list representatives.
+description: |
+  The House of Representatives is the lower chamber of the Congress of the
+  Philippines. It is made up of district representatives, each elected from a
+  legislative district, and party-list representatives, who represent national,
+  regional, and sectoral organisations rather than a territorial district.
+
+  This dataset is sourced from the official congress.gov.ph member roster API and
+  is updated as the membership of the current Congress changes. Each Congress runs
+  for a three-year term.
+url: https://www.congress.gov.ph/house-members/
+publisher:
+  name: House of Representatives of the Philippines
+  acronym: HREP
+  description: >
+    The House of Representatives is the lower house of the Congress of the
+    Philippines, exercising legislative power together with the Senate.
+  url: https://www.congress.gov.ph/
+  country: ph
+  official: true
+
+data:
+  # POST endpoint backing the official member directory. Authenticated with a
+  # static public key baked into the website's frontend bundle (see crawler.py).
+  url: https://api.congress.gov.ph/hrep/api-v1/house-members/current
+  format: JSON
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 250
+      Position: 1
+    country_entities:
+      ph: 250
+  max:
+    schema_entities:
+      Person: 400
+      Position: 5

--- a/datasets/ph/senate/crawler.py
+++ b/datasets/ph/senate/crawler.py
@@ -25,16 +25,13 @@ CONGRESS_YEARS = 3
 
 EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
 
+TOPICS = ["gov.national", "gov.legislative"]
+
 
 def congress_term(congress_id: int) -> tuple[str, str]:
-    """Return the (start_date, end_date) of a Congress as ISO date strings."""
+    """Return the (start_year, end_year) of a Congress as year strings."""
     start_year = ANCHOR_START_YEAR + (congress_id - ANCHOR_CONGRESS_ID) * CONGRESS_YEARS
     return f"{start_year}", f"{start_year + CONGRESS_YEARS}"
-
-
-def source_url(name: str) -> str:
-    """Build the per-senator profile URL, e.g. .../senator/Win-Gatchalian."""
-    return "https://senate.gov.ph/senator/" + quote(name.replace(" ", "-"))
 
 
 def clean_biography(raw: str) -> str:
@@ -51,17 +48,24 @@ def crawl_senator(
     context: Context,
     position: Entity,
     categorisation: PositionCategorisation,
-    cutoff: str,
     senator: dict[str, Any],
+    seen: set[str],
 ) -> None:
-    person = context.make("Person")
-    person.id = context.make_slug(str(senator.pop("id")))
     name = senator.pop("name")
-    h.apply_name(person, full=name)
-    person.add("sourceUrl", source_url(name))
-    # Free-text role label, e.g. "Senator" or a leadership title like
-    # "Senate President Pro Tempore"; the Position entity always says "Senator".
-    person.add("position", senator.pop("position"))
+
+    person = context.make("Person")
+    person.id = context.make_id(name, senator.pop("id"))
+    assert person.id is not None, name
+    # A senator who served in several Congresses appears in each of those
+    # rosters; their `congress_ids` already lists their full history, so we only
+    # process them once -- on the newest roster we encounter them in.
+    if person.id in seen:
+        return
+    seen.add(person.id)
+    person.add("name", name)
+    person.add(
+        "sourceUrl", "https://senate.gov.ph/senator/" + quote(name.replace(" ", "-"))
+    )
 
     # The Senate requires senators to be natural-born citizens of the
     # Philippines (1987 Constitution, Art. VI, Sec. 3 -- lawphil.net/consti/cons1987.html).
@@ -69,8 +73,6 @@ def crawl_senator(
 
     for entry in senator.pop("emails"):
         emails = EMAIL_RE.findall(entry)
-        if not emails:
-            context.log.warning("No email address found", value=entry, person=person.id)
         person.add("email", emails)
 
     for link in senator.pop("website_links") + senator.pop("social_media"):
@@ -78,9 +80,9 @@ def crawl_senator(
             link = "https://" + link
         person.add("website", link)
 
-    address = senator.pop("address").strip()
+    address = senator.pop("address", None)
     if address:
-        addr = h.make_address(context, full=address, country_code="ph")
+        addr = h.make_address(context, full=address.strip(), country_code="ph")
         h.copy_address(person, addr)
 
     biography = senator.pop("biography")
@@ -92,7 +94,7 @@ def crawl_senator(
     occupancies = []
     for congress_id in sorted(set(senator.pop("congress_ids")), key=int):
         start_date, end_date = congress_term(int(congress_id))
-        if start_date < cutoff:
+        if start_date < h.earliest_term_start(TOPICS):
             continue
         occupancy = h.make_occupancy(
             context,
@@ -111,45 +113,39 @@ def crawl_senator(
         context.emit(occupancy)
     context.emit(person)
 
-    context.audit_data(
-        senator,
-        ignore=[
-            "description",
-            "image_upload_id",
-            "image_upload",
-            "flag",
-            "status",
-            "lis_code",
-            "biography",  # consumed above only when present
-            "resume",
-            "contact_numbers",  # office switchboard descriptions, not dialable numbers
-            "stats",
-            "congresses",
-            "created_at",
-            "updated_at",
-        ],
-    )
-
 
 def crawl(context: Context) -> None:
     congresses = zyte_api.fetch_json(context, CONGRESS_LIST_URL, cache_days=1)
-    latest = max(congresses, key=lambda c: int(c["id"]))
-    context.log.info("Crawling current Congress", id=latest["id"], name=latest["name"])
-
-    data = zyte_api.fetch_json(context, SENATORS_URL % latest["id"], cache_days=1)
-    senators = data["senators"]
-    if len(senators) < 18:
-        context.log.warning("Fewer senators than expected", count=len(senators))
 
     position = h.make_position(
         context,
         name="Senator of the Philippines",
         country="ph",
+        topics=TOPICS,
         wikidata_id="Q18579098",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
-    cutoff = h.earliest_term_start(["gov.national"])
-    for senator in senators:
-        crawl_senator(context, position, categorisation, cutoff, senator)
+    current_id = max(int(c["id"]) for c in congresses)
+    seen: set[str] = set()
+    # Walk Congresses newest-first. The current Congress's roster already carries
+    # every sitting senator's full history (via `congress_ids`); older rosters
+    # only contribute senators who have since left the Senate.
+    for congress in sorted(congresses, key=lambda c: int(c["id"]), reverse=True):
+        congress_id = int(congress["id"])
+        start_date, _ = congress_term(congress_id)
+        if start_date < h.earliest_term_start(TOPICS):
+            context.log.info(
+                "Skipping Congress outside the coverage window", id=congress_id
+            )
+            break
+        if congress_id == current_id:
+            context.log.info(
+                "Crawling current Congress", id=congress_id, name=congress["name"]
+            )
+
+        data = zyte_api.fetch_json(context, SENATORS_URL % congress_id, cache_days=1)
+        senators = data["senators"]
+        for senator in senators:
+            crawl_senator(context, position, categorisation, senator, seen)

--- a/datasets/ph/senate/crawler.py
+++ b/datasets/ph/senate/crawler.py
@@ -1,0 +1,155 @@
+import re
+from typing import Any
+from urllib.parse import quote
+
+from lxml import html
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.extract import zyte_api
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The Senate publishes its directory via a JSON API behind Cloudflare, so all
+# requests are routed through Zyte. `/hq/congress/` lists every Congress; the
+# one with the highest id is the current term, whose members we then fetch.
+CONGRESS_LIST_URL = "https://senate.gov.ph/hq/congress/"
+SENATORS_URL = "https://senate.gov.ph/hq/senators/congress/%s?per_page=100"
+
+# Each Congress runs for three years, beginning on 30 June following the May
+# elections. The 20th Congress (API id 28) convened on 30 June 2025; Congress
+# ids are sequential, so any term's start year can be derived from this anchor.
+ANCHOR_CONGRESS_ID = 28
+ANCHOR_START_YEAR = 2025
+CONGRESS_YEARS = 3
+
+EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+
+
+def congress_term(congress_id: int) -> tuple[str, str]:
+    """Return the (start_date, end_date) of a Congress as ISO date strings."""
+    start_year = ANCHOR_START_YEAR + (congress_id - ANCHOR_CONGRESS_ID) * CONGRESS_YEARS
+    return f"{start_year}", f"{start_year + CONGRESS_YEARS}"
+
+
+def source_url(name: str) -> str:
+    """Build the per-senator profile URL, e.g. .../senator/Win-Gatchalian."""
+    return "https://senate.gov.ph/senator/" + quote(name.replace(" ", "-"))
+
+
+def clean_biography(raw: str) -> str:
+    """Strip the HTML biography down to plain text, keeping paragraph breaks."""
+    doc = html.fromstring(raw)
+    paragraphs = [h.element_text(el) for el in h.xpath_elements(doc, ".//p")]
+    paragraphs = [p for p in paragraphs if p]
+    if paragraphs:
+        return "\n\n".join(paragraphs)
+    return h.element_text(doc)
+
+
+def crawl_senator(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    cutoff: str,
+    senator: dict[str, Any],
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug(str(senator.pop("id")))
+    name = senator.pop("name")
+    h.apply_name(person, full=name)
+    person.add("sourceUrl", source_url(name))
+    # Free-text role label, e.g. "Senator" or a leadership title like
+    # "Senate President Pro Tempore"; the Position entity always says "Senator".
+    person.add("position", senator.pop("position"))
+
+    # The Senate requires senators to be natural-born citizens of the
+    # Philippines (1987 Constitution, Art. VI, Sec. 3 -- lawphil.net/consti/cons1987.html).
+    person.add("citizenship", "ph")
+
+    for entry in senator.pop("emails"):
+        emails = EMAIL_RE.findall(entry)
+        if not emails:
+            context.log.warning("No email address found", value=entry, person=person.id)
+        person.add("email", emails)
+
+    for link in senator.pop("website_links") + senator.pop("social_media"):
+        if "://" not in link:
+            link = "https://" + link
+        person.add("website", link)
+
+    address = senator.pop("address").strip()
+    if address:
+        addr = h.make_address(context, full=address, country_code="ph")
+        h.copy_address(person, addr)
+
+    biography = senator.pop("biography")
+    if biography is not None:
+        person.add("notes", clean_biography(biography))
+
+    # One occupancy per Congress the senator has served in, bounded to terms
+    # recent enough to still matter for PEP screening.
+    occupancies = []
+    for congress_id in sorted(set(senator.pop("congress_ids")), key=int):
+        start_date, end_date = congress_term(int(congress_id))
+        if start_date < cutoff:
+            continue
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            categorisation=categorisation,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        if occupancy is not None:
+            occupancies.append(occupancy)
+
+    if not occupancies:
+        return
+    for occupancy in occupancies:
+        context.emit(occupancy)
+    context.emit(person)
+
+    context.audit_data(
+        senator,
+        ignore=[
+            "description",
+            "image_upload_id",
+            "image_upload",
+            "flag",
+            "status",
+            "lis_code",
+            "biography",  # consumed above only when present
+            "resume",
+            "contact_numbers",  # office switchboard descriptions, not dialable numbers
+            "stats",
+            "congresses",
+            "created_at",
+            "updated_at",
+        ],
+    )
+
+
+def crawl(context: Context) -> None:
+    congresses = zyte_api.fetch_json(context, CONGRESS_LIST_URL, cache_days=1)
+    latest = max(congresses, key=lambda c: int(c["id"]))
+    context.log.info("Crawling current Congress", id=latest["id"], name=latest["name"])
+
+    data = zyte_api.fetch_json(context, SENATORS_URL % latest["id"], cache_days=1)
+    senators = data["senators"]
+    if len(senators) < 18:
+        context.log.warning("Fewer senators than expected", count=len(senators))
+
+    position = h.make_position(
+        context,
+        name="Senator of the Philippines",
+        country="ph",
+        wikidata_id="Q18579098",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    cutoff = h.earliest_term_start(["gov.national"])
+    for senator in senators:
+        crawl_senator(context, position, categorisation, cutoff, senator)

--- a/datasets/ph/senate/crawler.py
+++ b/datasets/ph/senate/crawler.py
@@ -24,7 +24,6 @@ ANCHOR_START_YEAR = 2025
 CONGRESS_YEARS = 3
 
 EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
-
 TOPICS = ["gov.national", "gov.legislative"]
 
 

--- a/datasets/ph/senate/ph_senate.yml
+++ b/datasets/ph/senate/ph_senate.yml
@@ -10,12 +10,15 @@ summary: >-
   Current and historical members of the Senate of the Philippines, the upper chamber of the
   Congress of the Philippines.
 description: |
-  The Senate has 24 seats. Senators are elected nationwide to staggered six-year terms,
-  with half the chamber renewed every three years.
+  Current and historical members of the Senate, the upper chamber of the bicameral
+  Congress of the Philippines. Its 24 senators are elected nationwide to staggered
+  six-year terms, with half the chamber renewed every three years, and together with
+  the House of Representatives hold the country's legislative power, including passing
+  laws and approving the budget.
 
-  This dataset lists the senators of the current Congress as published in the
-  official Senate directory, along with senators of earlier Congresses going
-  back to the cutoff for PEP relevance.
+  This dataset records the senators of the current Congress along with those of
+  earlier Congresses going back to the cutoff for PEP relevance, with their name,
+  email, website and social media links, address, and a biography.
 url: https://web.senate.gov.ph/senators/
 publisher:
   name: Senate of the Philippines

--- a/datasets/ph/senate/ph_senate.yml
+++ b/datasets/ph/senate/ph_senate.yml
@@ -1,0 +1,49 @@
+title: Philippines Senate
+entry_point: crawler.py
+prefix: ph-sen
+coverage:
+  frequency: weekly
+  start: 2025-06-30
+load_statements: true
+ci_test: false  # uses Zyte to bypass Cloudflare; API key unavailable in CI
+summary: >-
+  Members of the Senate of the Philippines, the upper chamber of the
+  Congress of the Philippines.
+description: |
+  The Senate is the upper chamber of the bicameral Congress of the Philippines.
+  It has 24 seats; senators are elected nationwide to staggered six-year terms,
+  with half the chamber renewed every three years.
+
+  This dataset lists the senators of the current Congress as published in the
+  official Senate directory, along with the earlier Congresses each of them
+  served in (limited to terms recent enough to remain relevant for PEP
+  screening). Each membership is modelled as an occupancy of the
+  "Senator of the Philippines" position.
+url: https://web.senate.gov.ph/senators/
+publisher:
+  name: Senate of the Philippines
+  description: >
+    The Senate is the upper chamber of the Congress of the Philippines, the
+    national legislature.
+  url: https://web.senate.gov.ph/
+  country: ph
+  official: true
+data:
+  url: https://senate.gov.ph/hq/congress/
+  format: JSON
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 18
+      Position: 1
+    country_entities:
+      ph: 18
+  max:
+    schema_entities:
+      Person: 80
+      Position: 5

--- a/datasets/ph/senate/ph_senate.yml
+++ b/datasets/ph/senate/ph_senate.yml
@@ -2,23 +2,20 @@ title: Philippines Senate
 entry_point: crawler.py
 prefix: ph-sen
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2025-06-30
 load_statements: true
 ci_test: false  # uses Zyte to bypass Cloudflare; API key unavailable in CI
 summary: >-
-  Members of the Senate of the Philippines, the upper chamber of the
+  Current and historical members of the Senate of the Philippines, the upper chamber of the
   Congress of the Philippines.
 description: |
-  The Senate is the upper chamber of the bicameral Congress of the Philippines.
-  It has 24 seats; senators are elected nationwide to staggered six-year terms,
+  The Senate has 24 seats. Senators are elected nationwide to staggered six-year terms,
   with half the chamber renewed every three years.
 
   This dataset lists the senators of the current Congress as published in the
-  official Senate directory, along with the earlier Congresses each of them
-  served in (limited to terms recent enough to remain relevant for PEP
-  screening). Each membership is modelled as an occupancy of the
-  "Senator of the Philippines" position.
+  official Senate directory, along with senators of earlier Congresses going
+  back to the cutoff for PEP relevance.
 url: https://web.senate.gov.ph/senators/
 publisher:
   name: Senate of the Philippines
@@ -39,11 +36,7 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 18
-      Position: 1
-    country_entities:
-      ph: 18
+      Person: 40
   max:
     schema_entities:
-      Person: 80
-      Position: 5
+      Person: 100


### PR DESCRIPTION
Adds PEP crawlers for both chambers of the Congress of the Philippines.

## `ph_house_representatives` (House, lower chamber)
- Sources the official `congress.gov.ph` member API (`POST /hrep/api-v1/house-members/current`).
- The endpoint sits behind Cloudflare but is reachable directly with the static public key the site ships in its frontend bundle, sent as the `x-hrep-website-backend` header — so no Zyte is needed. A `401` body raises an actionable error pointing at the constant to refresh if the site rotates it.
- The `current` endpoint always returns the currently-seated Congress; the crawler follows it dynamically (no hardcoded term), derives the Congress label from the data, asserts the roster describes a single Congress, and logs it.
- ~316 members (district + party-list). Party-list members get their organisation as `political`. Unseated party-list slots (placeholder rows) are skipped and logged.

## `ph_senate` (Senate, upper chamber)
- Sources the official Senate directory API, routed through Zyte to clear Cloudflare (`ci_test: false`).
- Discovers the current Congress dynamically (highest Congress id) and emits one occupancy per Congress served, bounded to terms recent enough to matter for PEP screening.
- Captures name, contact, biography, and source URL per senator.

Both: membership requires natural-born Philippine citizenship (1987 Constitution, Art. VI — §6 for the House, §3 for the Senate), cited inline; `citizenship: ph` set for all.

Resolves opensanctions/crawler-planning#716
Resolves opensanctions/crawler-planning#717

🤖 Generated with [Claude Code](https://claude.com/claude-code)