### PR TITLE
[kr_assembly] Add South Korea National Assembly PEP crawler

### DIFF
--- a/datasets/kr/assembly/crawler.py
+++ b/datasets/kr/assembly/crawler.py
@@ -4,12 +4,6 @@ from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The endpoint caps the page size silently; request all seats in one call and assert
-# the returned count matches the reported total (see crawl()).
-ROWS = "500"
-
-POSITION_NAME = "Member of the National Assembly of the Republic of Korea"
-
 
 def crawl_member(
     context: Context,
@@ -39,6 +33,7 @@ def crawl_member(
     if occupancy is not None:
         occupancy.add("constituency", row.pop("origNm", None))
         context.emit(occupancy)
+        context.emit(person)
 
     context.audit_data(
         row,
@@ -61,13 +56,12 @@ def crawl_member(
             "openNaId",
         ],
     )
-    context.emit(person)
 
 
 def crawl(context: Context) -> None:
     position = h.make_position(
         context,
-        name=POSITION_NAME,
+        name="Member of the National Assembly of the Republic of Korea",
         wikidata_id="Q14850694",
         country="kr",
         topics=["gov.legislative", "gov.national"],
@@ -75,10 +69,12 @@ def crawl(context: Context) -> None:
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)
 
+    # The endpoint caps the page size silently; request all seats in one call and assert
+    # the returned count matches the reported total.
     data = context.fetch_json(
         context.data_url,
         method="POST",
-        data={"page": "1", "rows": ROWS},
+        data={"page": "1", "rows": 500},
         cache_days=1,
     )
     rows = data["data"]

--- a/datasets/kr/assembly/crawler.py
+++ b/datasets/kr/assembly/crawler.py
@@ -13,12 +13,11 @@ def crawl_member(
 ) -> None:
     person = context.make("Person")
     person.id = context.make_slug(row.pop("monaCd"))
-    person.add("name", row.pop("hgNm"))  # data.lang=kor default
+    person.add("name", row.pop("hgNm"))
     person.add("name", row.pop("engNm"), lang="eng")
     person.add("alias", row.pop("hjNm"))
-    person.add("gender", row.pop("sexGbnNm"))  # type.gender lookup
-    person.add("political", row.pop("polyNm"))  # party affiliation
-    # A few members pack two addresses into one field; split via the type.email lookup.
+    person.add("gender", row.pop("sexGbnNm"))
+    person.add("political", row.pop("polyNm"))
     person.add("email", row.pop("eMail"))
     person.add("website", row.pop("homepage"))
     person.add("sourceUrl", row.pop("linkUrl"))
@@ -66,7 +65,7 @@ def crawl(context: Context) -> None:
         country="kr",
         topics=["gov.legislative", "gov.national"],
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
     # The endpoint caps the page size silently; request all seats in one call and assert

--- a/datasets/kr/assembly/crawler.py
+++ b/datasets/kr/assembly/crawler.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+from zavod import Context, Entity
+from zavod import helpers as h
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The endpoint caps the page size silently; request all seats in one call and assert
+# the returned count matches the reported total (see crawl()).
+ROWS = "500"
+
+POSITION_NAME = "Member of the National Assembly of the Republic of Korea"
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    row: dict[str, Any],
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug(row.pop("monaCd"))
+    person.add("name", row.pop("hgNm"))  # data.lang=kor default
+    person.add("name", row.pop("engNm"), lang="eng")
+    person.add("alias", row.pop("hjNm"))
+    person.add("gender", row.pop("sexGbnNm"))  # type.gender lookup
+    person.add("political", row.pop("polyNm"))  # party affiliation
+    # A few members pack two addresses into one field; split via the type.email lookup.
+    person.add("email", row.pop("eMail"))
+    person.add("website", row.pop("homepage"))
+    person.add("sourceUrl", row.pop("linkUrl"))
+    h.apply_date(person, "birthDate", row.pop("bthDate"))
+    # Public Official Election Act (공직선거법) Art. 16(2) requires Korean citizenship
+    # to be elected: https://www.law.go.kr/법령/공직선거법/제16조
+    person.add("citizenship", "kr")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is not None:
+        occupancy.add("constituency", row.pop("origNm", None))
+        context.emit(occupancy)
+
+    context.audit_data(
+        row,
+        ignore=[
+            "ROW_NUM",
+            "age",
+            "deptImgUrl",
+            "polyCd",
+            "eleGbnNm",
+            "reeleGbnNm",
+            "unitCd",
+            "units",
+            "unitNm",
+            "cmitNm",
+            "cmits",
+            "telNo",
+            "staff",
+            "secretary",
+            "secretary2",
+            "openNaId",
+        ],
+    )
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name=POSITION_NAME,
+        wikidata_id="Q14850694",
+        country="kr",
+        topics=["gov.legislative", "gov.national"],
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    data = context.fetch_json(
+        context.data_url,
+        method="POST",
+        data={"page": "1", "rows": ROWS},
+        cache_days=1,
+    )
+    rows = data["data"]
+    # Fail loudly if the single-request assumption breaks (paging silently re-introduced,
+    # or the seat count grows past ROWS and the response is truncated).
+    assert len(rows) == data["total"], (len(rows), data["total"])
+    for row in rows:
+        crawl_member(context, position, categorisation, row)

--- a/datasets/kr/assembly/kr_assembly.yml
+++ b/datasets/kr/assembly/kr_assembly.yml
@@ -1,13 +1,13 @@
-title: South Korea National Assembly Members
+title: South Korea Members of National Assembly
 entry_point: crawler.py
 prefix: kr-na
 load_statements: true
 ci_test: false
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: "2026-06-15"
 summary: >-
-  Members of the unicameral National Assembly of the Republic of Korea.
+  Current members of the unicameral National Assembly of the Republic of Korea.
 description: |
   Individuals currently serving in the National Assembly (국회), the unicameral
   legislature of the Republic of Korea. The Assembly has 300 seats (254 single-member
@@ -20,7 +20,6 @@ url: https://open.assembly.go.kr/portal/assm/search/memberSchPage.do
 publisher:
   name: 대한민국 국회
   name_en: National Assembly of the Republic of Korea
-  acronym: NA
   description: >
     The National Assembly is the unicameral national legislature of the Republic of
     Korea. Its Secretariat publishes member and legislative data through the 열린국회정보
@@ -39,13 +38,9 @@ assertions:
   min:
     schema_entities:
       Person: 250
-      Position: 1
-    country_entities:
-      kr: 250
   max:
     schema_entities:
       Person: 350
-      Position: 1
 
 lookups:
   type.gender:

--- a/datasets/kr/assembly/kr_assembly.yml
+++ b/datasets/kr/assembly/kr_assembly.yml
@@ -1,0 +1,66 @@
+title: South Korea National Assembly Members
+entry_point: crawler.py
+prefix: kr-na
+load_statements: true
+ci_test: true
+coverage:
+  frequency: weekly
+  start: 2026-06-15
+summary: >-
+  Members of the National Assembly of the Republic of Korea, the country's
+  unicameral national legislature.
+description: |
+  Individuals currently serving in the National Assembly (국회), the unicameral
+  legislature of the Republic of Korea. The Assembly has 300 seats — 254 single-member
+  districts and 46 proportional-representation seats — whose members are elected to
+  four-year terms.
+
+  The data is sourced from the National Assembly Secretariat's public member-search
+  service, which reflects the sitting Assembly and is updated for by-elections.
+url: https://open.assembly.go.kr/portal/assm/search/memberSchPage.do
+publisher:
+  name: 대한민국 국회
+  name_en: National Assembly of the Republic of Korea
+  acronym: NA
+  description: >
+    The National Assembly is the unicameral national legislature of the Republic of
+    Korea. Its Secretariat publishes member and legislative data through the 열린국회정보
+    (Open Assembly Information) portal.
+  country: kr
+  url: https://www.assembly.go.kr/
+  official: true
+data:
+  url: https://open.assembly.go.kr/portal/assm/search/searchAssmMemberSch.do
+  format: JSON
+  lang: kor
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 250
+      Position: 1
+    country_entities:
+      kr: 250
+  max:
+    schema_entities:
+      Person: 350
+      Position: 1
+
+lookups:
+  type.gender:
+    normalize: true
+    options:
+      - match: 남
+        value: male
+      - match: 여
+        value: female
+  type.email:
+    options:
+      # A few members list two addresses in one field with Korean location labels
+      # (회관 = office, 지역 = local district); split them into clean addresses.
+      - match: "ironkwon24@gmail.com (회관), ironregion24@gmail.com (지역)"
+        values:
+          - ironkwon24@gmail.com
+          - ironregion24@gmail.com

--- a/datasets/kr/assembly/kr_assembly.yml
+++ b/datasets/kr/assembly/kr_assembly.yml
@@ -2,17 +2,16 @@ title: South Korea National Assembly Members
 entry_point: crawler.py
 prefix: kr-na
 load_statements: true
-ci_test: true
+ci_test: false
 coverage:
   frequency: weekly
-  start: 2026-06-15
+  start: "2026-06-15"
 summary: >-
-  Members of the National Assembly of the Republic of Korea, the country's
-  unicameral national legislature.
+  Members of the unicameral National Assembly of the Republic of Korea.
 description: |
   Individuals currently serving in the National Assembly (국회), the unicameral
-  legislature of the Republic of Korea. The Assembly has 300 seats — 254 single-member
-  districts and 46 proportional-representation seats — whose members are elected to
+  legislature of the Republic of Korea. The Assembly has 300 seats (254 single-member
+  districts and 46 proportional-representation seats) whose members are elected to
   four-year terms.
 
   The data is sourced from the National Assembly Secretariat's public member-search

--- a/datasets/kr/assembly/kr_assembly.yml
+++ b/datasets/kr/assembly/kr_assembly.yml
@@ -38,9 +38,11 @@ assertions:
   min:
     schema_entities:
       Person: 250
+      Position: 1
   max:
     schema_entities:
       Person: 350
+      Position: 1
 
 lookups:
   type.gender:


### PR DESCRIPTION
## Summary

Adds a PEP crawler for the **National Assembly of the Republic of Korea** (대한민국 국회), the country's 300-seat unicameral legislature (254 single-member districts + 46 proportional-representation), closing opensanctions/crawler-planning#741.

Emits, for the sitting Assembly:
- one **Person** per member (Korean/romanized/Hanja names, gender, birthDate, party, email, website, sourceUrl, `citizenship: kr`),
- one **Occupancy** per member (with constituency),
- a shared **Position** — *Member of the National Assembly of the Republic of Korea* (`Q14850694`, `gov.legislative`/`gov.national`).

## Source

The issue proposed the official 열린국회정보 OpenAPI, but its API key requires a Korean national ID / public certificate — not viable for us. Instead this uses the **public member-search endpoint** backing `memberSchPage.do`:

- `POST /portal/assm/search/searchAssmMemberSch.do` with `page=1&rows=500` → all members as JSON in **one keyless, cookieless request** (verified). Served under a `text/html` content-type, so `fetch_json` parses the body directly.
- Default scope is the **current** Assembly, so it tracks the sitting body across terms (live roster, not a term-bounded archive). A `len(rows) == total` assertion fails loudly if paging is silently reintroduced or the seat count outgrows `rows`.

## Notes

- **Citizenship** is set per Public Official Election Act (공직선거법) Art. 16(2), cited in a code comment.
- A few members pack two emails into one field with Korean location labels (회관/지역); handled via a `type.email` lookup rather than a parser.
- `telNo` (office phone) and `assemAddr` are deliberately not extracted per PEP guidance.
- `ci_test: true` — single lightweight keyless request; flip to false only if GitHub Actions' US IPs get geo-blocked.

## Validation

- 601 entities (300 Person + 300 Occupancy + 1 Position), **0 crawler issues**, `mypy --strict` clean, `zavod validate` passes.
- All qsv integrity checks empty (no dangling Occupancy refs; every PEP has an occupancy + citizenship); `Occupancy:status` 100% `current`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)