### PR TITLE
[ui] Bump frontend dependencies

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,12 +10,12 @@
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.5.0",
-        "@opensanctions/followthemoney": "^4.8.4",
+        "@opensanctions/followthemoney": "^4.9.2",
         "@uiw/react-codemirror": "^4.25.10",
         "bootstrap": "^5.3.8",
         "codemirror-json-schema": "^0.8.1",
         "jose": "^6.2.3",
-        "json-schema-library": "^11.4.1",
+        "json-schema-library": "^11.6.1",
         "kysely": "^0.29.2",
         "next": "16.2.9",
         "pg": "^8.21.0",
@@ -23,7 +23,7 @@
         "react-bootstrap": "^2.10.10",
         "react-bootstrap-icons": "^1.11.6",
         "react-dom": "^19.2.7",
-        "sass": "^1.100.0",
+        "sass": "^1.101.0",
         "turndown": "^7.2.4",
         "yaml": "^2.9.0"
       },
@@ -35,7 +35,7 @@
         "@types/react-dom": "^19",
         "@types/turndown": "^5.0.6",
         "eslint": "^9.39.4",
-        "eslint-config-next": "^16.2.7",
+        "eslint-config-next": "^16.2.9",
         "eslint-plugin-import": "^2.32.0",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.11",
@@ -2350,9 +2350,9 @@
       }
     },
     "node_modules/@opensanctions/followthemoney": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@opensanctions/followthemoney/-/followthemoney-4.9.1.tgz",
-      "integrity": "sha512-0jYqAX4/UYZxlcsn14K/wqlS3KyEw9pESakMiBFRJ97CUAEAlVAekaaQ30GQZogYEQjsNYcf1h//aIT2A5tGBw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@opensanctions/followthemoney/-/followthemoney-4.9.2.tgz",
+      "integrity": "sha512-ftjFuojdhc0VYe7t5VeuZd/lU55oDbwtQhsIxLu9DepAkhJsDH2qfYzgQ3+zi7ylAfEItXHSdNAQHRCnEWcHmg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,12 +13,12 @@
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
-    "@opensanctions/followthemoney": "^4.8.4",
+    "@opensanctions/followthemoney": "^4.9.2",
     "@uiw/react-codemirror": "^4.25.10",
     "bootstrap": "^5.3.8",
     "codemirror-json-schema": "^0.8.1",
     "jose": "^6.2.3",
-    "json-schema-library": "^11.4.1",
+    "json-schema-library": "^11.6.1",
     "kysely": "^0.29.2",
     "next": "16.2.9",
     "pg": "^8.21.0",
@@ -26,7 +26,7 @@
     "react-bootstrap": "^2.10.10",
     "react-bootstrap-icons": "^1.11.6",
     "react-dom": "^19.2.7",
-    "sass": "^1.100.0",
+    "sass": "^1.101.0",
     "turndown": "^7.2.4",
     "yaml": "^2.9.0"
   },
@@ -41,7 +41,7 @@
     "ts-jest": "^29.4.11",
     "typescript": "^6",
     "eslint": "^9.39.4",
-    "eslint-config-next": "^16.2.7",
+    "eslint-config-next": "^16.2.9",
     "eslint-plugin-import": "^2.32.0"
   },
   "overrides": {


### PR DESCRIPTION
Routine minor/patch bumps to the review UI dependencies:

- `@opensanctions/followthemoney` 4.8.4 → 4.9.2
- `json-schema-library` 11.4.1 → 11.6.1
- `sass` 1.100.0 → 1.101.0
- `eslint-config-next` 16.2.7 → 16.2.9

ESLint stays on `^9.39.4`: `eslint-config-next` still depends transitively on `eslint-plugin-import@^2.32.0`, whose peer range tops out at eslint `^9` (eslint 10 support is still unmerged upstream — import-js/eslint-plugin-import#3230).

🤖 Generated with [Claude Code](https://claude.com/claude-code)