### PR TITLE
[xk_assembly] Add Assembly of Kosovo PEP crawler

### DIFF
--- a/datasets/xk/assembly/crawler.py
+++ b/datasets/xk/assembly/crawler.py
@@ -1,0 +1,154 @@
+from urllib.parse import urlparse, parse_qs
+
+from lxml.etree import _Element
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.extract.zyte_api import fetch_html
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Albanian biography labels in the collapsed ".bio-hidden" block, mapped to the
+# FollowTheMoney property they populate. Labels not listed here are passed to
+# audit_data() so a new or renamed field fails loudly.
+# Date of birth is handled separately (apply_date + backslash normalisation).
+DOB_LABEL = "Datëlindja"
+BIO_PROPS = {
+    "Gjinia": "gender",
+    "Përkatësia etnike": "ethnicity",
+    "Vendlindja": "birthPlace",
+    "Arsimimi": "education",
+}
+# "Partia" (party) also appears in the bio block, but we take it from the structural
+# PARTIA row in ".bio", which is present even when the collapsed bio is empty.
+# Bio labels we deliberately drop: no suitable FTM property / not useful for matching.
+BIO_IGNORE = [
+    "Partia",  # party — taken from the structural PARTIA row instead
+    "Statusi civil",  # marital status
+    "Gjuhë tjetër përveç amtares",  # other languages spoken
+    "Aktivitete dhe funksione paraprake apo të tanishme",  # prior/current occupations
+]
+
+
+def parse_bio(context: Context, doc: _Element) -> dict[str, str]:
+    """Parse the "Label: value" biography rows from the collapsed bio block.
+
+    Each field is its own ``<p>`` (e.g. ``Datëlindja: 19/08/1997;``), so we parse per
+    paragraph rather than splitting on ";" — a value may itself contain ";" (e.g. a list
+    of languages). Minority-community profiles use bilingual ``Albanian\\Serbian`` labels;
+    we keep the Albanian (first) half. The block is empty for some deputies, in which case
+    an empty dict is returned.
+    """
+    block = doc.find(".//div[@class='bio-hidden']")
+    if block is None:
+        return {}
+    result: dict[str, str] = {}
+    for para in h.xpath_elements(block, "./p"):
+        text = h.element_text(para).replace("\xa0", " ").rstrip(";").strip()
+        if text == "":
+            continue
+        if ":" not in text:
+            context.log.warning("Bio row without label", row=text)
+            continue
+        label, value = text.split(":", 1)
+        label = label.split("\\")[0].strip()  # drop Serbian half of bilingual labels
+        result[label] = value.strip()
+    return result
+
+
+def crawl_member(
+    context: Context, position: Entity, categorisation: PositionCategorisation, url: str
+) -> None:
+    # The site is behind Cloudflare, but Zyte's anti-ban proxy passes it without browser
+    # rendering — the HTML is server-rendered, so httpResponseBody returns the full page.
+    doc = fetch_html(
+        context,
+        url,
+        unblock_validator=".//h1[@class='name']",
+        html_source="httpResponseBody",
+        cache_days=20,
+    )
+    deputy_id = parse_qs(urlparse(url).query)["deputy"][0]
+
+    person = context.make("Person")
+    person.id = context.make_slug(deputy_id)
+    person.add("name", h.element_text(h.xpath_element(doc, ".//h1[@class='name']")))
+    person.add("sourceUrl", url)
+    # Deputies of the Assembly must be citizens of Kosovo: Constitution Art. 71(1)
+    # (https://www.constituteproject.org/constitution/Kosovo_2016) and Law No. 03/L-073
+    # on General Elections (https://www.te.gob.mx/vota_elections/page/download/16375).
+    person.add("citizenship", "xk")
+
+    # Party and parliamentary group are labelled <p> rows next to the name. The party
+    # is also in the bio block, but those rows are present even when the bio is empty.
+    group: str | None = None
+    for para in h.xpath_elements(doc, ".//div[@class='bio']/p[span[@class='label']]"):
+        label = h.xpath_element(para, "./span[@class='label']")
+        label_text = h.element_text(label).rstrip(":").strip()
+        value = (label.tail or "").strip()
+        if value == "":
+            continue
+        if label_text == "PARTIA":
+            person.add("political", value)
+        elif label_text == "GRUPI PARLAMENTAR":
+            # politicalGroup is the in-chamber faction, distinct from party membership.
+            group = value
+
+    bio = parse_bio(context, doc)
+    # Dates use "/" or, on some profiles, "\" as the separator (e.g. 29\03\1970).
+    h.apply_date(person, "birthDate", bio.pop(DOB_LABEL, "").replace("\\", "/"))
+    for bio_label, prop in BIO_PROPS.items():
+        person.add(prop, bio.pop(bio_label, ""))
+    context.audit_data(bio, ignore=BIO_IGNORE)
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+        no_end_implies_current=True,
+    )
+    if occupancy is None:
+        return
+    if group is not None:
+        occupancy.add("politicalGroup", group)
+
+    context.emit(person)
+    context.emit(occupancy)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Assembly of Kosovo",
+        country="xk",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q22262242",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    doc = fetch_html(
+        context,
+        context.data_url,
+        unblock_validator=".//a[contains(@href, 'deputydetails')]",
+        html_source="httpResponseBody",
+        absolute_links=True,
+        cache_days=20,
+    )
+    urls = set()
+    for anchor in h.xpath_elements(doc, ".//a[contains(@href, 'deputydetails')]"):
+        href = anchor.get("href")
+        if href is not None and "deputy=" in href:
+            urls.add(href)
+
+    if not urls:
+        raise ValueError("No deputy detail links found on the listing page")
+
+    urls_sorted = sorted(urls)
+    for index, url in enumerate(urls_sorted, start=1):
+        context.log.info(f"Crawling deputy {index}/{len(urls_sorted)}", url=url)
+        crawl_member(context, position, categorisation, url)
+        # Commit the HTTP cache after each page so a long, interruptible run (every
+        # page is a slow Zyte fetch behind Cloudflare) keeps its progress.
+        context.flush()

--- a/datasets/xk/assembly/xk_assembly.yml
+++ b/datasets/xk/assembly/xk_assembly.yml
@@ -1,0 +1,62 @@
+title: Assembly of the Republic of Kosovo (Kuvendi i Kosovës)
+entry_point: crawler.py
+prefix: xk-kuv
+coverage:
+  frequency: weekly
+  start: "2026-06-13"
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the unicameral Assembly of the Republic of Kosovo.
+description: |
+  The Assembly of the Republic of Kosovo (Kuvendi i Republikës së Kosovës) is the
+  unicameral national legislature of Kosovo. It has 120 seats: 100 general seats and
+  20 reserved for ethnic minority communities, with members elected for four-year terms.
+
+  This dataset captures the current sitting members listed on the Assembly's official
+  website. For each deputy it collects the name, party affiliation, parliamentary group
+  and, where the profile page provides them, date and place of birth, gender, ethnicity
+  and education. The roster is updated after elections and by-elections; not every
+  member's profile carries the full set of biographical fields.
+url: https://www.kuvendikosoves.org/shq/deputetet/
+publisher:
+  name: Assembly of the Republic of Kosovo
+  acronym: Kuvendi
+  description: >
+    The Assembly is the unicameral parliament of the Republic of Kosovo, exercising
+    legislative power under the Constitution. Its 120 deputies are elected for
+    four-year terms.
+  url: https://www.kuvendikosoves.org/
+  country: xk
+  official: true
+data:
+  url: https://www.kuvendikosoves.org/shq/deputetet/
+  format: HTML
+  lang: sqi
+
+dates:
+  formats: ["%d/%m/%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 100
+      Position: 1
+    country_entities:
+      xk: 100
+  max:
+    schema_entities:
+      Person: 200
+      Position: 1
+
+lookups:
+  type.gender:
+    normalize: true
+    options:
+      - match: [Femër]
+        value: female
+      - match: [Mashkull]
+        value: male


### PR DESCRIPTION
Adds a PEP crawler for the **Assembly of the Republic of Kosovo** (Kuvendi i Kosovës)
closes opensanctions/crawler-planning#693.

## Output (verified locally)
- **120 Person**, **1 Position** (Member of the Assembly of Kosovo, `Q22262242`), **120 Occupancy**
- Per MP: name, party (`political`), parliamentary group (`Occupancy:politicalGroup`), citizenship `xk`; and where the profile provides them — gender, ethnicity, date/place of birth, education (~24 MPs; most profiles have an empty biography block at source)
- `zavod validate` passes; all entity-graph integrity checks clean (no dangling holder/post refs, every PEP has an occupancy + citizenship)

## Notes
- The site is behind a **Cloudflare** bot challenge. Requests route through **Zyte's anti-ban proxy** using `httpResponseBody` — the pages are server-rendered, so no browser rendering is needed. `ci_test: false` since the Zyte key isn't available in CI.
- Each profile's collapsed biography is parsed **per `<p>`** (values can contain `;`). Minority-community profiles use bilingual `Albanian\Serbian` labels — the Albanian half is kept. Some birth dates use `\` separators, normalised to `/`.
- Zyte occasionally hits an intermittent ban (HTTP 520) on this host; a re-run resumes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)