### PR TITLE
Empower the issues agent to cause all kinds of mayhem

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -76,7 +76,21 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install -y -qq libicu-dev poppler-utils
+          # libicu-dev/poppler-utils for zavod; jq + xmllint for the agent to
+          # inspect JSON issue logs and XML source documents while debugging.
+          sudo apt-get install -y -qq libicu-dev poppler-utils jq libxml2-utils
+
+      - name: Install qsv
+        if: ${{ matrix.task.needs_zavod }}
+        env:
+          # Pinned: qsv is the standard tool for spot-checking emitted data
+          # (e.g. `qsv frequency -s prop statements.pack`), see crawler-guide.md.
+          QSV_VERSION: "21.0.0"
+        run: |
+          curl -fsSL -o /tmp/qsv.zip \
+            "https://github.com/dathere/qsv/releases/download/${QSV_VERSION}/qsv-${QSV_VERSION}-x86_64-unknown-linux-gnu.zip"
+          sudo unzip -o -j /tmp/qsv.zip qsv -d /usr/local/bin
+          qsv --version
 
       - name: Install zavod
         if: ${{ matrix.task.needs_zavod }}

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -83,12 +83,15 @@ jobs:
       - name: Install qsv
         if: ${{ matrix.task.needs_zavod }}
         env:
-          # Pinned: qsv is the standard tool for spot-checking emitted data
-          # (e.g. `qsv frequency -s prop statements.pack`), see crawler-guide.md.
-          QSV_VERSION: "21.0.0"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -fsSL -o /tmp/qsv.zip \
-            "https://github.com/dathere/qsv/releases/download/${QSV_VERSION}/qsv-${QSV_VERSION}-x86_64-unknown-linux-gnu.zip"
+          # qsv is the standard tool for spot-checking emitted data
+          # (e.g. `qsv frequency -s prop statements.pack`), see crawler-guide.md.
+          # Resolve the latest release asset rather than pinning a version.
+          URL=$(gh release view --repo dathere/qsv --json assets \
+            -q '.assets[] | select(.name | test("^qsv-.*x86_64-unknown-linux-gnu.zip$")) | .url' \
+            | head -1)
+          curl -fsSL -o /tmp/qsv.zip "$URL"
           sudo unzip -o -j /tmp/qsv.zip qsv -d /usr/local/bin
           qsv --version
 

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -39,6 +39,12 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     name: ${{ matrix.task.name }}
+    # Match build.yml so `zavod crawl` behaves the same as in normal CI: the
+    # agent runs the crawler to verify its fixes (for datasets where ci_test
+    # allows it), so it needs a working zavod install, not just lookup edits.
+    env:
+      OPENSSL_CONF: "contrib/openssl.cnf"
+      FTM_USER_AGENT: "Mozilla/5.0 (compatible; github-actions-zavod/0.8; tech@opensanctions.org)"
     strategy:
       matrix:
         task: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
@@ -46,14 +52,33 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # - uses: actions/setup-node@v6
-      #   with:
-      #     cache: 'npm'
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          # Key the pip download/build cache to zavod's dependency spec so the
+          # compiled wheels (lxml, icu, leveldb, pydantic) are reused across runs
+          # instead of rebuilt every time.
+          cache-dependency-path: zavod/pyproject.toml
+
+      - name: Install system dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -qq libicu-dev poppler-utils
+
+      - name: Install zavod
+        working-directory: zavod
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install --no-cache-dir -e ".[dev]"
 
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ matrix.task.prompt }}
-          claude_args: "--max-turns 50 --allowed-tools \"Bash(git:*),Bash(curl:*),View,Edit,Write,GlobTool,GrepTool,WebFetch,mcp__github__create_pull_request\""
+          claude_args: "--max-turns 50 --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,mcp__github__create_pull_request\""
           show_full_output: true
 

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Generate sub-tasks
         id: gen
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           MATRIX=$(python contrib/issues_agent/tasks.py)
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -20,6 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install task generator dependencies
+        run: pip install requests pyyaml jinja2
+
       - name: Generate sub-tasks
         id: gen
         env:

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -45,14 +45,22 @@ jobs:
     env:
       OPENSSL_CONF: "contrib/openssl.cnf"
       FTM_USER_AGENT: "Mozilla/5.0 (compatible; github-actions-zavod/0.8; tech@opensanctions.org)"
+    # Cap the worst case: a hung crawl otherwise burns up to the 6h default.
+    timeout-minutes: 30
     strategy:
       matrix:
         task: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       fail-fast: false
+      # Bound concurrent agents so we don't spike Anthropic API rate limits or cost.
+      max-parallel: 4
     steps:
       - uses: actions/checkout@v6
 
+      # The Python/zavod install is only needed for crawler datasets (mypy +
+      # crawling). Enrichment and lookup-only datasets edit YAML only, so they
+      # skip it and start the agent immediately.
       - name: Set up Python
+        if: ${{ matrix.task.needs_zavod }}
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -63,6 +71,7 @@ jobs:
           cache-dependency-path: zavod/pyproject.toml
 
       - name: Install system dependencies
+        if: ${{ matrix.task.needs_zavod }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
@@ -70,6 +79,7 @@ jobs:
           sudo apt-get install -y -qq libicu-dev poppler-utils
 
       - name: Install zavod
+        if: ${{ matrix.task.needs_zavod }}
         working-directory: zavod
         run: |
           python -m pip install --upgrade pip wheel
@@ -79,6 +89,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ matrix.task.prompt }}
-          claude_args: "--max-turns 50 --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,mcp__github__create_pull_request\""
+          claude_args: "--model ${{ matrix.task.model }} --max-turns ${{ matrix.task.max_turns }} --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,mcp__github__create_pull_request\""
           show_full_output: true
 

--- a/contrib/issues_agent/prompt.md
+++ b/contrib/issues_agent/prompt.md
@@ -68,6 +68,8 @@ Some warnings are deliberate signals for a maintainer to investigate, not someth
 
 {% if code_path %}
 - Prefer lookups. Only change code when no lookup can express the fix.
+- Code changes must be minimal, targeted, and behavior-preserving: fix only the warning at hand, do not refactor, and do not change what the crawler emits beyond that fix.
+- Never change entity IDs — do not alter the values passed to `make_id` / `make_slug`, and never put PII into `make_slug`. Re-keying entities breaks downstream data.
 {% endif %}
 - When adding lookups, NEVER define new YAML options or structures beyond what the datapatch reference describes. Editing existing `assertions:` thresholds is allowed, as described above.
 {% if code_path %}
@@ -88,11 +90,13 @@ Some warnings are deliberate signals for a maintainer to investigate, not someth
 5. Apply the fixes: edit {{ yaml_path }}{% if code_path %}, and {{ code_path }} where a code change is warranted{% endif %}.
 {% if code_path %}
 6. Verify your changes:
+   - Any code change MUST pass the same checks CI runs, or the PR is dead on arrival: `mypy --strict {{ code_path }}` and `ruff check {{ code_path }}` (and `ruff format`). Note that raw lxml `.xpath()` returns `Any` and fails strict mode — use the typed `h.xpath_*` helpers. Do not open the PR if these fail.
 {% if ci_test %}
-   - This crawler runs in CI. After making your changes, run `zavod crawl --clear-data {{ yaml_path }}`, then read `data/datasets/{{ name }}/issues.log` and confirm the warnings you targeted are gone and that you have not introduced new warnings. Do not open the PR if the crawl fails or warnings increase.
+   - This crawler runs in CI, so also confirm the fix works end to end: run `zavod crawl --clear-data {{ yaml_path }}`, then read `data/datasets/{{ name }}/issues.log` and confirm the warnings you targeted are gone and that you have not introduced new ones. Do not open the PR if the crawl fails or warnings increase.
 {% else %}
-   - This crawler CANNOT run in CI (it needs credentials we don't have here, or is too slow). You cannot verify a code change by crawling. Make any code change conservatively, and state clearly in the PR body that the code change is unverified and needs human review before merge.
+   - This crawler CANNOT run in CI (it needs credentials we don't have here, or is too slow), so you cannot verify the fix by crawling. State clearly in the PR body that the code change is unverified and needs human review before merge.
 {% endif %}
+   - Assertion-threshold changes need no verification — a widened bound is taken on trust and reviewed by a human. Do not try to crawl to confirm it.
 {% endif %}
 
 ## Submit

--- a/contrib/issues_agent/prompt.md
+++ b/contrib/issues_agent/prompt.md
@@ -30,12 +30,29 @@ The "Common runtime warnings and the lookup that fixes them" and "Property name 
 
 The full FollowTheMoney property listing, when a warning mentions a property not covered by the mapping table, is at: https://www.opensanctions.org/reference/
 
+## Assertion failures
+
+Some warnings are not dirty values but assertion failures, e.g.:
+
+    Assertion schema_entities failed for Security: 669973 is not <= threshold 418000
+
+These mean the dataset's expected size envelope, declared under `assertions:` in {{ yaml_path }}, no longer matches reality because the source legitimately grew or shrank. The fix is to **widen the envelope in the direction it drifted**, to a round number that leaves headroom so normal fluctuation will not immediately re-trip it. Never tighten a threshold toward the current value — that just re-breaks on the next run.
+
+Read the message as `<value> is not <op> threshold <threshold>` and edit the matching entry under `assertions.min.<metric>.<key>` or `assertions.max.<metric>.<key>` (the `<metric>`, e.g. `schema_entities`, and `<key>`, e.g. `Security`, come straight from the message):
+
+- `is not <= threshold` — a `max:` bound was exceeded (the count grew). Raise that `max:` entry to a round number comfortably **above** `<value>` (roughly +15–20%). Example: value 5200 over a max of 4000 → set the max to `6000`.
+- `is not >= threshold` — a `min:` bound was undercut (the count shrank). Lower that `min:` entry to a round number comfortably **below** `<value>` (roughly −15–20%, never below 0). Example: value 117 under a min of 130 → set the min to `100`.
+
+The same logic applies to the other count metrics (`entity_count`, `countries`, `country_entities`). For `property_fill_rate` the threshold is a 0–1 rate, so widen by a small decimal margin instead of rounding.
+
+If you cannot tell whether the drift is legitimate or a sign the crawler broke, still open the PR with the widened threshold — a reviewer can close it if the envelope should not move.
+
 ## Scope
 
 {% if code_path %}
 - Prefer lookups. Only change code when no lookup can express the fix.
 {% endif %}
-- NEVER define new YAML options or structures beyond what the datapatch reference describes.
+- When adding lookups, NEVER define new YAML options or structures beyond what the datapatch reference describes. Editing existing `assertions:` thresholds is allowed, as described above.
 {% if code_path %}
 - NEVER modify any file other than {{ yaml_path }} and {{ code_path }}.
 {% else %}
@@ -50,7 +67,7 @@ The full FollowTheMoney property listing, when a warning mentions a property not
 1. Read `zavod/docs/best_practices/datapatch_lookups.md` in full before producing any fixes. The lookup YAML format and the warning-to-recipe mapping in that file are authoritative; do not rely on memory or invent syntax.
 2. Fetch {{ issues_url }} and parse the JSON.
 3. Group entries by the `message` field to identify recurring patterns.
-4. For each fixable group, decide {% if code_path %}whether a lookup or a code change is appropriate{% else %}on a lookup option{% endif %}. For lookups, follow the consolidation rule under "Result values" in the doc — merge inputs that share a result, keep inputs with different results separate. Respect the existing lookup conventions in the file (lookup names, casing flags, ordering).
+4. For each fixable group, decide which fix applies: a lookup, an assertion-threshold widening, {% if code_path %}or a crawler code change{% else %}or skip it if neither fits{% endif %}. For lookups, follow the consolidation rule under "Result values" in the doc — merge inputs that share a result, keep inputs with different results separate. Respect the existing lookup conventions in the file (lookup names, casing flags, ordering).
 5. Apply the fixes: edit {{ yaml_path }}{% if code_path %}, and {{ code_path }} where a code change is warranted{% endif %}.
 {% if code_path %}
 6. Verify your changes:

--- a/contrib/issues_agent/prompt.md
+++ b/contrib/issues_agent/prompt.md
@@ -29,6 +29,16 @@ Datapatch lookups — the YAML structure, matching modes, result fields, the pro
 The "Common runtime warnings and the lookup that fixes them" and "Property name to type lookup" sections on that page are the primary reference. Use them to translate each warning into a lookup option.
 
 The full FollowTheMoney property listing, when a warning mentions a property not covered by the mapping table, is at: https://www.opensanctions.org/reference/
+{% if code_path %}
+
+When a fix needs a crawler code change, these best-practice guides are the relevant references — read the one that matches the warning:
+
+- `zavod/docs/best_practices/dates_meta.md` — parsing and formatting dates (for "failed to parse date" warnings)
+- `zavod/docs/best_practices/addresses.md` — constructing addresses
+- `zavod/docs/best_practices/xpath_and_html.md` — extracting values from HTML
+- `zavod/docs/best_practices/entity_id.md` — how entity IDs are generated; do NOT change the inputs to an entity's ID
+- `zavod/docs/best_practices/patterns.md` and `zavod/docs/helpers.md` — common crawler patterns and the `h.*` helpers
+{% endif %}
 
 ## Assertion failures
 
@@ -36,7 +46,7 @@ Some warnings are not dirty values but assertion failures, e.g.:
 
     Assertion schema_entities failed for Security: 669973 is not <= threshold 418000
 
-These mean the dataset's expected size envelope, declared under `assertions:` in {{ yaml_path }}, no longer matches reality because the source legitimately grew or shrank. The fix is to **widen the envelope in the direction it drifted**, to a round number that leaves headroom so normal fluctuation will not immediately re-trip it. Never tighten a threshold toward the current value — that just re-breaks on the next run.
+These mean the dataset's expected size envelope, declared under `assertions:` in {{ yaml_path }}, no longer matches reality because the source legitimately grew or shrank. See the "Data assertions" section of `zavod/docs/metadata.md` for how thresholds work. The fix is to **widen the envelope in the direction it drifted**, to a round number that leaves headroom so normal fluctuation will not immediately re-trip it. Never tighten a threshold toward the current value — that just re-breaks on the next run.
 
 Read the message as `<value> is not <op> threshold <threshold>` and edit the matching entry under `assertions.min.<metric>.<key>` or `assertions.max.<metric>.<key>` (the `<metric>`, e.g. `schema_entities`, and `<key>`, e.g. `Security`, come straight from the message):
 
@@ -46,6 +56,13 @@ Read the message as `<value> is not <op> threshold <threshold>` and edit the mat
 The same logic applies to the other count metrics (`entity_count`, `countries`, `country_entities`). For `property_fill_rate` the threshold is a 0–1 rate, so widen by a small decimal margin instead of rounding.
 
 If you cannot tell whether the drift is legitimate or a sign the crawler broke, still open the PR with the widened threshold — a reviewer can close it if the envelope should not move.
+
+## Leave these for humans
+
+Some warnings are deliberate signals for a maintainer to investigate, not something to auto-fix. Skip them — do not edit anything in response to:
+
+- Change-detection tripwires: `DOM hash changed`, `URL hash changed`, `File hash changed`. These flag that a source page or file changed and a human needs to check whether the crawler still parses it correctly. "Fixing" the hash would just hide the change.
+- Transient runtime errors: `Runner failed with ...`, HTTP errors, timeouts. These are not fixable by editing the dataset.
 
 ## Scope
 

--- a/contrib/issues_agent/prompt.md
+++ b/contrib/issues_agent/prompt.md
@@ -1,6 +1,24 @@
-You are a data engineer tasked with fixing warnings resulting from unexpected data in an ETL workflow. The warnings have been written to an online issues logfile at: {ISSUES_URL}
+You are a data engineer tasked with fixing warnings resulting from unexpected data in an ETL workflow. The warnings have been written to an online issues logfile at: {{ issues_url }}
 
-Your task is to identify warnings that can be addressed by adding lookup options to the dataset YAML at: {YAML_PATH}, and to submit a combined PR with the fixes.
+The dataset is `{{ name }}`. Its metadata YAML is at: {{ yaml_path }}
+{% if code_path %}
+Its crawler source code is at: {{ code_path }}
+{% else %}
+This is an enrichment dataset — it has no dataset-local crawler code, so the only thing you can change is the metadata YAML.
+{% endif %}
+
+Your task is to fix as many warnings as you confidently can and submit a single combined PR.
+
+{% if code_path %}
+## Two kinds of fix
+
+1. **Lookups (preferred — always try this first).** Most value-level dirt (an unmapped country, an unparseable date, an unknown gender) is fixed by adding a lookup option to {{ yaml_path }}. Lookups are low-risk and reviewable, so reach for them whenever they can express the fix.
+2. **Crawler code changes.** When a warning cannot be expressed as a lookup — e.g. a parsing bug, a field read from the wrong column, a value that needs transforming before it is added — you may edit the crawler at {{ code_path }} instead. Keep the change as small and targeted as possible.
+{% else %}
+## How to fix
+
+Warnings are fixed by adding lookup options to {{ yaml_path }}. A lookup maps a dirty source value (an unmapped country, an unparseable date, an unknown gender) to a clean one. They are low-risk and reviewable.
+{% endif %}
 
 ## Reference
 
@@ -8,26 +26,42 @@ Datapatch lookups — the YAML structure, matching modes, result fields, the pro
 
 `zavod/docs/best_practices/datapatch_lookups.md`
 
-The "Common runtime warnings and the lookup that fixes them" and "Property name to type lookup" sections on that page are the primary reference for this task. Use them to translate each warning into a lookup option.
+The "Common runtime warnings and the lookup that fixes them" and "Property name to type lookup" sections on that page are the primary reference. Use them to translate each warning into a lookup option.
 
 The full FollowTheMoney property listing, when a warning mentions a property not covered by the mapping table, is at: https://www.opensanctions.org/reference/
 
 ## Scope
 
-- Address only warnings that can be fixed by adding one or more lookup options.
+{% if code_path %}
+- Prefer lookups. Only change code when no lookup can express the fix.
+{% endif %}
 - NEVER define new YAML options or structures beyond what the datapatch reference describes.
-- NEVER modify any file other than {YAML_PATH}.
-- NEVER try to install, build, or execute the `zavod` system or modify the crawler code.
-- It is fine to open a PR that addresses only some of the warnings for a file. Skip warnings that are unclear or require crawler changes.
-- If the correct mapping for a value is genuinely uncertain — i.e. you cannot determine from context what it should be — skip that warning. Do not guess. A skipped warning gets human review later; a wrong lookup ships incorrect data.
+{% if code_path %}
+- NEVER modify any file other than {{ yaml_path }} and {{ code_path }}.
+{% else %}
+- NEVER modify any file other than {{ yaml_path }}.
+{% endif %}
+- It is fine to open a PR that fixes only some of the warnings. Skip warnings that are unclear.
+- If the correct fix for a value is genuinely uncertain — i.e. you cannot determine from context what it should be — skip that warning. Do not guess. A skipped warning gets human review later; a wrong fix ships incorrect data.
 - Do NOT open a PR if no fixes are needed.
 
 ## Workflow
 
 1. Read `zavod/docs/best_practices/datapatch_lookups.md` in full before producing any fixes. The lookup YAML format and the warning-to-recipe mapping in that file are authoritative; do not rely on memory or invent syntax.
-2. Fetch {ISSUES_URL} and parse the line-based JSON.
+2. Fetch {{ issues_url }} and parse the JSON.
 3. Group entries by the `message` field to identify recurring patterns.
-4. For each fixable group, decide on lookup options using the reference doc above. Follow the consolidation rule under "Result values" in the doc — merge inputs that share a result, keep inputs with different results separate.
-5. Edit {YAML_PATH} to add or extend the relevant lookup. Existing lookup conventions in the file (lookup names, casing flags, ordering) should be respected.
-6. Commit to a branch. The branch name MUST be exactly `{BRANCH}` — do not invent your own name or add a slug.
-7. Open a PR via `mcp__github__create_pull_request` from the `{BRANCH}` branch. The title MUST start with `[{NAME}]` followed by a short headline, and the body must list the warning patterns being fixed.
+4. For each fixable group, decide {% if code_path %}whether a lookup or a code change is appropriate{% else %}on a lookup option{% endif %}. For lookups, follow the consolidation rule under "Result values" in the doc — merge inputs that share a result, keep inputs with different results separate. Respect the existing lookup conventions in the file (lookup names, casing flags, ordering).
+5. Apply the fixes: edit {{ yaml_path }}{% if code_path %}, and {{ code_path }} where a code change is warranted{% endif %}.
+{% if code_path %}
+6. Verify your changes:
+{% if ci_test %}
+   - This crawler runs in CI. After making your changes, run `zavod crawl --clear-data {{ yaml_path }}`, then read `data/datasets/{{ name }}/issues.log` and confirm the warnings you targeted are gone and that you have not introduced new warnings. Do not open the PR if the crawl fails or warnings increase.
+{% else %}
+   - This crawler CANNOT run in CI (it needs credentials we don't have here, or is too slow). You cannot verify a code change by crawling. Make any code change conservatively, and state clearly in the PR body that the code change is unverified and needs human review before merge.
+{% endif %}
+{% endif %}
+
+## Submit
+
+- Commit to a branch. The branch name MUST be exactly `{{ branch }}` — do not invent your own name or add a slug.
+- Open a PR via `mcp__github__create_pull_request` from the `{{ branch }}` branch. The title MUST start with `[{{ name }}]` followed by a short headline, and the body must list the warning patterns being fixed{% if code_path %} and flag any crawler code changes separately from lookup changes{% endif %}.

--- a/contrib/issues_agent/prompt.md
+++ b/contrib/issues_agent/prompt.md
@@ -29,5 +29,5 @@ The full FollowTheMoney property listing, when a warning mentions a property not
 3. Group entries by the `message` field to identify recurring patterns.
 4. For each fixable group, decide on lookup options using the reference doc above. Follow the consolidation rule under "Result values" in the doc — merge inputs that share a result, keep inputs with different results separate.
 5. Edit {YAML_PATH} to add or extend the relevant lookup. Existing lookup conventions in the file (lookup names, casing flags, ordering) should be respected.
-6. Commit to a branch named `issues/{NAME}-<slug>` where `<slug>` summarizes the warnings addressed.
-7. Open a PR via `mcp__github__create_pull_request` with title `[{NAME}] <headline>` and a body that lists the warning patterns being fixed.
+6. Commit to a branch. The branch name MUST be exactly `{BRANCH}` — do not invent your own name or add a slug.
+7. Open a PR via `mcp__github__create_pull_request` from the `{BRANCH}` branch. The title MUST start with `[{NAME}]` followed by a short headline, and the body must list the warning patterns being fixed.

--- a/contrib/issues_agent/prompt.md
+++ b/contrib/issues_agent/prompt.md
@@ -92,7 +92,7 @@ Some warnings are deliberate signals for a maintainer to investigate, not someth
 6. Verify your changes:
    - Any code change MUST pass the same checks CI runs, or the PR is dead on arrival: `mypy --strict {{ code_path }}` and `ruff check {{ code_path }}` (and `ruff format`). Note that raw lxml `.xpath()` returns `Any` and fails strict mode — use the typed `h.xpath_*` helpers. Do not open the PR if these fail.
 {% if ci_test %}
-   - This crawler runs in CI, so also confirm the fix works end to end: run `zavod crawl --clear-data {{ yaml_path }}`, then read `data/datasets/{{ name }}/issues.log` and confirm the warnings you targeted are gone and that you have not introduced new ones. Do not open the PR if the crawl fails or warnings increase.
+   - This crawler runs in CI, so also confirm the fix works end to end: run `zavod crawl --clear-data {{ yaml_path }}`, then read `data/datasets/{{ name }}/issues.log` and confirm the warnings you targeted are gone and that you have not introduced new ones. Do not open the PR if the crawl fails or warnings increase. `jq` (for the JSON logs) and `qsv` (for spot-checking the emitted `data/datasets/{{ name }}/statements.pack`, e.g. `qsv frequency -s prop`) are available.
 {% else %}
    - This crawler CANNOT run in CI (it needs credentials we don't have here, or is too slow), so you cannot verify the fix by crawling. State clearly in the PR body that the code change is unverified and needs human review before merge.
 {% endif %}

--- a/contrib/issues_agent/tasks.py
+++ b/contrib/issues_agent/tasks.py
@@ -17,6 +17,15 @@ datasets_path = Path(repo_path_) / "datasets"
 
 INDEX_URL = "https://data.opensanctions.org/datasets/latest/index.json"
 MAX_ISSUES = 1000
+
+# Match compute to task difficulty. Lookup/assertion edits on YAML are mechanical,
+# so a mid-tier model with few turns suffices. Datasets with a crawler may need an
+# actual code fix — stronger reasoning, plus turns to run mypy, crawl, and iterate.
+MODEL_LOOKUP = "claude-sonnet-4-6"
+MODEL_CODE = "claude-opus-4-8"
+MAX_TURNS_LOOKUP = 30
+MAX_TURNS_CODE_VERIFIABLE = 100  # ci_test true: edit, then crawl-verify and iterate
+MAX_TURNS_CODE_BLIND = 60  # ci_test false: edit + mypy/ruff, no crawl loop
 # Rendered per dataset with the diagnostic context (paths, branch, ci_test) so
 # the prompt can branch between lookup-only and code-fix instructions. autoescape
 # stays off (default) so markdown and YAML examples pass through untouched.
@@ -238,6 +247,17 @@ def index_jobs():
         entry_point, ci_test = read_dataset_meta(path)
         code_path = get_code_path(path, entry_point)
 
+        # Only crawler datasets can require code, so only they need zavod
+        # installed (for mypy and crawling) and the heavier model/turn budget.
+        if code_path is not None:
+            model = MODEL_CODE
+            max_turns = MAX_TURNS_CODE_VERIFIABLE if ci_test else MAX_TURNS_CODE_BLIND
+            needs_zavod = True
+        else:
+            model = MODEL_LOOKUP
+            max_turns = MAX_TURNS_LOOKUP
+            needs_zavod = False
+
         prompt = PROMPT.render(
             name=name,
             issues_url=dataset.get("issues_url"),
@@ -247,7 +267,16 @@ def index_jobs():
             ci_test=ci_test,
         )
         title = f"[{name}]: {warnings} warnings"
-        tasks.append({"prompt": prompt, "name": title, "branch": branch})
+        tasks.append(
+            {
+                "prompt": prompt,
+                "name": title,
+                "branch": branch,
+                "model": model,
+                "max_turns": max_turns,
+                "needs_zavod": needs_zavod,
+            }
+        )
 
     print(json.dumps(tasks))
 

--- a/contrib/issues_agent/tasks.py
+++ b/contrib/issues_agent/tasks.py
@@ -2,10 +2,12 @@ import os
 import re
 import sys
 import json
+import yaml
 import hashlib
-from typing import Any, List
+from typing import Any, List, Optional, Tuple
 import requests
 from pathlib import Path
+from jinja2 import Template
 
 
 session = requests.Session()
@@ -15,7 +17,14 @@ datasets_path = Path(repo_path_) / "datasets"
 
 INDEX_URL = "https://data.opensanctions.org/datasets/latest/index.json"
 MAX_ISSUES = 1000
-PROMPT = open(Path(__file__).parent / "prompt.md", "r").read()
+# Rendered per dataset with the diagnostic context (paths, branch, ci_test) so
+# the prompt can branch between lookup-only and code-fix instructions. autoescape
+# stays off (default) so markdown and YAML examples pass through untouched.
+PROMPT = Template(
+    (Path(__file__).parent / "prompt.md").read_text(),
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
 
 # Outages are tracked on the org-level GitHub Projects v2 board #6, not as plain
 # issues. The board carries two custom fields we care about: `dataset` (which
@@ -141,6 +150,40 @@ def pr_exists(branch: str) -> bool:
     return response.json().get("total_count", 0) > 0
 
 
+def get_code_path(yaml_path: str, entry_point: Optional[str]) -> Optional[str]:
+    """Resolve a dataset's entry_point to the crawler source file, if it has one.
+
+    Use this to give the agent the actual code to read and fix, not just the
+    metadata YAML. Mirrors zavod's loader (zavod/runtime/loader.py): an
+    entry_point naming an installed module — e.g. `zavod.runner.enrich:enrich`,
+    used by enrichment datasets — has no dataset-local code to edit, so return
+    None. Otherwise the entry_point names a file relative to the dataset
+    directory (`crawler.py`, `crawler`, `ofac_advanced.py:crawl`); return its path.
+    """
+    if entry_point is None:
+        return None
+    module_name = entry_point.split(":", 1)[0]
+    base = Path(yaml_path).parent
+    for candidate in (module_name, f"{module_name}.py"):
+        file_path = base / candidate
+        if file_path.is_file():
+            return file_path.as_posix()
+    return None
+
+
+def read_dataset_meta(yaml_path: str) -> Tuple[Optional[str], bool]:
+    """Return the `entry_point` and `ci_test` flag from a dataset YAML.
+
+    `ci_test` indicates whether the crawler can run in CI at all: it is set to
+    false for crawlers that need credentials we don't have in CI (Zyte, GPT
+    keys) or are too slow. It tells the agent whether re-running the crawler to
+    verify a fix is even possible. Defaults to True, matching the zavod model.
+    """
+    with open(yaml_path, "r") as fh:
+        data = yaml.safe_load(fh)
+    return data.get("entry_point"), data.get("ci_test", True)
+
+
 def get_issue_details(issue_url):
     try:
         response = session.get(issue_url)
@@ -192,11 +235,17 @@ def index_jobs():
             continue
 
         path = get_path_from_name(name)
-        prompt = str(PROMPT)
-        prompt = prompt.replace("{NAME}", name)
-        prompt = prompt.replace("{ISSUES_URL}", dataset.get("issues_url"))
-        prompt = prompt.replace("{YAML_PATH}", path)
-        prompt = prompt.replace("{BRANCH}", branch)
+        entry_point, ci_test = read_dataset_meta(path)
+        code_path = get_code_path(path, entry_point)
+
+        prompt = PROMPT.render(
+            name=name,
+            issues_url=dataset.get("issues_url"),
+            yaml_path=path,
+            branch=branch,
+            code_path=code_path,
+            ci_test=ci_test,
+        )
         title = f"[{name}]: {warnings} warnings"
         tasks.append({"prompt": prompt, "name": title, "branch": branch})
 

--- a/contrib/issues_agent/tasks.py
+++ b/contrib/issues_agent/tasks.py
@@ -1,5 +1,8 @@
 import os
+import re
+import sys
 import json
+import hashlib
 from typing import Any, List
 import requests
 from pathlib import Path
@@ -14,12 +17,128 @@ INDEX_URL = "https://data.opensanctions.org/datasets/latest/index.json"
 MAX_ISSUES = 1000
 PROMPT = open(Path(__file__).parent / "prompt.md", "r").read()
 
+# Outages are tracked on the org-level GitHub Projects v2 board #6, not as plain
+# issues. The board carries two custom fields we care about: `dataset` (which
+# dataset the item is about) and `Status` (whether it's a passing "Issue" or an
+# active "Outage"). Field ids are stable and mirror site/lib/github.ts.
+GITHUB_API = "https://api.github.com"
+GITHUB_REPO = os.environ.get("GITHUB_REPOSITORY", "opensanctions/opensanctions")
+PROJECT_ORG = "opensanctions"
+PROJECT_NUMBER = 6
+FIELD_DATASET = 271254866
+FIELD_STATUS = 271254605
+OUTAGE_STATUS = "Outage"
+
 
 def get_path_from_name(name: str) -> str:
     for path in datasets_path.glob("**/*.y*ml"):
         if path.stem == name:
             return path.as_posix()
     raise RuntimeError(f"Dataset {name!r} not found in: {datasets_path}")
+
+
+# Python object reprs carry a memory address (e.g. "<Element div at 0x7f...>")
+# that changes every run. The address tells us nothing about which issue this is,
+# so strip it before checksumming.
+HEX_ADDR_RE = re.compile(r"0x[0-9a-fA-F]+")
+
+
+def issues_checksum(issues: List[Any]) -> str:
+    """Return a checksum that identifies a constant set of crawl issues.
+
+    Use this to seed a deterministic branch name: two crawls that surface the
+    same warnings hash to the same value, so a re-run over an unchanged issue
+    set reuses the branch (and dedupes against an existing PR), while a genuinely
+    changed set produces a new branch.
+
+    Only run-invariant content is hashed. Each issue's `timestamp` and `id` are
+    dropped — `id` is itself a hash that folds in the timestamp, so it churns
+    every run — and memory addresses are scrubbed from the remaining fields. The
+    page-content hashes that live in `data` (e.g. the expected/actual values of a
+    "DOM hash changed" warning) are stable and are kept, so a real source change
+    still moves the checksum.
+    """
+    normalized = [
+        {k: issue.get(k) for k in ("level", "module", "message", "entity", "data")}
+        for issue in issues
+    ]
+    # Sort so the order issues happen to appear in the log doesn't affect the hash.
+    normalized.sort(key=lambda i: json.dumps(i, sort_keys=True, ensure_ascii=False))
+    canonical = json.dumps(normalized, sort_keys=True, ensure_ascii=False)
+    canonical = HEX_ADDR_RE.sub("0x*", canonical)
+    return hashlib.sha1(canonical.encode("utf-8")).hexdigest()
+
+
+def get_outage_datasets() -> set[str]:
+    """Return the names of datasets that have an active outage on the project board.
+
+    Use this to skip datasets whose source is known to be down: their warnings
+    are a symptom of the outage, not something a lookup or code change can fix,
+    so the agent should leave them for the humans tracking the outage.
+
+    Reads the public Projects v2 board #6 (no auth needed — the project is
+    public), paginating via the Link header, and keeps items whose `Status`
+    field is "Outage". Mirrors getOpenIssues() in site/lib/github.ts.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        # Required header for the Projects v2 REST API (currently in preview).
+        "X-GitHub-Api-Version": "2026-03-10",
+    }
+    url: str | None = (
+        f"{GITHUB_API}/orgs/{PROJECT_ORG}/projectsV2/{PROJECT_NUMBER}/items"
+        f"?fields[]={FIELD_DATASET}&fields[]={FIELD_STATUS}&q=is:open&per_page=100"
+    )
+    outages: set[str] = set()
+    while url is not None:
+        response = session.get(url, headers=headers)
+        response.raise_for_status()
+
+        # Each field value has a different shape depending on its data_type.
+        for item in response.json():
+            if item.get("content_type") != "Issue":
+                continue
+            dataset: str | None = None
+            status: str | None = None
+            for field in item.get("fields", []):
+                if field["id"] == FIELD_DATASET:
+                    dataset = field.get("value", {}).get("raw")
+                elif field["id"] == FIELD_STATUS:
+                    status = field.get("value", {}).get("name", {}).get("raw")
+            if dataset is not None and status == OUTAGE_STATUS:
+                outages.add(dataset)
+
+        # Follow the `Link: <url>; rel="next"` header until exhausted.
+        next_link = response.links.get("next")
+        url = next_link["url"] if next_link is not None else None
+
+    return outages
+
+
+def pr_exists(branch: str) -> bool:
+    """Return True if a PR for this branch already exists, in any state.
+
+    The branch name encodes a checksum of the issue set, so a PR whose head is
+    this branch — whether open, merged, or closed-unmerged — means this exact
+    set of warnings has already been handled: open (awaiting review), merged
+    (fixed, but the published index still shows the old issues until the next
+    crawl), or closed (a human rejected this fix). In every case we skip rather
+    than re-open, which is what makes the agent idempotent across daily runs.
+
+    Searches as the authenticated `GITHUB_TOKEN` when present (required for the
+    search API in CI); falls back to unauthenticated for local runs.
+    """
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = session.get(
+        f"{GITHUB_API}/search/issues",
+        params={"q": f"repo:{GITHUB_REPO} is:pr head:{branch}"},
+        headers=headers,
+    )
+    response.raise_for_status()
+    return response.json().get("total_count", 0) > 0
 
 
 def get_issue_details(issue_url):
@@ -32,33 +151,54 @@ def get_issue_details(issue_url):
         return None
 
 
+def log(message: str) -> None:
+    """Emit a diagnostic line to stderr.
+
+    stdout carries the matrix JSON that GitHub Actions captures, so anything we
+    want a human to read in the run log has to go to stderr to avoid corrupting it.
+    """
+    print(message, file=sys.stderr)
+
+
 def index_jobs():
     response = session.get(INDEX_URL)
     response.raise_for_status()
     index_data = response.json()
+    outage_datasets = get_outage_datasets()
     tasks: List[Any] = []
 
     for dataset in index_data.get("datasets", []):
-        levels = dataset.get("issue_levels", {})
-        warnings = levels.get("warning", 0)
-        errors = levels.get("error", 0)
-        if warnings == 0:
-            continue
-        if (warnings + errors) > MAX_ISSUES:
-            continue
         name = dataset.get("name")
         if not name:
             continue
+        levels = dataset.get("issue_levels", {})
+        warnings = levels.get("warning", 0)
+        errors = levels.get("error", 0)
+
+        if warnings == 0:
+            continue
+        if name in outage_datasets:
+            log(f"Documented outage: {name}")
+            continue
+        if (warnings + errors) > MAX_ISSUES:
+            log(f"Fubar: {name}")
+            continue
+
+        issues = get_issue_details(dataset.get("issues_url")) or {}
+        checksum = issues_checksum(issues.get("issues", []))
+        branch = f"autofix/{name.replace('_', '-')}-{checksum[:10]}"
+        if pr_exists(branch):
+            log(f"PR exists: {name} ({branch})")
+            continue
 
         path = get_path_from_name(name)
-        # print(f"Dataset: {name}, Issues: {levels}, Path: {path}")
-
         prompt = str(PROMPT)
         prompt = prompt.replace("{NAME}", name)
         prompt = prompt.replace("{ISSUES_URL}", dataset.get("issues_url"))
         prompt = prompt.replace("{YAML_PATH}", path)
+        prompt = prompt.replace("{BRANCH}", branch)
         title = f"[{name}]: {warnings} warnings"
-        tasks.append({"prompt": prompt, "name": title})
+        tasks.append({"prompt": prompt, "name": title, "branch": branch})
 
     print(json.dumps(tasks))
 


### PR DESCRIPTION
Evolves the issues agent (`contrib/issues_agent/`) from opening lookup-only YAML PRs toward proposing actual crawler **code changes**, and makes its daily runs idempotent so it stops re-opening the same PR.

## What changed

**Idempotence (`tasks.py`)**
- `issues_checksum()` — a stable checksum over the normalized issue set (drops the per-run `timestamp`/`id`, scrubs `0x…` memory addresses). Branch names are now `autofix/{dataset}-{checksum}`.
- `pr_exists()` — skips a dataset when a PR for that branch already exists in any state (open/merged/closed), so an unchanged issue set is never re-proposed.
- `get_outage_datasets()` — skips datasets with an active outage on the public Projects v2 board #6.
- Order of operations: no-warnings → skip; outage → log + skip; over `MAX_ISSUES` → log + skip; existing PR → log + skip.

**Diagnostic context for code fixes (`tasks.py` + `prompt.md`)**
- `get_code_path()` resolves each dataset's `entry_point` to its crawler source file (or `None` for enrichment datasets), mirroring zavod's loader.
- `read_dataset_meta()` reads the `ci_test` flag (can the crawler run in CI at all?).
- The prompt is now a Jinja2 template that branches three ways: lookup-only (enrichers), code-fix-with-verification (crawlers that run in CI), and code-fix-unverified (crawlers needing credentials).

**Executable code-fix loop (`issues-agent.yml`)**
- `run-tasks` now installs zavod (mirroring `build.yml`) and runs with full `Bash`, so the agent can `zavod crawl` and confirm its fix dropped the warnings before opening a PR.
- pip cache keyed to `zavod/pyproject.toml` so compiled wheels are reused.

## Not included
- Gating code-fix mode to only the datasets where it's viable (the `code_path`/`ci_test` fields are on the task dict but not yet used to filter the matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)