### PR TITLE
[au_sa_parliament] Add Parliament of South Australia PEP crawler

### DIFF
--- a/datasets/au/sa_parliament/au_sa_parliament.yml
+++ b/datasets/au/sa_parliament/au_sa_parliament.yml
@@ -4,7 +4,7 @@ prefix: au-saparl
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: "2026-06-13"
+  start: "2026-06-15"
 load_statements: true
 
 summary: >-
@@ -44,6 +44,11 @@ dates:
 
 tags:
   - list.pep
+
+# The site returns 403 to the default zavod user agent; a browser UA
+# (transparently suffixed) is accepted.
+http:
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36 (zavod; opensanctions.org)"
 
 assertions:
   min:

--- a/datasets/au/sa_parliament/au_sa_parliament.yml
+++ b/datasets/au/sa_parliament/au_sa_parliament.yml
@@ -1,0 +1,65 @@
+title: Australia Parliament of South Australia
+name: au_sa_parliament
+prefix: au-saparl
+entry_point: crawler.py
+coverage:
+  frequency: weekly
+  start: "2026-06-13"
+load_statements: true
+
+summary: >-
+  Current members of both houses of the Parliament of South Australia.
+
+description: |
+  The Parliament of South Australia is the bicameral state legislature of South
+  Australia. This dataset covers the current members of both chambers:
+
+  - The House of Assembly (lower house), with 47 members each representing a
+    single-member electorate.
+  - The Legislative Council (upper house), with 22 members serving 8-year
+    staggered terms, elected statewide by proportional representation.
+
+  Members are sourced from the Parliament's official member-search API, and
+  ministerial and presiding-officer roles are captured as positions.
+
+url: https://www.parliament.sa.gov.au/Members/Member-Details
+
+publisher:
+  name: Parliament of South Australia
+  acronym: SA Parliament
+  description: >
+    The bicameral state legislature of South Australia, comprising the House of
+    Assembly and the Legislative Council.
+  url: https://www.parliament.sa.gov.au/
+  country: au
+  official: true
+
+data:
+  url: https://membersapp.parliament.sa.gov.au/api/members
+  format: JSON
+  lang: eng
+
+dates:
+  formats: ["%b %d %Y", "%Y-%m-%d"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 55
+      Position: 2
+    country_entities:
+      au: 55
+  max:
+    schema_entities:
+      Person: 105
+      Position: 2
+
+lookups:
+  type.string:
+    options:
+      # Not a party — flags members who have represented more than one over time.
+      - match: "Represented multiple parties"
+        value: null

--- a/datasets/au/sa_parliament/crawler.py
+++ b/datasets/au/sa_parliament/crawler.py
@@ -1,0 +1,172 @@
+import re
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The two chamber listing pages expose a second, also-unauthenticated feed whose
+# `positions` arrays carry the ministerial portfolios the member-search API lacks.
+CONTACT_URLS = [
+    "https://contact-details-api.parliament.sa.gov.au/api/HAMembersDetails",
+    "https://contact-details-api.parliament.sa.gov.au/api/LCMembersDetails",
+]
+# The member-search UI links each member to their profile by this opaque pmId.
+PROFILE_URL = "https://www.parliament.sa.gov.au/Search/Member?type=member&id=%s"
+BR_RE = re.compile(r"<br\s*/?>")
+
+
+def fetch_portfolios(context: Context) -> dict[int, list[str]]:
+    """Map each member's pmId to their ministerial / portfolio role labels.
+
+    These come from the contact-details feeds rather than the member-search API,
+    which only reports a single generic role (e.g. "Minister") per member. The
+    source strings are dirty: a single entry can pack two roles via an embedded
+    ``<br/>``, and values carry stray whitespace and duplicates.
+    """
+    portfolios: dict[int, list[str]] = {}
+    for url in CONTACT_URLS:
+        payload = context.fetch_json(url, cache_days=1)
+        for member in payload["memberContacts"]:
+            roles: list[str] = []
+            for raw in member.get("positions", []):
+                for part in BR_RE.split(raw):
+                    part = part.strip()
+                    if part:
+                        roles.append(part)
+            if roles:
+                portfolios[member["pmId"]] = roles
+    return portfolios
+
+
+def crawl_member(
+    context: Context,
+    positions: dict[str, tuple[Entity, PositionCategorisation]],
+    portfolios: dict[int, list[str]],
+    row: dict[str, Any],
+) -> None:
+    house = (row.pop("houseName") or "").strip()
+    if house not in positions:
+        context.log.warning("Unknown house", house=house)
+        return
+    position, categorisation = positions[house]
+
+    pm_id = row.pop("pm_Id")
+    first = (row.pop("pm_FirstName") or "").strip()
+    other = (row.pop("pm_OtherNames") or "").strip()
+    last = (row.pop("pm_LastName") or "").strip()
+
+    person = context.make("Person")
+    person.id = context.make_slug("member", str(pm_id))
+    h.apply_name(
+        person,
+        first_name=first,
+        middle_name=other or None,
+        last_name=last,
+        lang="eng",
+    )
+    person.add("title", (row.pop("pm_Title") or "").strip())
+    dob = row.pop("pm_DateOfBirth")
+    if dob:
+        # ISO timestamp at midnight; keep day precision only.
+        h.apply_date(person, "birthDate", dob.split("T")[0])
+    # The "Represented multiple parties" sentinel is nulled via a type.string lookup.
+    person.add("political", row.pop("pp_name"))
+    person.add("sourceUrl", PROFILE_URL % pm_id)
+    # Constitution Act 1934 (SA) s 31 (Assembly) / s 17 (Council), each subsection
+    # (1)(ab): a member's seat is vacated if the member "is not or ceases to be an
+    # Australian citizen".
+    # https://www.legislation.sa.gov.au/lz?path=%2Fc%2Fa%2Fconstitution+act+1934
+    person.add("citizenship", "au")
+
+    # Leadership roles go in Person:position (entity.add dedupes). Portfolios come
+    # from the contact-details feeds; pm_Position adds the presiding/whip/leader
+    # roles those feeds omit, skipping the generic "Member"/"Minister" labels.
+    person.add("position", portfolios.get(pm_id))
+    pm_position = (row.pop("pm_Position") or "").strip()
+    if pm_position not in ("", "Member", "Minister"):
+        person.add("position", pm_position)
+
+    elected = row.pop("mb_ElectedDate")
+    start_date: str | None = None
+    if elected:
+        # e.g. "Mar 21 2026 12:00AM" / "May  4 2021 12:00AM" — drop the midnight
+        # time component; .split() also collapses the double space on single digits.
+        parts = elected.split()
+        if len(parts) >= 3:
+            start_date = " ".join(parts[:3])
+        else:
+            context.log.warning("Unparsable elected date", value=elected)
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+        start_date=start_date,
+    )
+    if occupancy is None:
+        return
+    electorate = (row.pop("electorate") or "").strip()
+    # House of Assembly only; Legislative Council members are elected statewide and
+    # carry the literal "Unknown" here.
+    if electorate and electorate != "Unknown":
+        occupancy.add("constituency", electorate)
+    context.audit_data(
+        row,
+        ignore=[
+            "ho_name",
+            "pm_PositionDesc",
+            "pm_ArchiveDate",
+            "pm_Deceased",
+            "dateTo",
+        ],
+    )
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    house_assembly = h.make_position(
+        context,
+        name="Member of the South Australian House of Assembly",
+        country="au",
+        subnational_area="South Australia",
+        wikidata_id="Q18220900",
+        topics=["gov.state", "gov.legislative"],
+    )
+    legislative_council = h.make_position(
+        context,
+        name="Member of the South Australian Legislative Council",
+        country="au",
+        subnational_area="South Australia",
+        wikidata_id="Q18662245",
+        topics=["gov.state", "gov.legislative"],
+    )
+    context.emit(house_assembly)
+    context.emit(legislative_council)
+    # Keyed by the API's `houseName` so members map straight to their chamber.
+    positions: dict[str, tuple[Entity, PositionCategorisation]] = {
+        "House of Assembly": (
+            house_assembly,
+            categorise(context, house_assembly, default_is_pep=True),
+        ),
+        "Legislative Council": (
+            legislative_council,
+            categorise(context, legislative_council, default_is_pep=True),
+        ),
+    }
+
+    portfolios = fetch_portfolios(context)
+    data = context.fetch_json(
+        context.data_url,
+        method="POST",
+        data=b'{"memberType":"current"}',
+        headers={"Content-Type": "application/json"},
+        cache_days=1,
+    )
+    if not isinstance(data, list) or not (55 <= len(data) <= 105):
+        context.log.warning("Unexpected member count", count=len(data))
+    for row in data:
+        crawl_member(context, positions, portfolios, row)


### PR DESCRIPTION
Closes opensanctions/crawler-planning#665

Adds a PEP crawler for the **Parliament of South Australia** (bicameral): the 47-seat House of Assembly and the 22-seat Legislative Council.

## Source

The issue's URL (`/Members/Member-Details`) is a JS search UI backed by an unauthenticated JSON API that returns both chambers in one `POST` (`membersapp.parliament.sa.gov.au/api/members`, body `{"memberType":"current"}` — auto-selects the current parliament). It carries name, DOB, date first elected, electorate, party and house per member. Ministerial / presiding-officer roles (which the search API only reports generically) are enriched from the parliament's secondary contact-details feed.

## Modelling

- **Two Position entities** — `Member of the South Australian House of Assembly` (`Q18220900`) and `Member of the South Australian Legislative Council` (`Q18662245`), each `gov.state` + `gov.legislative`, `subnational_area: South Australia`.
- **One current Occupancy per member**, with `startDate` from the date first elected and `constituency` from the electorate (House of Assembly only; the Legislative Council is elected statewide).
- **Leadership / ministerial roles → `Person:position`** (free-text, multi-valued), merged from both feeds and de-duplicated; portfolio strings are split on embedded `<br/>` and whitespace-trimmed.
- **Citizenship** `au`, per Constitution Act 1934 (SA) ss 31/17 (1)(ab).
- The non-party sentinel `Represented multiple parties` is nulled via a `type.string` lookup.

## Validation

- `mypy --strict`: clean
- `zavod crawl`: 69 Person, 2 Position, 69 Occupancy; no issues logged
- `zavod validate`: passes
- qsv integrity checks: Occupancy post/holder resolve; every `role.pep` person has an occupancy and a citizenship

🤖 Generated with [Claude Code](https://claude.com/claude-code)