### PR TITLE
Warn about stale files in datasets/latest/

### DIFF
--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -20,6 +20,7 @@ log = get_logger(__name__)
 StatementGen = Generator[Statement, None, None]
 DATASETS = "datasets"
 ARTIFACTS = "artifacts"
+LATEST = "latest"
 STATEMENTS_FILE = "statements.pack"
 HASH_FILE = "entities.hash"
 DELTA_EXPORT_FILE = "entities.delta.json"
@@ -150,7 +151,7 @@ def get_artifact_object(
 
     # FIXME: legacy fallback option of using the latest release
     # REMOVE THIS AFTER MIGRATION
-    name = f"{DATASETS}/latest/{dataset_name}/{resource}"
+    name = f"{DATASETS}/{LATEST}/{dataset_name}/{resource}"
     object = backend.get_object(name)
     if object.exists():
         return object
@@ -189,7 +190,7 @@ def publish_resource(
     path: Path,
     dataset_name: Optional[str],
     resource: str,
-    latest: bool = True,
+    republish_to_latest: bool = True,
     mime_type: Optional[str] = None,
 ) -> None:
     """Resources are files published to the main publication directory of the dataset."""
@@ -202,8 +203,8 @@ def publish_resource(
     release_object.publish(path, mime_type=mime_type, ttl=TTL_MEDIUM)
     invalidate_archive_cache(release_name)
 
-    if latest and settings.RELEASE != "latest":
-        latest_name = f"{DATASETS}/latest/{resource}"
+    if republish_to_latest and settings.RELEASE != LATEST:
+        latest_name = f"{DATASETS}/{LATEST}/{resource}"
         latest_object = backend.get_object(latest_name)
         latest_object.republish(release_name)
         invalidate_archive_cache(latest_name)

--- a/zavod/zavod/archive/backend.py
+++ b/zavod/zavod/archive/backend.py
@@ -1,8 +1,9 @@
 import shutil
 import warnings
+from datetime import datetime, timezone
 from functools import cache
 from pathlib import Path
-from typing import Dict, Optional, TextIO, Type, cast
+from typing import Dict, Iterator, Optional, TextIO, Type, cast
 
 from google.cloud.storage import Blob, Client  # type: ignore
 
@@ -27,6 +28,9 @@ class ArchiveObject(object):
     def size(self) -> int:
         raise NotImplementedError
 
+    def updated_at(self) -> datetime:
+        raise NotImplementedError
+
     def backfill(self, dest: Path) -> None:
         raise NotImplementedError
 
@@ -48,6 +52,10 @@ class ArchiveObject(object):
 
 class ArchiveBackend(object):
     def get_object(self, name: str) -> ArchiveObject:
+        raise NotImplementedError
+
+    def list_objects(self, prefix: str) -> Iterator[ArchiveObject]:
+        """List all objects with the given prefix."""
         raise NotImplementedError
 
 
@@ -77,6 +85,13 @@ class GoogleCloudObject(ArchiveObject):
         if self.blob is None:
             return 0
         return self.blob.size or 0
+
+    def updated_at(self) -> datetime:
+        if self.blob is None:
+            raise RuntimeError("Object does not exist: %s" % self.name)
+        updated = self.blob.updated
+        assert updated is not None
+        return cast(datetime, updated)
 
     def open(self) -> TextIO:
         if self.blob is None:
@@ -130,6 +145,12 @@ class GoogleCloudBackend(ArchiveBackend):
     def get_object(self, name: str) -> GoogleCloudObject:
         return GoogleCloudObject(self, name)
 
+    def list_objects(self, prefix: str) -> Iterator[ArchiveObject]:
+        for blob in self.bucket.list_blobs(prefix=prefix):
+            object = GoogleCloudObject(self, blob.name)
+            object._blob = blob
+            yield object
+
 
 class FileSystemObject(ArchiveObject):
     def __init__(self, backend: "FileSystemBackend", name: str) -> None:
@@ -144,6 +165,9 @@ class FileSystemObject(ArchiveObject):
         if not self.path.exists():
             return 0
         return self.path.stat().st_size
+
+    def updated_at(self) -> datetime:
+        return datetime.fromtimestamp(self.path.stat().st_mtime, tz=timezone.utc)
 
     def open(self) -> TextIO:
         return open(self.path, "r", buffering=BLOB_CHUNK)
@@ -184,6 +208,16 @@ class FileSystemObject(ArchiveObject):
 class FileSystemBackend(ArchiveBackend):
     def get_object(self, name: str) -> FileSystemObject:
         return FileSystemObject(self, name)
+
+    def list_objects(self, prefix: str) -> Iterator[ArchiveObject]:
+        prefix_path = settings.ARCHIVE_PATH / prefix
+        if not prefix_path.is_dir():
+            return
+        for path in prefix_path.rglob("*"):
+            if path.is_file():
+                yield FileSystemObject(
+                    self, path.relative_to(settings.ARCHIVE_PATH).as_posix()
+                )
 
 
 backends: Dict[str, Type[ArchiveBackend]] = {

--- a/zavod/zavod/cli/etl.py
+++ b/zavod/zavod/cli/etl.py
@@ -76,7 +76,7 @@ def publish(dataset_path: Path, latest: bool = False) -> None:
     dataset = _load_dataset(dataset_path)
     make_version(dataset, settings.RUN_VERSION, append_new_version_to_history=False)
     try:
-        publish_dataset(dataset, latest=latest)
+        publish_dataset(dataset, republish_to_latest=latest)
     except Exception:
         log.exception("Failed to publish: %s" % dataset_path)
         sys.exit(1)
@@ -134,7 +134,7 @@ def run(
         export_dataset(dataset, view)
         # Set the version as successful in the version file, which will be archived by publish_dataset.
         set_last_successful_version(dataset, settings.RUN_VERSION)
-        publish_dataset(dataset, latest=latest)
+        publish_dataset(dataset, republish_to_latest=latest)
 
         if not dataset.is_collection and dataset.model.load_statements:
             log.info("Loading dataset into database...", dataset=dataset.name)

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -1,9 +1,10 @@
 from rigour.mime.types import JSON
 
+from zavod.archive.backend import get_archive_backend
 from zavod.exporters.metadata import DatasetVersionResult
 from zavod.meta import Dataset
 from zavod.logs import get_logger
-from zavod.archive import publish_resource, dataset_resource_path
+from zavod.archive import DATASETS, LATEST, publish_resource, dataset_resource_path
 from zavod.archive import publish_dataset_version, publish_artifact
 from zavod.archive import INDEX_FILE, CATALOG_FILE
 from zavod.archive import STATEMENTS_FILE, RESOURCES_FILE, STATISTICS_FILE
@@ -34,7 +35,7 @@ def _archive_artifacts(dataset: Dataset) -> None:
     publish_dataset_version(dataset.name)
 
 
-def publish_dataset(dataset: Dataset, latest: bool = True) -> None:
+def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
     """Publish a dataset to the archive, i.e. to /datasets."""
     resources = DatasetResources(dataset)
     for resource in resources.all():
@@ -52,20 +53,48 @@ def publish_dataset(dataset: Dataset, latest: bool = True) -> None:
             path,
             dataset.name,
             resource.name,
-            latest=latest,
+            republish_to_latest=republish_to_latest,
             mime_type=resource.mime_type,
         )
-    files = [INDEX_FILE]
+    meta_files = [INDEX_FILE]
     if dataset.is_collection:
-        files.extend([CATALOG_FILE])
-    for meta in files:
-        path = dataset_resource_path(dataset.name, meta)
+        meta_files.extend([CATALOG_FILE])
+    for meta_file in meta_files:
+        path = dataset_resource_path(dataset.name, meta_file)
         if not path.is_file():
             log.error("Metadata file not found: %s" % path, dataset=dataset.name)
             continue
-        mime_type = JSON if meta.endswith(".json") else None
-        publish_resource(path, dataset.name, meta, latest=latest, mime_type=mime_type)
+        mime_type = JSON if meta_file.endswith(".json") else None
+        publish_resource(
+            path,
+            dataset.name,
+            meta_file,
+            republish_to_latest=republish_to_latest,
+            mime_type=mime_type,
+        )
+
+    if republish_to_latest:
+        all_published_files = set(meta_files) | {r.name for r in resources.all()}
+        _warn_about_stale_latest_files(dataset, all_published_files)
+
     _archive_artifacts(dataset)
+
+
+def _warn_about_stale_latest_files(dataset: Dataset, published_files: set[str]) -> None:
+    """Warn about files in datasets/latest/<dataset>/ that we no longer publish
+    so we can clean them up by hand. We don't delete automatically because
+    deleting from the bucket is scary."""
+    backend = get_archive_backend()
+    latest_prefix = f"{DATASETS}/{LATEST}/{dataset.name}/"
+    for object in backend.list_objects(latest_prefix):
+        basename = object.name[len(latest_prefix) :]
+        if basename not in published_files:
+            log.warning(
+                f"Stale file in datasets/latest/{dataset.name}: {basename}",
+                dataset=dataset.name,
+                object=object.name,
+                updated_at=object.updated_at().isoformat(),
+            )
 
 
 def archive_failure(dataset: Dataset, latest: bool = True) -> None:

--- a/zavod/zavod/tests/test_archive.py
+++ b/zavod/zavod/tests/test_archive.py
@@ -19,12 +19,12 @@ def test_archive_publish(testdataset1: Dataset):
         fh.write("hello, world!\n")
     archive_path = dataset_archive_path / settings.RELEASE / testdataset1.name / name
     assert not archive_path.exists()
-    publish_resource(local_path, testdataset1.name, name, latest=False)
+    publish_resource(local_path, testdataset1.name, name, republish_to_latest=False)
     assert archive_path.exists()
 
     latest_path = dataset_archive_path / "latest" / testdataset1.name / name
     assert not latest_path.exists()
-    publish_resource(local_path, testdataset1.name, name, latest=True)
+    publish_resource(local_path, testdataset1.name, name, republish_to_latest=True)
     assert latest_path.exists()
 
     backend = get_archive_backend()

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -39,7 +39,7 @@ def test_publish_dataset(testdataset1: Dataset):
     view = store.view(testdataset1)
     export_dataset(testdataset1, view)
 
-    publish_dataset(testdataset1, latest=False)
+    publish_dataset(testdataset1, republish_to_latest=False)
     history = _read_history(testdataset1.name)
     assert history is not None
     assert history.latest is not None
@@ -57,7 +57,7 @@ def test_publish_dataset(testdataset1: Dataset):
     assert not latest_path.joinpath(INDEX_FILE).exists()
     assert release_path.joinpath("entities.ftm.json").exists()
 
-    publish_dataset(testdataset1, latest=True)
+    publish_dataset(testdataset1, republish_to_latest=True)
     assert latest_path.joinpath(INDEX_FILE).exists()
 
     # Test backfill:


### PR DESCRIPTION
## Summary

Refs https://github.com/opensanctions/opensanctions/issues/3781.

After republishing a dataset to `datasets/latest/`, list the files already there and emit a warning for anything we no longer publish so we can clean them up by hand. We don't delete automatically because deleting from the bucket is scary.

Adds `ArchiveBackend.list_objects(prefix)` and `ArchiveObject.updated_at()` so the warning can include the file's last-modified timestamp. Also renames the `latest` kwarg on `publish_dataset`/`publish_resource` to `republish_to_latest` for clarity and introduces a `LATEST` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)