### PR TITLE
[hn_legislature] Add Honduras National Congress PEP crawler

### DIFF
--- a/datasets/hn/legislature/crawler.py
+++ b/datasets/hn/legislature/crawler.py
@@ -1,0 +1,92 @@
+import json
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Fields not emitted: the official work email, photo, the internal record id ("dni" — a
+# 1-6 digit site id, not a real national identity number), the electoral department, the
+# formula/priority ordering, and the timestamp.
+# `firstName`/`lastName`/`delegate_id` are redundant duplicates of nombres/apellidos/dni
+# present on some records.
+IGNORE_FIELDS = [
+    "titulo",
+    "departamento",
+    "email",
+    "img",
+    "formula",
+    "priority",
+    "createAt",
+    "firstName",
+    "lastName",
+    "delegate_id",
+]
+
+
+def crawl_deputy(
+    context: Context,
+    row: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    # Only titular deputies (propietarios) are emitted; their alternates are suplentes.
+    cargo = row.pop("cargo")
+    if cargo != "PROPIETARIO":
+        return
+
+    record_id = row.pop("dni")
+    nombres = row.pop("nombres")
+    apellidos = row.pop("apellidos")
+    bancada = row.pop("bancada")
+
+    person = context.make("Person")
+    person.id = context.make_slug(str(record_id))
+    h.apply_name(person, first_name=nombres, last_name=apellidos)
+    # Deputies must be Honduran by birth ("hondureño por nacimiento"); naturalised
+    # citizens are not eligible (Constitution of Honduras, Art. 198).
+    # https://pdba.georgetown.edu/Constitutions/Honduras/hond82.html
+    person.add("citizenship", "hn")
+    person.add("political", bancada)
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(row, ignore=IGNORE_FIELDS)
+
+
+def crawl(context: Context) -> None:
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    # The deputy roster is embedded in the Next.js page data; parsing it (rather than the
+    # versioned _next/data endpoint) keeps the crawler independent of the build id.
+    script = h.xpath_element(doc, ".//script[@id='__NEXT_DATA__']")
+    if script.text is None:
+        raise ValueError("Empty __NEXT_DATA__ payload")
+    data = json.loads(script.text)
+    deputies = data["props"]["pageProps"]["congresistastemp"]["congresistas"]
+    if not isinstance(deputies, list) or len(deputies) < 100:
+        raise ValueError("Unexpected deputy payload: %r" % type(deputies))
+
+    position = h.make_position(
+        context,
+        name="Member of the National Congress of Honduras",
+        country="hn",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q19300340",
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    context.emit(position)
+
+    for row in deputies:
+        crawl_deputy(context, row, position, categorisation)

--- a/datasets/hn/legislature/crawler.py
+++ b/datasets/hn/legislature/crawler.py
@@ -6,15 +6,10 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# Fields not emitted: the official work email, photo, the internal record id ("dni" — a
-# 1-6 digit site id, not a real national identity number), the electoral department, the
-# formula/priority ordering, and the timestamp.
-# `firstName`/`lastName`/`delegate_id` are redundant duplicates of nombres/apellidos/dni
-# present on some records.
+# `firstName`/`lastName`/`delegate_id` are duplicates of nombres/apellidos/dni
+# present on some records or None
 IGNORE_FIELDS = [
     "titulo",
-    "departamento",
-    "email",
     "img",
     "formula",
     "priority",
@@ -49,16 +44,17 @@ def crawl_deputy(
     # https://pdba.georgetown.edu/Constitutions/Honduras/hond82.html
     person.add("citizenship", "hn")
     person.add("political", bancada)
+    person.add("email", row.pop("email"))
 
     occupancy = h.make_occupancy(
         context,
         person,
         position,
-        no_end_implies_current=True,
         categorisation=categorisation,
     )
     if occupancy is None:
         return
+    occupancy.add("constituency", row.pop("departamento"))
 
     context.emit(occupancy)
     context.emit(person)
@@ -74,8 +70,6 @@ def crawl(context: Context) -> None:
         raise ValueError("Empty __NEXT_DATA__ payload")
     data = json.loads(script.text)
     deputies = data["props"]["pageProps"]["congresistastemp"]["congresistas"]
-    if not isinstance(deputies, list) or len(deputies) < 100:
-        raise ValueError("Unexpected deputy payload: %r" % type(deputies))
 
     position = h.make_position(
         context,
@@ -85,7 +79,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q19300340",
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     context.emit(position)
 
     for row in deputies:

--- a/datasets/hn/legislature/hn_legislature.yml
+++ b/datasets/hn/legislature/hn_legislature.yml
@@ -1,0 +1,47 @@
+title: Honduras National Congress (Deputies)
+entry_point: crawler.py
+prefix: hn-cn
+coverage:
+  frequency: weekly
+  start: 2026-06-16
+load_statements: true
+ci_test: false
+summary: >-
+  Deputies of the National Congress of Honduras, the country's unicameral national
+  legislature
+description: |
+  The National Congress (Congreso Nacional) is the unicameral legislature of Honduras,
+  made up of 128 deputies elected by department for four-year terms.
+
+  This dataset covers the sitting titular deputies (propietarios) as published on the
+  Congress's official website; their alternates (suplentes), listed alongside them by
+  the source, are not included.
+url: https://congresonacional.hn/congresistas
+publisher:
+  name: Congreso Nacional de Honduras
+  name_en: National Congress of Honduras
+  acronym: CN
+  description: >
+    The National Congress is the unicameral national legislature of Honduras.
+  url: https://congresonacional.hn/
+  country: hn
+  official: true
+data:
+  url: https://congresonacional.hn/congresistas
+  format: HTML
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 100
+      Position: 1
+    country_entities:
+      hn: 100
+  max:
+    schema_entities:
+      Person: 145
+      Position: 1

--- a/datasets/hn/legislature/hn_legislature.yml
+++ b/datasets/hn/legislature/hn_legislature.yml
@@ -1,8 +1,8 @@
-title: Honduras National Congress (Deputies)
+title: Honduras Deputies of National Congress
 entry_point: crawler.py
 prefix: hn-cn
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-16
 load_statements: true
 ci_test: false
@@ -10,11 +10,13 @@ summary: >-
   Deputies of the National Congress of Honduras, the country's unicameral national
   legislature
 description: |
-  The National Congress (Congreso Nacional) is the unicameral legislature of Honduras,
-  made up of 128 deputies elected by department for four-year terms.
+  Current deputies of the National Congress (Congreso Nacional), the unicameral
+  national legislature of Honduras. Its 128 deputies are elected by department for
+  four-year terms and hold the country's legislative power, including passing laws and
+  approving the budget.
 
-  This dataset covers the sitting titular deputies (propietarios) as published on the
-  Congress's official website; their alternates (suplentes), listed alongside them by
+  This dataset records each sitting titular deputy (propietario) with their name and
+  parliamentary group (bancada). Their alternates (suplentes), listed alongside them by
   the source, are not included.
 url: https://congresonacional.hn/congresistas
 publisher:


### PR DESCRIPTION
Closes opensanctions/crawler-planning#59 (milestone: Central America PEPs — Legislative Bodies).

Adds a PEP crawler for the titular deputies of the National Congress of Honduras (Congreso Nacional), the unicameral national legislature (128 seats).

## Source

Uses the **official** Congress website (`congresonacional.hn`), **not** the civil-society source (`cna.hn`) named in the issue, per request to stick to the official source. The site is a Next.js app; the full deputy roster is embedded in the page's `__NEXT_DATA__` JSON (`props.pageProps.congresistastemp.congresistas`), so the crawler parses that directly — independent of the build id. The roster carries 256 records (128 propietarios + 128 suplentes); only the titular deputies (propietarios) are emitted.

Note: use the bare domain `congresonacional.hn` — the `www.` host presents a TLS certificate that doesn't cover it.

## What it emits

- One `Position` — "Member of the National Congress of Honduras" (`Q19300340`), `gov.national` + `gov.legislative`.
- One `Person` per titular deputy: name, `citizenship=hn`, and `political` (parliamentary caucus / bancada).
- One current `Occupancy` per deputy.

Local crawl: 257 entities (128 Person · 128 Occupancy · 1 Position), 0 issues; all four PEP integrity checks pass; party present on all 128.

## Notes

- **Citizenship**: deputies must be **Honduran by birth** ("hondureño por nacimiento"); naturalised citizens are not eligible (Constitution Art. 198). Source cited in code.
- The record `dni` field is **not** a real national identity number (1–6 digit internal site ids), so it is used only as a stable entity key, not emitted as `idNumber`. Email, photo, and electoral department are not emitted.
- **Freshness observation**: as of this writing the official roster still reflects the **2022–2026** Congress (party split Libre 50 / Nacional 44 / Liberal 22 / PSH 10 / DC 1 / PAC 1; `createAt` 2022) rather than the 2026–2030 term installed in January 2026 — i.e. the publisher appears not to have updated it yet. The crawler reads the live roster, so it will pick up the new term automatically once the site is updated.
- `ci_test: false` — fetches a live page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)