### PR TITLE
Enable Skill tool for the issues agent

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -106,6 +106,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ matrix.task.prompt }}
-          claude_args: "--model ${{ matrix.task.model }} --max-turns ${{ matrix.task.max_turns }} --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,mcp__github__create_pull_request\""
+          claude_args: "--model ${{ matrix.task.model }} --max-turns ${{ matrix.task.max_turns }} --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,Skill,mcp__github__create_pull_request\""
           show_full_output: true
 


### PR DESCRIPTION
Adds `Skill` to the issues-agent's `--allowed-tools` so the autofix agent can invoke the repo's crawler skills (e.g. `/typechecker-fixes`, `/debug-crawler`) when working a code fix, instead of only being able to `Read` their `SKILL.md` files.

Companion to the same change on the `@claude` PR assistant (#4474), which also gained an `--append-system-prompt` pointer to the key docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)