### PR TITLE
[ni_legislature] Add Nicaragua National Assembly PEP crawler

### DIFF
--- a/datasets/ni/legislature/crawler.py
+++ b/datasets/ni/legislature/crawler.py
@@ -6,20 +6,6 @@ from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import Element
 
-# The site rejects the default crawler User-Agent with HTTP 403, but serves a browser UA.
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
-    )
-}
-
-# The deputy title encodes gender: "Diputado Propietario" (m) / "Diputada Propietaria" (f).
-GENDERS = {
-    "Diputado Propietario": "male",
-    "Diputada Propietaria": "female",
-}
-
 
 def crawl_deputy(
     context: Context,
@@ -27,7 +13,7 @@ def crawl_deputy(
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
-    doc = context.fetch_html(url, headers=HEADERS, cache_days=7)
+    doc = context.fetch_html(url, cache_days=7)
 
     # The detail page is an IBM XPages document; the deputy title span ("Diputado
     # Propietario" / "Diputada Propietaria") is immediately followed by the name span.
@@ -41,16 +27,14 @@ def crawl_deputy(
     person = context.make("Person")
     person.id = context.make_slug(url.rsplit("documentId=", 1)[-1].split("&")[0])
     person.add("name", name)
-    gender = GENDERS.get(title)
-    if gender is None:
-        raise ValueError("Unexpected deputy title: %r" % title)
-    person.add("gender", gender)
+    # The deputy title encodes gender
+    person.add("gender", title)
     # Deputies must be Nicaraguan nationals (Political Constitution of Nicaragua,
     # Art. 134); nationality by birth is not specifically required.
     # https://pdba.georgetown.edu/Constitutions/Nica/nica95.html
     person.add("citizenship", "ni")
     # Party as published, e.g. "Alianza FSLN"; some deputies sit without one.
-    person.add("political", party or None)
+    person.add("political", party)
 
     occupancy = h.make_occupancy(
         context,
@@ -67,7 +51,7 @@ def crawl_deputy(
 
 
 def crawl(context: Context) -> None:
-    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+    doc = context.fetch_html(context.data_url, cache_days=1)
 
     anchors: list[Element] = h.xpath_elements(
         doc, ".//a[contains(@href, 'InfoDiputado.xsp')]"
@@ -81,8 +65,6 @@ def crawl(context: Context) -> None:
         absolute = urljoin(context.data_url, href)
         doc_id = absolute.rsplit("documentId=", 1)[-1].split("&")[0]
         urls[doc_id] = absolute
-    if len(urls) < 75:
-        raise ValueError("Expected at least 75 deputies, found %d" % len(urls))
 
     position = h.make_position(
         context,
@@ -92,7 +74,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q18616113",
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
     for url in urls.values():

--- a/datasets/ni/legislature/crawler.py
+++ b/datasets/ni/legislature/crawler.py
@@ -1,0 +1,99 @@
+from urllib.parse import urljoin
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+# The site rejects the default crawler User-Agent with HTTP 403, but serves a browser UA.
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+    )
+}
+
+# The deputy title encodes gender: "Diputado Propietario" (m) / "Diputada Propietaria" (f).
+GENDERS = {
+    "Diputado Propietario": "male",
+    "Diputada Propietaria": "female",
+}
+
+
+def crawl_deputy(
+    context: Context,
+    url: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    doc = context.fetch_html(url, headers=HEADERS, cache_days=7)
+
+    # The detail page is an IBM XPages document; the deputy title span ("Diputado
+    # Propietario" / "Diputada Propietaria") is immediately followed by the name span.
+    title_el = h.xpath_element(doc, ".//span[contains(text(), 'Propietari')]")
+    title = h.element_text(title_el)
+    name = h.element_text(h.xpath_element(title_el, "./following-sibling::span[1]"))
+    party = h.element_text(
+        h.xpath_element(doc, ".//span[contains(@id, 'partidoPolitico1')]")
+    )
+
+    person = context.make("Person")
+    person.id = context.make_slug(url.rsplit("documentId=", 1)[-1].split("&")[0])
+    person.add("name", name)
+    gender = GENDERS.get(title)
+    if gender is None:
+        raise ValueError("Unexpected deputy title: %r" % title)
+    person.add("gender", gender)
+    # Deputies must be Nicaraguan nationals (Political Constitution of Nicaragua,
+    # Art. 134); nationality by birth is not specifically required.
+    # https://pdba.georgetown.edu/Constitutions/Nica/nica95.html
+    person.add("citizenship", "ni")
+    # Party as published, e.g. "Alianza FSLN"; some deputies sit without one.
+    person.add("political", party or None)
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+
+    anchors: list[Element] = h.xpath_elements(
+        doc, ".//a[contains(@href, 'InfoDiputado.xsp')]"
+    )
+    # Deduplicate by document id; the listing may repeat links across view columns.
+    urls: dict[str, str] = {}
+    for anchor in anchors:
+        href = anchor.get("href")
+        if href is None:
+            continue
+        absolute = urljoin(context.data_url, href)
+        doc_id = absolute.rsplit("documentId=", 1)[-1].split("&")[0]
+        urls[doc_id] = absolute
+    if len(urls) < 75:
+        raise ValueError("Expected at least 75 deputies, found %d" % len(urls))
+
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of Nicaragua",
+        country="ni",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q18616113",
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    for url in urls.values():
+        crawl_deputy(context, url, position, categorisation)

--- a/datasets/ni/legislature/ni_legislature.yml
+++ b/datasets/ni/legislature/ni_legislature.yml
@@ -1,8 +1,8 @@
-title: Nicaragua National Assembly (Deputies)
+title: Nicaragua Deputies of National Assembly
 entry_point: crawler.py
 prefix: ni-an
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-16
 load_statements: true
 ci_test: false
@@ -10,14 +10,14 @@ summary: >-
   Deputies of the National Assembly of Nicaragua, the country's unicameral national
   legislature
 description: |
-  The National Assembly (Asamblea Nacional) is the unicameral legislature of Nicaragua,
-  made up of 91 deputies (national- and department-list seats plus seats assigned by
-  constitutional formula).
+  Current deputies of the National Assembly (Asamblea Nacional), the unicameral
+  national legislature of Nicaragua. Its 91 deputies — elected from national and
+  department lists, plus seats assigned by constitutional formula — serve five-year
+  terms and hold the country's legislative power, including passing laws and approving
+  the budget.
 
-  This dataset covers the currently listed deputies as published on the Assembly's
-  official legislative information site. Membership is treated as authoritative-current
-  on each run rather than fixed for a term, since it has changed mid-term (for example
-  through citizenship-stripping of sitting deputies).
+  This dataset records each currently listed deputy with their name, gender, and
+  political party.
 url: http://legislacion.asamblea.gob.ni/Tablas%20Generales.nsf/Main.xsp
 publisher:
   name: Asamblea Nacional de Nicaragua
@@ -34,8 +34,20 @@ data:
   format: HTML
   lang: spa
 
+http:
+  # The site rejects the default crawler User-Agent with HTTP 403, but serves a browser UA.
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+
 tags:
   - list.pep
+
+lookups:
+  type.gender:
+    options:
+      - match: Diputado Propietario
+        value: male
+      - match: Diputada Propietaria
+        value: female
 
 assertions:
   min:

--- a/datasets/ni/legislature/ni_legislature.yml
+++ b/datasets/ni/legislature/ni_legislature.yml
@@ -1,0 +1,50 @@
+title: Nicaragua National Assembly (Deputies)
+entry_point: crawler.py
+prefix: ni-an
+coverage:
+  frequency: weekly
+  start: 2026-06-16
+load_statements: true
+ci_test: false
+summary: >-
+  Deputies of the National Assembly of Nicaragua, the country's unicameral national
+  legislature
+description: |
+  The National Assembly (Asamblea Nacional) is the unicameral legislature of Nicaragua,
+  made up of 91 deputies (national- and department-list seats plus seats assigned by
+  constitutional formula).
+
+  This dataset covers the currently listed deputies as published on the Assembly's
+  official legislative information site. Membership is treated as authoritative-current
+  on each run rather than fixed for a term, since it has changed mid-term (for example
+  through citizenship-stripping of sitting deputies).
+url: http://legislacion.asamblea.gob.ni/Tablas%20Generales.nsf/Main.xsp
+publisher:
+  name: Asamblea Nacional de Nicaragua
+  name_en: National Assembly of Nicaragua
+  acronym: AN
+  description: >
+    The National Assembly is the unicameral national legislature of Nicaragua. Its
+    legislative information site publishes the directory of sitting deputies.
+  url: http://legislacion.asamblea.gob.ni/
+  country: ni
+  official: true
+data:
+  url: http://legislacion.asamblea.gob.ni/Tablas%20Generales.nsf/Main.xsp
+  format: HTML
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 75
+      Position: 1
+    country_entities:
+      ni: 75
+  max:
+    schema_entities:
+      Person: 100
+      Position: 1


### PR DESCRIPTION
Closes opensanctions/crawler-planning#770 (milestone: Central America PEPs — Legislative Bodies).

Adds a PEP crawler for the deputies of the National Assembly of Nicaragua (Asamblea Nacional), the country's unicameral national legislature.

## Source

The official legislative information site `legislacion.asamblea.gob.ni` (IBM Domino/XPages). The main `asamblea.gob.ni` domain blocks scripted access, and even the legislative subdomain returns **HTTP 403 to the default crawler User-Agent** — the crawler sends a browser User-Agent, which the site accepts. It lists the deputy index, then reads each `InfoDiputado.xsp` detail page.

## What it emits

- One `Position` — "Member of the National Assembly of Nicaragua" (`Q18616113`), `gov.national` + `gov.legislative`.
- One `Person` per deputy: name, gender (from the "Diputado Propietario" / "Diputada Propietaria" title), `citizenship=ni`, and `political` (party).
- One current `Occupancy` per deputy.

Local crawl: 181 entities (90 Person · 90 Occupancy · 1 Position), 0 issues; all four PEP integrity checks pass; gender on all 90, party on 89 (one sits without a party).

## Notes

- The site currently lists **90** deputies (of the 91-seat formula) — matches what the issue observed; assertions allow for the range.
- **Citizenship**: deputies must be Nicaraguan nationals (Political Constitution Art. 134 — nationality, not specifically by birth); source cited in a code comment. Membership is treated as authoritative-current per run rather than term-fixed, since it has changed mid-term (e.g. citizenship-stripping of sitting deputies).
- Date of birth is not exposed by this source. Detail-page selectors target the stable XPages field ids / the deputy-title span rather than generic component numbering.
- `ci_test: false` — fetches live pages (1 index + ~90 detail pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)