### PR TITLE
Add @claude PR assistant workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+# yamllint disable
+name: Claude PR assistant
+
+# Lets repo editors steer Claude on a PR or issue by mentioning @claude in a
+# comment or review. Distinct from issues-agent.yml: that runs on a schedule
+# with an explicit prompt; this is interactive "tag" mode, which the action
+# auto-detects when no prompt is passed and a comment mentions @claude.
+"on":
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    # Only react to @claude mentions, and only from org members / repo
+    # collaborators. This `if` is a cheap pre-filter that avoids spinning up a
+    # runner for unrelated comments; claude-code-action additionally enforces
+    # real write-access on the actor before doing anything, which is the
+    # authoritative gate (author_association alone can include org members
+    # without write on this repo).
+    if: |
+      (
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) || (
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      )
+    runs-on: ubuntu-latest
+    # One Claude run per PR/issue at a time; a follow-up comment queues rather
+    # than cancelling a run that may be mid-edit.
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--model claude-opus-4-8 --max-turns 30 --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch\""


### PR DESCRIPTION
Adds an interactive `@claude` responder so repo editors can steer Claude directly on a PR or issue — e.g. to refine a lookup or adjust an assertion threshold on one of the issues-agent's autofix PRs, instead of editing by hand.

This is **tag mode** (`claude-code-action@v1` auto-detects it when no prompt is passed and a comment mentions `@claude`), distinct from the scheduled explicit-prompt run in `issues-agent.yml`. It checks out the PR's branch and pushes changes back to it automatically.

## Access control (Layer 1 + 2)
- **`if:` pre-filter:** the job only starts when a comment/review mentions `@claude` *and* the author is `OWNER`/`MEMBER`/`COLLABORATOR` — avoids waking a runner for unrelated comments.
- **Authoritative gate:** `claude-code-action` independently verifies the actor's real write access before doing anything, which covers the case of an org member who lacks write on this repo.

## Notes
- Reuses the existing `ANTHROPIC_API_KEY` secret — no new secrets.
- Triggers on `issue_comment`, `pull_request_review_comment`, `pull_request_review`.
- `concurrency` with `cancel-in-progress: false` so a follow-up comment queues rather than killing an in-flight edit.
- **No zavod/qsv** in this responder — it can edit YAML/code, read, and discuss, but can't re-crawl or run `mypy`. A zavod-capable variant can be added later if we want `@claude` to verify code changes (at ~2–4 min install per invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)