### PR TITLE
[ph_senate] Lower min Person assertion; [al_kuvendi] pop name fields

### DIFF
--- a/datasets/al/kuvendi/crawler.py
+++ b/datasets/al/kuvendi/crawler.py
@@ -34,8 +34,8 @@ def clean_birth_date(raw: str | None) -> str | None:
 
 def crawl_member(context: Context, position: Entity, record: dict[str, Any]) -> None:
     person = context.make("Person")
-    first_name = record.get("emer")
-    last_name = record.get("mbiemer")
+    first_name = record.pop("emer")
+    last_name = record.pop("mbiemer")
     person.id = context.make_id(first_name, last_name, record.pop("id"))
 
     # `atesi` (patronymic) is sometimes a "-" placeholder rather than a name.

--- a/datasets/ph/senate/ph_senate.yml
+++ b/datasets/ph/senate/ph_senate.yml
@@ -39,7 +39,7 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 40
+      Person: 20
   max:
     schema_entities:
       Person: 100


### PR DESCRIPTION
Fixes two issues surfaced in recent crawler runs.

**ph_senate** — the crawler emits 34 Person entities (24 sitting senators plus historical ones still inside the PEP window), below the min `schema_entities` floor of 40. Lowered the floor to 20.

**al_kuvendi** — `emer`/`mbiemer` are already mapped to first/last name, but were read with `.get()`, so they lingered in the record and tripped the `Unexpected data found in fields: ['emer', 'mbiemer']` warning from `audit_data`. Changed to `.pop()` to consume them like the other mapped fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)