### PR TITLE
[jp_sangiin] Add House of Councillors (Sangiin) PEP crawler

### DIFF
--- a/datasets/jp/sangiin/crawler.py
+++ b/datasets/jp/sangiin/crawler.py
@@ -1,0 +1,204 @@
+import re
+import unicodedata
+from urllib.parse import urljoin
+
+from lxml import html
+from requests import HTTPError
+
+from zavod import Context, Entity
+from zavod import helpers as h
+from zavod import settings
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+# The /current/ redirect stub links to the active Diet-session roster, e.g.
+# /japanese/joho1/kousei/giin/221/giin.htm — capture the session number from it.
+SESSION_RE = re.compile(r"/giin/(\d+)/giin\.htm")
+PROFILE_RE = re.compile(r"profile/(\d+)\.htm")
+SESSION_URL = "https://www.sangiin.go.jp/japanese/joho1/kousei/giin/%d/giin.htm"
+# The site only keeps recent sessions online; descending from the latest until a 404
+# walks the whole live window. The cap is a runaway backstop, not an expected bound.
+MAX_SESSIONS = 30
+
+# Japanese era (和暦) → Gregorian: year = base + era-year (era-year 1 may be written 元).
+ERA_BASE = {"令和": 2018, "平成": 1988, "昭和": 1925, "大正": 1911, "明治": 1867}
+# Term-end dates (任期満了) on the roster are always full era dates, e.g. 令和10年7月25日.
+ERA_DATE_RE = re.compile(r"(令和|平成|昭和|大正|明治)(元|\d+)年(\d+)月(\d+)日")
+# Profiles open with the birth date — either an era date or a plain Gregorian year, with
+# or without month/day — so match the date itself rather than relying on a fixed suffix.
+DOB_RE = re.compile(r"^\s*(令和|平成|昭和|大正|明治)?(\d+|元)年(?:(\d+)月(\d+)日)?")
+# The birthplace, when cleanly stated, follows the date up to a birth marker (生まれ/生).
+# Bounded to one clause; profiles that bury it in prose are left without a birthplace.
+BIRTHPLACE_RE = re.compile(r"^[、\s]*([^。、]{1,30}?)(?:に|にて|で)?(?:生まれ|生)")
+
+
+def era_to_iso(text: str) -> str | None:
+    """Convert the first full Japanese era date in `text` (e.g. 令和10年7月25日) to ISO."""
+    m = ERA_DATE_RE.search(unicodedata.normalize("NFKC", text))
+    if m is None:
+        return None
+    era, year, month, day = m.groups()
+    gregorian = ERA_BASE[era] + (1 if year == "元" else int(year))
+    return f"{gregorian:04d}-{int(month):02d}-{int(day):02d}"
+
+
+def parse_birth(text: str) -> tuple[str | None, str | None]:
+    """Extract (birthDate, birthPlace) from a profile's lead paragraph.
+
+    Profiles open with the member's birth date; an optional birthplace clause follows
+    (e.g. `昭和40年8月18日東京都墨田区生まれ。`, `1956年仙台市生まれ。`). The date is
+    captured to whatever precision is given (year, or full date); the birthplace is
+    best-effort and omitted when not cleanly delimited. Returns (None, None) when the
+    paragraph does not start with a recognisable date.
+    """
+    norm = unicodedata.normalize("NFKC", text)
+    m = DOB_RE.match(norm)
+    if m is None:
+        return None, None
+    era, year, month, day = m.groups()
+    gregorian = ERA_BASE[era] + (1 if year == "元" else int(year)) if era else int(year)
+    if gregorian < 1900 or gregorian > 2010:
+        return None, None  # leading number was not a plausible birth year
+    date = f"{gregorian:04d}"
+    if month is not None and day is not None:
+        date = f"{date}-{int(month):02d}-{int(day):02d}"
+    place_match = BIRTHPLACE_RE.match(norm[m.end() :])
+    place = place_match.group(1).strip() if place_match is not None else None
+    return date, (place or None)
+
+
+def fetch_doc(context: Context, url: str, cache_days: int) -> Element:
+    """Fetch and parse an HTML page, decoding it as the UTF-8 the page declares.
+
+    The site sends no charset in its HTTP headers, so `fetch_text` falls back to
+    ISO-8859-1 and mangles the Japanese. ISO-8859-1 is byte-preserving, so re-encoding
+    recovers the raw bytes and lets lxml honour the UTF-8 `<meta>` charset.
+    """
+    text = context.fetch_text(url, cache_days=cache_days)
+    if text is None or len(text) == 0:
+        raise ValueError("Empty document: %s" % url)
+    return html.fromstring(text.encode("latin-1"))
+
+
+def session_rows(context: Context, session: int) -> list[Element] | None:
+    """Return the member rows of one session roster, or None if the session is 404.
+
+    A 404 marks the lower edge of the rolling window of online sessions.
+    """
+    try:
+        doc = fetch_doc(context, SESSION_URL % session, cache_days=1)
+    except HTTPError as err:
+        if err.response is not None and err.response.status_code == 404:
+            return None
+        raise
+    return h.xpath_elements(doc, ".//tr[.//a[contains(@href, 'profile/')]]")
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    member: dict[str, str | bool],
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug(str(member["profile_id"]))
+    person.add("name", member["name"])  # kanji; data.lang=jpn default
+    person.add("alias", member["reading"])  # kana reading (読み方)
+    person.add("sourceUrl", member["profile_url"])
+    # Public Offices Election Act (公職選挙法) Art. 10 requires Japanese nationality for
+    # eligibility to the House of Councillors: https://laws.e-gov.go.jp/law/325AC1000000100/
+    person.add("citizenship", "jp")
+
+    # Profile pages carry DOB/birthplace but 404 once a member has left the chamber.
+    try:
+        prof = fetch_doc(context, str(member["profile_url"]), cache_days=7)
+        para = h.xpath_elements(prof, ".//p[@class='profile2']")
+        if para:
+            birth_date, birth_place = parse_birth(h.element_text(para[0]))
+            h.apply_date(person, "birthDate", birth_date)
+            person.add("birthPlace", birth_place)
+    except HTTPError as err:
+        if err.response is None or err.response.status_code != 404:
+            raise
+        context.log.info("No profile page (departed member)", id=member["profile_id"])
+
+    # Status: current members carry a future term-end (任期満了) → `current`. A departed
+    # member whose term-end is already past simply reached the end of their term (→ `ended`);
+    # one whose term-end is still in the future left mid-term, so the scheduled date is not a
+    # real end date and is dropped (→ `unknown`).
+    end_iso = era_to_iso(str(member["term_end"]))
+    today = settings.RUN_TIME.date().isoformat()
+    if member["in_latest"] or (end_iso is not None and end_iso < today):
+        occupancy = h.make_occupancy(
+            context, person, position, end_date=end_iso, categorisation=categorisation
+        )
+    else:
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            end_date=None,
+            no_end_implies_current=False,
+            categorisation=categorisation,
+        )
+    if occupancy is None:
+        # Term ended beyond the PEP after-office window — no longer a PEP, don't emit.
+        return
+    occupancy.add("politicalGroup", member["faction"])  # 会派, in-chamber faction
+    occupancy.add("constituency", member["district"])  # 選挙区
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the House of Councillors of Japan",
+        wikidata_id="Q14552828",
+        country="jp",
+        topics=["gov.legislative", "gov.national"],
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    # Discover the active session from the /current/ redirect stub.
+    landing = fetch_doc(context, context.data_url, cache_days=1)
+    anchor = h.xpath_element(landing, ".//a[contains(@href, '/giin/')]")
+    session_match = SESSION_RE.search(anchor.get("href") or "")
+    assert session_match is not None, anchor.get("href")
+    latest = int(session_match.group(1))
+
+    # Walk the rolling window newest-first; union members keyed on the stable profile id,
+    # so each person keeps their most recent faction/constituency/term-end and we record
+    # whether they still sit in the latest session.
+    members: dict[str, dict[str, str | bool]] = {}
+    for session in range(latest, latest - MAX_SESSIONS, -1):
+        rows = session_rows(context, session)
+        if rows is None:
+            break
+        if session == latest:
+            assert len(rows) > 200, len(rows)
+        for row in rows:
+            cells = h.xpath_elements(row, "./td")
+            assert len(cells) >= 5, len(cells)
+            link = h.xpath_element(cells[0], ".//a")
+            profile_url = urljoin(SESSION_URL % session, link.get("href"))
+            profile_match = PROFILE_RE.search(profile_url)
+            assert profile_match is not None, profile_url
+            profile_id = profile_match.group(1)
+            if profile_id in members:
+                continue  # already captured from a more recent session
+            members[profile_id] = {
+                "profile_id": profile_id,
+                "profile_url": profile_url,
+                "in_latest": session == latest,
+                "name": h.element_text(link),
+                "reading": h.element_text(cells[1]),
+                "faction": h.element_text(cells[2]),
+                "district": h.element_text(cells[3]),
+                "term_end": h.element_text(cells[4]),
+            }
+    assert members, "no sessions found"
+
+    for member in members.values():
+        crawl_member(context, position, categorisation, member)

--- a/datasets/jp/sangiin/crawler.py
+++ b/datasets/jp/sangiin/crawler.py
@@ -128,21 +128,21 @@ def crawl_member(
     # real end date and is dropped (→ `unknown`).
     end_iso = era_to_iso(str(member["term_end"]))
     today = settings.RUN_TIME.date().isoformat()
-    if member["in_latest"] or (end_iso is not None and end_iso < today):
-        occupancy = h.make_occupancy(
-            context, person, position, end_date=end_iso, categorisation=categorisation
-        )
-    else:
-        occupancy = h.make_occupancy(
-            context,
-            person,
-            position,
-            end_date=None,
-            no_end_implies_current=False,
-            categorisation=categorisation,
-        )
+    # The scheduled term-end is a reliable end date only when the member still sits in the
+    # latest session or the date is already past; a departed member with a future term-end
+    # left mid-term, so we drop the date and let status fall to `unknown`.
+    term_end_reliable = bool(member["in_latest"]) or (
+        end_iso is not None and end_iso < today
+    )
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        end_date=end_iso if term_end_reliable else None,
+        no_end_implies_current=term_end_reliable,
+        categorisation=categorisation,
+    )
     if occupancy is None:
-        # Term ended beyond the PEP after-office window — no longer a PEP, don't emit.
         return
     occupancy.add("politicalGroup", member["faction"])  # 会派, in-chamber faction
     occupancy.add("constituency", member["district"])  # 選挙区
@@ -158,7 +158,7 @@ def crawl(context: Context) -> None:
         country="jp",
         topics=["gov.legislative", "gov.national"],
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
     # Discover the active session from the /current/ redirect stub.

--- a/datasets/jp/sangiin/crawler.py
+++ b/datasets/jp/sangiin/crawler.py
@@ -102,7 +102,13 @@ def crawl_member(
 ) -> None:
     person = context.make("Person")
     person.id = context.make_slug(str(member["profile_id"]))
-    person.add("name", member["name"])  # kanji; data.lang=jpn default
+    h.apply_reviewed_names(
+        context,
+        person,
+        original=h.Names(name=str(member["name"])),
+        llm_cleaning=True,
+        lang="jpn",
+    )
     person.add("alias", member["reading"])  # kana reading (読み方)
     person.add("sourceUrl", member["profile_url"])
     # Public Offices Election Act (公職選挙法) Art. 10 requires Japanese nationality for

--- a/datasets/jp/sangiin/jp_sangiin.yml
+++ b/datasets/jp/sangiin/jp_sangiin.yml
@@ -1,4 +1,4 @@
-title: Japan House of Councillors (Sangiin) Members
+title: Japan Members of House of Councillors (Sangiin)
 entry_point: crawler.py
 prefix: jp-san
 load_statements: true
@@ -9,15 +9,15 @@ coverage:
 summary: >-
   Japanese House of Councillors (Sangiin), the upper house of the National Diet of Japan.
 description: |
-  Individuals serving in the House of Councillors (参議院), the upper chamber of Japan's
-  National Diet. The chamber has 248 seats; members are elected to six-year terms with
-  half renewed every three years.
+  Current and recent members of the House of Councillors (参議院), the upper chamber of
+  Japan's bicameral National Diet. Its 248 councillors are elected to six-year terms,
+  with half the chamber renewed every three years, and together with the House of
+  Representatives hold the country's legislative power, including passing laws and
+  approving the budget.
 
-  The official site publishes one member roster per Diet session but only retains the most
-  recent sessions online. This dataset walks that rolling window of live sessions and takes
-  the union of members across it, so members who have left the chamber during the window
-  are also captured (marked as no longer current). Each member's date and place of birth
-  are read from their individual profile page where available.
+  This dataset records the councillors of the current session along with those who have
+  left the chamber over recent sessions, with their name, date and place of birth, in-chamber faction, and
+  electoral district.
 publisher:
   name: 参議院
   name_en: House of Councillors

--- a/datasets/jp/sangiin/jp_sangiin.yml
+++ b/datasets/jp/sangiin/jp_sangiin.yml
@@ -1,0 +1,47 @@
+title: Japan House of Councillors (Sangiin) Members
+entry_point: crawler.py
+prefix: jp-san
+load_statements: true
+ci_test: false
+coverage:
+  frequency: monthly
+  start: 2026-06-15
+summary: >-
+  Japanese House of Councillors (Sangiin), the upper house of the National Diet of Japan.
+description: |
+  Individuals serving in the House of Councillors (参議院), the upper chamber of Japan's
+  National Diet. The chamber has 248 seats; members are elected to six-year terms with
+  half renewed every three years.
+
+  The official site publishes one member roster per Diet session but only retains the most
+  recent sessions online. This dataset walks that rolling window of live sessions and takes
+  the union of members across it, so members who have left the chamber during the window
+  are also captured (marked as no longer current). Each member's date and place of birth
+  are read from their individual profile page where available.
+publisher:
+  name: 参議院
+  name_en: House of Councillors
+  official: true
+  description: |
+    The House of Councillors (Sangiin) is the upper house of the National Diet of Japan.
+  country: jp
+  url: https://www.sangiin.go.jp/
+tags:
+  - list.pep
+url: https://www.sangiin.go.jp/japanese/joho1/kousei/giin/current/giin.htm
+data:
+  url: https://www.sangiin.go.jp/japanese/joho1/kousei/giin/current/giin.htm
+  format: HTML
+  lang: jpn
+
+assertions:
+  min:
+    schema_entities:
+      Person: 200
+      Position: 1
+    country_entities:
+      jp: 200
+  max:
+    schema_entities:
+      Person: 340
+      Position: 1


### PR DESCRIPTION
Adds a PEP crawler for the **House of Councillors (参議院 / Sangiin)**, the upper house of Japan's National Diet — complementing the existing `jp_shugiin` (House of Representatives) crawler. Closes opensanctions/crawler-planning#739.

## Source

Official roster at `sangiin.go.jp`. The site publishes one member list per Diet session but only retains a **rolling window of recent sessions** online (currently 216–221). The crawler:

1. Follows the `/current/` redirect stub to discover the active session number.
2. Descends session by session until the first 404 marks the window's lower edge.
3. Unions members across the window, keyed on the stable per-person profile id — so it captures both sitting members and those who left during the window.

## Modelling

- One shared `Position` — *Member of the House of Councillors of Japan* (`Q14552828`), `gov.legislative` + `gov.national`.
- One `Occupancy` per member. Status derives from the term-end date (任期満了): sitting members → `current`; members whose term has already expired → `ended`.
- `politicalGroup` ← 会派 (in-chamber faction), `constituency` ← 選挙区.
- Date and place of birth read from each member's profile page (Japanese era or Gregorian notation). `citizenship: jp` per Public Offices Election Act Art. 10.

## Notes

- Pages are served without a charset header, so HTML is re-decoded as the UTF-8 they declare.
- Departed members' profile pages 404, so they carry roster data only (no DOB).

## Verification

- `zavod crawl` + `zavod validate` pass; `issues.json` clean (info-level only).
- 304 Persons (247 current + 57 ended), 1 Position, 304 Occupancies; birthDate on all 247 current members.
- All PEP integrity checks pass (no orphan occupancies, no dangling refs, every PEP has an occupancy and citizenship).
- `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)