### PR TITLE
Translate Wikidata position labels

### DIFF
--- a/zavod/zavod/shed/trans.py
+++ b/zavod/zavod/shed/trans.py
@@ -45,8 +45,17 @@ names, do not separate them in the output but adhere strictly to the output spec
 """
 POSITION_TRANS_PROMPT = """
 Translate the following public office position label from the language denoted by the
- ISO 639-2 code {code}, returning a JSON object where the key 'eng' has the value in
- English.
+ ISO 639-2 code {code} into English, returning a JSON object where the key 'eng' has
+ the value in English.
+
+Keep place names (countries, cities, regions, administrative areas) intact rather than
+ translating their meaning. Only replace a place name with its established English
+ exonym for very common, widely recognised cases — e.g. "Россия" → "Russia", "Москва"
+ → "Moscow", "Wien" → "Vienna", "München" → "Munich". For anything less obvious, err
+ on the side of keeping the original place name: if it is already in Latin script,
+ keep it verbatim (e.g. "São Paulo" stays "São Paulo", not "Saint Paul"); if it is in
+ a non-Latin script, transliterate it to Latin script rather than translating it
+ (e.g. "Карачаево-Черкесия" → "Karachayevo-Cherkesiya", not "Karachay-Cherkessia").
 """
 
 

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -134,23 +134,28 @@ def wikidata_position(
         # else is the next-best language Wikidata gave us, and we translate it to
         # English. Picking what to translate may get more complex in the future,
         # but for now translating the next-best pick after English works for us.
-        if item.label.lang in ("eng", MULTI_LANG):
+        if item.label.lang in ("eng", MULTI_LANG, None):
             item.label.apply(position, "name", clean=clean_wikidata_name)
-        elif item.label.lang is not None:
-            prompt = make_position_translation_prompt(item.label.lang)
-            for translated in run_translation_prompt(
-                context, prompt, item.label.text
-            ).texts:
-                clean_text = clean_wikidata_name(translated.text)
-                if clean_text is None or clean_text.strip() == "":
-                    continue
-                position.add(
-                    "name",
-                    clean_text,
-                    lang=translated.lang,
-                    original_value=item.label.text,
-                    origin=DEFAULT_MODEL,
-                )
+        else:
+            clean_label_text = clean_wikidata_name(item.label.text)
+            if clean_label_text is not None and clean_label_text.strip() != "":
+                assert item.label.lang is not None
+                prompt = make_position_translation_prompt(item.label.lang)
+                translations = run_translation_prompt(
+                    context, prompt=prompt, text=item.label.text
+                ).texts
+                # if for some reason the translation fails, fall back to the original
+                if len(translations) == 0:
+                    item.label.apply(position, "name", clean=clean_wikidata_name)
+                else:
+                    for translated in translations:
+                        position.add(
+                            "name",
+                            translated.text,
+                            lang=translated.lang,
+                            original_value=item.label.text,
+                            origin=DEFAULT_MODEL,
+                        )
 
     for claim in item.claims:
         if claim.property in ("P1001", "P17", "P27") and claim.qid is not None:

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -2,12 +2,18 @@ from typing import Dict, Optional, Set
 
 from followthemoney import registry
 from nomenklatura.wikidata import Item, WikidataClient, Claim
+from nomenklatura.wikidata.lang import MULTI_LANG
 from nomenklatura.wikidata.value import clean_wikidata_name
 from rigour.territories import get_territory_by_qid
 
 from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.constants import ORIGIN_INFERRED
+from zavod.extract.llm import DEFAULT_MODEL
+from zavod.shed.trans import (
+    make_position_translation_prompt,
+    run_translation_prompt,
+)
 from zavod.stateful.positions import categorise
 from zavod.shed.wikidata.country import is_historical_country, item_countries
 
@@ -121,8 +127,30 @@ def wikidata_position(
     position = context.make("Position")
     position.id = item.id
     position.add("wikidataId", item.id)
-    if item.label is not None:
-        item.label.apply(position, "name", clean=clean_wikidata_name)
+    if item.label is not None and item.label.text is not None:
+        # item.label is picked from the available labels in PREFERRED_WD_LANGS order
+        # (English first, then "mul"/multilingual, then the next-best preferred
+        # language). English and multilingual labels can be used as-is; anything
+        # else is the next-best language Wikidata gave us, and we translate it to
+        # English. Picking what to translate may get more complex in the future,
+        # but for now translating the next-best pick after English works for us.
+        if item.label.lang in ("eng", MULTI_LANG):
+            item.label.apply(position, "name", clean=clean_wikidata_name)
+        elif item.label.lang is not None:
+            prompt = make_position_translation_prompt(item.label.lang)
+            for translated in run_translation_prompt(
+                context, prompt, item.label.text
+            ).texts:
+                clean_text = clean_wikidata_name(translated.text)
+                if clean_text is None or clean_text.strip() == "":
+                    continue
+                position.add(
+                    "name",
+                    clean_text,
+                    lang=translated.lang,
+                    original_value=item.label.text,
+                    origin=DEFAULT_MODEL,
+                )
 
     for claim in item.claims:
         if claim.property in ("P1001", "P17", "P27") and claim.qid is not None:


### PR DESCRIPTION
## Summary

- Translates non-English Wikidata position labels into English using the existing LLM helper (`run_text_prompt`) with a position-specific prompt instead of Google Translate.
- Adds a small `shed/wikidata/debug.py` click tool that prints the statements a single QID would emit through the `_wikidata/peps` helpers — useful for inspecting individual items without running the full crawler.

## Why not Google Translate?

The task is a literal translation of role/office words while keeping place names intact (or transliterated to Latin script when the source isn't Latin). Google Translate treats place names as ordinary words and translates them by meaning — e.g. for `conseiller communautaire des Forêts du Perche` it returns `community councillor for the Perche Forests`, when what we want is closer to `community councillor of Forêts du Perche`. The LLM prompt can express the "keep place names intact, use English exonyms only for very common cases" rule directly, and in spot checks does the right thing.

Statement origin for translated names is the model identifier (matching `apply_translit_names`), so we can re-run when we change models.

Related: https://github.com/opensanctions/opensanctions/issues/2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)