### PR TITLE
Dedupe crawler doc references via the crawler-guide hub

### DIFF
--- a/.claude/docs/crawler-guide.md
+++ b/.claude/docs/crawler-guide.md
@@ -71,7 +71,8 @@ assertions:
 Key rules:
 - Always set `load_statements: true`.
 - Set assertions to ~80% min / ~150% max of expected counts. Checked by
-  `zavod validate`, not by `zavod crawl`.
+  `zavod validate`, not by `zavod crawl`. See the "Data assertions" section of
+  `zavod/docs/metadata.md` for the metrics and comparison semantics.
 - Write `summary` and `description` to be **time-agnostic** — describe the source's
   purpose and update cadence, not the current snapshot (e.g. "Members of parliament,
   updated after each election" not "Members since the 2023 elections").
@@ -234,6 +235,8 @@ for row in h.parse_xlsx_sheet(context, wb["Sheet1"]):
 ```
 
 ## Lookups
+
+Full reference: `zavod/docs/best_practices/datapatch_lookups.md` — the YAML structure, matching modes, result fields, and the property-name → type-lookup mapping.
 
 ```yaml
 lookups:

--- a/.claude/skills/name-framework-migration-first-step/SKILL.md
+++ b/.claude/skills/name-framework-migration-first-step/SKILL.md
@@ -27,7 +27,6 @@ Before making any changes:
 - [examples/migrations.md](examples/migrations.md) — real before/after migrations; read before touching any crawler
 - `zavod/docs/extract/names.md#migrating-to-the-name-cleaning-helpers` — full three-step procedure and rationale
 - `zavod/zavod/helpers/names.py` — exact signatures for `review_names`, `check_names_regularity`, `Names`
-- `datasets/CLAUDE.md` — name cleaning section
 
 ## Trigger patterns to find
 

--- a/contrib/issues_agent/prompt.md
+++ b/contrib/issues_agent/prompt.md
@@ -31,13 +31,7 @@ The "Common runtime warnings and the lookup that fixes them" and "Property name 
 The full FollowTheMoney property listing, when a warning mentions a property not covered by the mapping table, is at: https://www.opensanctions.org/reference/
 {% if code_path %}
 
-When a fix needs a crawler code change, these best-practice guides are the relevant references — read the one that matches the warning:
-
-- `zavod/docs/best_practices/dates_meta.md` — parsing and formatting dates (for "failed to parse date" warnings)
-- `zavod/docs/best_practices/addresses.md` — constructing addresses
-- `zavod/docs/best_practices/xpath_and_html.md` — extracting values from HTML
-- `zavod/docs/best_practices/entity_id.md` — how entity IDs are generated; do NOT change the inputs to an entity's ID
-- `zavod/docs/best_practices/patterns.md` and `zavod/docs/helpers.md` — common crawler patterns and the `h.*` helpers
+When a fix needs a crawler code change, `.claude/docs/crawler-guide.md` is the hub: it covers the common patterns and links the relevant `zavod/docs` best-practice guides (dates, addresses, HTML/XPath, entity IDs, helpers). Read it, then the specific guide matching the warning.
 {% endif %}
 
 ## Assertion failures


### PR DESCRIPTION
The issues agent prompt re-listed six best-practice docs (`dates_meta`, `addresses`, `xpath_and_html`, `entity_id`, `patterns`, `helpers`) that `.claude/docs/crawler-guide.md` already curates — and the agent auto-loads `CLAUDE.md`, which already points at that guide. So the list was a redundant third copy.

Changes:
- **Prompt** (`contrib/issues_agent/prompt.md`): the `{% if code_path %}` code-change section now points at `.claude/docs/crawler-guide.md` as the hub instead of enumerating the six docs. (The "never change entity IDs" guardrail it carried is unaffected — it's already stated in the prompt's Scope section.)
- **Hub** (`.claude/docs/crawler-guide.md`): completed it by linking `datapatch_lookups.md` from the Lookups section and `metadata.md` (Data assertions) from the assertions rules — the two references the prompt relies on that the hub was missing.

Layering is now: `CLAUDE.md` → `crawler-guide.md` (hub) → `zavod/docs` (authoritative), with the prompt keeping only its task-specific primaries (`datapatch_lookups.md` for lookups, `metadata.md` for assertions) inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)