### PR TITLE
Rebuild store by default in zavod export and validate

### DIFF
--- a/.claude/skills/debug-crawler/SKILL.md
+++ b/.claude/skills/debug-crawler/SKILL.md
@@ -98,7 +98,7 @@ Check `data/datasets/<dataset_name>/issues.log` for remaining warnings. Then exp
 and confirm the delta is plausible:
 
 ```bash
-zavod export --rebuild-store datasets/<path>/<dataset_name>.yml
+zavod export datasets/<path>/<dataset_name>.yml
 ```
 
 A healthy run shows:

--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -91,7 +91,7 @@ HTTP requests for GET requests are automatically retried for connection and HTTP
 
 Data assertions are intended to "smoke test" the data. Assertions are checked on export. If assertions aren't met, warnings are emitted.
 
-Data assertions are checked when running `zavod run` (and `zavod validate --rebuild-store` is useful when developing a crawler).
+Data assertions are checked when running `zavod run` (and `zavod validate` is useful when developing a crawler).
 
 Data assertions are useful to communicate our expectations about what's in a dataset. `min` validations set a baseline for what should be in the dataset and are fatal to the export if they fail. `max` validations emit a warning when the dataset has grown beyond the validity of our earlier baseline (or if something's gone horribly wrong and emitted way more than expected)
 

--- a/zavod/zavod/cli/etl.py
+++ b/zavod/zavod/cli/etl.py
@@ -34,8 +34,8 @@ def crawl(dataset_path: Path, dry_run: bool = False, clear_data: bool = False) -
 
 @cli.command("validate", help="Check the integrity of a dataset")
 @click.argument("dataset_path", type=DatasetInPath)
-@click.option("-r", "--rebuild-store", is_flag=True, default=False)
-def validate(dataset_path: Path, rebuild_store: bool = False) -> None:
+@click.option("--rebuild-store/--keep-store", is_flag=True, default=True)
+def validate(dataset_path: Path, rebuild_store: bool = True) -> None:
     dataset = _load_dataset(dataset_path)
     if dataset.model.disabled:
         log.info("Dataset is disabled, skipping: %s" % dataset.name)
@@ -53,8 +53,8 @@ def validate(dataset_path: Path, rebuild_store: bool = False) -> None:
 
 @cli.command("export", help="Export data from a specific dataset")
 @click.argument("dataset_path", type=DatasetInPath)
-@click.option("-r", "--rebuild-store", is_flag=True, default=False)
-def export(dataset_path: Path, rebuild_store: bool = False) -> None:
+@click.option("--rebuild-store/--keep-store", is_flag=True, default=True)
+def export(dataset_path: Path, rebuild_store: bool = True) -> None:
     dataset = _load_dataset(dataset_path)
     if dataset.model.disabled:
         log.info("Dataset is disabled, skipping: %s" % dataset.name)


### PR DESCRIPTION
## Summary

- Flip the default for `zavod export` and `zavod validate` to rebuild the store from scratch (matching prod / `zavod run` behavior).
- Use `--keep-store` to opt out, mirroring the `--clear-data/--keep-data` pattern on `crawl`.
- Drop the now-redundant `--rebuild-store` from `zavod/docs/metadata.md` and the `debug-crawler` skill doc.

Closes https://github.com/opensanctions/opensanctions/issues/3836.

Note: I left the explicit `--rebuild-store` in `.github/workflows/build.yml` — redundant now but arguably clearer about intent. Happy to drop it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)