### PR TITLE
Remove country propagation from make_occupancy

### DIFF
--- a/datasets/au/tas_parliament/crawler.py
+++ b/datasets/au/tas_parliament/crawler.py
@@ -70,7 +70,6 @@ def crawl_person(
         person,
         position,
         categorisation=categorisation,
-        propagate_country=True,
     )
     if occupancy is not None:
         if jurisdiction is not None:

--- a/datasets/au/vic_parliament/crawler.py
+++ b/datasets/au/vic_parliament/crawler.py
@@ -50,7 +50,6 @@ def crawl_member(
         person,
         position,
         categorisation=categorisation,
-        propagate_country=True,
     )
     if occupancy is not None:
         context.emit(occupancy)

--- a/datasets/ca/commons/crawler.py
+++ b/datasets/ca/commons/crawler.py
@@ -52,7 +52,6 @@ def crawl_member(context: Context, el: etree._Element) -> None:
         position=position,
         start_date=el.findtext("FromDateTime"),
         end_date=el.findtext("ToDateTime"),
-        propagate_country=False,
     )
     if occupancy is not None:
         context.emit(occupancy)
@@ -100,7 +99,6 @@ def yes_minister(context: Context, el: etree._Element) -> None:
         position=position,
         start_date=el.findtext("FromDateTime"),
         end_date=el.findtext("ToDateTime"),
-        propagate_country=False,
     )
     if occupancy is not None:
         context.emit(occupancy)

--- a/datasets/ca/senate/crawler.py
+++ b/datasets/ca/senate/crawler.py
@@ -38,7 +38,6 @@ def crawl(context: Context) -> None:
             position=position,
             start_date=cells[3],
             end_date=cells[4],
-            propagate_country=False,
         )
         if occupancy:
             context.emit(occupancy)

--- a/datasets/ch/parlament/crawler.py
+++ b/datasets/ch/parlament/crawler.py
@@ -110,7 +110,6 @@ def crawl_councillor(context: Context, councillor_id: int) -> None:
             position,
             start_date=mem.get("entryDate"),
             end_date=mem.get("leavingDate"),
-            propagate_country=False,
         )
         if occupancy is None:
             continue

--- a/datasets/de/bundestag/crawler.py
+++ b/datasets/de/bundestag/crawler.py
@@ -53,7 +53,6 @@ def crawl_person(context: Context, mdb: etree._Element, position: Entity) -> Non
             # MDBWP: Mitglied des Bundestags (MoP) Wahlperiode (term):
             start_date=period.findtext("./MDBWP_VON"),
             end_date=period.findtext("./MDBWP_BIS"),
-            propagate_country=True,
         )
         if occupancy is not None:
             has_occupancy = True

--- a/datasets/eu/cor_members/crawler.py
+++ b/datasets/eu/cor_members/crawler.py
@@ -43,7 +43,6 @@ def crawl_person(context: Context, item: Dict[str, Any]) -> None:
         start_date=item.pop("from"),
         end_date=item.pop("to"),
         categorisation=categorisation,
-        propagate_country=False,
     )
     if occupancy is not None:
         for member_status in item.pop("memberStatuses", []):

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -40,7 +40,6 @@ def crawl_node(
         person,
         position,
         categorisation=categorisation,
-        propagate_country=False,
     )
     if occupancy is not None:
         context.emit(occupancy)

--- a/datasets/hr/public_officials/crawler.py
+++ b/datasets/hr/public_officials/crawler.py
@@ -92,7 +92,6 @@ def make_affiliation_entities(
         person,
         position,
         categorisation=categorisation,
-        propagate_country=True,
         start_date=start_date,
         end_date=end_date,
     )

--- a/datasets/in/sansad/crawler.py
+++ b/datasets/in/sansad/crawler.py
@@ -93,7 +93,6 @@ def crawl_ls_member(
             position,
             start_date=start,
             end_date=end,
-            propagate_country=False,
         )
         if occupancy is not None:
             context.emit(occupancy)
@@ -195,7 +194,6 @@ def crawl_rs_member(context: Context, position: Entity, member: Dict[str, Any]) 
                 position,
                 start_date=start,
                 end_date=end,
-                propagate_country=False,
             )
             if occupancy is not None:
                 context.emit(occupancy)

--- a/datasets/lu/bourgmestres/crawler.py
+++ b/datasets/lu/bourgmestres/crawler.py
@@ -49,7 +49,6 @@ def crawl_record(
         categorisation=categorisation,
         start_date=start_date,
         end_date=end_date or None,
-        propagate_country=True,
     )
     if occupancy is not None:
         context.emit(position)

--- a/datasets/mt/parlament/crawler.py
+++ b/datasets/mt/parlament/crawler.py
@@ -48,7 +48,6 @@ def crawl_person(
         position,
         start_date=start,
         end_date=end,
-        propagate_country=False,
     )
     if occupancy is not None:
         context.emit(occupancy)

--- a/datasets/se/riksdag/crawler.py
+++ b/datasets/se/riksdag/crawler.py
@@ -170,7 +170,6 @@ def crawl(context: Context) -> None:
                 categorisation=categorisation,
                 # Citizenship is set explicitly above; don't let an MEP seat
                 # (country "eu") propagate onto the person as a country.
-                propagate_country=False,
             )
             if occupancy is not None:
                 if role.get("typ") == "kammaruppdrag":

--- a/datasets/si/dz_rs/crawler.py
+++ b/datasets/si/dz_rs/crawler.py
@@ -103,7 +103,6 @@ def crawl_person(
         context,
         person,
         position,
-        propagate_country=True,
     )
     if occupancy is not None:
         context.emit(occupancy)

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -1,13 +1,10 @@
 from datetime import datetime
-from functools import cache
 from typing import Iterable, List, Optional
 
 from banal import ensure_list
-from followthemoney import registry
 
 from zavod import helpers as h
 from zavod import settings
-from zavod.logs import get_logger
 from zavod.constants import ORIGIN_INFERRED
 from zavod.context import Context
 from zavod.entity import Entity
@@ -18,8 +15,6 @@ from zavod.stateful.positions import (
     get_after_office,
     occupancy_status,
 )
-
-log = get_logger(__name__)
 
 
 def make_position(
@@ -95,18 +90,6 @@ def make_position(
     return position
 
 
-@cache
-def _tmp_warn_propagate_country(context: Context) -> None:
-    # Chaos datasets excluded. There's probably more?
-    if context.dataset.name in ("wd_peps", "wd_categories"):
-        return
-    log.warning(
-        "Passing person entities with no country affiliation into make_occupancy is "
-        "deprecated and will be removed in a future release. Please add citizenship "
-        "to Person entities before calling make_occupancy."
-    )
-
-
 def make_occupancy(
     context: Context,
     person: Entity,
@@ -120,13 +103,12 @@ def make_occupancy(
     election_date: Optional[str] = None,
     categorisation: Optional[PositionCategorisation] = None,
     status: Optional[OccupancyStatus] = None,
-    propagate_country: bool = True,
     key_prefix: Optional[str] = None,
 ) -> Optional[Entity]:
     """Creates and returns an Occupancy entity if the arguments meet our criteria
-    for PEP position occupancy, otherwise returns None. Also adds the position countries
-    and the `role.pep` topic to the person if an Occupancy is returned.
-    **Emit the person after calling this to include these changes.**
+    for PEP position occupancy, otherwise returns None. Also adds the `role.pep` topic
+    to the person if an Occupancy is returned.
+    **Emit the person after calling this to include this change.**
 
     Unless `status` is overridden, Occupancies are only returned if end_date is None or
     less than the after-office period after current_time.
@@ -214,14 +196,6 @@ def make_occupancy(
         occupancy.add("status", status.value)
 
     person.add("topics", "role.pep", origin=ORIGIN_INFERRED)
-    if propagate_country:
-        # TODO: Begin to warn here about removing this, then remove it.
-        for country in position.get("country"):
-            # Only propagate to Person.country it isn't already set
-            # in another field (such as citizenship).
-            if country not in person.get_type_values(registry.country, matchable=True):
-                _tmp_warn_propagate_country(context)
-                person.add("country", country, origin=ORIGIN_INFERRED)
 
     return occupancy
 

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -263,7 +263,6 @@ def wikidata_occupancy(
         no_end_implies_current=False,
         start_date=start_date,
         end_date=end_date,
-        propagate_country=False,
         key_prefix="wd_peps",
     )
 

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -1,11 +1,13 @@
 from typing import Dict, Optional, Set
 
+from followthemoney import registry
 from nomenklatura.wikidata import Item, WikidataClient, Claim
 from nomenklatura.wikidata.value import clean_wikidata_name
 from rigour.territories import get_territory_by_qid
 
 from zavod import Context, Entity
 from zavod import helpers as h
+from zavod.constants import ORIGIN_INFERRED
 from zavod.stateful.positions import categorise
 from zavod.shed.wikidata.country import is_historical_country, item_countries
 
@@ -248,8 +250,6 @@ def wikidata_occupancy(
             else:
                 end_date = max(end_date, qual_date)
 
-    # Diplomatic positions tend to be associated with the receiving country,
-    # so we don't want to propagate that to the person.
     position_topics = position.get("topics")
     is_diplomat = "role.diplo" in position_topics
 
@@ -263,12 +263,20 @@ def wikidata_occupancy(
         no_end_implies_current=False,
         start_date=start_date,
         end_date=end_date,
-        propagate_country=not is_diplomat,
+        propagate_country=False,
         key_prefix="wd_peps",
     )
 
     if occupancy is None:
         return None
+
+    # Wikidata persons frequently lack their own citizenship statement, so we
+    # associate confirmed PEPs with the position's country. Diplomatic posts name
+    # the receiving country rather than the person's, so those are left out.
+    if not is_diplomat:
+        for country in position.get("country"):
+            if country not in person.get_type_values(registry.country, matchable=True):
+                person.add("country", country, origin=ORIGIN_INFERRED)
 
     # reference URL:
     for ref in claim.references:

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -250,9 +250,6 @@ def wikidata_occupancy(
             else:
                 end_date = max(end_date, qual_date)
 
-    position_topics = position.get("topics")
-    is_diplomat = "role.diplo" in position_topics
-
     # Set the key prefix in order to avoid duplicating occupancies for the same
     # position held by the same person across multiple datasets. The choice is
     # somewhat arbitrary, but it avoids a larger delta if we chose "wikidata".
@@ -270,9 +267,10 @@ def wikidata_occupancy(
         return None
 
     # Wikidata persons frequently lack their own citizenship statement, so we
-    # associate confirmed PEPs with the position's country. Diplomatic posts name
-    # the receiving country rather than the person's, so those are left out.
-    if not is_diplomat:
+    # associate confirmed PEPs with the position's country. Diplomatic posts
+    # (role.diplo) name the receiving country rather than the person's, so those
+    # are left out.
+    if "role.diplo" not in position.get("topics"):
         for country in position.get("country"):
             if country not in person.get_type_values(registry.country, matchable=True):
                 person.add("country", country, origin=ORIGIN_INFERRED)

--- a/zavod/zavod/tests/helpers/test_positions.py
+++ b/zavod/zavod/tests/helpers/test_positions.py
@@ -84,7 +84,8 @@ def test_make_occupancy(testdataset1: Dataset):
     assert occupancy.get("endDate") == ["2021-01-02"]
     assert occupancy.get("status") == ["ended"]
 
-    assert person.get("country") == ["ls"]
+    # make_occupancy no longer propagates the position's country to the person.
+    assert person.get("country") == []
     assert person.get("topics") == ["role.pep"]
     context.close()
 


### PR DESCRIPTION
Part of the PEP alignment cleanup (#3805), finishing the country-propagation deprecation warned via #3860.

`make_occupancy` used to copy the position's `country` onto the person when `propagate_country` was true (the default). The warning ran in production for ~a month; outside `wd_peps`, nothing still relied on it.

## Changes
- **`wd_peps` migration** (first commit): the wikidata shed now sets the position's country on the person explicitly for non-diplomat positions, behaviour-identical to the old `propagate_country=not is_diplomat` (same `ORIGIN_INFERRED`, same not-already-present guard, only for confirmed PEPs). It no longer depends on the mechanism.
- **Remove the mechanism** (second commit): drop the `propagate_country` param, the propagation loop, `_tmp_warn_propagate_country`, and the now-unused `registry` import.
- **Call sites**: delete `propagate_country=` from all 16 dataset sites. The 10 `=False` sites match the new no-propagation default; the 6 `=True` sites (`de/bundestag`, `lu/bourgmestres`, `hr/public_officials`, `au/vic_parliament`, `au/tas_parliament`, `si/dz_rs`) already set `citizenship`/`country`/`nationality` directly, so propagation was already a no-op.
- **Test**: `test_make_occupancy` updated — country is no longer propagated.

No behaviour change expected for any dataset.

## Verification
- `mypy --strict` on zavod: clean
- `zavod/tests/helpers/test_positions.py` + `stateful/test_positions.py`: pass
- `ruff check` + `ruff format`: clean; `mypy-datasets` pre-commit: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)