### PR TITLE
[pa_legislature] Add Panama National Assembly PEP crawler

### DIFF
--- a/datasets/pa/legislature/crawler.py
+++ b/datasets/pa/legislature/crawler.py
@@ -1,0 +1,116 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Fields carried by the source we deliberately do not emit: contact details and social
+# media (private), images and document links, attendance/score/budget metrics, and
+# editorial profile text. The alternate deputy (suplente) is a different person who is
+# not currently in office, so they are not emitted as a deputy either.
+IGNORE_FIELDS = [
+    "slug",
+    "circuito",
+    "provincia",
+    "suplente",
+    "imagen",
+    "biografia",
+    "email",
+    "telefono",
+    "redesSociales",
+    "profesion",
+    "educacion",
+    "experiencia",
+    "cv",
+    "propuestaPolitica",
+    "asistenciaPlenarias",
+    "asistenciaComisiones",
+    "proyectosPresentados",
+    "proyectosAprobados",
+    "intervenciones",
+    "puntajeViajesViaticos",
+    "puntajeDeclaracionIntereses",
+    "puntajeDeclaracionPatrimonio",
+    "calificacionPonderada",
+    "planillaMonto",
+    "viajesViaticosMonto",
+    "comisionPrincipal",
+    "comisionesSecundarias",
+    "periodoInicio",
+    "periodoFin",
+    "declaracionIntereses",
+    "declaracionPatrimonio",
+    "tieneDeclaraciones",
+    "planilla",
+    "viajesViaticos",
+    "createdAt",
+    "updatedAt",
+]
+
+
+def crawl_deputy(
+    context: Context,
+    row: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    # `activo` marks deputies currently in office; skip anyone flagged inactive.
+    activo = row.pop("activo")
+    if activo is not True:
+        return
+
+    deputy_id = row.pop("id")
+    name = row.pop("nombreCompleto")
+    row.pop("nombre")
+    row.pop("apellido")
+    born = row.pop("borndate")
+
+    person = context.make("Person")
+    person.id = context.make_slug(str(deputy_id))
+    person.add("name", name)
+    # `borndate` is an ISO timestamp (e.g. "1989-10-14T05:00:00.000Z"); keep the date.
+    if born is not None:
+        h.apply_date(person, "birthDate", born[:10])
+    # Deputies must be Panamanian — by birth, or naturalised with fifteen years' residence
+    # (Political Constitution of Panama, Art. 153).
+    # https://constitucion.te.gob.pa/organo-legislativo/
+    person.add("citizenship", "pa")
+    person.add("political", row.pop("partido"))
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(row, ignore=IGNORE_FIELDS)
+
+
+def crawl(context: Context) -> None:
+    data = context.fetch_json(context.data_url, cache_days=1)
+    if data.get("success") is not True:
+        raise ValueError("Unexpected API response: %r" % data.get("success"))
+    deputies = data["diputados"]
+    if len(deputies) < 50:
+        raise ValueError("Expected at least 50 deputies, got %d" % len(deputies))
+
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of Panama",
+        country="pa",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21295996",
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    for row in deputies:
+        crawl_deputy(context, row, position, categorisation)

--- a/datasets/pa/legislature/pa_legislature.yml
+++ b/datasets/pa/legislature/pa_legislature.yml
@@ -1,0 +1,51 @@
+title: Panama National Assembly (Deputies)
+entry_point: crawler.py
+prefix: pa-an
+coverage:
+  frequency: weekly
+  start: 2026-06-16
+load_statements: true
+ci_test: false
+summary: >-
+  Deputies of the National Assembly of Panama, the country's unicameral national
+  legislature
+description: |
+  The National Assembly (Asamblea Nacional) is the unicameral legislature of Panama,
+  made up of 71 deputies elected by electoral circuit for five-year terms.
+
+  This dataset covers the currently serving deputies. The Assembly's own website does
+  not expose structured deputy data (it is behind an anti-bot challenge), so the crawler
+  uses the deputy directory published by Espacio Cívico, a Panamanian civil-society
+  organisation that compiles and monitors official information on the deputies.
+url: https://espaciocivico.org/diputados
+publisher:
+  name: Espacio Cívico
+  description: >
+    Espacio Cívico is a Panamanian civil-society organisation that publishes a monitored
+    directory of the deputies of the National Assembly, compiling official information on
+    their profiles, attendance and declarations.
+  url: https://espaciocivico.org/
+  country: pa
+  official: false
+data:
+  url: https://espaciocivico.org/api/diputados
+  format: JSON
+  lang: spa
+
+dates:
+  formats: ["%Y-%m-%d"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 60
+      Position: 1
+    country_entities:
+      pa: 60
+  max:
+    schema_entities:
+      Person: 85
+      Position: 1


### PR DESCRIPTION
Closes opensanctions/crawler-planning#639 (milestone: Central America PEPs — Legislative Bodies).

Adds a PEP crawler for the 71 deputies of the National Assembly of Panama (Asamblea Nacional), the country's unicameral national legislature.

## Source

The Assembly's official site (`asamblea.gob.pa/Diputados`) turned out to be behind an **F5 BIG-IP anti-bot JS challenge** — not the plain HTML the issue assumed — so it can't be fetched without browser rendering. Instead the crawler uses the deputy directory **JSON API** published by **Espacio Cívico**, a Panamanian civil-society organisation that compiles and monitors official deputy information (`https://espaciocivico.org/api/diputados`). The data reflects the current 2024–2029 term (71 deputies, exact).

## What it emits

- One `Position` — "Member of the National Assembly of Panama" (`Q21295996`), `gov.national` + `gov.legislative`.
- One `Person` per currently-serving deputy: name, date of birth, `citizenship=pa`, and `political` (party).
- One current `Occupancy` per deputy (the source carries no term dates and is refreshed, so it is treated as a live roster).

Local crawl: 143 entities (71 Person · 71 Occupancy · 1 Position), 0 issues; all four PEP integrity checks pass; 70/71 have a birth date.

## Notes

- **Citizenship**: deputies must be Panamanian — by birth, or naturalised with fifteen years' residence (Political Constitution Art. 153); source cited in a code comment.
- Skips alternates (`suplente` — a different, non-sitting person), inactive deputies (`activo != true`), and private contact details / attendance metrics.
- `ci_test: false` — fetches a live API.
- The official site could later be crawled directly via Zyte browser-rendering if preferred over the civil-society source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)