### PR TITLE
[gt_legislature] Add Guatemala Congress PEP crawler

### DIFF
--- a/datasets/gt/legislature/crawler.py
+++ b/datasets/gt/legislature/crawler.py
@@ -1,0 +1,94 @@
+import re
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Each record links to the deputy's official profile, e.g.
+# "https://www.congreso.gob.gt/perfil_diputado/929" — the numeric id is stable and
+# official, so it keys the entity.
+PROFILE_RE = re.compile(r"/perfil_diputado/(\d+)")
+# Real birth dates are "DD-MM-YYYY"; missing ones are published as the placeholder
+# "30-11--0001", which we skip rather than feed to apply_date.
+BIRTH_RE = re.compile(r"^\d{2}-\d{2}-(19|20)\d{2}$")
+
+# Contact details (private) and image/profile links are not emitted. "Unnamed: 9" is an
+# occasional stray column (a duplicate of the bloc) in the source export.
+IGNORE_FIELDS = [
+    "Distrito al que representa:",
+    "E-mail:",
+    "Teléfono de la oficina:",
+    "Dirección de la oficina:",
+    "Imagen URL",
+    "Perfil URL",
+    "ImagenGithub",
+    "Unnamed: 9",
+]
+
+
+def crawl_deputy(
+    context: Context,
+    row: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    name = row.pop("Nombre")
+    born = row.pop("Fecha de nacimiento:")
+    bloque = row.pop("Bloque al que representa")
+    profile_url = row.get("Perfil URL") or ""
+
+    match = PROFILE_RE.search(profile_url)
+    if match is None:
+        raise ValueError("No profile id for deputy %r (%r)" % (name, profile_url))
+
+    person = context.make("Person")
+    person.id = context.make_slug(match.group(1))
+    person.add("name", name)
+    if born is not None and BIRTH_RE.match(born):
+        h.apply_date(person, "birthDate", born)
+    # Deputies must be Guatemalan by origin ("guatemalteco de origen"); naturalised
+    # citizens are not eligible (Political Constitution of Guatemala, Art. 162).
+    # https://www.constituteproject.org/constitution/Guatemala_1993
+    person.add("citizenship", "gt")
+
+    # The bloc is published as "Party Name - ACRONYM"; store the party name. Deputies
+    # sitting as independents ("Independiente - IND") have no party affiliation.
+    party_name = bloque.rpartition(" - ")[0] or bloque
+    if party_name != "Independiente":
+        person.add("political", party_name)
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(row, ignore=IGNORE_FIELDS)
+
+
+def crawl(context: Context) -> None:
+    deputies = context.fetch_json(context.data_url, cache_days=1)
+    if not isinstance(deputies, list) or len(deputies) < 120:
+        raise ValueError("Expected a list of at least 120 deputies, got %r" % type(deputies))
+
+    position = h.make_position(
+        context,
+        name="Member of the Congress of the Republic of Guatemala",
+        country="gt",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q18277108",
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    for row in deputies:
+        crawl_deputy(context, row, position, categorisation)

--- a/datasets/gt/legislature/gt_legislature.yml
+++ b/datasets/gt/legislature/gt_legislature.yml
@@ -1,0 +1,53 @@
+title: Guatemala Congress of the Republic (Deputies)
+entry_point: crawler.py
+prefix: gt-cong
+coverage:
+  frequency: weekly
+  start: 2026-06-16
+load_statements: true
+ci_test: false
+summary: >-
+  Deputies of the Congress of the Republic of Guatemala, the country's unicameral
+  national legislature
+description: |
+  The Congress of the Republic (Congreso de la República) is the unicameral legislature
+  of Guatemala, made up of 160 deputies elected for four-year terms.
+
+  This dataset covers the currently serving deputies. The official congressional member
+  directory (congreso.gob.gt) is behind an Incapsula anti-bot firewall and cannot be
+  fetched directly, so the crawler uses the open dataset published by Red Ciudadana, a
+  Guatemalan civil-society organisation that compiles deputy information from official
+  congressional sources. Each record links back to the deputy's official congressional
+  profile, whose identifier is used as the entity key.
+url: https://redciudadana.github.io/DatosAbiertos.gt/
+publisher:
+  name: Red Ciudadana
+  description: >
+    Red Ciudadana is a Guatemalan civil-society organisation that promotes transparency
+    and open data. It compiles and republishes information on the deputies of the
+    Congress of the Republic from official congressional sources.
+  url: https://redciudadana.org/
+  country: gt
+  official: false
+data:
+  url: https://raw.githubusercontent.com/RedCiudadana/Monitor_Legislativo/main/_data/diputados.json
+  format: JSON
+  lang: spa
+
+dates:
+  formats: ["%d-%m-%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 140
+      Position: 1
+    country_entities:
+      gt: 140
+  max:
+    schema_entities:
+      Person: 175
+      Position: 1


### PR DESCRIPTION
Closes opensanctions/crawler-planning#637 (milestone: Central America PEPs — Legislative Bodies).

Adds a PEP crawler for the deputies of the Congress of the Republic of Guatemala (Congreso de la República), the country's unicameral national legislature (160 seats).

## Source

The official member directory (`congreso.gob.gt/buscador_diputados`) is behind an **Incapsula anti-bot firewall** (HTTP 403 to automated requests), as the issue notes. The crawler instead uses the open dataset published by **Red Ciudadana**, a Guatemalan civil-society / open-data organisation that compiles deputy information from official congressional sources (`Monitor_Legislativo/_data/diputados.json`). Each record links back to the deputy's official `congreso.gob.gt/perfil_diputado/{id}` profile, and that **official id keys the entity**. The data reflects the current 2024–2028 term.

## What it emits

- One `Position` — "Member of the Congress of the Republic of Guatemala" (`Q18277108`), `gov.national` + `gov.legislative`.
- One `Person` per deputy: name, date of birth, `citizenship=gt`, and `political` (party, parsed from the "Party Name - ACRONYM" bloc; independents get none).
- One current `Occupancy` per deputy (the source carries no term dates, so it is treated as a live roster).

Local crawl: 319 entities (159 Person · 159 Occupancy · 1 Position), 0 issues; all four PEP integrity checks pass; 157/159 have a birth date, 134 have a party (25 sit as independents).

## Notes

- The source currently lists **159** deputies (of 160) — likely one vacancy/gap in the civil-society dataset; assertions allow for this.
- **Citizenship**: deputies must be Guatemalan **by origin** — naturalised citizens are not eligible (Political Constitution Art. 162); source cited in a code comment.
- Skips private contact details and image/profile links; a placeholder birth date (`30-11--0001`) and a stray `Unnamed: 9` export column are handled explicitly.
- `ci_test: false` — fetches a live file.
- The official site could later be crawled directly via Zyte if preferred over the civil-society source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)