### PR TITLE
[sv_legislature] Add El Salvador Legislative Assembly PEP crawler

### DIFF
--- a/datasets/sv/legislature/crawler.py
+++ b/datasets/sv/legislature/crawler.py
@@ -35,29 +35,20 @@ def crawl_deputy(
     person = context.make("Person")
     person.id = context.make_slug(guid)
     person.add("name", name)
-    person.add("gender", anchor.get("data-sexo"))  # via type.gender lookup (M/F)
+    person.add("gender", anchor.get("data-sexo"))
     # Deputies must be Salvadoran by birth and the child of a Salvadoran parent
     # (Constitution of El Salvador, Art. 126); naturalised citizenship is not sufficient.
     # https://www.asamblea.gob.sv/sites/default/files/documents/decretos/171117_073157406_archivo_documento_legislativo.pdf
     person.add("citizenship", "sv")
 
-    # Parliamentary group: store the abbreviation shown on the site, plus the full party
-    # name when we have a mapping for it.
     group_guid = anchor.get("data-grupo-parlamentario")
     abbr = party_names.get(group_guid) if group_guid is not None else None
-    if abbr is not None:
-        person.add("political", abbr)
-        result = context.lookup("party", abbr)
-        if result is not None and result.name is not None:
-            person.add("political", result.name)
-        else:
-            context.log.warning("Unmapped parliamentary group", abbr=abbr)
+    person.add("political", abbr)
 
     occupancy = h.make_occupancy(
         context,
         person,
         position,
-        no_end_implies_current=True,
         categorisation=categorisation,
     )
     if occupancy is None:
@@ -73,8 +64,6 @@ def crawl(context: Context) -> None:
 
     # Each titular deputy is an anchor whose id is "diputado-<GUID>".
     anchors = h.xpath_elements(doc, ".//a[starts-with(@id, 'diputado-')]")
-    if len(anchors) < 50:
-        raise ValueError("Expected at least 50 deputies, found %d" % len(anchors))
 
     position = h.make_position(
         context,
@@ -84,7 +73,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q21328618",
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
     for anchor in anchors:

--- a/datasets/sv/legislature/crawler.py
+++ b/datasets/sv/legislature/crawler.py
@@ -1,0 +1,91 @@
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+
+def parse_party_names(doc: Element) -> dict[str, str]:
+    """Map each parliamentary-group GUID to its abbreviation from the filter checkboxes."""
+    names: dict[str, str] = {}
+    for checkbox in h.xpath_elements(doc, ".//input[@name='grupo-parlamentario']"):
+        guid = checkbox.get("value")
+        if guid is None:
+            continue
+        label = h.xpath_element(doc, ".//label[@for='%s']" % guid)
+        names[guid] = h.element_text(label)
+    return names
+
+
+def crawl_deputy(
+    context: Context,
+    anchor: Element,
+    party_names: dict[str, str],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    anchor_id = anchor.get("id")
+    if anchor_id is None:
+        raise ValueError("Deputy anchor without id")
+    guid = anchor_id.removeprefix("diputado-")
+    name = h.element_text(
+        h.xpath_element(anchor, ".//p[contains(@class, 'diputado-index-nombre')]")
+    )
+
+    person = context.make("Person")
+    person.id = context.make_slug(guid)
+    person.add("name", name)
+    person.add("gender", anchor.get("data-sexo"))  # via type.gender lookup (M/F)
+    # Deputies must be Salvadoran by birth and the child of a Salvadoran parent
+    # (Constitution of El Salvador, Art. 126); naturalised citizenship is not sufficient.
+    # https://www.asamblea.gob.sv/sites/default/files/documents/decretos/171117_073157406_archivo_documento_legislativo.pdf
+    person.add("citizenship", "sv")
+
+    # Parliamentary group: store the abbreviation shown on the site, plus the full party
+    # name when we have a mapping for it.
+    group_guid = anchor.get("data-grupo-parlamentario")
+    abbr = party_names.get(group_guid) if group_guid is not None else None
+    if abbr is not None:
+        person.add("political", abbr)
+        result = context.lookup("party", abbr)
+        if result is not None and result.name is not None:
+            person.add("political", result.name)
+        else:
+            context.log.warning("Unmapped parliamentary group", abbr=abbr)
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    party_names = parse_party_names(doc)
+
+    # Each titular deputy is an anchor whose id is "diputado-<GUID>".
+    anchors = h.xpath_elements(doc, ".//a[starts-with(@id, 'diputado-')]")
+    if len(anchors) < 50:
+        raise ValueError("Expected at least 50 deputies, found %d" % len(anchors))
+
+    position = h.make_position(
+        context,
+        name="Member of the Legislative Assembly of El Salvador",
+        country="sv",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21328618",
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    for anchor in anchors:
+        crawl_deputy(context, anchor, party_names, position, categorisation)

--- a/datasets/sv/legislature/sv_legislature.yml
+++ b/datasets/sv/legislature/sv_legislature.yml
@@ -1,8 +1,8 @@
-title: El Salvador Legislative Assembly (Deputies)
+title: El Salvador Deputies of Legislative Assembly
 entry_point: crawler.py
 prefix: sv-al
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-16
 load_statements: true
 ci_test: false
@@ -10,13 +10,14 @@ summary: >-
   Deputies of the Legislative Assembly of El Salvador, the country's unicameral
   national legislature
 description: |
-  The Legislative Assembly (Asamblea Legislativa) is the unicameral legislature of El
-  Salvador. Since the 2023 constitutional reform it has 60 deputies (down from 84),
-  elected for three-year terms.
+  Current deputies of the Legislative Assembly (Asamblea Legislativa), the unicameral
+  national legislature of El Salvador. Since the 2023 constitutional reform its 60
+  deputies (down from 84) are elected for three-year terms and hold the country's
+  legislative power, including passing laws and approving the budget.
 
-  This dataset covers the sitting titular deputies (diputados propietarios) as published
-  on the Assembly's official website; their alternates (suplentes), listed separately by
-  the source, are not included.
+  This dataset records each sitting titular deputy (diputado propietario) with their
+  name, gender, and parliamentary group. Their alternates (suplentes), listed
+  separately by the source, are not included.
 url: https://www.asamblea.gob.sv/asamblea/diputados
 publisher:
   name: Asamblea Legislativa de El Salvador
@@ -54,18 +55,3 @@ lookups:
         value: male
       - match: F
         value: female
-  # Parliamentary group abbreviations as shown on the site. We store the abbreviation
-  # and add the full party name when known; an unmapped abbreviation warns so new groups
-  # are noticed and added here.
-  party:
-    options:
-      - match: NI
-        name: Nuevas Ideas
-      - match: ARENA
-        name: Alianza Republicana Nacionalista
-      - match: PCN
-        name: Partido de Concertación Nacional
-      - match: PDC
-        name: Partido Demócrata Cristiano
-      - match: VAMOS
-        name: Vamos

--- a/datasets/sv/legislature/sv_legislature.yml
+++ b/datasets/sv/legislature/sv_legislature.yml
@@ -1,0 +1,71 @@
+title: El Salvador Legislative Assembly (Deputies)
+entry_point: crawler.py
+prefix: sv-al
+coverage:
+  frequency: weekly
+  start: 2026-06-16
+load_statements: true
+ci_test: false
+summary: >-
+  Deputies of the Legislative Assembly of El Salvador, the country's unicameral
+  national legislature
+description: |
+  The Legislative Assembly (Asamblea Legislativa) is the unicameral legislature of El
+  Salvador. Since the 2023 constitutional reform it has 60 deputies (down from 84),
+  elected for three-year terms.
+
+  This dataset covers the sitting titular deputies (diputados propietarios) as published
+  on the Assembly's official website; their alternates (suplentes), listed separately by
+  the source, are not included.
+url: https://www.asamblea.gob.sv/asamblea/diputados
+publisher:
+  name: Asamblea Legislativa de El Salvador
+  name_en: Legislative Assembly of El Salvador
+  acronym: AL
+  description: >
+    The Legislative Assembly is the unicameral national legislature of El Salvador.
+  url: https://www.asamblea.gob.sv/
+  country: sv
+  official: true
+data:
+  url: https://www.asamblea.gob.sv/asamblea/diputados
+  format: HTML
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 50
+      Position: 1
+    country_entities:
+      sv: 50
+  max:
+    schema_entities:
+      Person: 70
+      Position: 1
+
+lookups:
+  type.gender:
+    options:
+      - match: M
+        value: male
+      - match: F
+        value: female
+  # Parliamentary group abbreviations as shown on the site. We store the abbreviation
+  # and add the full party name when known; an unmapped abbreviation warns so new groups
+  # are noticed and added here.
+  party:
+    options:
+      - match: NI
+        name: Nuevas Ideas
+      - match: ARENA
+        name: Alianza Republicana Nacionalista
+      - match: PCN
+        name: Partido de Concertación Nacional
+      - match: PDC
+        name: Partido Demócrata Cristiano
+      - match: VAMOS
+        name: Vamos


### PR DESCRIPTION
Closes opensanctions/crawler-planning#769 (milestone: Central America PEPs — Legislative Bodies).

Adds a PEP crawler for the 60 titular deputies of the Legislative Assembly of El Salvador (Asamblea Legislativa), the country's unicameral national legislature (reduced from 84 to 60 by the 2023 reform; current term 2024–2027).

## Source

The official Assembly site (`asamblea.gob.sv/asamblea/diputados`). The deputy directory turned out **not** to use `/node/<id>` detail pages as the issue assumed — each deputy is a listing anchor carrying `data-sexo` (gender) and a `data-grupo-parlamentario` GUID that maps to a party abbreviation via the page's filter checkboxes. So the crawler reads **everything from the listing page** — no per-deputy (N+1) fetches needed. Only titular deputies are emitted (the alternates / suplentes are a separate page).

## What it emits

- One `Position` — "Member of the Legislative Assembly of El Salvador" (`Q21328618`), `gov.national` + `gov.legislative`.
- One `Person` per deputy: name, gender, `citizenship=sv`, and `political` (parliamentary group abbreviation + full party name).
- One current `Occupancy` per deputy.

Local crawl: 121 entities (60 Person · 60 Occupancy · 1 Position), 0 issues; all four PEP integrity checks pass; gender and party present on all 60. Party split matches the source (NI 54 / ARENA 2 / PCN 2 / VAMOS 1 / PDC 1).

## Notes

- **Citizenship**: deputies must be Salvadoran by birth and the child of a Salvadoran parent (Constitution Art. 126); source cited in a code comment.
- Date of birth and department are not exposed by this source.
- `ci_test: false` — fetches a live page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)