### PR TITLE
[tw_legislature] Add Taiwan Legislative Yuan PEP crawler

### DIFF
--- a/datasets/tw/legislature/crawler.py
+++ b/datasets/tw/legislature/crawler.py
@@ -1,4 +1,3 @@
-import re
 from html import unescape
 
 from zavod import Context
@@ -6,19 +5,8 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-DATE_RE = re.compile(r"^\d{4}/\d{2}/\d{2}$")
 
-
-def check_date(value: str) -> str:
-    """Assert the source `YYYY/MM/DD` date shape and return it unchanged.
-
-    The source uses a single date format throughout; fail loudly if that ever changes so
-    we don't silently misorder terms or mis-bound occupancies. The raw value is returned
-    so that `apply_date` records it as the statement's original value; the lexicographic
-    order of `YYYY/MM/DD` strings matches chronological order, so they sort correctly."""
-    if not DATE_RE.match(value):
-        raise ValueError("Unexpected date format: %r" % value)
-    return value
+TOPICS = ["gov.national", "gov.legislative"]
 
 
 def term_starts(rows: list[dict[str, str]]) -> dict[str, str]:
@@ -34,26 +22,9 @@ def term_starts(rows: list[dict[str, str]]) -> dict[str, str]:
         onboard = row.get("onboardDate")
         if not onboard:
             continue
-        onboard = check_date(onboard)
         if term not in starts or onboard < starts[term]:
             starts[term] = onboard
     return starts
-
-
-def add_political(
-    context: Context, entity: Entity, prop: str, value: str | None
-) -> None:
-    """Add a party affiliation / parliamentary caucus name as published (Chinese).
-
-    The `party` lookup only maps non-affiliation markers (independent, a data glitch) to
-    null so they are dropped; every other value is kept verbatim — names are not
-    translated."""
-    if not value:
-        return
-    result = context.lookup("party", value)
-    if result is not None and result.value is None:
-        return
-    entity.add(prop, value, lang="zho")
 
 
 def crawl_member(
@@ -68,7 +39,7 @@ def crawl_member(
     row = {k: unescape(v) if isinstance(v, str) else v for k, v in row.items()}
     term = row.pop("term")
     name = row.pop("name")
-    onboard = check_date(row.pop("onboardDate"))
+    onboard = row.pop("onboardDate")
 
     # End date: an early departure (leaveDate) takes precedence; otherwise the member
     # served to the end of the term, which is the start of the following term; the most
@@ -81,22 +52,18 @@ def crawl_member(
     if leave_flag == "是":
         if leave_date is None:
             raise ValueError("Departed member without leaveDate: %r" % name)
-        end_date = check_date(leave_date)
+        end_date = leave_date
     else:
         end_date = next_start[term]
 
     person = context.make("Person")
-    # No stable per-person id is published (picUrl is missing for older terms and is
-    # term-prefixed where present), so key on the term plus name; the onboarding date
-    # disambiguates a hypothetical same-name collision within a term. The same person
-    # across terms becomes several entities, merged downstream by the resolver.
     person.id = context.make_id(term, name, onboard)
     person.add("name", name)
-    person.add("name", row.pop("ename"), lang="eng")  # romanised; kept verbatim
-    person.add("gender", row.pop("sex"))  # via type.gender lookup
+    person.add("name", row.pop("ename"), lang="eng")
+    person.add("gender", row.pop("sex"))
     # The free-text degree field uses angle brackets for annotations (e.g.
     # 學士<鋼琴演奏>); normalise them to CJK parentheses so they aren't flagged as markup.
-    degree = row.pop("degree") or None
+    degree = row.pop("degree")
     if degree is not None:
         degree = degree.replace("<", "（").replace(">", "）")
     person.add("education", degree)
@@ -105,6 +72,13 @@ def crawl_member(
     # requires candidates to be electors (Art. 24).
     # https://law.moj.gov.tw/ENG/LawClass/LawAll.aspx?pcode=D0020010
     person.add("citizenship", "tw")
+
+    party = row.pop("party")
+    party_res = context.lookup("party", party)
+    person.add("political", party_res.value if party_res else party, lang="zho")
+
+    political_group = row.pop("partyGroup")
+    political_group_res = context.lookup("party", political_group)
 
     occupancy = h.make_occupancy(
         context,
@@ -115,12 +89,13 @@ def crawl_member(
         categorisation=categorisation,
     )
     if occupancy is None:
-        # Party affiliation doesn't affect PEP status, so it is set only for members we
-        # actually emit — avoids spurious "unmapped party" warnings for dropped terms.
         return
-
-    add_political(context, person, "political", row.pop("party") or None)
-    add_political(context, occupancy, "politicalGroup", row.pop("partyGroup") or None)
+    occupancy.add(
+        "politicalGroup",
+        political_group_res.value if political_group_res else political_group,
+        lang="zho",
+    )
+    occupancy.add("constituency", row.pop("areaName"))
 
     context.emit(occupancy)
     context.emit(person)
@@ -128,7 +103,6 @@ def crawl_member(
     context.audit_data(
         row,
         ignore=[
-            "areaName",
             "committee",
             "tel",
             "fax",
@@ -145,7 +119,14 @@ def crawl(context: Context) -> None:
     # returns the full historical roster, so the crawler stays current across new terms
     # without pinning a term number. (ID 9, "當屆委員資料", only ever returns the current
     # term and ignores the `term` filter.)
-    data = context.fetch_json(context.data_url, cache_days=1)
+    # The server (behind a uproxy) intermittently sends a `Content-Encoding: gzip`
+    # header with a body that isn't valid gzip, breaking the client decompressor. Opt
+    # out of gzip so it returns the response as plain `text/plain`.
+    data = context.fetch_json(
+        context.data_url,
+        cache_days=1,
+        headers={"Accept-Encoding": "identity"},
+    )
     rows: list[dict[str, str]] = [r for r in data["dataList"] if r.get("name")]
 
     starts = term_starts(rows)
@@ -154,23 +135,18 @@ def crawl(context: Context) -> None:
         term: starts[ordered[i + 1]] if i + 1 < len(ordered) else None
         for i, term in enumerate(ordered)
     }
-
-    # Only consider terms recent enough to still be in the PEP look-back window; the
-    # precise per-member end-date cut-off is then applied by make_occupancy.
-    cutoff = h.earliest_term_start(["gov.national"])
-
     position = h.make_position(
         context,
         name="Member of the Legislative Yuan",
         country="tw",
-        topics=["gov.national", "gov.legislative"],
+        topics=TOPICS,
         wikidata_id="Q6310593",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
     for row in rows:
         # `cutoff` is ISO (dash-separated); normalise the source separator to compare.
-        if starts[row["term"]].replace("/", "-") < cutoff:
+        if starts[row["term"]].replace("/", "-") < h.earliest_term_start(TOPICS):
             continue
         crawl_member(context, row, starts, next_start, position, categorisation)

--- a/datasets/tw/legislature/crawler.py
+++ b/datasets/tw/legislature/crawler.py
@@ -6,9 +6,6 @@ from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
 
-TOPICS = ["gov.national", "gov.legislative"]
-
-
 def term_starts(rows: list[dict[str, str]]) -> dict[str, str]:
     """Map each term id to its start date (raw `YYYY/MM/DD`).
 
@@ -139,7 +136,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Legislative Yuan",
         country="tw",
-        topics=TOPICS,
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q6310593",
     )
     categorisation = categorise(context, position)
@@ -147,6 +144,8 @@ def crawl(context: Context) -> None:
 
     for row in rows:
         # `cutoff` is ISO (dash-separated); normalise the source separator to compare.
-        if starts[row["term"]].replace("/", "-") < h.earliest_term_start(TOPICS):
+        if starts[row["term"]].replace("/", "-") < h.earliest_term_start(
+            position.get("topics")
+        ):
             continue
         crawl_member(context, row, starts, next_start, position, categorisation)

--- a/datasets/tw/legislature/crawler.py
+++ b/datasets/tw/legislature/crawler.py
@@ -1,0 +1,176 @@
+import re
+from html import unescape
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+DATE_RE = re.compile(r"^\d{4}/\d{2}/\d{2}$")
+
+
+def check_date(value: str) -> str:
+    """Assert the source `YYYY/MM/DD` date shape and return it unchanged.
+
+    The source uses a single date format throughout; fail loudly if that ever changes so
+    we don't silently misorder terms or mis-bound occupancies. The raw value is returned
+    so that `apply_date` records it as the statement's original value; the lexicographic
+    order of `YYYY/MM/DD` strings matches chronological order, so they sort correctly."""
+    if not DATE_RE.match(value):
+        raise ValueError("Unexpected date format: %r" % value)
+    return value
+
+
+def term_starts(rows: list[dict[str, str]]) -> dict[str, str]:
+    """Map each term id to its start date (raw `YYYY/MM/DD`).
+
+    Legislative Yuan terms are contiguous, so the start of one term is the end of the
+    previous one. Each term's start is the earliest onboarding date among its members
+    (consistently 1 February of the election year), which lets us derive term-end dates
+    from the data instead of hardcoding a constitutional date table."""
+    starts: dict[str, str] = {}
+    for row in rows:
+        term = row["term"]
+        onboard = row.get("onboardDate")
+        if not onboard:
+            continue
+        onboard = check_date(onboard)
+        if term not in starts or onboard < starts[term]:
+            starts[term] = onboard
+    return starts
+
+
+def add_political(
+    context: Context, entity: Entity, prop: str, value: str | None
+) -> None:
+    """Add a party affiliation / parliamentary caucus name as published (Chinese).
+
+    The `party` lookup only maps non-affiliation markers (independent, a data glitch) to
+    null so they are dropped; every other value is kept verbatim — names are not
+    translated."""
+    if not value:
+        return
+    result = context.lookup("party", value)
+    if result is not None and result.value is None:
+        return
+    entity.add(prop, value, lang="zho")
+
+
+def crawl_member(
+    context: Context,
+    row: dict[str, str],
+    starts: dict[str, str],
+    next_start: dict[str, str | None],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    # The source occasionally HTML-escapes characters (e.g. &#183; for a middle dot).
+    row = {k: unescape(v) if isinstance(v, str) else v for k, v in row.items()}
+    term = row.pop("term")
+    name = row.pop("name")
+    onboard = check_date(row.pop("onboardDate"))
+
+    # End date: an early departure (leaveDate) takes precedence; otherwise the member
+    # served to the end of the term, which is the start of the following term; the most
+    # recent term has no successor yet, so its sitting members have no end date.
+    leave_flag = row.pop("leaveFlag")
+    leave_date = row.pop("leaveDate") or None
+    if leave_flag not in ("否", "是"):
+        raise ValueError("Unexpected leaveFlag: %r" % leave_flag)
+    end_date: str | None
+    if leave_flag == "是":
+        if leave_date is None:
+            raise ValueError("Departed member without leaveDate: %r" % name)
+        end_date = check_date(leave_date)
+    else:
+        end_date = next_start[term]
+
+    person = context.make("Person")
+    # No stable per-person id is published (picUrl is missing for older terms and is
+    # term-prefixed where present), so key on the term plus name; the onboarding date
+    # disambiguates a hypothetical same-name collision within a term. The same person
+    # across terms becomes several entities, merged downstream by the resolver.
+    person.id = context.make_id(term, name, onboard)
+    person.add("name", name)
+    person.add("name", row.pop("ename"), lang="eng")  # romanised; kept verbatim
+    person.add("gender", row.pop("sex"))  # via type.gender lookup
+    # The free-text degree field uses angle brackets for annotations (e.g.
+    # 學士<鋼琴演奏>); normalise them to CJK parentheses so they aren't flagged as markup.
+    degree = row.pop("degree") or None
+    if degree is not None:
+        degree = degree.replace("<", "（").replace(">", "）")
+    person.add("education", degree)
+    # Members of a national legislature must be ROC nationals: the Civil Servants Election
+    # and Recall Act (公職人員選舉罷免法) limits suffrage to ROC citizens (Art. 14) and
+    # requires candidates to be electors (Art. 24).
+    # https://law.moj.gov.tw/ENG/LawClass/LawAll.aspx?pcode=D0020010
+    person.add("citizenship", "tw")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        start_date=onboard,
+        end_date=end_date,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        # Party affiliation doesn't affect PEP status, so it is set only for members we
+        # actually emit — avoids spurious "unmapped party" warnings for dropped terms.
+        return
+
+    add_political(context, person, "political", row.pop("party") or None)
+    add_political(context, occupancy, "politicalGroup", row.pop("partyGroup") or None)
+
+    context.emit(occupancy)
+    context.emit(person)
+
+    context.audit_data(
+        row,
+        ignore=[
+            "areaName",
+            "committee",
+            "tel",
+            "fax",
+            "addr",
+            "experience",
+            "leaveReason",
+            "picUrl",
+        ],
+    )
+
+
+def crawl(context: Context) -> None:
+    # Dataset ID 16 ("歷屆委員資料", all-terms legislators). Without a `term` filter it
+    # returns the full historical roster, so the crawler stays current across new terms
+    # without pinning a term number. (ID 9, "當屆委員資料", only ever returns the current
+    # term and ignores the `term` filter.)
+    data = context.fetch_json(context.data_url, cache_days=1)
+    rows: list[dict[str, str]] = [r for r in data["dataList"] if r.get("name")]
+
+    starts = term_starts(rows)
+    ordered = sorted(starts, key=int)
+    next_start: dict[str, str | None] = {
+        term: starts[ordered[i + 1]] if i + 1 < len(ordered) else None
+        for i, term in enumerate(ordered)
+    }
+
+    # Only consider terms recent enough to still be in the PEP look-back window; the
+    # precise per-member end-date cut-off is then applied by make_occupancy.
+    cutoff = h.earliest_term_start(["gov.national"])
+
+    position = h.make_position(
+        context,
+        name="Member of the Legislative Yuan",
+        country="tw",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q6310593",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    for row in rows:
+        # `cutoff` is ISO (dash-separated); normalise the source separator to compare.
+        if starts[row["term"]].replace("/", "-") < cutoff:
+            continue
+        crawl_member(context, row, starts, next_start, position, categorisation)

--- a/datasets/tw/legislature/crawler.py
+++ b/datasets/tw/legislature/crawler.py
@@ -55,7 +55,15 @@ def crawl_member(
 
     person = context.make("Person")
     person.id = context.make_id(term, name, onboard)
-    person.add("name", name)
+
+    h.apply_reviewed_names(
+        context,
+        person,
+        original=h.Names(name=name),
+        llm_cleaning=True,
+        lang="zho",
+    )
+
     person.add("name", row.pop("ename"), lang="eng")
     person.add("gender", row.pop("sex"))
     # The free-text degree field uses angle brackets for annotations (e.g.

--- a/datasets/tw/legislature/tw_legislature.yml
+++ b/datasets/tw/legislature/tw_legislature.yml
@@ -31,6 +31,11 @@ data:
   format: JSON
   lang: zho
 
+http:
+  # The site sits behind a uproxy WAF that returns 403 for the default
+  # python-requests User-Agent, so present a browser User-Agent instead.
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+
 dates:
   formats: ["%Y/%m/%d"]
 
@@ -50,6 +55,12 @@ assertions:
       Position: 2
 
 lookups:
+  party:
+    options:
+      - match:
+          - 0無  # "0 none'
+          - 無黨籍 # no party affiliation
+        value: null
   type.gender:
     options:
       - match: 男

--- a/datasets/tw/legislature/tw_legislature.yml
+++ b/datasets/tw/legislature/tw_legislature.yml
@@ -39,6 +39,12 @@ http:
 dates:
   formats: ["%Y/%m/%d"]
 
+names:
+  schema_rules:
+    Person:
+      # some names are mixed-script
+      reject_chars: "．"
+
 tags:
   - list.pep
 

--- a/datasets/tw/legislature/tw_legislature.yml
+++ b/datasets/tw/legislature/tw_legislature.yml
@@ -1,21 +1,21 @@
-title: Taiwan Legislative Yuan (Members)
+title: Taiwan Members of the Legislative Yuan
 entry_point: crawler.py
 prefix: tw-ly
 coverage:
-  frequency: daily
+  frequency: monthly
   start: 2026-06-15
 load_statements: true
 ci_test: true
 summary: >-
   Members of the Legislative Yuan, Taiwan's national legislature
 description: |
-  The Legislative Yuan is the unicameral legislature of the Republic of China (Taiwan).
+  Current and recent members of the Legislative Yuan (立法院), the unicameral national
+  legislature of Taiwan. Its 113 legislators are directly
+  elected to four-year terms and hold the country's legislative power, including
+  passing laws, approving the budget, and confirming senior appointments.
 
-  This dataset covers legislators of recent terms — both current members and those who
-  served in earlier terms that fall within the politically-exposed-person look-back
-  window — as published on the Legislative Yuan Open Data Service Platform and updated
-  daily. The source publishes the full historical roster; the crawler emits the terms
-  recent enough to still be relevant.
+  This dataset records the legislators of the current and recent terms, with their
+  name, gender, education, party affiliation, and parliamentary caucus.
 url: https://data.ly.gov.tw/
 publisher:
   name: Legislative Yuan
@@ -56,10 +56,3 @@ lookups:
         value: male
       - match: 女
         value: female
-  # Party affiliation (Person:political) and in-chamber caucus (Occupancy:politicalGroup)
-  # are stored verbatim as published; this lookup only drops non-affiliation markers
-  # (independent / a data glitch), not translate names.
-  party:
-    options:
-      - match: [無黨籍, 0無]      # independent / no caucus
-        value: null

--- a/datasets/tw/legislature/tw_legislature.yml
+++ b/datasets/tw/legislature/tw_legislature.yml
@@ -1,0 +1,65 @@
+title: Taiwan Legislative Yuan (Members)
+entry_point: crawler.py
+prefix: tw-ly
+coverage:
+  frequency: daily
+  start: 2026-06-15
+load_statements: true
+ci_test: true
+summary: >-
+  Members of the Legislative Yuan, Taiwan's national legislature
+description: |
+  The Legislative Yuan is the unicameral legislature of the Republic of China (Taiwan).
+
+  This dataset covers legislators of recent terms — both current members and those who
+  served in earlier terms that fall within the politically-exposed-person look-back
+  window — as published on the Legislative Yuan Open Data Service Platform and updated
+  daily. The source publishes the full historical roster; the crawler emits the terms
+  recent enough to still be relevant.
+url: https://data.ly.gov.tw/
+publisher:
+  name: Legislative Yuan
+  acronym: LY
+  description: >
+    The Legislative Yuan (立法院) is the unicameral national legislature of the Republic
+    of China (Taiwan). Its members are directly elected to four-year terms.
+  url: https://www.ly.gov.tw/
+  country: tw
+  official: true
+data:
+  url: https://data.ly.gov.tw/odw/ID16Action.action?fileType=json
+  format: JSON
+  lang: zho
+
+dates:
+  formats: ["%Y/%m/%d"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 300
+      Position: 1
+    country_entities:
+      tw: 300
+  max:
+    schema_entities:
+      Person: 1200
+      Position: 2
+
+lookups:
+  type.gender:
+    options:
+      - match: 男
+        value: male
+      - match: 女
+        value: female
+  # Party affiliation (Person:political) and in-chamber caucus (Occupancy:politicalGroup)
+  # are stored verbatim as published; this lookup only drops non-affiliation markers
+  # (independent / a data glitch), not translate names.
+  party:
+    options:
+      - match: [無黨籍, 0無]      # independent / no caucus
+        value: null


### PR DESCRIPTION
Adds a PEP crawler for members of Taiwan's unicameral **Legislative Yuan** (立法院), sourced from the Legislative Yuan Open Data platform.

Closes https://github.com/opensanctions/crawler-planning/issues/738

## Source
- Dataset **ID 16** (「歷屆委員資料」, all-terms legislators), fetched with no `term` filter so it returns the full historical roster. (ID 9, suggested in the issue, is current-term only and ignores the `term` filter.)
- JSON, Traditional Chinese, updated daily.

## Design notes
- **No term pinning.** Term boundaries are derived from the data — terms are contiguous, so each term's end is the start of the next, and the latest term is open-ended. The crawler stays correct as new terms are published, with nothing to bump.
- **Look-back window.** `h.earliest_term_start(["gov.national"])` pre-filters old terms; `make_occupancy`'s 20-year after-office cut does the precise per-member filtering. Currently emits ~6 recent terms.
- **Occupancy dates.** `startDate` is the member's onboarding date; `endDate` is the early-departure date (`leaveDate`) when present, otherwise the derived term end; sitting members of the latest term have no end. Source `YYYY/MM/DD` strings are preserved as `original_value`.
- **Party vs caucus.** Party affiliation → `Person:political`; in-chamber caucus → `Occupancy:politicalGroup`. Both stored verbatim in Chinese (no translation). Gender mapped to the FtM enum via lookup.
- **Citizenship** `tw` is set per the legal requirement (Civil Servants Election and Recall Act, Arts. 14 & 24), cited inline.
- **Entity IDs** key on `(term, name, onboardDate)` via `make_id`; a person serving multiple terms becomes one entity per term, merged downstream.

## Validation
- Clean `zavod crawl` (no warnings/errors) and `zavod validate`.
- `mypy --strict` passes.
- ~853 Persons / 853 Occupancies / 1 Position; referential-integrity checks (occupancy→person/position, every PEP has citizenship) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)