### PR TITLE
[au_parliament] Lower entity-count assertion floors to match actual output

### DIFF
--- a/datasets/au/parliament/au_parliament.yml
+++ b/datasets/au/parliament/au_parliament.yml
@@ -38,10 +38,10 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 400
+      Person: 250
       Position: 2
     country_entities:
-      au: 400
+      au: 250
   max:
     schema_entities:
       Person: 900


### PR DESCRIPTION
The `min` assertions floored `Person` and `au` entities at 400, but the crawler actually emits ~326/328 — only handbook records whose parliamentary terms still qualify them as PEPs (the `~1.9k people` figure was the total handbook record count, not the qualifying subset).

This was surfaced as assertion failures on https://www.opensanctions.org/issues/au_parliament/:

- `Assertion schema_entities failed for Person: 326 is not >= threshold 400`
- `Assertion country_entities failed for au: 328 is not >= threshold 400`

Lower both `min` floors from 400 → 250, leaving buffer below the observed counts to absorb normal churn (members aging out of the PEP window, new terms). `max` stays at 900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)