### PR TITLE
[mo_legislature] Add Macau Legislative Assembly PEP crawler

### DIFF
--- a/datasets/mo/legislature/crawler.py
+++ b/datasets/mo/legislature/crawler.py
@@ -60,8 +60,8 @@ def crawl_member(
     person = context.make("Person")
     person.id = context.make_id(deputy_id, name_zho)
     person.add("name", name_zho, lang="zho")
-    person.add("name", name_lat, lang="por")
-    person.add("name", listing_name, lang="por")
+    person.add("name", name_lat, lang="eng")
+    person.add("name", listing_name, lang="eng")
     h.apply_date(person, "birthDate", birth)
     # Members of the Legislative Assembly are only legally required to be permanent
     # residents of Macau (Basic Law Art. 68); they need not be Chinese nationals — Chinese

--- a/datasets/mo/legislature/crawler.py
+++ b/datasets/mo/legislature/crawler.py
@@ -1,0 +1,149 @@
+import re
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The source publishes only the sitting legislature and carries no per-member or per-term
+# dates — just the legislature number in the page heading (e.g. "8ª Legislatura"). We map
+# each legislature number to the date it took office, so occupancies can be dated. When a
+# new legislature is seated the heading number changes; the crawler then fails loudly (see
+# crawl()) until the new start date is recorded here, rather than silently dating members
+# to the wrong term. The 8th Legislature took office on 16 October 2025 for a five-year
+# term.
+LEGISLATURE_START = {
+    "8": "2025-10-16",
+}
+
+LEGISLATURE_RE = re.compile(r"(\d+)ª\s*Legislatura")
+
+# Detail-page table labels. Only the name and birth-year rows are extracted; the office
+# contact rows (email, website, etc.) are intentionally not captured (see audit_data).
+LABEL_NAME_ZHO = "中文名字:"  # Chinese name
+LABEL_NAME_LAT = "葡文名字:"  # Portuguese / romanised name
+LABEL_BIRTH = "date of birth:"
+# Office section header and known contact-detail labels, ignored on audit.
+IGNORE_LABELS = ["議員辦事處資料", "LABEL_EMAIL:", "LABEL_WEBSITE:"]
+
+
+def crawl_member(
+    context: Context,
+    url: str,
+    deputy_id: str,
+    listing_name: str,
+    term_start: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    doc = context.fetch_html(url, cache_days=7)
+    table = h.xpath_element(doc, ".//div[@class='deputies-detail']//table")
+
+    # The detail page is a label/value table: each data row is `<td>label</td>
+    # <td>value</td>`. Section headers and spacer rows have fewer than two cells and are
+    # skipped here; the office section header is also listed in IGNORE_LABELS in case the
+    # markup ever changes.
+    row: dict[str, str] = {}
+    for tr in h.xpath_elements(table, ".//tr"):
+        cells = h.xpath_elements(tr, "./td")
+        if len(cells) < 2:
+            continue
+        label = h.element_text(cells[0])
+        if not label:
+            continue
+        row[label] = h.element_text(cells[1])
+
+    name_zho = row.pop(LABEL_NAME_ZHO, "")
+    name_lat = row.pop(LABEL_NAME_LAT, "")
+    birth = row.pop(LABEL_BIRTH, "")
+
+    person = context.make("Person")
+    # No cross-source identifier is published; the numeric site id is stable within the
+    # source and the Chinese name disambiguates any hypothetical id reuse across terms.
+    # make_id hashes its inputs, so including the (PII) name here is fine.
+    person.id = context.make_id(deputy_id, name_zho)
+    person.add("name", name_zho)  # Traditional Chinese (data.lang default)
+    person.add("name", name_lat, lang="por")  # romanised form, as published (all caps)
+    person.add(
+        "name", listing_name, lang="por"
+    )  # title-cased form from the listing page
+    h.apply_date(person, "birthDate", birth)
+    # Members of the Legislative Assembly are only legally required to be permanent
+    # residents of Macau (Basic Law Art. 68); they need not be Chinese nationals — Chinese
+    # nationality is required only of the President and Vice-President (Art. 72), and
+    # members may hold other nationalities (e.g. Portuguese). We therefore record their
+    # connection to Macau as `country`, not as a citizenship/nationality claim.
+    # https://en.wikisource.org/wiki/Basic_Law_of_the_Macao_Special_Administrative_Region/Chapter_IV/Section_3
+    person.add("country", "mo")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        start_date=term_start,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(row, ignore=IGNORE_LABELS)
+
+
+def crawl(context: Context) -> None:
+    doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
+
+    # Derive the sitting legislature from the page heading and look up its start date.
+    heading = h.element_text(h.xpath_element(doc, ".//h3[contains(., 'Legislatura')]"))
+    match = LEGISLATURE_RE.search(heading)
+    if match is None:
+        raise ValueError("Could not parse legislature from heading: %r" % heading)
+    legislature = match.group(1)
+    term_start = LEGISLATURE_START.get(legislature)
+    if term_start is None:
+        raise ValueError(
+            "Unknown legislature %r — a new term has been seated; add its start date "
+            "to LEGISLATURE_START." % legislature
+        )
+
+    position = h.make_position(
+        context,
+        name="Member of the Legislative Assembly of Macau",
+        country="mo",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q28941940",
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    # The listing groups deputies by election method (directly/indirectly elected,
+    # appointed) under `channel-title` headings. That distinction has no clean FTM
+    # property, so it is not emitted; all members hold the same position.
+    links = h.xpath_elements(
+        doc,
+        ".//div[contains(@class, 'channel-deputy')]//a[contains(@href, '/deputies/')]",
+    )
+    if len(links) < 20:
+        raise ValueError("Expected at least 20 deputy links, found %d" % len(links))
+
+    seen: set[str] = set()
+    for link in links:
+        href = link.get("href")
+        if href is None:
+            raise ValueError("Deputy link without href")
+        deputy_id = href.rstrip("/").rsplit("/", 1)[-1]
+        if deputy_id in seen:
+            continue
+        seen.add(deputy_id)
+        crawl_member(
+            context,
+            href,
+            deputy_id,
+            h.element_text(link),
+            term_start,
+            position,
+            categorisation,
+        )

--- a/datasets/mo/legislature/crawler.py
+++ b/datasets/mo/legislature/crawler.py
@@ -58,23 +58,18 @@ def crawl_member(
     birth = row.pop(LABEL_BIRTH, "")
 
     person = context.make("Person")
-    # No cross-source identifier is published; the numeric site id is stable within the
-    # source and the Chinese name disambiguates any hypothetical id reuse across terms.
-    # make_id hashes its inputs, so including the (PII) name here is fine.
     person.id = context.make_id(deputy_id, name_zho)
-    person.add("name", name_zho)  # Traditional Chinese (data.lang default)
-    person.add("name", name_lat, lang="por")  # romanised form, as published (all caps)
-    person.add(
-        "name", listing_name, lang="por"
-    )  # title-cased form from the listing page
+    person.add("name", name_zho, lang="zho")
+    person.add("name", name_lat, lang="por")
+    person.add("name", listing_name, lang="por")
     h.apply_date(person, "birthDate", birth)
     # Members of the Legislative Assembly are only legally required to be permanent
     # residents of Macau (Basic Law Art. 68); they need not be Chinese nationals — Chinese
     # nationality is required only of the President and Vice-President (Art. 72), and
-    # members may hold other nationalities (e.g. Portuguese). We therefore record their
-    # connection to Macau as `country`, not as a citizenship/nationality claim.
+    # members may hold other nationalities (e.g. Portuguese).
     # https://en.wikisource.org/wiki/Basic_Law_of_the_Macao_Special_Administrative_Region/Chapter_IV/Section_3
     person.add("country", "mo")
+    person.add("sourceUrl", url)
 
     occupancy = h.make_occupancy(
         context,
@@ -116,18 +111,13 @@ def crawl(context: Context) -> None:
         wikidata_id="Q28941940",
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
-    # The listing groups deputies by election method (directly/indirectly elected,
-    # appointed) under `channel-title` headings. That distinction has no clean FTM
-    # property, so it is not emitted; all members hold the same position.
     links = h.xpath_elements(
         doc,
         ".//div[contains(@class, 'channel-deputy')]//a[contains(@href, '/deputies/')]",
     )
-    if len(links) < 20:
-        raise ValueError("Expected at least 20 deputy links, found %d" % len(links))
 
     seen: set[str] = set()
     for link in links:

--- a/datasets/mo/legislature/mo_legislature.yml
+++ b/datasets/mo/legislature/mo_legislature.yml
@@ -1,8 +1,8 @@
-title: Macau Legislative Assembly (Members)
+title: Macau Members of Legislative Assembly
 entry_point: crawler.py
 prefix: mo-al
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-15
 load_statements: true
 ci_test: false
@@ -10,21 +10,21 @@ summary: >-
   Members of the Legislative Assembly of Macau, the legislature of the Macao
   Special Administrative Region of China
 description: |
-  The Legislative Assembly (立法會 / Assembleia Legislativa) is the unicameral
-  legislature of the Macao Special Administrative Region. Under the Basic Law it has
-  33 members: directly elected, indirectly elected by professional sectors, and
-  appointed by the Chief Executive.
+  Current members of the Legislative Assembly (立法會 / Assembleia Legislativa), the
+  unicameral legislature of the Macao Special Administrative Region of China. Under the
+  Basic Law its 33 members serve five-year terms and hold the region's legislative power,
+  including passing laws and approving the budget.
+  Some members are directly elected, some indirectly elected by
+  professional sectors, and some appointed by the Chief Executive.
 
-  This dataset covers the members of the sitting legislature as published on the
-  Assembly's official website. The source publishes only the current legislature; the
-  crawler emits its members and re-derives the term when a new legislature takes office.
+  This dataset records each member of the sitting legislature with their name and year of birth.
 url: https://www.al.gov.mo/en/deputies
 publisher:
-  name: Legislative Assembly of the Macao SAR
-  name_zht: 澳門特別行政區立法會
+  name_en: Legislative Assembly of the Macao SAR
+  name: 澳門特別行政區立法會
   acronym: AL
   description: >
-    The Legislative Assembly (立法會 / Assembleia Legislativa) is the unicameral
+    The Legislative Assembly is the unicameral
     legislature of the Macao Special Administrative Region of the People's Republic of
     China, established under the Macau Basic Law.
   url: https://www.al.gov.mo/

--- a/datasets/mo/legislature/mo_legislature.yml
+++ b/datasets/mo/legislature/mo_legislature.yml
@@ -1,0 +1,54 @@
+title: Macau Legislative Assembly (Members)
+entry_point: crawler.py
+prefix: mo-al
+coverage:
+  frequency: weekly
+  start: 2026-06-15
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Legislative Assembly of Macau, the legislature of the Macao
+  Special Administrative Region of China
+description: |
+  The Legislative Assembly (立法會 / Assembleia Legislativa) is the unicameral
+  legislature of the Macao Special Administrative Region. Under the Basic Law it has
+  33 members: directly elected, indirectly elected by professional sectors, and
+  appointed by the Chief Executive.
+
+  This dataset covers the members of the sitting legislature as published on the
+  Assembly's official website. The source publishes only the current legislature; the
+  crawler emits its members and re-derives the term when a new legislature takes office.
+url: https://www.al.gov.mo/en/deputies
+publisher:
+  name: Legislative Assembly of the Macao SAR
+  name_zht: 澳門特別行政區立法會
+  acronym: AL
+  description: >
+    The Legislative Assembly (立法會 / Assembleia Legislativa) is the unicameral
+    legislature of the Macao Special Administrative Region of the People's Republic of
+    China, established under the Macau Basic Law.
+  url: https://www.al.gov.mo/
+  country: mo
+  official: true
+data:
+  url: https://www.al.gov.mo/en/deputies
+  format: HTML
+  lang: zho
+
+dates:
+  formats: ["%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 28
+      Position: 1
+    country_entities:
+      mo: 28
+  max:
+    schema_entities:
+      Person: 45
+      Position: 1


### PR DESCRIPTION
Closes opensanctions/crawler-planning#737 (milestone #6 — East Asia PEPs: Legislative Bodies).

Adds a PEP crawler for the members of the Legislative Assembly of Macau (立法會 / Assembleia Legislativa), the unicameral legislature of the Macao SAR. Source: the Assembly's official website (`https://www.al.gov.mo/en/deputies`), static server-rendered HTML.

## What it emits

- One `Position` — "Member of the Legislative Assembly of Macau" (`Q28941940`), `gov.national` + `gov.legislative`.
- One `Person` per deputy with Chinese (`zho`) and romanised (`por`) name forms and year of birth.
- One `Occupancy` per deputy (status `current`, dated to the term start).

Local crawl: 67 entities (33 Person · 33 Occupancy · 1 Position), 0 issues.

## Design notes

- **Term freshness guard**: the source publishes only the sitting legislature and carries no per-member dates. The crawler parses the legislature number from the page heading (e.g. "8ª Legislatura") and maps it to its start date (`2025-10-16` for the 8th). When a new legislature is seated the heading number changes and the crawler raises loudly until the new start date is recorded — rather than silently dating members to the wrong term.
- **Citizenship**: members are only legally required to be permanent residents of Macau (Basic Law Art. 68); they need not be Chinese nationals (nationality is required only of the President/VP, Art. 72, and members may hold e.g. Portuguese nationality). The crawler therefore records `country=mo`, not a citizenship/nationality claim. Legal source cited in a code comment.
- **Not emitted**: election method (directly/indirectly elected, appointed) — no clean FTM property — and office contact details (privacy).
- `ci_test: false` — the crawler makes 1 + 33 live fetches to a foreign government site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)