### PR TITLE
Add a 2pm CET run of the issues agent

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -5,6 +5,10 @@ name: Issues agent
   workflow_dispatch: {}
   schedule:
     - cron: "0 3 * * 1-5"
+    # 12:00 UTC = 14:00 CEST (summer) / 13:00 CET (winter). GHA cron is always
+    # UTC and ignores DST, so this lands at 2pm Central European time only
+    # during summer time; in winter it runs an hour earlier.
+    - cron: "0 12 * * 1-5"
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds a second weekday schedule so the issues agent also runs in the early afternoon (when maintainers are around to review its PRs), keeping the existing 03:00 UTC run.

```
- cron: "0 3 * * 1-5"
- cron: "0 12 * * 1-5"   # new
```

**On the time:** GitHub Actions cron is **always UTC and ignores DST**, so there's no single value that's 2pm CET year-round. `12:00 UTC` = **14:00 CEST** (summer, current) / **13:00 CET** (winter). I picked the value that hits 2pm *now*; in winter it'll run an hour earlier. If you'd rather it be 2pm in winter (3pm in summer), use `0 13 * * 1-5`.

Notes:
- Kept the existing 03:00 run; I read "another run" as additive. Happy to drop it if you'd rather just move the agent to the afternoon.
- The extra daily run is cheap now that idempotence skips any dataset with an open `autofix/` PR (#4472).
- Schedule changes only take effect once merged to `main`; for an immediate run, use the **Run workflow** (workflow_dispatch) button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)