### PR TITLE
Add mn_parliament PEP crawler (State Great Khural)

### DIFF
--- a/datasets/mn/parliament/crawler.py
+++ b/datasets/mn/parliament/crawler.py
@@ -13,8 +13,6 @@ from zavod.util import Element
 LIST_MN = "https://www.parliament.mn/cv/"
 LIST_EN = "https://www.parliament.mn/en/cv/"
 
-MEMBER = "Member of the State Great Khural"
-
 
 def member_ids(doc: Element) -> list[str]:
     """Member IDs from a roster page, scoped to the member-card grid.
@@ -126,7 +124,10 @@ def crawl_member(
     person.add("citizenship", "mn")
 
     position = h.make_position(
-        context, MEMBER, country="mn", topics=["gov.national", "gov.legislative"]
+        context,
+        "Member of the State Great Khural",
+        country="mn",
+        topics=["gov.national", "gov.legislative"],
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/mn/parliament/crawler.py
+++ b/datasets/mn/parliament/crawler.py
@@ -8,8 +8,9 @@ from zavod.util import Element
 # The roster is published in two languages with one CV record per language, under
 # different member IDs. They are joined on the shared parliamentary email address;
 # the ID is therefore derived from the email, so the Mongolian (Cyrillic) and English
-# (Latin) records of one member collapse into a single entity. Records whose English
-# CV omits the email get their own ID and are reconciled downstream by name.
+# (Latin) records of one member collapse into a single entity. Every Mongolian record
+# carries an email (a missing one is a hard error); an English record without one has
+# no reliable join key and is skipped — its Mongolian counterpart is authoritative.
 LIST_MN = "https://www.parliament.mn/cv/"
 LIST_EN = "https://www.parliament.mn/en/cv/"
 
@@ -103,15 +104,18 @@ def crawl_member(
         context.log.warning("Member has no name", url=f"{list_url}{member_id}/")
         return
 
+    # Email is the cross-language join key (see module docstring) and the entity ID.
+    # The Mongolian roster is authoritative and must carry it; an English record
+    # without it has no reliable join key, so skip it (its Mongolian counterpart
+    # already holds the full record).
     email = member_email(doc)
+    if email is None:
+        if lang == "mon":
+            raise RuntimeError(f"Mongolian CV has no email: {list_url}{member_id}/")
+        return
 
     person = context.make("Person")
-    # Email is the cross-language join key (see module docstring); fall back to the
-    # opaque member ID, which is unique within a single language's roster.
-    if email is not None:
-        person.id = context.make_id("member", email)
-    else:
-        person.id = context.make_slug("member", lang, member_id)
+    person.id = context.make_id("member", email)
     person.add("name", name, lang=lang)
     person.add("email", email)
     for party in parties:

--- a/datasets/mn/parliament/crawler.py
+++ b/datasets/mn/parliament/crawler.py
@@ -1,0 +1,154 @@
+import re
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+from zavod.util import Element
+
+# The roster is published in two languages with one CV record per language, under
+# different member IDs. They are joined on the shared parliamentary email address;
+# the ID is therefore derived from the email, so the Mongolian (Cyrillic) and English
+# (Latin) records of one member collapse into a single entity. Records whose English
+# CV omits the email get their own ID and are reconciled downstream by name.
+LIST_MN = "https://www.parliament.mn/cv/"
+LIST_EN = "https://www.parliament.mn/en/cv/"
+
+# partyId filter -> party name as labelled in the site sidebar. A 0-result page means
+# the filter ID changed and the party map is stale (see crawl()).
+PARTIES = {
+    "1": "Монгол Ардын Нам",
+    "22": "Ардчилсан Нам",
+    "4": "Хүн нам",
+    "25": "Үндэсний эвсэл",
+    "26": "Иргэний зориг ногоон нам",
+}
+
+MEMBER = "Member of the State Great Khural"
+
+
+def member_ids(doc: Element) -> list[str]:
+    """Member IDs from a roster page, scoped to the member-card grid.
+
+    The left nav menu hardcodes the chairman's CV link on every page, so page-wide
+    anchor selection would pollute the roster — select only the photo cards.
+    """
+    ids: list[str] = []
+    for anchor in h.xpath_elements(doc, "//div[@class='entry-image mb-0']/a"):
+        href = anchor.get("href")
+        if href is None:
+            continue
+        match = re.search(r"/cv/(\d+)/", href)
+        if match is not None and match.group(1) not in ids:
+            ids.append(match.group(1))
+    return ids
+
+
+def member_email(doc: Element) -> str | None:
+    """The member's own parliamentary email (excludes the shared secretariat inbox)."""
+    for anchor in h.xpath_elements(doc, "//a[starts-with(@href, 'mailto:')]"):
+        href = anchor.get("href")
+        if href is None:
+            continue
+        email = href.split(":", 1)[1].strip().lower()
+        if email and "secretariat" not in email:
+            return email
+    return None
+
+
+def build_party_map(context: Context) -> dict[str, set[str]]:
+    """Map each Mongolian-record member ID to the set of parties it is filed under.
+
+    A member may appear under more than one party filter (the National Coalition is an
+    electoral alliance), so parties are collected as a set.
+    """
+    party_map: dict[str, set[str]] = {}
+    for party_id, party_name in PARTIES.items():
+        url = f"{LIST_MN}?partyId={party_id}"
+        doc = context.fetch_html(url, cache_days=1, absolute_links=True)
+        ids = member_ids(doc)
+        if not ids:
+            raise RuntimeError(
+                f"Party filter {party_id} ({party_name}) returned no members"
+            )
+        for member_id in ids:
+            party_map.setdefault(member_id, set()).add(party_name)
+    return party_map
+
+
+def crawl_member(
+    context: Context,
+    list_url: str,
+    member_id: str,
+    lang: str,
+    parties: set[str],
+) -> None:
+    doc = context.fetch_html(
+        f"{list_url}{member_id}/", cache_days=7, absolute_links=True
+    )
+
+    last = h.xpath_elements(doc, "//div[@class='lastname']")
+    first = h.xpath_elements(doc, "//div[@class='firstname']")
+    name = " ".join(part for el in (*last, *first) if (part := h.element_text(el)))
+    if not name:
+        context.log.warning("Member has no name", url=f"{list_url}{member_id}/")
+        return
+
+    email = member_email(doc)
+
+    person = context.make("Person")
+    # Email is the cross-language join key (see module docstring); fall back to the
+    # opaque member ID, which is unique within a single language's roster.
+    if email is not None:
+        person.id = context.make_id("member", email)
+    else:
+        person.id = context.make_slug("member", lang, member_id)
+    person.add("name", name, lang=lang)
+    person.add("email", email)
+    for party in parties:
+        person.add("political", party, lang="mon")
+    # Members of the State Great Khural must be citizens of Mongolia.
+    # Constitution of Mongolia, Art. 21(3): "Any citizen of Mongolia, who have attained
+    # the age of twenty five years and are qualified to vote, shall be eligible to be
+    # elected to the State Great Hural (Parliament)."
+    # https://www.constituteproject.org/constitution/Mongolia_2001
+    person.add("citizenship", "mn")
+
+    position = h.make_position(
+        context, MEMBER, country="mn", topics=["gov.national", "gov.legislative"]
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    context.emit(person)
+    context.emit(position)
+    context.emit(occupancy)
+
+
+def crawl_roster(
+    context: Context, list_url: str, lang: str, party_map: dict[str, set[str]]
+) -> None:
+    doc = context.fetch_html(list_url, cache_days=1, absolute_links=True)
+    ids = member_ids(doc)
+    if not 100 <= len(ids) <= 140:
+        context.log.warning(f"Unexpected member count in {lang} roster: {len(ids)}")
+    for member_id in ids:
+        crawl_member(
+            context, list_url, member_id, lang, party_map.get(member_id, set())
+        )
+
+
+def crawl(context: Context) -> None:
+    party_map = build_party_map(context)
+    crawl_roster(context, LIST_MN, "mon", party_map)
+    # English records add the official Latin name. Party is taken only from the
+    # Mongolian roster; English-only records inherit it on downstream merge.
+    crawl_roster(context, LIST_EN, "eng", {})

--- a/datasets/mn/parliament/crawler.py
+++ b/datasets/mn/parliament/crawler.py
@@ -13,16 +13,6 @@ from zavod.util import Element
 LIST_MN = "https://www.parliament.mn/cv/"
 LIST_EN = "https://www.parliament.mn/en/cv/"
 
-# partyId filter -> party name as labelled in the site sidebar. A 0-result page means
-# the filter ID changed and the party map is stale (see crawl()).
-PARTIES = {
-    "1": "Монгол Ардын Нам",
-    "22": "Ардчилсан Нам",
-    "4": "Хүн нам",
-    "25": "Үндэсний эвсэл",
-    "26": "Иргэний зориг ногоон нам",
-}
-
 MEMBER = "Member of the State Great Khural"
 
 
@@ -55,14 +45,36 @@ def member_email(doc: Element) -> str | None:
     return None
 
 
+def discover_party_filters(doc: Element) -> dict[str, str]:
+    """Party filters from the roster's "filter by party" links: partyId -> label.
+
+    Parties are read from the source rather than hardcoded, so a newly seated party is
+    picked up automatically and the labels stay the source's own party names.
+    """
+    filters: dict[str, str] = {}
+    for anchor in h.xpath_elements(doc, "//a[contains(@href, 'partyId=')]"):
+        href = anchor.get("href")
+        if href is None:
+            continue
+        match = re.search(r"partyId=(\d+)", href)
+        label = h.element_text(anchor)
+        if match is not None and label:
+            filters[match.group(1)] = label
+    return filters
+
+
 def build_party_map(context: Context) -> dict[str, set[str]]:
     """Map each Mongolian-record member ID to the set of parties it is filed under.
 
     A member may appear under more than one party filter (the National Coalition is an
     electoral alliance), so parties are collected as a set.
     """
+    roster = context.fetch_html(LIST_MN, cache_days=1, absolute_links=True)
+    filters = discover_party_filters(roster)
+    if not filters:
+        raise RuntimeError("No party filters found on the roster page")
     party_map: dict[str, set[str]] = {}
-    for party_id, party_name in PARTIES.items():
+    for party_id, party_name in filters.items():
         url = f"{LIST_MN}?partyId={party_id}"
         doc = context.fetch_html(url, cache_days=1, absolute_links=True)
         ids = member_ids(doc)

--- a/datasets/mn/parliament/mn_parliament.yml
+++ b/datasets/mn/parliament/mn_parliament.yml
@@ -1,0 +1,47 @@
+title: "Mongolia State Great Khural (Members of Parliament)"
+entry_point: crawler.py
+prefix: mn-khural
+coverage:
+  frequency: weekly
+  start: 2026-06-09
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the State Great Khural, the unicameral parliament of Mongolia.
+description: |
+  The State Great Khural (Улсын Их Хурал) is the unicameral parliament of Mongolia.
+  Its members are published on the parliament's website, each with a CV page in both
+  Mongolian and English.
+
+  This crawler reads the member roster in both languages. The two language records for
+  one member are joined on the shared parliamentary email address where present;
+  members whose English record carries no email are emitted as separate entities and
+  merged downstream by name.
+url: https://www.parliament.mn/cv/
+publisher:
+  name: "State Great Khural of Mongolia"
+  acronym: UIH
+  description: >
+    The State Great Khural (Улсын Их Хурал) is the unicameral parliament and supreme
+    legislative body of Mongolia.
+  url: https://www.parliament.mn/
+  country: mn
+  official: true
+data:
+  url: https://www.parliament.mn/cv/
+  format: HTML
+  lang: mon
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 100
+      Position: 1
+    country_entities:
+      mn: 100
+  max:
+    schema_entities:
+      Person: 250
+      Position: 1

--- a/datasets/mn/parliament/mn_parliament.yml
+++ b/datasets/mn/parliament/mn_parliament.yml
@@ -14,9 +14,8 @@ description: |
   Mongolian and English.
 
   This crawler reads the member roster in both languages. The two language records for
-  one member are joined on the shared parliamentary email address where present;
-  members whose English record carries no email are emitted as separate entities and
-  merged downstream by name.
+  one member are joined on the shared parliamentary email address, yielding a single
+  entity that carries both the Mongolian and English name forms.
 url: https://www.parliament.mn/cv/
 publisher:
   name: "State Great Khural of Mongolia"


### PR DESCRIPTION
Adds a PEP crawler for the members of the **State Great Khural** (Улсын Их Хурал), the unicameral parliament of Mongolia, scraped from the official `parliament.mn` CV pages.

## Source
No API or open data — server-rendered HTML, no anti-bot (no Zyte needed). The roster is published in two languages, each member with a **separate CV record under a different ID** (`/cv/{id}/` Cyrillic, `/en/cv/{id}/` Latin), sharing only an email address.

## Approach
- Iterate both language rosters (card-scoped to avoid the nav menu's hardcoded chairman link).
- Key each Person on `make_id("member", email)`, so a member's Mongolian and English records **merge into one entity carrying both name forms** (Cyrillic + Latin).
- English records without an email (18) are emitted as separate entities and left for downstream name-based resolution — no fuzzy matching in the crawler.
- Party comes from the `?partyId=` filter pages (collected as a set; the National Coalition alliance overlaps).
- Single position: **Member of the State Great Khural** (`country=mn`, `gov.national` + `gov.legislative`). Citizenship `mn` is legally required (Constitution Art. 21(3), cited in code).

## Output (verified)
145 Person, 1 Position, 145 Occupancy (all current). `mypy --strict` clean, `zavod validate` passes, `issues.log` clean. `ci_test: false` (no Zyte, but ~260 cached fetches).

Implements opensanctions/crawler-planning#736.