### PR TITLE
[ann_graph_topics] Document propagation mechanism and external/internal semantics

### DIFF
--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -1,3 +1,62 @@
+"""Propagate risk topics across the entity graph by relationship adjacency.
+
+Sanctions lists and PEP registers flag individual entities, but risk rarely
+stops at the named entity: the spouse of a PEP, a subsidiary of a sanctioned
+company, or a vessel owned through several ownership tiers all carry derived
+risk. This analyzer walks the resolved graph and emits topic patches that
+capture that derived risk so the affected entities become visible to screening
+(and eligible for further enrichment). It implements the "risk propagation"
+step of the enrichment pipeline.
+
+Three propagation rules are applied per entity:
+
+- ``role.rca`` — a Person reachable via a ``Family`` edge from a ``role.pep``
+  is tagged as a relative or close associate.
+- ``sanction.linked`` — an entity adjacent to a ``sanction`` entity through a
+  curated set of edge schemata (Ownership, Directorship, Membership,
+  Employment, Associate, Family, Succession), plus Securities issued by a
+  sanctioned entity, is tagged as sanction-linked.
+- ``sanction.linked`` along ownership chains — an asset owned by an already
+  ``sanction.linked`` owner is itself tagged, pushing the tag one ownership hop
+  further on each run.
+
+Requirements and invariants that make this correct:
+
+- **Self-exclusion.** ``non_graph_topics`` ignores topic statements contributed
+  by this dataset itself, so a tag this analyzer emits does not, on its own,
+  re-trigger the rules that produced it. The one deliberate exception is the
+  ownership-chain rule, which reads prior ``sanction.linked`` values from the
+  store in order to walk one hop at a time.
+- **Iterative convergence.** Because ownership propagation advances a single hop
+  per run, a multi-tier corporate hierarchy only materializes over successive
+  runs. The dataset must be re-run for the graph to converge; a single pass is
+  not sufficient.
+- **External vs. internal, and why the view is ``external=True``.** A statement
+  is "external" when it is excluded from the published ``default`` exports.
+  Enrichers emit adjacency "passengers" — entities pulled in only because they
+  sit next to a match, carrying no risk topic of their own — as external, so
+  they drop out of ``default`` rather than bloating it (without this, untagged
+  enrichment passengers are roughly a quarter of all matchable entities). This
+  analyzer reads the store with ``external=True`` precisely so it can *see*
+  those passengers and apply the rules to them; with an internal-only view it
+  would be blind to exactly the entities it needs to evaluate.
+- **Patches inherit the related entity's external-ness.** A patch is emitted
+  internal iff the related entity already has at least one internal statement
+  (``Entity.external`` is true only when *every* statement is external),
+  otherwise external. So a derived topic on a genuinely published entity is
+  published, while a topic on a purely-external passenger stays external. Either
+  way the topic is visible in the ``external=True`` view and continues to feed
+  the next ownership hop — but tagging a passenger does not, on its own, force
+  it into the published export.
+- **Edge end dates terminate propagation.** Relationships carrying an
+  ``endDate`` are skipped: a former director or ex-spouse does not propagate
+  risk.
+- **Output is a patch dataset.** Each rule emits a minimal patch carrying only
+  the new topic (reduced to ``LegalEntity`` for legal-entity subtypes so stale
+  annotations don't pin a more specific schema); these are merged into the
+  target entities downstream rather than replacing them.
+"""
+
 from typing import Set
 
 from followthemoney import registry


### PR DESCRIPTION
Adds a module-level docstring to the `ann_graph_topics` analyzer. No behaviour change.

The analyzer is the risk-propagation step of the enrichment pipeline, but the rules and (especially) the external/internal semantics adopted in operations#2583 weren't documented in the code. The docstring captures:

- **Why it exists** — derived risk (RCAs, sanction-linked subsidiaries, ownership chains) doesn't stop at the named entity.
- **The three propagation rules** — `role.rca` via Family edges, `sanction.linked` via the curated edge schemata + sanctioned-issuer Securities, and the one-hop-per-run ownership-chain walk.
- **The non-obvious invariants** — self-exclusion via `non_graph_topics`, iterative convergence over successive runs, endDate terminating propagation, and the patch-dataset output shape.
- **External/internal semantics** — why the store view is `external=True` (so enrichment passengers are visible to the rules), and how each patch inherits the related entity's external-ness so untagged passengers stay out of `default` while still feeding the next propagation hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)