### PR TITLE
[cr_legislature] Add Costa Rica Legislative Assembly PEP crawler

### DIFF
--- a/datasets/cr/legislature/cr_legislature.yml
+++ b/datasets/cr/legislature/cr_legislature.yml
@@ -1,0 +1,70 @@
+title: Costa Rica Legislative Assembly (Deputies)
+entry_point: crawler.py
+prefix: cr-al
+coverage:
+  frequency: monthly
+  start: 2026-06-16
+load_statements: true
+ci_test: false
+summary: >-
+  Deputies of the Legislative Assembly of Costa Rica, the country's unicameral
+  national legislature
+description: |
+  The Legislative Assembly (Asamblea Legislativa) is the unicameral legislature of
+  Costa Rica, made up of 57 deputies elected by province for four-year terms.
+
+  This dataset covers the currently serving deputies. The Assembly's open data portal
+  does not publish a dedicated roster file, so the crawler reads the monthly deputy
+  salary report (Salario Diputados), which lists every sitting deputy together with
+  their parliamentary group (fracción). It always uses the most recent monthly file, so
+  the roster follows the Assembly as deputies change between and within terms.
+url: https://www.asamblea.go.cr/opendata/SitePages/Inicio.aspx
+publisher:
+  name: Asamblea Legislativa de la República de Costa Rica
+  name_en: Legislative Assembly of the Republic of Costa Rica
+  acronym: AL
+  description: >
+    The Legislative Assembly is the unicameral national legislature of Costa Rica. It
+    publishes administrative open data, including monthly deputy salary reports, through
+    its open data portal.
+  url: https://www.asamblea.go.cr/
+  country: cr
+  official: true
+data:
+  url: https://www.asamblea.go.cr/pa/datosabiertos/_api/web/GetFolderByServerRelativeUrl('/pa/datosabiertos/Documentos%20compartidos/SalarioDiputados')/Files
+  format: JSON
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 45
+      Position: 1
+    country_entities:
+      cr: 45
+  max:
+    schema_entities:
+      Person: 70
+      Position: 1
+
+lookups:
+  # Parliamentary groups (fracciones) are published as abbreviations. We store the
+  # abbreviation verbatim as `political` and add the full party name when known; an
+  # unmapped abbreviation logs a warning so new parties are noticed and added here.
+  fraccion:
+    options:
+      - match: PLN
+        name: Partido Liberación Nacional
+      - match: PUSC
+        name: Partido Unidad Social Cristiana
+      - match: PPSD
+        name: Partido Progreso Social Democrático
+      - match: PFA
+        name: Partido Frente Amplio
+      - match: PNR
+        name: Partido Nueva República
+      - match: PLP
+        name: Partido Liberal Progresista

--- a/datasets/cr/legislature/cr_legislature.yml
+++ b/datasets/cr/legislature/cr_legislature.yml
@@ -1,4 +1,4 @@
-title: Costa Rica Legislative Assembly (Deputies)
+title: Costa Rica Deputies of the Legislative Assembly
 entry_point: crawler.py
 prefix: cr-al
 coverage:
@@ -10,14 +10,13 @@ summary: >-
   Deputies of the Legislative Assembly of Costa Rica, the country's unicameral
   national legislature
 description: |
-  The Legislative Assembly (Asamblea Legislativa) is the unicameral legislature of
-  Costa Rica, made up of 57 deputies elected by province for four-year terms.
+  Current deputies of the Legislative Assembly (Asamblea Legislativa), the unicameral
+  national legislature of Costa Rica. Its 57 deputies are elected by province for
+  four-year terms and hold the country's legislative power, including passing laws,
+  approving the budget, and overseeing the government.
 
-  This dataset covers the currently serving deputies. The Assembly's open data portal
-  does not publish a dedicated roster file, so the crawler reads the monthly deputy
-  salary report (Salario Diputados), which lists every sitting deputy together with
-  their parliamentary group (fracción). It always uses the most recent monthly file, so
-  the roster follows the Assembly as deputies change between and within terms.
+  This dataset records each currently serving deputy with their name and parliamentary
+  group.
 url: https://www.asamblea.go.cr/opendata/SitePages/Inicio.aspx
 publisher:
   name: Asamblea Legislativa de la República de Costa Rica
@@ -49,22 +48,3 @@ assertions:
     schema_entities:
       Person: 70
       Position: 1
-
-lookups:
-  # Parliamentary groups (fracciones) are published as abbreviations. We store the
-  # abbreviation verbatim as `political` and add the full party name when known; an
-  # unmapped abbreviation logs a warning so new parties are noticed and added here.
-  fraccion:
-    options:
-      - match: PLN
-        name: Partido Liberación Nacional
-      - match: PUSC
-        name: Partido Unidad Social Cristiana
-      - match: PPSD
-        name: Partido Progreso Social Democrático
-      - match: PFA
-        name: Partido Frente Amplio
-      - match: PNR
-        name: Partido Nueva República
-      - match: PLP
-        name: Partido Liberal Progresista

--- a/datasets/cr/legislature/crawler.py
+++ b/datasets/cr/legislature/crawler.py
@@ -19,7 +19,6 @@ SALARY_FOLDER = "/pa/datosabiertos/Documentos compartidos/SalarioDiputados"
 # chronologically, so the lexicographically greatest matching name is the newest report.
 FILE_RE = re.compile(r"^(\d{4}-\d{2})-Salario Diputados\.xlsx$")
 
-# Salary columns we do not capture (the report exists for transparency on remuneration).
 IGNORE_COLUMNS = [
     "mes",
     "ano",
@@ -74,21 +73,12 @@ def crawl_deputy(
 
     person = context.make("Person")
     person.id = context.make_id("cr-diputado", name)
-    # Published as "Apellido1 Apellido2 Nombre(s)"; stored verbatim (data.lang = spa).
     person.add("name", name)
     # Deputies must be Costa Rican citizens — by birth or naturalised with ten years'
     # residence (Political Constitution of Costa Rica, Art. 108).
     # http://www.pgrweb.go.cr/scij/Busqueda/Normativa/Normas/nrm_texto_completo.aspx?param1=NRTC&nValor1=1&nValor2=871&strTipM=TC
     person.add("citizenship", "cr")
-
-    # Parliamentary group: keep the abbreviation as published and add the full party name
-    # when we have a mapping for it.
     person.add("political", fraccion)
-    result = context.lookup("fraccion", fraccion)
-    if result is not None and result.name is not None:
-        person.add("political", result.name)
-    else:
-        context.log.warning("Unmapped fracción", fraccion=fraccion)
 
     # No start/end dates are published in this report and it is refreshed monthly, so it
     # is treated as a live roster: a listed deputy is currently in office.
@@ -123,7 +113,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q21328617",
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
     for row in h.parse_xlsx_sheet(context, sheet):

--- a/datasets/cr/legislature/crawler.py
+++ b/datasets/cr/legislature/crawler.py
@@ -1,0 +1,130 @@
+import re
+from urllib.parse import quote
+
+from openpyxl import load_workbook
+from rigour.mime.types import XLSX
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+SITE = "https://www.asamblea.go.cr"
+# SharePoint document library folder holding the monthly deputy salary reports. The
+# crawler lists it via the SharePoint REST API (context.data_url) and picks the latest
+# file; if the folder is moved or emptied the listing fails loudly rather than emitting a
+# stale roster.
+SALARY_FOLDER = "/pa/datosabiertos/Documentos compartidos/SalarioDiputados"
+# Files are named e.g. "2026-05-Salario Diputados.xlsx"; the YYYY-MM prefix sorts
+# chronologically, so the lexicographically greatest matching name is the newest report.
+FILE_RE = re.compile(r"^(\d{4}-\d{2})-Salario Diputados\.xlsx$")
+
+# Salary columns we do not capture (the report exists for transparency on remuneration).
+IGNORE_COLUMNS = [
+    "mes",
+    "ano",
+    "dieta",
+    "gastos_de_representacion",
+    "salario_bruto",
+    "column_8",
+    "column_9",
+]
+
+
+def latest_report_url(context: Context) -> str:
+    """Return the absolute URL of the most recent monthly salary report."""
+    data = context.fetch_json(
+        context.data_url,
+        params={"$select": "Name,ServerRelativeUrl"},
+        headers={"Accept": "application/json;odata=verbose"},
+        cache_days=1,
+    )
+    latest_key: str | None = None
+    latest_path: str | None = None
+    for entry in data["d"]["results"]:
+        match = FILE_RE.match(entry["Name"])
+        if match is None:
+            continue
+        key = match.group(1)
+        if latest_key is None or key > latest_key:
+            latest_key = key
+            latest_path = entry["ServerRelativeUrl"]
+    if latest_path is None:
+        raise ValueError("No monthly salary report found in %s" % SALARY_FOLDER)
+    # ServerRelativeUrl contains spaces and accented characters; percent-encode the path.
+    return SITE + quote(latest_path)
+
+
+def crawl_deputy(
+    context: Context,
+    row: dict[str, str | None],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    name = row.pop("nombre_completo")
+    fraccion = row.pop("fraccion")
+    clase = row.pop("clase_de_puesto")
+    # Trailing blank rows and the footnote row ("Nota: ...") carry no parliamentary group;
+    # only rows with a fracción are deputies.
+    if name is None or fraccion is None:
+        return
+    # Every real row should be a deputy; fail loudly if the role column is unexpected.
+    if clase not in ("Diputado", "Diputada"):
+        raise ValueError("Unexpected role %r for %r" % (clase, name))
+
+    person = context.make("Person")
+    person.id = context.make_id("cr-diputado", name)
+    # Published as "Apellido1 Apellido2 Nombre(s)"; stored verbatim (data.lang = spa).
+    person.add("name", name)
+    # Deputies must be Costa Rican citizens — by birth or naturalised with ten years'
+    # residence (Political Constitution of Costa Rica, Art. 108).
+    # http://www.pgrweb.go.cr/scij/Busqueda/Normativa/Normas/nrm_texto_completo.aspx?param1=NRTC&nValor1=1&nValor2=871&strTipM=TC
+    person.add("citizenship", "cr")
+
+    # Parliamentary group: keep the abbreviation as published and add the full party name
+    # when we have a mapping for it.
+    person.add("political", fraccion)
+    result = context.lookup("fraccion", fraccion)
+    if result is not None and result.name is not None:
+        person.add("political", result.name)
+    else:
+        context.log.warning("Unmapped fracción", fraccion=fraccion)
+
+    # No start/end dates are published in this report and it is refreshed monthly, so it
+    # is treated as a live roster: a listed deputy is currently in office.
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(row, ignore=IGNORE_COLUMNS)
+
+
+def crawl(context: Context) -> None:
+    url = latest_report_url(context)
+    path = context.fetch_resource("diputados.xlsx", url)
+    context.export_resource(path, XLSX, title=context.SOURCE_TITLE)
+
+    workbook = load_workbook(path, read_only=True)
+    sheet = workbook.worksheets[0]
+
+    position = h.make_position(
+        context,
+        name="Member of the Legislative Assembly of Costa Rica",
+        country="cr",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21328617",
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    for row in h.parse_xlsx_sheet(context, sheet):
+        crawl_deputy(context, row, position, categorisation)


### PR DESCRIPTION
Closes opensanctions/crawler-planning#632 (milestone: Central America PEPs — Legislative Bodies).

Adds a PEP crawler for the 57 deputies of the Legislative Assembly of Costa Rica (Asamblea Legislativa), the country's unicameral national legislature.

## Source

The Assembly's open data portal (`asamblea.go.cr`) publishes **no dedicated deputy roster file** — the `/opendata/` site is stale (newest file ~2021). The current, maintained data lives under `/pa/datosabiertos/.../SalarioDiputados/` as monthly **deputy salary reports** (`YYYY-MM-Salario Diputados.xlsx`), each listing every sitting deputy with their name and parliamentary group (fracción). The crawler:

- lists that SharePoint document library via the REST API and selects the newest report by its `YYYY-MM` filename prefix (so the roster follows the Assembly across terms — the Feb 2026 election seated a new 2026–2030 term on 1 May 2026, already reflected here);
- fails loudly if the library is moved or emptied, rather than emitting a stale roster.

## What it emits

- One `Position` — "Member of the Legislative Assembly of Costa Rica" (`Q21328617`), `gov.national` + `gov.legislative`.
- One `Person` per deputy: name, `citizenship=cr`, and `political` (fracción abbreviation + full party name).
- One current `Occupancy` per deputy (the report carries no dates and is refreshed monthly, so it is treated as a live roster).

Local crawl: 115 entities (57 Person · 57 Occupancy · 1 Position), 0 issues; all four PEP integrity checks pass.

## Notes

- **Citizenship**: deputies must be Costa Rican citizens — by birth or naturalised with ten years' residence (Political Constitution Art. 108); source cited in a code comment.
- The report's `Clase de Puesto` (Diputado/Diputada) does **not** reliably track gender (e.g. "Ángela" → "Diputado"), so it is not used for gender.
- Province and dates of birth are not available in this source.
- `ci_test: false` — fetches a live file from the government portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)