### PR TITLE
[be_senate] Lower min entity assertions to match production

### DIFF
--- a/datasets/be/senate/be_senate.yml
+++ b/datasets/be/senate/be_senate.yml
@@ -58,10 +58,10 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 250
+      Person: 100
       Position: 1
     country_entities:
-      be: 250
+      be: 100
   max:
     schema_entities:
       Person: 800


### PR DESCRIPTION
The first production run of `be_senate` produced 125 Person / 126 Belgium entities, below the initial `min` assertion of 250, failing the import: https://www.opensanctions.org/issues/be_senate/

The in-window senator roster is smaller than estimated when the crawler was written, so this lowers the minimums (Person and `be` country entities) to 100, leaving comfortable margin below the observed 125. The max ceiling is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)