### PR TITLE
docs: drop removed make_occupancy mechanisms from PEP docs

### DIFF
--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -17,7 +17,7 @@ context about the dataset.
 
 **Consult on demand** (open only when you actually need the section — don't pre-load):
 
-- `.claude/skills/crawler-pep/examples.md` — full code examples (Patterns A/B/C, subnational variant, freshness check, qsv recipes). Open when you're stuck on a pattern or want a worked example.
+- `.claude/skills/crawler-pep/examples.md` — full code examples (Patterns A/B/C, subnational variant, occupancy date edge cases, associates). Open when you're stuck on a pattern or want a worked example.
 - `zavod/docs/peps.md` — depth on Position naming, `categorise()`, Occupancy duration rules, and which person/PEP properties to capture (its "Properties to capture" section). Open if you need more than the summary in this skill.
 - `zavod/docs/metadata.md` — full YAML field reference. Open if you're using a field not covered by the template in `crawler-guide.md`.
 - `zavod/docs/extract/names.md` — open only if you're doing LLM-assisted or reviewed name cleaning.
@@ -38,7 +38,7 @@ In addition to the general checks (fields, date formats, language, record count)
 - What are the position types (parliament, cabinet, judiciary, etc.)?
 - Current members only, or historical terms too?
 - Are start/end dates provided?
-- **Term-bounded data?** Identify a freshness signal (dataset count, page URL, file name) so the crawler fails loudly when a new term lands. See `examples.md` → "New-election freshness check".
+- **Term-bounded data?** Identify a freshness signal (dataset count, page URL, file name) so the crawler fails loudly when a new term lands.
 - **Does the position legally require citizenship?** Don't assume from position type — national parliaments usually do (UK is an exception), but sub-national elected positions (mayors, councils) often don't. Spawn a subagent (`Agent` with `WebSearch`/`WebFetch`) to find the **legal document** (electoral law, constitution, official government guidance) that stipulates the citizenship requirement for this specific position. In a code comment next to the `person.add("citizenship", ...)` call — or, if citizenship is not required, next to the omission — include the URL to that legal document.
 
 ## Step 2: YAML metadata — PEP-specific parts
@@ -128,3 +128,38 @@ LLM-assisted (`h.clean_names()`) and reviewed-name (`h.apply_reviewed_names()`) 
 ## Step 4: Validate
 
 Run `zavod crawl <path>` then `zavod validate <path>`.
+
+Spot-check the crawl output with qsv against `data/datasets/<dataset>/statements.pack`.
+The `prop` column is `Schema:property`, so entity type is recoverable; within one
+dataset's pack `entity_id` matches the ids that `Occupancy:holder`/`post` reference (this
+is pre-resolution crawl output). Each integrity check below should print nothing:
+
+```bash
+P=data/datasets/<dataset>/statements.pack
+
+# Entity counts — sanity-check against the assertions block
+for s in Person Position Occupancy; do
+  echo "$s: $(qsv search -s prop "^${s}:id\$" "$P" | qsv behead | wc -l)"
+done
+
+# 1. Occupancy.post referencing a Position that wasn't emitted
+comm -23 \
+  <(qsv search -s prop '^Occupancy:post$' "$P" | qsv select value     | qsv behead | sort -u) \
+  <(qsv search -s prop '^Position:'       "$P" | qsv select entity_id | qsv behead | sort -u)
+
+# 2. Occupancy.holder referencing a Person that wasn't emitted
+comm -23 \
+  <(qsv search -s prop '^Occupancy:holder$' "$P" | qsv select value     | qsv behead | sort -u) \
+  <(qsv search -s prop '^Person:'           "$P" | qsv select entity_id | qsv behead | sort -u)
+
+# 3. role.pep Person that never holds an Occupancy
+comm -23 \
+  <(qsv search -s prop '^Person:topics$' "$P" | qsv search -s value '^role\.pep$' | qsv select entity_id | qsv behead | sort -u) \
+  <(qsv search -s prop '^Occupancy:holder$' "$P" | qsv select value | qsv behead | sort -u)
+
+# 4. PEP Person with no country/citizenship/nationality (make_occupancy no longer
+#    back-fills country from the position, so this must be set explicitly)
+comm -23 \
+  <(qsv search -s prop '^Person:topics$' "$P" | qsv search -s value '^role\.pep$' | qsv select entity_id | qsv behead | sort -u) \
+  <(qsv search -s prop '^Person:(citizenship|country|nationality)$' "$P" | qsv select entity_id | qsv behead | sort -u)
+```

--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -127,4 +127,4 @@ LLM-assisted (`h.clean_names()`) and reviewed-name (`h.apply_reviewed_names()`) 
 
 ## Step 4: Validate
 
-Run `zavod crawl <path>` then `zavod validate <path>`. PEP-specific qsv recipes (referential integrity for Person↔Occupancy, country propagation check) are in `examples.md` → "qsv validation checks".
+Run `zavod crawl <path>` then `zavod validate <path>`.

--- a/.claude/skills/crawler-pep/examples.md
+++ b/.claude/skills/crawler-pep/examples.md
@@ -44,7 +44,6 @@ def crawl_member(
         categorisation=categorisation,
         start_date=row.pop("term_start", None),
         end_date=row.pop("term_end", None),
-        propagate_country=True,
     )
     if occupancy is not None:
         context.emit(occupancy)
@@ -179,7 +178,8 @@ def crawl(context: Context) -> None:
 
 ## Current-only positions (no dates)
 
-When the source only lists current officeholders with no term dates:
+When the source only lists current officeholders with no term dates, call
+`make_occupancy` with no dates and it records a `current` occupancy:
 
 ```python
 occupancy = h.make_occupancy(
@@ -187,8 +187,6 @@ occupancy = h.make_occupancy(
     person,
     position,
     categorisation=categorisation,
-    is_current=True,        # no start_date/end_date needed
-    propagate_country=True,
 )
 ```
 

--- a/.claude/skills/crawler-pep/examples.md
+++ b/.claude/skills/crawler-pep/examples.md
@@ -1,6 +1,6 @@
 # PEP Crawler Examples
 
-## Pattern A: Known PEPs with `is_pep=True` (most common)
+## Pattern A: Known PEPs with `default_is_pep=True` (most common)
 
 For sources that definitionally list PEPs (e.g. a national parliament):
 
@@ -60,7 +60,7 @@ def crawl(context: Context) -> None:
         country="xx",
         wikidata_id="Q...",
     )
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)
 
     data = context.fetch_json(context.data_url)
@@ -68,7 +68,7 @@ def crawl(context: Context) -> None:
         crawl_member(context, position, categorisation, member)
 ```
 
-## Pattern B: Mixed dataset with `is_pep=None` (declaration-style)
+## Pattern B: Mixed dataset with `default_is_pep=None` (declaration-style)
 
 For sources that list officials across many roles where some are PEP and some aren't.
 PEP status is determined by the UI review workflow, not the crawler.
@@ -77,8 +77,8 @@ PEP status is determined by the UI review workflow, not the crawler.
 def crawl_member(context: Context, row: dict[str, Any]) -> None:
     role = row.pop("role")
     position = h.make_position(context, name=role, country="fr")
-    # is_pep=None: defers PEP determination to the UI
-    categorisation = categorise(context, position, is_pep=None)
+    # default_is_pep=None: defers PEP determination to the UI
+    categorisation = categorise(context, position, default_is_pep=None)
 
     if not categorisation.is_pep:
         return  # UI has not (yet) marked this position as PEP
@@ -103,14 +103,14 @@ def crawl_member(context: Context, row: dict[str, Any]) -> None:
 ```
 
 Key differences from Pattern A:
-- `is_pep=None` — positions start uncategorised; the UI must mark them.
+- `default_is_pep=None` — positions start uncategorised; the UI must mark them.
 - `no_end_implies_current=False` — a declaration doesn't prove current office.
 - `status=OccupancyStatus.UNKNOWN` — end date reliability is low.
 - Position is created per-record (each unique role string becomes a position).
 
 ### Subnational variant (per-municipality / per-region positions)
 
-Same `is_pep=None` shape as Pattern B, but used for sources where each record names
+Same `default_is_pep=None` shape as Pattern B, but used for sources where each record names
 a sub-national position (e.g. mayor of municipality X). Two extras:
 
 - Translate the role label to English via a `position` lookup.
@@ -127,7 +127,7 @@ position = h.make_position(
     subnational_area=commune_label,           # NOT wikidata_id — per-locality
     lang="fra",
 )
-categorisation = categorise(context, position, is_pep=None)
+categorisation = categorise(context, position, default_is_pep=None)
 if not categorisation.is_pep:
     return
 ```
@@ -144,7 +144,7 @@ lookups:
         value: Alderman
 ```
 
-## Pattern C: Multi-position crawler with `is_pep=True`
+## Pattern C: Multi-position crawler with `default_is_pep=True`
 
 For sources that list officials across known, enumerable position types:
 
@@ -169,7 +169,7 @@ def crawl(context: Context) -> None:
             country="ie",
             wikidata_id=config.get("wikidata_id"),
         )
-        categorisation = categorise(context, position, is_pep=True)
+        categorisation = categorise(context, position, default_is_pep=True)
         context.emit(position)
         positions[key] = (position, categorisation)
 

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -219,10 +219,9 @@ for role in person_data.pop("roles"):
         context,
         person,
         position,
-        True,
         start_date=role.get("start_date", None),
         end_date=role.get("end_date", None),
-        categorisation=categorisation
+        categorisation=categorisation,
     )
     if occupancy:
         pep_entities.append(position)


### PR DESCRIPTION
Docs sweep accompanying the `make_occupancy` cleanup (#4444, #4445, #4446), part of #3805. Scrubs the PEP docs of removed mechanisms, fixes dead cross-references, and adds real validation recipes.

- **`crawler-pep/examples.md`**: drop `propagate_country=True`; fix the "current-only positions" example, which passed a non-existent `is_current=True` arg — it now just omits dates and relies on the `no_end_implies_current=True` default. Also fixes `categorise(..., is_pep=...)` → `default_is_pep` (the keyword-only param; `categorisation.is_pep` attribute accesses left as-is).
- **`crawler-pep/SKILL.md`**: remove three dangling cross-references to `examples.md` sections that never existed ("qsv validation checks", "New-election freshness check", and the on-demand summary listing them). Replace them with the real thing — a **Step 4 set of qsv checks** over the dataset `statements.pack`: entity counts plus referential integrity for `Occupancy.holder`/`post` and PEP country coverage. The country-coverage check directly catches the failure mode that removing country propagation could introduce. All recipes verified against a crawled dataset.
- **`zavod/docs/peps.md`**: drop the positional `True` for `no_end_implies_current` from the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)