### PR TITLE
[bz] Add Belize House of Representatives and Senate PEP crawlers

### DIFF
--- a/datasets/bz/national_assembly/bz_national_assembly.yml
+++ b/datasets/bz/national_assembly/bz_national_assembly.yml
@@ -1,0 +1,49 @@
+title: Belize National Assembly (Members)
+entry_point: crawler.py
+prefix: bz-na
+coverage:
+  frequency: weekly
+  start: 2026-06-16
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the National Assembly of Belize — the elected House of Representatives
+  and the appointed Senate
+description: |
+  The National Assembly is the bicameral national legislature of Belize. It comprises
+  the House of Representatives (31 elected members plus the Speaker) and the Senate
+  (the President and appointed senators).
+
+  This dataset covers the currently sitting members of both chambers as published on
+  the National Assembly's official website. Senate membership in particular is treated
+  as authoritative-current on each run, since appointed senators can be replaced
+  mid-term without an election.
+url: https://www.nationalassembly.gov.bz/
+publisher:
+  name: National Assembly of Belize
+  acronym: NA
+  description: >
+    The National Assembly is the bicameral national legislature of Belize, made up of
+    the House of Representatives and the Senate.
+  url: https://www.nationalassembly.gov.bz/
+  country: bz
+  official: true
+data:
+  url: https://www.nationalassembly.gov.bz/
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 38
+      Position: 2
+    country_entities:
+      bz: 38
+  max:
+    schema_entities:
+      Person: 60
+      Position: 4

--- a/datasets/bz/national_assembly/bz_national_assembly.yml
+++ b/datasets/bz/national_assembly/bz_national_assembly.yml
@@ -7,8 +7,7 @@ coverage:
 load_statements: true
 ci_test: false
 summary: >-
-  Members of the National Assembly of Belize — the elected House of Representatives
-  and the appointed Senate
+  Members of the elected House of Representatives and the appointed Senate of Belize
 description: |
   Current members of the National Assembly, the bicameral national legislature of
   Belize, which holds the country's legislative power, including passing laws and

--- a/datasets/bz/national_assembly/bz_national_assembly.yml
+++ b/datasets/bz/national_assembly/bz_national_assembly.yml
@@ -1,8 +1,8 @@
-title: Belize National Assembly (Members)
+title: Belize Members of National Assembly
 entry_point: crawler.py
 prefix: bz-na
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-16
 load_statements: true
 ci_test: false
@@ -10,18 +10,18 @@ summary: >-
   Members of the National Assembly of Belize — the elected House of Representatives
   and the appointed Senate
 description: |
-  The National Assembly is the bicameral national legislature of Belize. It comprises
-  the House of Representatives (31 elected members plus the Speaker) and the Senate
-  (the President and appointed senators).
+  Current members of the National Assembly, the bicameral national legislature of
+  Belize, which holds the country's legislative power, including passing laws and
+  approving the budget. It comprises the House of Representatives — 31 directly elected
+  members plus the Speaker — and the Senate, made up of the President and senators
+  appointed by the Governor-General.
 
-  This dataset covers the currently sitting members of both chambers as published on
-  the National Assembly's official website. Senate membership in particular is treated
-  as authoritative-current on each run, since appointed senators can be replaced
-  mid-term without an election.
+  This dataset records each sitting member of both chambers with their name and, where
+  stated, their political party. Senate membership is treated as current on each run,
+  since appointed senators can be replaced mid-term without an election.
 url: https://www.nationalassembly.gov.bz/
 publisher:
   name: National Assembly of Belize
-  acronym: NA
   description: >
     The National Assembly is the bicameral national legislature of Belize, made up of
     the House of Representatives and the Senate.
@@ -32,6 +32,11 @@ data:
   url: https://www.nationalassembly.gov.bz/
   format: HTML
   lang: eng
+
+http:
+  # The server returns HTTP 406 without a browser-like Accept header.
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+  accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
 
 tags:
   - list.pep

--- a/datasets/bz/national_assembly/crawler.py
+++ b/datasets/bz/national_assembly/crawler.py
@@ -1,39 +1,12 @@
-import re
-
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import Element
 
-HOUSE_URL = "https://www.nationalassembly.gov.bz/house-of-representatives/"
-SENATE_URL = "https://www.nationalassembly.gov.bz/senate/"
-
-# The server returns HTTP 406 without a browser-like Accept header.
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
-    ),
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-}
-
-# Leading honorifics to drop from the published name.
-HONORIFIC_RE = re.compile(
-    r"^(Hon\.|Honourable|Senator|Reverend|Rev\.|Dr\.)\s+", re.IGNORECASE
-)
 
 # Party names that may appear in the role/affiliation line.
 PARTIES = ["People's United Party", "United Democratic Party"]
-
-
-def clean_name(raw: str) -> str:
-    name = raw.strip()
-    while True:
-        stripped = HONORIFIC_RE.sub("", name)
-        if stripped == name:
-            return name
-        name = stripped
 
 
 def parse_members(doc: Element) -> list[tuple[str, str]]:
@@ -67,21 +40,20 @@ def emit_member(
 ) -> None:
     person = context.make("Person")
     person.id = context.make_id(position.id, name)
-    person.add("name", clean_name(name))
+    person.add("name", name)
     # Members of both chambers must be citizens of Belize (Constitution of Belize, s. 57
     # for the House and s. 62 for the Senate); the Commonwealth-citizen allowance applies
     # only to voting, not to membership.
     # https://www.nationalassembly.gov.bz/wp-content/uploads/2022/01/Belize-Constitution-Chapter-4-2021.pdf
     person.add("citizenship", "bz")
-    for party in PARTIES:
-        if party in role:
-            person.add("political", party)
+    matched = [party for party in PARTIES if party in role]
+    if matched:
+        person.add("political", matched)
 
     occupancy = h.make_occupancy(
         context,
         person,
         position,
-        no_end_implies_current=True,
         categorisation=categorisation,
     )
     if occupancy is None:
@@ -101,17 +73,17 @@ def make_chamber_position(
         wikidata_id=wikidata_id,
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
     return position, categorisation
 
 
 def crawl(context: Context) -> None:
     # House of Representatives: the Speaker plus the elected members.
-    house_doc = context.fetch_html(HOUSE_URL, headers=HEADERS, cache_days=1)
+    house_doc = context.fetch_html(
+        context.data_url + "house-of-representatives/", cache_days=1
+    )
     members = parse_members(house_doc)
-    if len(members) < 25:
-        raise ValueError("Expected at least 25 House members, found %d" % len(members))
     speaker_pos, speaker_cat = make_chamber_position(
         context, "Speaker of the House of Representatives of Belize", "Q6597925"
     )
@@ -125,7 +97,7 @@ def crawl(context: Context) -> None:
             emit_member(context, name, role, rep_pos, rep_cat)
 
     # Senate: the President plus the appointed senators.
-    senate_doc = context.fetch_html(SENATE_URL, headers=HEADERS, cache_days=1)
+    senate_doc = context.fetch_html(context.data_url + "senate/", cache_days=1)
     senators = parse_members(senate_doc)
     if len(senators) < 10:
         raise ValueError("Expected at least 10 senators, found %d" % len(senators))

--- a/datasets/bz/national_assembly/crawler.py
+++ b/datasets/bz/national_assembly/crawler.py
@@ -2,14 +2,14 @@ from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
-from zavod.util import Element
+from lxml.etree import _Element
 
 
 # Party names that may appear in the role/affiliation line.
 PARTIES = ["People's United Party", "United Democratic Party"]
 
 
-def parse_members(doc: Element) -> list[tuple[str, str]]:
+def parse_members(doc: _Element) -> list[tuple[str, str]]:
     """Pair each present member's name (h4 title) with its role/affiliation line (h5).
 
     Both pages render one title-heading and one custom-heading per sitting member, in
@@ -38,6 +38,8 @@ def emit_member(
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
+    name = name.replace("Hon.", "").strip()
+
     person = context.make("Person")
     person.id = context.make_id(position.id, name)
     person.add("name", name)

--- a/datasets/bz/national_assembly/crawler.py
+++ b/datasets/bz/national_assembly/crawler.py
@@ -1,0 +1,142 @@
+import re
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+HOUSE_URL = "https://www.nationalassembly.gov.bz/house-of-representatives/"
+SENATE_URL = "https://www.nationalassembly.gov.bz/senate/"
+
+# The server returns HTTP 406 without a browser-like Accept header.
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+}
+
+# Leading honorifics to drop from the published name.
+HONORIFIC_RE = re.compile(
+    r"^(Hon\.|Honourable|Senator|Reverend|Rev\.|Dr\.)\s+", re.IGNORECASE
+)
+
+# Party names that may appear in the role/affiliation line.
+PARTIES = ["People's United Party", "United Democratic Party"]
+
+
+def clean_name(raw: str) -> str:
+    name = raw.strip()
+    while True:
+        stripped = HONORIFIC_RE.sub("", name)
+        if stripped == name:
+            return name
+        name = stripped
+
+
+def parse_members(doc: Element) -> list[tuple[str, str]]:
+    """Pair each present member's name (h4 title) with its role/affiliation line (h5).
+
+    Both pages render one title-heading and one custom-heading per sitting member, in
+    document order, so they pair positionally. Past office-holders are listed elsewhere
+    (not as title headings), so this only yields current members."""
+    names = [
+        h.element_text(e)
+        for e in h.xpath_elements(doc, ".//h4[contains(@class, 'title-heading')]")
+    ]
+    roles = [
+        h.element_text(e)
+        for e in h.xpath_elements(doc, ".//h5[contains(@class, 'vc_custom_heading')]")
+    ]
+    if len(names) != len(roles):
+        raise ValueError(
+            "Member name/role count mismatch: %d names, %d roles"
+            % (len(names), len(roles))
+        )
+    return list(zip(names, roles))
+
+
+def emit_member(
+    context: Context,
+    name: str,
+    role: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_id(position.id, name)
+    person.add("name", clean_name(name))
+    # Members of both chambers must be citizens of Belize (Constitution of Belize, s. 57
+    # for the House and s. 62 for the Senate); the Commonwealth-citizen allowance applies
+    # only to voting, not to membership.
+    # https://www.nationalassembly.gov.bz/wp-content/uploads/2022/01/Belize-Constitution-Chapter-4-2021.pdf
+    person.add("citizenship", "bz")
+    for party in PARTIES:
+        if party in role:
+            person.add("political", party)
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def make_chamber_position(
+    context: Context, name: str, wikidata_id: str
+) -> tuple[Entity, PositionCategorisation]:
+    position = h.make_position(
+        context,
+        name=name,
+        country="bz",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id=wikidata_id,
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+    return position, categorisation
+
+
+def crawl(context: Context) -> None:
+    # House of Representatives: the Speaker plus the elected members.
+    house_doc = context.fetch_html(HOUSE_URL, headers=HEADERS, cache_days=1)
+    members = parse_members(house_doc)
+    if len(members) < 25:
+        raise ValueError("Expected at least 25 House members, found %d" % len(members))
+    speaker_pos, speaker_cat = make_chamber_position(
+        context, "Speaker of the House of Representatives of Belize", "Q6597925"
+    )
+    rep_pos, rep_cat = make_chamber_position(
+        context, "Member of the House of Representatives of Belize", "Q21290854"
+    )
+    for name, role in members:
+        if "Speaker" in role:
+            emit_member(context, name, role, speaker_pos, speaker_cat)
+        else:
+            emit_member(context, name, role, rep_pos, rep_cat)
+
+    # Senate: the President plus the appointed senators.
+    senate_doc = context.fetch_html(SENATE_URL, headers=HEADERS, cache_days=1)
+    senators = parse_members(senate_doc)
+    if len(senators) < 10:
+        raise ValueError("Expected at least 10 senators, found %d" % len(senators))
+    pres_pos, pres_cat = make_chamber_position(
+        context, "President of the Senate of Belize", "Q6594868"
+    )
+    sen_pos, sen_cat = make_chamber_position(
+        context, "Member of the Senate of Belize", "Q21295124"
+    )
+    for name, role in senators:
+        if "President of the Senate" in role:
+            emit_member(context, name, role, pres_pos, pres_cat)
+        else:
+            emit_member(context, name, role, sen_pos, sen_cat)

--- a/datasets/bz/national_assembly/crawler.py
+++ b/datasets/bz/national_assembly/crawler.py
@@ -80,7 +80,7 @@ def make_chamber_position(
     return position, categorisation
 
 
-def crawl(context: Context) -> None:
+def crawl_representatives(context: Context) -> None:
     # House of Representatives: the Speaker plus the elected members.
     house_doc = context.fetch_html(
         context.data_url + "house-of-representatives/", cache_days=1
@@ -98,6 +98,8 @@ def crawl(context: Context) -> None:
         else:
             emit_member(context, name, role, rep_pos, rep_cat)
 
+
+def crawl_senators(context: Context) -> None:
     # Senate: the President plus the appointed senators.
     senate_doc = context.fetch_html(context.data_url + "senate/", cache_days=1)
     senators = parse_members(senate_doc)
@@ -114,3 +116,8 @@ def crawl(context: Context) -> None:
             emit_member(context, name, role, pres_pos, pres_cat)
         else:
             emit_member(context, name, role, sen_pos, sen_cat)
+
+
+def crawl(context: Context) -> None:
+    crawl_representatives(context)
+    crawl_senators(context)


### PR DESCRIPTION
Closes [opensanctions/crawler-planning#767](https://github.com/opensanctions/crawler-planning/issues/767) and [opensanctions/crawler-planning#768](https://github.com/opensanctions/crawler-planning/issues/768) (milestone: Central America PEPs — Legislative Bodies).

Adds a PEP crawler for the bicameral National Assembly of Belize, covering both chambers in one dataset (they share one official site and publisher): the House of Representatives and the Senate.

## Source
Both datasets are built from the **official** National Assembly site (`nationalassembly.gov.bz`) — the House page and the Senate page respectively. WordPress/Visual Composer HTML; the server returns **HTTP 406 to the default crawler request**, so a browser `Accept` header is sent. Members are rendered as title headings paired with a role/affiliation line; past office-holders live elsewhere on the page, so only current members are picked up.


## What it emits
Four positions (all `gov.national` + `gov.legislative`):

- Member of the House of Representatives of Belize (`Q21290854`) — 31
- Speaker of the House of Representatives of Belize (`Q6597925`) — 1
- Member of the Senate of Belize (`Q21295124`) — 13
- President of the Senate of Belize (`Q6594868`) — 1

Each member → a `Person` (name with honorifics stripped, `citizenship=bz`, party where stated) holding a current `Occupancy`.

Local crawl: 96 entities (46 Person · 46 Occupancy · 4 Position), 0 issues; all four PEP integrity checks pass. Party captured for 40 members (PUP/UDP); ministers, social-partner senators, and presiding officers have no party stated on the page.

## Notes

- **Citizenship**: members of both chambers must be **citizens of Belize** (Constitution s. 57 House / s. 62 Senate). Belize does *not* follow the UK model — the Commonwealth-citizen allowance applies only to voting, not membership. Source cited in code.
- Date of birth and gender are not exposed by this source.
- Senate membership is treated as authoritative-current per run, since appointed senators can be replaced mid-term without an election.
- `ci_test: false` — fetches live pages.