### PR TITLE
[au_parliament] Australia Members of Parliament (Federal) PEP crawler

### DIFF
--- a/datasets/au/parliament/au_parliament.yml
+++ b/datasets/au/parliament/au_parliament.yml
@@ -1,0 +1,61 @@
+title: Australia Members of Parliament
+entry_point: crawler.py
+prefix: au-parl
+coverage:
+  frequency: weekly
+  start: 2026-06-10
+load_statements: true
+ci_test: false # live external API, ~1.9k people
+summary: >-
+  Current and recent members of the Australian federal Parliament (House of
+  Representatives and Senate)
+description: |
+  Senators and Members of the House of Representatives of the Parliament of
+  Australia. The data is sourced from the Parliamentary Handbook, the official
+  biographical reference maintained by the Australian Parliamentary Library,
+  via its public API. The handbook covers all parliamentarians since Federation
+  (1901); a person is emitted when at least one of their parliamentary terms
+  still qualifies them as a politically exposed person.
+url: https://handbook.aph.gov.au/
+publisher:
+  name: Parliament of Australia
+  description: |
+    The federal bicameral legislature of Australia, consisting of the Monarch,
+    the Senate (76 seats) and the House of Representatives (150 seats). The
+    Parliamentary Handbook is maintained by the Parliamentary Library within
+    the Department of Parliamentary Services.
+  country: au
+  url: https://www.aph.gov.au/
+  official: true
+data:
+  url: https://handbookapi.aph.gov.au/api/individuals
+  format: JSON
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 400
+      Position: 2
+    country_entities:
+      au: 400
+  max:
+    schema_entities:
+      Person: 900
+
+lookups:
+  type.country:
+    options:
+      # 1918-1929 official name of the state that became Yugoslavia
+      - match: The Kingdom of Serbs, Croats and Slovenes
+        value: yucs
+  type.gender:
+    normalize: true
+    options:
+      - match: Male
+        value: male
+      - match: Female
+        value: female

--- a/datasets/au/parliament/crawler.py
+++ b/datasets/au/parliament/crawler.py
@@ -19,7 +19,6 @@ ONGOING = "1900-01-01"
 INDIVIDUAL_IGNORE = [
     "Age",
     "Age_String",
-    "DisplayName",
     "ElectedMemberNo",
     "ElectedSenatorNo",
     "Electorate",
@@ -32,7 +31,6 @@ INDIVIDUAL_IGNORE = [
     "InCurrentParliament",
     "MPorSenator",
     "MaritalStatus",
-    "Occupations",
     "ParliamentaryPositions",
     "PartyAbbrev",
     "PartyParliamentaryService",
@@ -122,6 +120,8 @@ def crawl_member(
             context.log.warning(
                 "Unexpected PreferredName shape", phid=phid, value=preferred
             )
+    # The handbook's formatted name, e.g. "ALBANESE, the Hon. Anthony Norman".
+    person.add("alias", record.pop("DisplayName") or None)
 
     h.apply_date(person, "birthDate", record.pop("DateOfBirth") or None)
     h.apply_date(person, "deathDate", record.pop("DateOfDeath") or None)
@@ -130,6 +130,8 @@ def crawl_member(
     person.add("birthCountry", record.pop("CountryOfBirth") or None)
     person.add("gender", record.pop("Gender") or None)
     person.add("political", record.pop("Party") or None)
+    # Pre-parliamentary career entries, as prose ("Lawyer from 2007 to 2012.").
+    person.add("profession", record.pop("Occupations") or None)
     # Commonwealth Electoral Act 1918 s 163(1)(b) requires members of either federal
     # chamber to be Australian citizens; Constitution s 44(i) bars foreign citizens.
     # https://www.legislation.gov.au/C1918A00027/latest/text

--- a/datasets/au/parliament/crawler.py
+++ b/datasets/au/parliament/crawler.py
@@ -1,0 +1,214 @@
+from collections import defaultdict
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The Parliamentary Handbook (handbook.aph.gov.au) is backed by this open OData API.
+# It covers every parliamentarian since Federation (1901); make_occupancy gates each
+# term on PEP duration, so only current and recently-ended terms survive.
+API = "https://handbookapi.aph.gov.au/api"
+# The API's sentinel date meaning "still in progress" on term end dates.
+ONGOING = "1900-01-01"
+
+# Biographical, career-summary and presentation fields we deliberately don't extract.
+# MPorSenator and the Represented*/ElectorateService/ServiceHistory_* aggregates are
+# career-scope rollups; the per-term service records are the source of truth instead.
+INDIVIDUAL_IGNORE = [
+    "Age",
+    "Age_String",
+    "DisplayName",
+    "ElectedMemberNo",
+    "ElectedSenatorNo",
+    "Electorate",
+    "ElectorateService",
+    "FirstNations",
+    "FirstNationsOption",
+    "FirstNationsText",
+    "Honours",
+    "Image",
+    "InCurrentParliament",
+    "MPorSenator",
+    "MaritalStatus",
+    "Occupations",
+    "ParliamentaryPositions",
+    "PartyAbbrev",
+    "PartyParliamentaryService",
+    "PlaceOfDeath",
+    "PortraitNote",
+    "Qualifications",
+    "RepresentedElectorates",
+    "RepresentedMinistries",
+    "RepresentedParliaments",
+    "RepresentedParties",
+    "RepresentedShadowMinistries",
+    "RepresentedStates",
+    "SecondaryOccupations",
+    "SecondarySchool",
+    "SenateState",
+    "ServiceHistory_Days",
+    "ServiceHistory_Duration",
+    "ServiceHistory_End",
+    "ServiceHistory_Start",
+    "State",
+    "StateAbbrev",
+    "StateOfDeath",
+    "StateOrTerritory",
+]
+SERVICE_IGNORE = [
+    "OBY",
+    "PHID",
+    "DisplayName",
+    "ROSTypeID",
+    "ValueAbbrev1",
+    "Text1",
+    "Text2",
+    "Text3",
+    "Value3",
+]
+
+
+def fetch_collection(
+    context: Context, resource: str, query: dict[str, str]
+) -> list[dict[str, Any]]:
+    params = dict(query)
+    params["$count"] = "true"
+    data = context.fetch_json(f"{API}/{resource}", params=params, cache_days=1)
+    records: list[dict[str, Any]] = data["value"]
+    # The API currently returns each collection in a single response. If server-side
+    # paging is ever enabled, fail rather than silently crawl a truncated dataset.
+    if "@odata.nextLink" in data:
+        raise ValueError(f"OData response for {resource} is paginated")
+    if len(records) != data["@odata.count"]:
+        raise ValueError(
+            f"OData response for {resource} is truncated: "
+            f"{len(records)} of {data['@odata.count']}"
+        )
+    return records
+
+
+def crawl_member(
+    context: Context,
+    positions: dict[str, tuple[Entity, PositionCategorisation]],
+    record: dict[str, Any],
+    terms: list[dict[str, Any]],
+) -> None:
+    phid = record.pop("PHID")
+    person = context.make("Person")
+    person.id = context.make_slug("person", phid)
+
+    # pop without a default: a renamed/removed field crashes here rather than silently
+    # dropping data, and audit_data surfaces any newly added field.
+    family_name = record.pop("FamilyName")
+    h.apply_name(
+        person,
+        first_name=record.pop("GivenName"),
+        middle_name=record.pop("MiddleNames") or None,
+        last_name=family_name,
+    )
+    preferred = record.pop("PreferredName")
+    if preferred:
+        # Always a parenthesised nickname, e.g. "(Tony)" on Anthony ABBOTT.
+        if preferred.startswith("(") and preferred.endswith(")"):
+            h.apply_name(
+                person,
+                first_name=preferred[1:-1],
+                last_name=family_name,
+                alias=True,
+            )
+        else:
+            context.log.warning(
+                "Unexpected PreferredName shape", phid=phid, value=preferred
+            )
+
+    h.apply_date(person, "birthDate", record.pop("DateOfBirth") or None)
+    h.apply_date(person, "deathDate", record.pop("DateOfDeath") or None)
+    birth_parts = [record.pop("PlaceOfBirth"), record.pop("StateOfBirth")]
+    person.add("birthPlace", ", ".join(p for p in birth_parts if p) or None)
+    person.add("birthCountry", record.pop("CountryOfBirth") or None)
+    person.add("gender", record.pop("Gender") or None)
+    person.add("political", record.pop("Party") or None)
+    # Commonwealth Electoral Act 1918 s 163(1)(b) requires members of either federal
+    # chamber to be Australian citizens; Constitution s 44(i) bars foreign citizens.
+    # https://www.legislation.gov.au/C1918A00027/latest/text
+    person.add("citizenship", "au")
+    person.add("sourceUrl", f"https://handbook.aph.gov.au/Parliamentarian/{phid}")
+    context.audit_data(record, ignore=INDIVIDUAL_IGNORE)
+
+    has_occupancy = False
+    for term in terms:
+        chamber = term.pop("MpOrSenator")
+        if chamber not in positions:
+            raise ValueError(f"Unexpected MpOrSenator value: {chamber!r}")
+        position, categorisation = positions[chamber]
+        # The secondary date pair is unused by the source (always the sentinel); a real
+        # value would be a second service period we'd otherwise drop.
+        if term.pop("DateStart2") != ONGOING or term.pop("DateEnd2") != ONGOING:
+            raise ValueError(f"Unexpected secondary service period for {phid}")
+        end_date = term.pop("DateEnd1")
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            categorisation=categorisation,
+            start_date=term.pop("DateStart1"),
+            end_date=None if end_date == ONGOING else end_date,
+        )
+        state = term.pop("Value1")
+        electorate = term.pop("Value2")
+        if occupancy is not None:
+            # House members sit for an electorate, senators for a state.
+            occupancy.add("constituency", electorate or state)
+            context.emit(occupancy)
+            has_occupancy = True
+        context.audit_data(term, ignore=SERVICE_IGNORE)
+
+    if has_occupancy:
+        context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    house = h.make_position(
+        context,
+        name="Member of the Australian House of Representatives",
+        country="au",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q18912794",
+    )
+    senate = h.make_position(
+        context,
+        name="Member of the Australian Senate",
+        country="au",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q6814428",
+    )
+    positions: dict[str, tuple[Entity, PositionCategorisation]] = {}
+    for chamber, position in (("Member", house), ("Senator", senate)):
+        categorisation = categorise(context, position, default_is_pep=True)
+        context.emit(position)
+        positions[chamber] = (position, categorisation)
+
+    # ROSTypeID 9 = "Parliamentary Service": one row per elected term, with chamber.
+    service = fetch_collection(
+        context, "recordsofservice", {"$filter": "ROSTypeID eq 9"}
+    )
+    terms_by_phid: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in service:
+        terms_by_phid[row["PHID"]].append(row)
+
+    for record in fetch_collection(context, "individuals", {}):
+        terms = terms_by_phid.pop(record["PHID"], [])
+        if not terms:
+            context.log.info(
+                "Individual without parliamentary service records", phid=record["PHID"]
+            )
+            continue
+        crawl_member(context, positions, record, terms)
+
+    if terms_by_phid:
+        context.log.warning(
+            "Parliamentary service records without a matching individual",
+            phids=sorted(terms_by_phid.keys()),
+        )


### PR DESCRIPTION
Adds a PEP crawler for the Australian federal Parliament (House of Representatives + Senate), resolving opensanctions/crawler-planning#645.

## Source

The Parliamentary Handbook (handbook.aph.gov.au), the official biographical reference maintained by the Parliamentary Library, is backed by an open, unauthenticated OData API at `handbookapi.aph.gov.au/api`. This sidesteps both the anti-bot protection on www.aph.gov.au and the CC-BY-SA licensing problem with OpenAustralia flagged in the issue. Crown copyright, official publisher.

The whole crawl is two bulk requests:
- `GET /api/individuals` — all 1,879 parliamentarians since Federation (1901): names, DOB/DOD, birthplace, gender, party
- `GET /api/recordsofservice?$filter=ROSTypeID eq 9` — 7,419 dated per-term "Parliamentary Service" rows with chamber, state and electorate

## Modelling

- Two positions: *Member of the Australian House of Representatives* (Q18912794) and *Member of the Australian Senate* (Q6814428), both `gov.national` + `gov.legislative`, `default_is_pep=True`
- One occupancy per service term, mapped to a position via the per-term chamber field (10 current members have served in both chambers, so the person-level chamber field can't be used); `make_occupancy` gates old terms
- `citizenship: au` — Commonwealth Electoral Act 1918 s 163(1)(b) requires Australian citizenship for either chamber; Constitution s 44(i) bars foreign citizens
- Electorate (House) / state (Senate) recorded as `Occupancy:constituency`

## Fail-loud guards

- Crash on `@odata.nextLink` or a `$count` mismatch, so future server-side paging can't silently truncate the crawl
- Crash on an unexpected per-term chamber value, or if the source starts using the (currently always-sentinel) secondary date pair
- `dict.pop()` + `audit_data` on both record types

## Results

607 Persons / 2 Positions / 1,660 Occupancies; exactly 226 occupancies have status `current`, matching the sitting membership (150 MPs + 76 senators). Empty `issues.log`, `zavod validate` passes, `mypy --strict` clean, and referential-integrity spot checks on `statements.pack` (post/holder references, role.pep ↔ occupancy, PEP country) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)