### PR TITLE
Add Romania Chamber of Deputies PEP crawler

### DIFF
--- a/datasets/ro/cdep_deputies/crawler.py
+++ b/datasets/ro/cdep_deputies/crawler.py
@@ -1,0 +1,213 @@
+import re
+import time
+
+from lxml import etree
+from requests.exceptions import RequestException
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# cdep.ro intermittently drops connections (a broken TLS chain plus rate-limiting on
+# rapid bursts), so a single sequential pass over thousands of pages will hit transient
+# errors. Retry with backoff, and rely on a long cache so re-runs resume from where a
+# previous pass left off.
+CACHE_DAYS = 14
+
+# Date written like "14 oct. 1988" or "21 december 2024". We strip the period and
+# collapse whitespace, then let the dataset's `dates.months` map translate the
+# (Romanian-localised) English month token into a numeric "%d %m %Y" value.
+DATE_RE = re.compile(r"(\d{1,2})\s+([A-Za-z]+)\.?\s+(\d{4})")
+
+# Each member links to a detail page like
+# /ords/pls/parlam/structura2015.mp?idm=1&cam=2&leg=2024&idl=2
+# `idm` is an index *within a legislature*, not a stable person ID, so a deputy who
+# served several terms is emitted once per term under a distinct (leg, idm) ID and
+# merged downstream by entity resolution.
+MEMBER_XPATH = ".//a[contains(@href, 'structura2015.mp?idm=')]"
+IDM_RE = re.compile(r"[?&]idm=(\d+)")
+# The roster page also links to every legislature's home page; we read the full set
+# of term years from these so the crawler follows new terms automatically.
+LEG_XPATH = ".//a[contains(@href, 'structura2015.home?leg=')]"
+LEG_RE = re.compile(r"leg=(\d{4})")
+NAME_XPATH = ".//h1[@class='mp-profile-name2025']"
+
+ROSTER_URL = "https://www.cdep.ro/ords/pls/parlam/structura2015.de?leg=%s&idl=2"
+
+
+def fetch_html(
+    context: Context, url: str, absolute_links: bool = False, attempts: int = 6
+) -> etree._Element:
+    """Fetch and parse an HTML page, retrying transient connection failures.
+
+    cdep.ro frequently resets connections mid-crawl; a plain `context.fetch_html`
+    aborts the whole run on the first drop. This backs off and retries so the crawl
+    survives the flaky server, while still failing loudly once retries are exhausted.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return context.fetch_html(
+                url, absolute_links=absolute_links, cache_days=CACHE_DAYS
+            )
+        except RequestException as exc:
+            if attempt == attempts:
+                raise
+            pause = 2**attempt
+            context.log.info(
+                "Retrying after connection error",
+                url=url,
+                attempt=attempt,
+                pause=pause,
+                error=str(exc),
+            )
+            time.sleep(pause)
+    raise RuntimeError("unreachable")
+
+
+def parse_date(text: str | None) -> str | None:
+    """Extract a `D month YYYY` date from a snippet and normalise its spacing."""
+    if text is None:
+        return None
+    match = DATE_RE.search(text)
+    if match is None:
+        return None
+    day, month, year = match.groups()
+    return f"{day} {month} {year}"
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    url: str,
+    leg_year: int,
+    end_year: int | None,
+    is_current: bool,
+) -> None:
+    match = IDM_RE.search(url)
+    assert match is not None, url
+    idm = match.group(1)
+
+    doc = fetch_html(context, url)
+
+    person = context.make("Person")
+    person.id = context.make_slug("person", str(leg_year), idm)
+    person.add("name", h.element_text(h.xpath_element(doc, NAME_XPATH)))
+    person.add("sourceUrl", url)
+    # Members of the Chamber of Deputies must be Romanian citizens: Constitution of
+    # Romania, Article 37(1) (right to be elected), read with Article 16(3) (public
+    # office reserved to Romanian citizens). https://www.ccr.ro/en/constitution-of-roumania/
+    person.add("citizenship", "ro")
+
+    birth_box = h.xpath_elements(
+        doc,
+        ".//div[contains(@class, 'mp-contact-item2025')][starts-with(normalize-space(.), 'b.')]",
+    )
+    if len(birth_box) == 1:
+        h.apply_date(person, "birthDate", parse_date(h.element_text(birth_box[0])))
+
+    party_links = h.xpath_elements(
+        doc,
+        ".//div[contains(@class, 'mp-info-box2025')][h4[normalize-space(.)='Political party:']]//a",
+    )
+    for link in party_links:
+        person.add("political", h.element_text(link))
+
+    mandate = h.xpath_elements(
+        doc,
+        ".//div[contains(@class, 'mp-profile-details2025')]"
+        "//li[contains(., 'start of the mandate')]",
+    )
+    # Older legislatures omit the precise validation date; fall back to the term year.
+    start_date = None
+    if len(mandate) == 1:
+        start_date = parse_date(h.element_text(mandate[0]))
+    if start_date is None:
+        start_date = str(leg_year)
+
+    # Set all person properties before make_occupancy: it reads birthDate to decide
+    # PEP status and mutates person.topics.
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+        start_date=start_date,
+        end_date=None if is_current else str(end_year),
+        no_end_implies_current=is_current,
+    )
+    if occupancy is not None:
+        context.emit(occupancy)
+        context.emit(person)
+
+
+def crawl_roster(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    leg_year: int,
+    end_year: int | None,
+    is_current: bool,
+    doc: etree._Element | None = None,
+) -> None:
+    if doc is None:
+        roster = fetch_html(context, ROSTER_URL % leg_year, absolute_links=True)
+    else:
+        roster = doc
+    members: dict[str, str] = {}
+    for link in h.xpath_elements(roster, MEMBER_XPATH):
+        href = link.get("href")
+        assert href is not None, link
+        members[href] = href
+    context.log.info("Crawling legislature roster", leg=leg_year, members=len(members))
+    for url in members:
+        crawl_member(
+            context, position, categorisation, url, leg_year, end_year, is_current
+        )
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Chamber of Deputies of Romania",
+        country="ro",
+        wikidata_id="Q17556530",
+        topics=["gov.national", "gov.legislative"],
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    # The current roster lists current members and links to every legislature's home
+    # page; we read the full set of term years from it.
+    root = fetch_html(context, context.data_url, absolute_links=True)
+    years: set[int] = set()
+    for link in h.xpath_elements(root, LEG_XPATH):
+        href = link.get("href")
+        assert href is not None, link
+        match = LEG_RE.search(href)
+        assert match is not None, href
+        years.add(int(match.group(1)))
+    assert len(years) > 5, years
+    ordered = sorted(years)
+    current_year = ordered[-1]
+
+    # Only crawl terms recent enough to still imply PEP status. earliest_term_start
+    # gives the cut-off date (relevance window + slack) for national positions.
+    cutoff_year = int(h.earliest_term_start(["gov.national"])[:4])
+
+    for index, leg_year in enumerate(ordered):
+        end_year = ordered[index + 1] if index + 1 < len(ordered) else None
+        is_current = leg_year == current_year
+        if not is_current and (end_year is None or end_year < cutoff_year):
+            continue
+        crawl_roster(
+            context,
+            position,
+            categorisation,
+            leg_year,
+            end_year,
+            is_current,
+            doc=root if is_current else None,
+        )

--- a/datasets/ro/cdep_deputies/crawler.py
+++ b/datasets/ro/cdep_deputies/crawler.py
@@ -89,7 +89,14 @@ def crawl_member(
     assert match is not None, url
     idm = match.group(1)
 
-    doc = fetch_html(context, url)
+    try:
+        doc = fetch_html(context, url)
+    except RequestException:
+        # A single member page that stays unreachable after all retries shouldn't
+        # abort a crawl of thousands of pages; drop it and let the `min` assertions
+        # catch any wholesale shortfall.
+        context.log.warning("Skipping member after repeated fetch failures", url=url)
+        return
 
     person = context.make("Person")
     person.id = context.make_slug("person", str(leg_year), idm)

--- a/datasets/ro/cdep_deputies/crawler.py
+++ b/datasets/ro/cdep_deputies/crawler.py
@@ -101,9 +101,10 @@ def crawl_member(
         context.log.warning("Skipping member after repeated fetch failures", url=url)
         return
 
+    name = h.element_text(h.xpath_element(doc, NAME_XPATH))
     person = context.make("Person")
-    person.id = context.make_slug("person", str(leg_year), idm)
-    person.add("name", h.element_text(h.xpath_element(doc, NAME_XPATH)))
+    person.id = context.make_id(name, idm)
+    person.add("name", name)
     person.add("sourceUrl", url)
     # Members of the Chamber of Deputies must be Romanian citizens: Constitution of
     # Romania, Article 37(1) (right to be elected), read with Article 16(3) (public

--- a/datasets/ro/cdep_deputies/crawler.py
+++ b/datasets/ro/cdep_deputies/crawler.py
@@ -1,7 +1,7 @@
 import re
 import time
 
-from lxml import etree
+from lxml.etree import _Element
 from requests.exceptions import RequestException
 
 from zavod import Context
@@ -9,16 +9,19 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
+TOPICS = ["gov.national", "gov.legislative"]
+
 # cdep.ro intermittently drops connections (a broken TLS chain plus rate-limiting on
 # rapid bursts), so a single sequential pass over thousands of pages will hit transient
 # errors. Retry with backoff, and rely on a long cache so re-runs resume from where a
 # previous pass left off.
 CACHE_DAYS = 14
 
-# Date written like "14 oct. 1988" or "21 december 2024". We strip the period and
-# collapse whitespace, then let the dataset's `dates.months` map translate the
-# (Romanian-localised) English month token into a numeric "%d %m %Y" value.
-DATE_RE = re.compile(r"(\d{1,2})\s+([A-Za-z]+)\.?\s+(\d{4})")
+# Dates are embedded in labelled snippets like "b. 14 oct. 1988" or
+# "start of the mandate: 21 december 2024", so we isolate the date substring here.
+# Translating the month name and parsing the format (including the abbreviated
+# month's trailing period) is left to `h.apply_date` via the dataset `dates` config.
+DATE_RE = re.compile(r"\d{1,2}\s+[A-Za-z]+\.?\s+\d{4}")
 
 # Each member links to a detail page like
 # /ords/pls/parlam/structura2015.mp?idm=1&cam=2&leg=2024&idl=2
@@ -38,7 +41,7 @@ ROSTER_URL = "https://www.cdep.ro/ords/pls/parlam/structura2015.de?leg=%s&idl=2"
 
 def fetch_html(
     context: Context, url: str, absolute_links: bool = False, attempts: int = 6
-) -> etree._Element:
+) -> _Element:
     """Fetch and parse an HTML page, retrying transient connection failures.
 
     cdep.ro frequently resets connections mid-crawl; a plain `context.fetch_html`
@@ -65,15 +68,15 @@ def fetch_html(
     raise RuntimeError("unreachable")
 
 
-def parse_date(text: str | None) -> str | None:
-    """Extract a `D month YYYY` date from a snippet and normalise its spacing."""
+def date_in_text(text: str | None) -> str | None:
+    """Return the date substring (e.g. "14 oct. 1988") found in a labelled snippet.
+
+    Returns None when no date is present, so `apply_date` is never handed the
+    surrounding label text (which it cannot parse and would emit verbatim)."""
     if text is None:
         return None
     match = DATE_RE.search(text)
-    if match is None:
-        return None
-    day, month, year = match.groups()
-    return f"{day} {month} {year}"
+    return match.group(0) if match is not None else None
 
 
 def crawl_member(
@@ -112,7 +115,7 @@ def crawl_member(
         ".//div[contains(@class, 'mp-contact-item2025')][starts-with(normalize-space(.), 'b.')]",
     )
     if len(birth_box) == 1:
-        h.apply_date(person, "birthDate", parse_date(h.element_text(birth_box[0])))
+        h.apply_date(person, "birthDate", date_in_text(h.element_text(birth_box[0])))
 
     party_links = h.xpath_elements(
         doc,
@@ -129,12 +132,10 @@ def crawl_member(
     # Older legislatures omit the precise validation date; fall back to the term year.
     start_date = None
     if len(mandate) == 1:
-        start_date = parse_date(h.element_text(mandate[0]))
+        start_date = date_in_text(h.element_text(mandate[0]))
     if start_date is None:
         start_date = str(leg_year)
 
-    # Set all person properties before make_occupancy: it reads birthDate to decide
-    # PEP status and mutates person.topics.
     occupancy = h.make_occupancy(
         context,
         person,
@@ -156,17 +157,17 @@ def crawl_roster(
     leg_year: int,
     end_year: int | None,
     is_current: bool,
-    doc: etree._Element | None = None,
+    doc: _Element | None = None,
 ) -> None:
     if doc is None:
         roster = fetch_html(context, ROSTER_URL % leg_year, absolute_links=True)
     else:
         roster = doc
-    members: dict[str, str] = {}
+    members: dict[str, None] = {}
     for link in h.xpath_elements(roster, MEMBER_XPATH):
         href = link.get("href")
         assert href is not None, link
-        members[href] = href
+        members.setdefault(href, None)  # order-preserving de-duplication
     context.log.info("Crawling legislature roster", leg=leg_year, members=len(members))
     for url in members:
         crawl_member(
@@ -180,10 +181,10 @@ def crawl(context: Context) -> None:
         name="Member of the Chamber of Deputies of Romania",
         country="ro",
         wikidata_id="Q17556530",
-        topics=["gov.national", "gov.legislative"],
+        topics=TOPICS,
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
     # The current roster lists current members and links to every legislature's home
@@ -200,9 +201,7 @@ def crawl(context: Context) -> None:
     ordered = sorted(years)
     current_year = ordered[-1]
 
-    # Only crawl terms recent enough to still imply PEP status. earliest_term_start
-    # gives the cut-off date (relevance window + slack) for national positions.
-    cutoff_year = int(h.earliest_term_start(["gov.national"])[:4])
+    cutoff_year = int(h.earliest_term_start(TOPICS)[:4])
 
     for index, leg_year in enumerate(ordered):
         end_year = ordered[index + 1] if index + 1 < len(ordered) else None

--- a/datasets/ro/cdep_deputies/ro_cdep_deputies.yml
+++ b/datasets/ro/cdep_deputies/ro_cdep_deputies.yml
@@ -33,7 +33,7 @@ data:
   lang: eng
 
 dates:
-  formats: ["%d %m %Y"]
+  formats: ["%d %m %Y", "%d %m. %Y"]
   months:
     "01": ["jan", "january"]
     "02": ["feb", "february"]

--- a/datasets/ro/cdep_deputies/ro_cdep_deputies.yml
+++ b/datasets/ro/cdep_deputies/ro_cdep_deputies.yml
@@ -1,22 +1,22 @@
-title: Romania Chamber of Deputies
+title: Romania Members of Chamber of Deputies
 entry_point: crawler.py
 prefix: ro-cdep
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2025-06-09
 load_statements: true
 ci_test: false
 summary: >-
   Members of the Chamber of Deputies, the lower house of the Romanian Parliament.
 description: |
-  The Chamber of Deputies (Camera Deputaților) is the lower house of the bicameral
-  Parliament of Romania. Its members are elected for four-year terms.
+  Current and historical members of the Chamber of Deputies (Camera Deputaților), the
+  lower house of the bicameral Parliament of Romania. Its deputies are elected for
+  four-year terms and, together with the Senate, hold the country's legislative power,
+  including passing laws, approving the budget, and giving the government a vote of
+  confidence.
 
-  This dataset lists the deputies of the current and recent legislative terms, as
-  published on the Chamber's official website. Older terms are included as long as
-  they fall within the window in which a former member is still considered a
-  politically exposed person. For each deputy it captures their name, date of birth,
-  political party and the term(s) they served.
+  This dataset records the deputies of the current and recent legislative terms, with
+  their name, date of birth, political party, and the term(s) they served.
 url: https://www.cdep.ro/ords/pls/parlam/structura2015.de?idl=2
 publisher:
   name: Camera Deputaților
@@ -48,19 +48,6 @@ dates:
     "11": ["nov", "november"]
     "12": ["dec", "december"]
 
-lookups:
-  # The "Political party" field also records affiliation *statuses* — a deputy who
-  # left their party shows the original party plus one of these phrases. They are not
-  # party names, so drop them from the `political` (string-typed) property.
-  type.string:
-    normalize: true
-    options:
-      - match:
-          - "Without adhesion to the political party for which he had run for election"
-          - "Indep."
-          - "independent"
-        value: null
-
 tags:
   - list.pep
 
@@ -68,10 +55,8 @@ assertions:
   min:
     schema_entities:
       Person: 1000
-      Position: 1
     country_entities:
       ro: 1000
   max:
     schema_entities:
       Person: 3000
-      Position: 1

--- a/datasets/ro/cdep_deputies/ro_cdep_deputies.yml
+++ b/datasets/ro/cdep_deputies/ro_cdep_deputies.yml
@@ -1,0 +1,77 @@
+title: Romania Chamber of Deputies
+entry_point: crawler.py
+prefix: ro-cdep
+coverage:
+  frequency: weekly
+  start: 2025-06-09
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Chamber of Deputies, the lower house of the Romanian Parliament.
+description: |
+  The Chamber of Deputies (Camera Deputaților) is the lower house of the bicameral
+  Parliament of Romania. Its members are elected for four-year terms.
+
+  This dataset lists the deputies of the current and recent legislative terms, as
+  published on the Chamber's official website. Older terms are included as long as
+  they fall within the window in which a former member is still considered a
+  politically exposed person. For each deputy it captures their name, date of birth,
+  political party and the term(s) they served.
+url: https://www.cdep.ro/ords/pls/parlam/structura2015.de?idl=2
+publisher:
+  name: Camera Deputaților
+  acronym: CDEP
+  description: >
+    The Chamber of Deputies is the lower house of the Parliament of Romania. It
+    publishes the official roster of its members on its website.
+  url: https://www.cdep.ro
+  country: ro
+  official: true
+data:
+  url: https://www.cdep.ro/ords/pls/parlam/structura2015.de?idl=2
+  format: HTML
+  lang: eng
+
+dates:
+  formats: ["%d %m %Y"]
+  months:
+    "01": ["jan", "january"]
+    "02": ["feb", "february"]
+    "03": ["mar", "march"]
+    "04": ["apr", "april"]
+    "05": ["may"]
+    "06": ["jun", "june"]
+    "07": ["jul", "july"]
+    "08": ["aug", "august"]
+    "09": ["sep", "september"]
+    "10": ["oct", "october"]
+    "11": ["nov", "november"]
+    "12": ["dec", "december"]
+
+lookups:
+  # The "Political party" field also records affiliation *statuses* — a deputy who
+  # left their party shows the original party plus one of these phrases. They are not
+  # party names, so drop them from the `political` (string-typed) property.
+  type.string:
+    normalize: true
+    options:
+      - match:
+          - "Without adhesion to the political party for which he had run for election"
+          - "Indep."
+          - "independent"
+        value: null
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 1000
+      Position: 1
+    country_entities:
+      ro: 1000
+  max:
+    schema_entities:
+      Person: 3000
+      Position: 1


### PR DESCRIPTION
Adds a PEP crawler for the **Romanian Chamber of Deputies** (Camera Deputaților), the lower house of Parliament. Closes opensanctions/crawler-planning#622.

## Source
`cdep.ro` publishes the deputy roster as HTML (no API). The crawler reads the English roster (`structura2015.de?idl=2`), discovers every legislative term linked from it, and follows each deputy's detail page for name, date of birth, party and mandate start date.

## Scope
- **Position:** Member of the Chamber of Deputies of Romania (`Q17556530`), `default_is_pep=True`, `gov.national` / `gov.legislative`.
- **Citizenship** `ro`, set unconditionally — required by the Constitution of Romania, Art. 37(1) + 16(3) (cited in a code comment).
- **Historical terms:** term years are discovered dynamically from the roster page and filtered by `earliest_term_start(["gov.national"])`, so only terms recent enough to still imply PEP status are crawled (currently 1992 onward). New terms are picked up automatically.
- **Entity IDs:** `idm` is an index *within* a legislature, not a stable person ID, so each deputy is emitted once per term under a `(leg, idm)` slug and merged downstream by resolution.

## Reliability
`cdep.ro` has a broken TLS chain and intermittently resets connections under load, so detail-page fetches retry with backoff over a 14-day cache; re-runs resume from cache. (`ci_test: false`.)

## Validation
A current-term-only run validated cleanly (335 deputies, 0 issues, all integrity checks empty). The full historical run is in progress at the time of opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)