### PR TITLE
cli: Archive failure on export errors

### DIFF
--- a/zavod/zavod/cli/etl.py
+++ b/zavod/zavod/cli/etl.py
@@ -129,11 +129,24 @@ def run(
         archive_failure(dataset)
         store.close()
         sys.exit(1)
-    # Export and Publish
+
+    # Export
     try:
         export_dataset(dataset, view)
         # Set the version as successful in the version file, which will be archived by publish_dataset.
         set_last_successful_version(dataset, settings.RUN_VERSION)
+    except Exception:
+        log.exception("Failed to export: %s" % dataset_path)
+        # archive_failure currently does not support collections
+        # see https://github.com/opensanctions/opensanctions/issues/2459 for context
+        # and an effort to change this.
+        if not dataset.is_collection:
+            archive_failure(dataset)
+        store.close()
+        sys.exit(1)
+
+    # Publish
+    try:
         publish_dataset(dataset, republish_to_latest=latest)
 
         if not dataset.is_collection and dataset.model.load_statements:
@@ -141,5 +154,5 @@ def run(
             load_dataset_to_db(dataset, linker, external=False)
         log.info("Dataset run is complete :)", dataset=dataset.name)
     except Exception:
-        log.exception("Failed to export and publish %r" % dataset.name)
+        log.exception("Failed to publish %r" % dataset.name)
         sys.exit(1)

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -99,7 +99,7 @@ def _warn_about_stale_latest_files(dataset: Dataset, published_files: set[str]) 
 
 def archive_failure(dataset: Dataset) -> None:
     """Upload failure information about a dataset to the archive."""
-    # Collections currently should never call publish_failure (as that only gets called for crawl and validate).
+    # Collections currently should never call archive_failure (as that only gets called for crawl and validate).
     # But if they ever did (for example to publish a failure in the export stage), we should think very well about
     # what exactly a failed index.json for default should look like. Currently, it would have empty resources,
     # and our clients likely wouldn't appreciate that.


### PR DESCRIPTION
## Summary

Split the export and publish steps into separate try/except blocks so that export failures also trigger `archive_failure`, ensuring an `issues.json` gets uploaded documenting the error.

Refs https://github.com/opensanctions/opensanctions/issues/2459

🤖 Generated with [Claude Code](https://claude.com/claude-code)