### PR TITLE
[au_wa_parliament] Add Parliament of Western Australia PEP crawler

### DIFF
--- a/datasets/au/wa_parliament/au_wa_parliament.yml
+++ b/datasets/au/wa_parliament/au_wa_parliament.yml
@@ -1,4 +1,4 @@
-title: Australia Parliament of Western Australia
+title: Australia State Parliament of Western Australia
 prefix: au-waparl
 entry_point: crawler.py
 coverage:
@@ -16,9 +16,9 @@ description: |
   Western Australia, Australia. This dataset covers the current members of both
   houses, as published on the Parliament's website:
 
-  - The Legislative Assembly (lower house), with 59 members each elected to a
+  - The Legislative Assembly (lower house), with each member elected to a
     single-member district.
-  - The Legislative Council (upper house), with 37 members elected from a single
+  - The Legislative Council (upper house), with each member elected from a single
     state-wide electorate by single transferable vote (since the 2025 reform).
 
   The roster is updated between elections as casual vacancies are filled — by

--- a/datasets/au/wa_parliament/au_wa_parliament.yml
+++ b/datasets/au/wa_parliament/au_wa_parliament.yml
@@ -1,0 +1,56 @@
+title: Australia Parliament of Western Australia
+prefix: au-waparl
+entry_point: crawler.py
+coverage:
+  frequency: weekly
+  start: "2026-06-12"
+load_statements: true
+ci_test: false
+
+summary: >
+  Current members of both houses of the Parliament of Western Australia — the
+  Legislative Assembly and the Legislative Council.
+
+description: |
+  The Parliament of Western Australia is the bicameral state legislature of
+  Western Australia, Australia. This dataset covers the current members of both
+  houses, as published on the Parliament's website:
+
+  - The Legislative Assembly (lower house), with 59 members each elected to a
+    single-member district.
+  - The Legislative Council (upper house), with 37 members elected from a single
+    state-wide electorate by single transferable vote (since the 2025 reform).
+
+  The roster is updated between elections as casual vacancies are filled — by
+  by-election in the Assembly, by count-back in the Council.
+
+url: https://www.parliament.wa.gov.au/parliament/memblist.nsf/WAllMembers
+
+publisher:
+  name: Parliament of Western Australia
+  description: >
+    The bicameral state legislature of Western Australia, Australia, comprising
+    the Legislative Assembly (59 members) and the Legislative Council (37 members).
+  url: https://www.parliament.wa.gov.au/
+  country: au
+  official: true
+
+data:
+  url: https://www.parliament.wa.gov.au/parliament/memblist.nsf/WAllMembers
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 80
+      Position: 2
+    country_entities:
+      au: 80
+  max:
+    schema_entities:
+      Person: 115
+      Position: 2

--- a/datasets/au/wa_parliament/crawler.py
+++ b/datasets/au/wa_parliament/crawler.py
@@ -1,0 +1,126 @@
+import re
+from urllib.parse import unquote_plus, urlparse
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.extract import zyte_api
+from zavod.util import Element
+
+MEMBERS_URL = "https://www.parliament.wa.gov.au/parliament/memblist.nsf/WAllMembers"
+# All 96 members (both houses) are listed in one table; each Member cell is an
+# anchor into the WAllMembersFlat2 Domino view, followed by a "MLA"/"MLC" suffix
+# and a "Party: <abbr>" line.
+MEMBER_LINKS = '//a[contains(@href, "WAllMembersFlat2")]'
+
+# The "MLA"/"MLC" suffix after the member anchor selects the chamber/position.
+CHAMBERS: dict[str, dict[str, str]] = {
+    "MLA": {
+        "name": "Member of the Western Australian Legislative Assembly",
+        "wikidata_id": "Q20165902",
+    },
+    "MLC": {
+        "name": "Member of the Western Australian Legislative Council",
+        "wikidata_id": "Q19627913",
+    },
+}
+
+# The chamber token sits in the anchor's tail, sometimes after a post-nominal
+# (e.g. "CSC, MLA"), so match it rather than comparing the whole tail.
+SUFFIX_RE = re.compile(r"\b(MLA|MLC)\b")
+PARTY_RE = re.compile(r"Party:\s*(.+)$")
+NICKNAME_RE = re.compile(r"\(([^)]+)\)")
+
+
+def parse_name(profile_url: str) -> tuple[str, str, str | None]:
+    """Return (first_name, last_name, preferred_name) from the URL key.
+
+    The Domino profile-link key is "Surname,+Firstname", sometimes with a
+    preferred name in parentheses ("Kent,+Alison+(Ali)"). We read the name from
+    the key because it is properly cased, unlike the visible anchor which
+    uppercases the surname. The key is the *display* name only; the entity ID
+    keys on the raw URL instead (see crawl_member).
+    """
+    key = unquote_plus(urlparse(profile_url).path.rstrip("/").rsplit("/", 1)[-1])
+    last_name, _, first_field = key.partition(",")
+    first_field = first_field.strip()
+    nick_match = NICKNAME_RE.search(first_field)
+    preferred = nick_match.group(1).strip() if nick_match else None
+    first_name = (h.remove_bracketed(first_field) or "").strip()
+    return first_name, last_name.strip(), preferred
+
+
+def crawl_member(
+    context: Context,
+    chambers: dict[str, tuple[Entity, PositionCategorisation]],
+    anchor: Element,
+) -> None:
+    profile_url = h.xpath_strings(anchor, "./@href")[0]
+    # The chamber token ("MLA" / "MLC") follows the member anchor.
+    suffix_match = SUFFIX_RE.search(anchor.tail or "")
+    if suffix_match is None:
+        context.log.warning("No chamber suffix", tail=anchor.tail, url=profile_url)
+        return
+    position, categorisation = chambers[suffix_match.group(1)]
+
+    # Row layout: Photo | Member | Electorate | Contact.
+    row_cells = h.xpath_elements(anchor, "./ancestor::tr[1]/td")
+    party_match = PARTY_RE.search(h.element_text(row_cells[1]))
+    party = party_match.group(1).strip() if party_match else None
+    electorate = h.element_text(row_cells[2]) or None
+
+    first_name, last_name, preferred = parse_name(profile_url)
+    person = context.make("Person")
+    # Key on the raw profile URL, not the cleaned name.
+    person.id = context.make_id(profile_url)
+    h.apply_name(person, first_name=first_name, last_name=last_name, lang="eng")
+    if preferred is not None and preferred != first_name:
+        h.apply_name(
+            person, first_name=preferred, last_name=last_name, lang="eng", alias=True
+        )
+    person.add("political", party)
+    person.add("sourceUrl", profile_url)
+    # Australian citizenship is a legal precondition for WA members: enrolment
+    # requires Australian citizenship (Electoral Act 1907 (WA) s 17(1)(a)), and
+    # candidate eligibility is tied to enrolment (s 76A).
+    # https://www.legislation.wa.gov.au/legislation/statutes.nsf/law_a247.html
+    person.add("citizenship", "au")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", electorate)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    chambers: dict[str, tuple[Entity, PositionCategorisation]] = {}
+    for suffix, config in CHAMBERS.items():
+        position = h.make_position(
+            context,
+            name=config["name"],
+            country="au",
+            subnational_area="Western Australia",
+            wikidata_id=config["wikidata_id"],
+        )
+        categorisation = categorise(context, position, default_is_pep=True)
+        context.emit(position)
+        chambers[suffix] = (position, categorisation)
+
+    doc = zyte_api.fetch_html(
+        context,
+        MEMBERS_URL,
+        unblock_validator=MEMBER_LINKS,
+        absolute_links=True,
+        cache_days=1,
+    )
+    anchors = h.xpath_elements(doc, MEMBER_LINKS)
+    if not (80 <= len(anchors) <= 115):
+        # 96 members (59 + 37); a wild count means the listing layout changed.
+        context.log.warning("Unexpected member count", count=len(anchors))
+    for anchor in anchors:
+        crawl_member(context, chambers, anchor)


### PR DESCRIPTION
Closes opensanctions/crawler-planning#666

Adds a PEP crawler for the **Parliament of Western Australia**, covering the current members of both houses (96 total).

## Source
- Member list: https://www.parliament.wa.gov.au/parliament/memblist.nsf/WAllMembers (Lotus Domino view)
- Behind an **Azure WAF JS challenge** → fetched via the **Zyte API** (`ci_test: false`).
- The entire roster (59 MLA + 37 MLC) is in **one table**, fetched in a single request. Member detail pages were checked and add nothing useful (no DOB, dates, or bio), so they aren't fetched.

## Modelling
- **Two Positions:** "Member of the Western Australian Legislative Assembly" (Wikidata `Q20165902`) and "...Legislative Council" (`Q19627913`), both `subnationalArea=Western Australia`. Chamber selected by the `MLA`/`MLC` suffix after each member's name.
- One **open current Occupancy** per member (the source carries no term/elected date); `constituency` = electorate (a district for MLAs, "Western Australia" state-wide for MLCs since the 2025 reform).
- `Person.political` = party abbreviation (ALP, LIB, NAT, …), kept verbatim.
- **Name** read from the properly-cased profile-URL key (the visible anchor uppercases surnames); the parenthetical preferred name (`Alison (Ali)`) is stripped from the primary name and emitted as an **alias** (`Ali Kent`). The **entity ID keys on the raw profile URL** (`make_id`), not on the cleaned name.
- `citizenship=au` — legally required (Electoral Act 1907 (WA) s 17(1)(a) for enrolment, tied to candidacy by s 76A; cited in a code comment).

## Verification
- Crawl: **194 entities** (2 Position + 96 Person + 96 Occupancy), 22 preferred-name aliases, **0 issues**.
- `mypy --strict`, `zavod validate` (assertions), and the PEP qsv integrity checks all pass.
- Party split (ALP 62 / LIB 17 / NAT 8 / GWA 4 / ONP 2 / AJP, AC, LCWA 1 each) matches the post-2025-election composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)