### PR TITLE
[au_nt_parliament] Add Northern Territory Legislative Assembly PEP crawler

### DIFF
--- a/datasets/au/nt_parliament/au_nt_parliament.yml
+++ b/datasets/au/nt_parliament/au_nt_parliament.yml
@@ -1,0 +1,51 @@
+title: Australia Northern Territory Legislative Assembly
+prefix: au-ntparl
+entry_point: crawler.py
+coverage:
+  frequency: weekly
+  start: "2026-06-11"
+load_statements: true
+ci_test: false
+
+summary: >
+  Current members (MLAs) of the unicameral Northern Territory Legislative
+  Assembly, as published on the Assembly website.
+
+description: |
+  The Northern Territory Legislative Assembly is the unicameral legislature of
+  the Northern Territory, Australia. It has 25 members (MLAs), each elected to a
+  single-member electorate (division) for a four-year term. The roster is updated
+  between elections as casual vacancies are filled by by-election. This dataset
+  covers the current members listed on the Assembly's website, with each member's
+  electorate and party affiliation.
+
+url: https://parliament.nt.gov.au/members/by-name
+
+publisher:
+  name: Northern Territory Legislative Assembly
+  description: >
+    The unicameral legislature of the Northern Territory, Australia, comprising
+    25 elected Members of the Legislative Assembly (MLAs).
+  url: https://parliament.nt.gov.au/
+  country: au
+  official: true
+
+data:
+  url: https://parliament.nt.gov.au/members/by-name
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 20
+      Position: 1
+    country_entities:
+      au: 20
+  max:
+    schema_entities:
+      Person: 30
+      Position: 1

--- a/datasets/au/nt_parliament/au_nt_parliament.yml
+++ b/datasets/au/nt_parliament/au_nt_parliament.yml
@@ -3,7 +3,7 @@ prefix: au-ntparl
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: "2026-06-11"
+  start: "2026-06-15"
 load_statements: true
 ci_test: false
 
@@ -14,7 +14,7 @@ summary: >
 description: |
   The Northern Territory Legislative Assembly is the unicameral legislature of
   the Northern Territory, Australia. It has 25 members (MLAs), each elected to a
-  single-member electorate (division) for a four-year term. The roster is updated
+  single-member electorate for a four-year term. The roster is updated
   between elections as casual vacancies are filled by by-election. This dataset
   covers the current members listed on the Assembly's website, with each member's
   electorate and party affiliation.

--- a/datasets/au/nt_parliament/crawler.py
+++ b/datasets/au/nt_parliament/crawler.py
@@ -1,0 +1,101 @@
+from urllib.parse import urlparse
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.extract import zyte_api
+from zavod.util import Element
+
+MEMBERS_URL = "https://parliament.nt.gov.au/members/by-name"
+# Member anchors live in the left-hand sub-navigation of the listing page.
+MEMBER_LINKS = (
+    '//div[contains(@class, "sub-subnav")]/a[contains(@href, "/members/by-name/")]'
+)
+
+
+def clean_member_name(name: str) -> str:
+    """Drop the leading "Hon"/"The Hon" courtesy style; keep the rest verbatim.
+
+    "(The) Honourable" is a parliamentary courtesy title applied to ministers and
+    members, not part of the personal name; post-nominals (e.g. OAM) are kept.
+    """
+    for prefix in ("The Hon ", "Hon "):
+        if name.startswith(prefix):
+            return name[len(prefix) :].strip()
+    return name
+
+
+def detail_field(detail: Element, label: str) -> str | None:
+    """Return the value cell of the label/value row whose <th> equals `label`."""
+    for row in h.xpath_elements(detail, "//tr[th and td]"):
+        th = h.element_text(h.xpath_elements(row, "./th")[0])
+        if th == label:
+            return h.element_text(h.xpath_elements(row, "./td")[0]) or None
+    return None
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    name: str,
+    slug: str,
+    detail_url: str,
+) -> None:
+    detail = zyte_api.fetch_html(
+        context, detail_url, unblock_validator=".//tr[th]", cache_days=7
+    )
+    electorate = detail_field(detail, "Electorate")
+    party = detail_field(detail, "Party")
+    if electorate is None or party is None:
+        context.log.warning("Member detail missing electorate/party", url=detail_url)
+
+    person = context.make("Person")
+    person.id = context.make_slug("member", slug)
+    person.add("name", clean_member_name(name))
+    person.add("political", party)
+    person.add("sourceUrl", detail_url)
+    # Australian citizenship is a legal precondition for an NT MLA, via delegation:
+    # Electoral Act 2004 (NT) ss 21 & 32(1)(e) -> Self-Government Act 1978 (Cth) s14
+    # -> Commonwealth Electoral Act 1918 (Cth) s93.
+    # https://legislation.nt.gov.au/en/Legislation/ELECTORAL-ACT-2004
+    person.add("citizenship", "au")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", electorate)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Legislative Assembly of the Northern Territory",
+        country="au",
+        subnational_area="Northern Territory",
+        wikidata_id="Q26998278",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    doc = zyte_api.fetch_html(
+        context,
+        MEMBERS_URL,
+        unblock_validator=MEMBER_LINKS,
+        absolute_links=True,
+        cache_days=1,
+    )
+    anchors = h.xpath_elements(doc, MEMBER_LINKS)
+    if not (20 <= len(anchors) <= 30):
+        # 25 seats; a wild count means the listing layout changed.
+        context.log.warning("Unexpected member count", count=len(anchors))
+    for anchor in anchors:
+        name = h.element_text(anchor)
+        detail_url = h.xpath_strings(anchor, "./@href")[0]
+        slug = urlparse(detail_url).path.rstrip("/").rsplit("/", 1)[-1]
+        crawl_member(context, position, categorisation, name, slug, detail_url)


### PR DESCRIPTION
Closes opensanctions/crawler-planning#669

Adds a PEP crawler for the **Northern Territory Legislative Assembly** (Australia), covering the 25 current members (MLAs) of the unicameral chamber.

## Source
- Listing: https://parliament.nt.gov.au/members/by-name
- Behind a Cloudflare managed challenge → fetched via the **Zyte API** (`ci_test: false`, like `tas_parliament`/`act_parliament`).
- The listing yields the slug→name roster (25 anchors); each member's detail page provides their **electorate** and **party**.

## Modelling
- **One Position:** "Member of the Legislative Assembly of the Northern Territory", `subnationalArea=Northern Territory`, Wikidata `Q26998278` (the office, not the institution).
- One **open current Occupancy** per member (the source carries no term/elected date), `constituency` = electorate.
- `Person.political` = party; `citizenship=au` (legally required for an NT MLA via Electoral Act 2004 (NT) ss 21 & 32(1)(e) → Self-Government Act 1978 (Cth) s14 → Commonwealth Electoral Act 1918 (Cth) s93 — cited in a code comment).
- Names: leading "Hon"/"The Hon" courtesy title stripped; post-nominals (e.g. OAM) kept verbatim.

## Verification
- Crawl: **51 entities** (1 Position + 25 Person + 25 Occupancy), 280 statements, **0 issues**.
- `mypy --strict`, `zavod validate` (assertions), and the PEP qsv integrity checks all pass.
- Party split 17 CLP / 5 Labor / 3 Independent matches the 2024 NT general election.

🤖 Generated with [Claude Code](https://claude.com/claude-code)