### PR TITLE
Release 13 PEP datasets into peps collection

### DIFF
--- a/.claude/skills/release-datasets/SKILL.md
+++ b/.claude/skills/release-datasets/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: release-datasets
+description: Release one or more datasets by adding them to a topical collection, bumping coverage.start, and verifying. Use when the user wants to release/publish specific crawled datasets into the OpenSanctions product.
+---
+
+# Release Datasets
+
+Release the datasets the user names by adding each to a topical collection's
+`children:` list and bumping its `coverage.start`. The datasets to release: $ARGUMENTS
+
+**Only release the datasets the user explicitly lists.** Never release every
+unreleased dataset in the pipeline — most unreleased datasets are work in
+progress or test scratch and are unreleased on purpose. If the user gives no
+list, ask which datasets they want to release before doing anything.
+
+## How a release works
+
+A crawler dataset (`datasets/<cc>/<name>/<name>.yml`, has an `entry_point`)
+crawls data but is **unreleased** until it is named in some collection's
+`children:` list. Releasing = editing the collection file, not the dataset file:
+
+- Collections live in `datasets/_collections/*.yml` (`type: collection`) and own
+  a `children:` list of dataset names. Membership is declared **only** there —
+  there is no reverse `collections:` key on the dataset itself.
+- The `default` collection lists the *topical collections* as its children, so
+  membership rolls up recursively: add a dataset to `peps` and it is
+  automatically in `default` too. **Do not edit `default.yml`** for an ordinary
+  dataset — only topical collections.
+- `contrib/check_hierarchy.py datasets` is the verifier: it warns
+  `"<name> has no collections"` for any non-collection, non-disabled dataset that
+  is not a child of any collection. A clean run for a dataset = released.
+
+## Steps
+
+For each dataset the user named:
+
+1. **Determine the target collection.**
+   - If the user specified one, use it.
+   - If not, suggest one from the dataset's topic — inspect its `.yml` `tags:`
+     (e.g. `list.pep`), `summary`/`description`, and the kind of entities it
+     emits. Use the table below. **Confirm the suggestion with the user** before
+     editing; don't guess silently.
+   - A dataset may join more than one collection if it genuinely fits.
+
+2. **Add the dataset name to `datasets/_collections/<collection>.yml`** under
+   `children:`, keeping the list **alphabetically sorted**. Insert at the correct
+   sorted position rather than appending.
+
+3. **Bump `coverage.start`** in the dataset's own `.yml` to today's release date,
+   **preserving the file's existing quoting style** (some files quote the date,
+   some don't).
+
+4. **Verify** with `python contrib/check_hierarchy.py datasets` — confirm the
+   dataset no longer warns `"has no collections"`. Remaining warnings for
+   datasets you were *not* asked to release are expected; leave them.
+
+5. **Validate the edited collection** (sorted + no dupes), e.g.:
+   ```
+   python -c "import yaml; c=yaml.safe_load(open('datasets/_collections/<collection>.yml'))['children']; assert c==sorted(c), 'not sorted'; assert len(c)==len(set(c)), 'dupes'; print('ok', len(c))"
+   ```
+
+## Collection suggestion guide
+
+These are the topical collections that roll up into `default` (the public
+product). Suggest from these:
+
+| Collection       | Holds                                                        |
+|------------------|--------------------------------------------------------------|
+| `peps`           | Parliaments, elected officials, PEP/asset declarations       |
+| `sanctions`      | Sanctions lists (consolidated)                               |
+| `eu_sanctions`   | EU-specific sanctions sources                                |
+| `crime`          | Criminal / investigative / leaked-records entities           |
+| `wanted`         | Wanted-persons lists                                         |
+| `debarment`      | Debarred companies and individuals                           |
+| `regulatory`     | Regulatory watchlists, investor alerts                       |
+| `enforcement`    | Enforcement actions, litigation, regulatory notices          |
+| `maritime`       | Vessels, port-state-control / maritime sources               |
+| `securities`     | Sanctioned/flagged securities issuers                        |
+| `special_interest` | Special-interest watchlists                                |
+| `enrichers`      | External enrichment sources                                  |
+
+If a dataset's topic is ambiguous, ask the user rather than picking.
+
+## Don't release
+
+- Test/scratch datasets (e.g. `alert_testing`).
+- `_externals/` and `_analysis/` specials — these are wired differently; flag
+  them to the user instead of adding them to a topical collection.
+
+## Commit
+
+Group the collection edit and the coverage bumps together. Use the house
+`[dataset_name]` commit-title prefix (one dataset → `[xx_foo] Release into peps`;
+several → describe the batch). Do not push during an in-flight session without
+explicit confirmation.

--- a/.claude/skills/release-datasets/SKILL.md
+++ b/.claude/skills/release-datasets/SKILL.md
@@ -5,87 +5,39 @@ description: Release one or more datasets by adding them to a topical collection
 
 # Release Datasets
 
-Release the datasets the user names by adding each to a topical collection's
-`children:` list and bumping its `coverage.start`. The datasets to release: $ARGUMENTS
+Release the datasets the user names into the OpenSanctions product. The datasets
+to release: $ARGUMENTS
 
-**Only release the datasets the user explicitly lists.** Never release every
-unreleased dataset in the pipeline — most unreleased datasets are work in
-progress or test scratch and are unreleased on purpose. If the user gives no
-list, ask which datasets they want to release before doing anything.
+The full release process — how collections work, choosing a collection, the
+edit steps, and verification — is documented in
+[`zavod/docs/best_practices/release.md`](../../../zavod/docs/best_practices/release.md).
+**Read that doc and follow it.** This skill only covers how to drive it.
 
-## How a release works
+## Before following the doc
 
-A crawler dataset (`datasets/<cc>/<name>/<name>.yml`, has an `entry_point`)
-crawls data but is **unreleased** until it is named in some collection's
-`children:` list. Releasing = editing the collection file, not the dataset file:
+1. **Only release the datasets the user explicitly lists.** Never release every
+   unreleased dataset in the pipeline — most are work in progress or test scratch
+   and are unreleased on purpose. If the user gave no list, ask which datasets
+   they want to release before doing anything.
 
-- Collections live in `datasets/_collections/*.yml` (`type: collection`) and own
-  a `children:` list of dataset names. Membership is declared **only** there —
-  there is no reverse `collections:` key on the dataset itself.
-- The `default` collection lists the *topical collections* as its children, so
-  membership rolls up recursively: add a dataset to `peps` and it is
-  automatically in `default` too. **Do not edit `default.yml`** for an ordinary
-  dataset — only topical collections.
-- `contrib/check_hierarchy.py datasets` is the verifier: it warns
-  `"<name> has no collections"` for any non-collection, non-disabled dataset that
-  is not a child of any collection. A clean run for a dataset = released.
-
-## Steps
-
-For each dataset the user named:
-
-1. **Determine the target collection.**
+2. **Determine the target collection for each dataset.**
    - If the user specified one, use it.
    - If not, suggest one from the dataset's topic — inspect its `.yml` `tags:`
-     (e.g. `list.pep`), `summary`/`description`, and the kind of entities it
-     emits. Use the table below. **Confirm the suggestion with the user** before
-     editing; don't guess silently.
-   - A dataset may join more than one collection if it genuinely fits.
+     (e.g. `list.pep`), `summary`/`description`, and the entities it emits, then
+     match against the collection table in `release.md`. **Confirm the suggestion
+     with the user** before editing; don't guess silently.
 
-2. **Add the dataset name to `datasets/_collections/<collection>.yml`** under
-   `children:`, keeping the list **alphabetically sorted**. Insert at the correct
-   sorted position rather than appending.
+## When editing
 
-3. **Bump `coverage.start`** in the dataset's own `.yml` to today's release date,
-   **preserving the file's existing quoting style** (some files quote the date,
-   some don't).
-
-4. **Verify** with `python contrib/check_hierarchy.py datasets` — confirm the
-   dataset no longer warns `"has no collections"`. Remaining warnings for
-   datasets you were *not* asked to release are expected; leave them.
-
-5. **Validate the edited collection** (sorted + no dupes), e.g.:
-   ```
-   python -c "import yaml; c=yaml.safe_load(open('datasets/_collections/<collection>.yml'))['children']; assert c==sorted(c), 'not sorted'; assert len(c)==len(set(c)), 'dupes'; print('ok', len(c))"
-   ```
-
-## Collection suggestion guide
-
-These are the topical collections that roll up into `default` (the public
-product). Suggest from these:
-
-| Collection       | Holds                                                        |
-|------------------|--------------------------------------------------------------|
-| `peps`           | Parliaments, elected officials, PEP/asset declarations       |
-| `sanctions`      | Sanctions lists (consolidated)                               |
-| `eu_sanctions`   | EU-specific sanctions sources                                |
-| `crime`          | Criminal / investigative / leaked-records entities           |
-| `wanted`         | Wanted-persons lists                                         |
-| `debarment`      | Debarred companies and individuals                           |
-| `regulatory`     | Regulatory watchlists, investor alerts                       |
-| `enforcement`    | Enforcement actions, litigation, regulatory notices          |
-| `maritime`       | Vessels, port-state-control / maritime sources               |
-| `securities`     | Sanctioned/flagged securities issuers                        |
-| `special_interest` | Special-interest watchlists                                |
-| `enrichers`      | External enrichment sources                                  |
-
-If a dataset's topic is ambiguous, ask the user rather than picking.
-
-## Don't release
-
-- Test/scratch datasets (e.g. `alert_testing`).
-- `_externals/` and `_analysis/` specials — these are wired differently; flag
-  them to the user instead of adding them to a topical collection.
+- Follow the steps in `release.md`: add the dataset to the collection's
+  `children:` (alphabetically sorted), bump `coverage.start` to today, and verify
+  with `python contrib/check_hierarchy.py datasets`.
+- Preserve each dataset file's existing date quoting style when bumping
+  `coverage.start` (some files quote the date, some don't).
+- After editing a collection, sanity-check it stays sorted and dupe-free:
+  ```
+  python -c "import yaml; c=yaml.safe_load(open('datasets/_collections/<collection>.yml'))['children']; assert c==sorted(c) and len(c)==len(set(c)); print('ok', len(c))"
+  ```
 
 ## Commit
 

--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -30,18 +30,26 @@ description: |
   item](https://www.opensanctions.org/faq/165/peps-only/).**
 children:
   - ad_consell_general
+  - al_kuvendi
   - am_hetq_officials
   - ann_pep_positions
   - ar_parliament
   - at_meine_abgeordneten
   - at_parlament
+  - au_act_parliament
   - au_nsw_parliament
+  - au_nt_parliament
   - au_parliament
+  - au_qld_parliament
+  - au_sa_parliament
   - au_tas_parliament
   - au_vic_parliament
+  - au_wa_parliament
   - az_parliament
+  - ba_parliament
   - be_chamber
   - be_flemish_parliament
+  - be_senate
   - be_walloon_parliament
   - bg_jud_declarations
   - bg_parliament
@@ -112,16 +120,21 @@ children:
   - no_brreg
   - no_storting
   - nz_parliament
+  - ph_house_representatives
+  - ph_senate
   - pl_sejm
   - pl_senate
   - pt_parliament
+  - ro_cdep_deputies
   - ro_fiu_declarations
+  - ro_senate
   - rs_national_assembly
   - se_riksdag
   - se_soe
   - sg_gov_dir
   - si_dz_rs
   - si_zvezoskop
+  - sk_nrsr_poslanci
   - sk_public_officials
   - th_cabinet
   - tr_parliament

--- a/datasets/al/kuvendi/al_kuvendi.yml
+++ b/datasets/al/kuvendi/al_kuvendi.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: al-kuv
 coverage:
   frequency: monthly
-  start: 2026-06-08
+  start: 2026-06-16
 load_statements: true
 summary: >-
   Current members of the Kuvendi, the unicameral parliament of the Republic of Albania

--- a/datasets/au/act_parliament/au_act_parliament.yml
+++ b/datasets/au/act_parliament/au_act_parliament.yml
@@ -3,7 +3,7 @@ prefix: au-actla
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: "2026-06-15"
+  start: "2026-06-16"
 load_statements: true
 ci_test: false
 

--- a/datasets/au/nt_parliament/au_nt_parliament.yml
+++ b/datasets/au/nt_parliament/au_nt_parliament.yml
@@ -3,7 +3,7 @@ prefix: au-ntparl
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: "2026-06-15"
+  start: "2026-06-16"
 load_statements: true
 ci_test: false
 

--- a/datasets/au/qld_parliament/au_qld_parliament.yml
+++ b/datasets/au/qld_parliament/au_qld_parliament.yml
@@ -3,7 +3,7 @@ prefix: au-qldparl
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: "2026-06-15"
+  start: "2026-06-16"
 load_statements: true
 
 summary: >

--- a/datasets/au/sa_parliament/au_sa_parliament.yml
+++ b/datasets/au/sa_parliament/au_sa_parliament.yml
@@ -4,7 +4,7 @@ prefix: au-saparl
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: "2026-06-15"
+  start: "2026-06-16"
 load_statements: true
 
 summary: >-

--- a/datasets/au/wa_parliament/au_wa_parliament.yml
+++ b/datasets/au/wa_parliament/au_wa_parliament.yml
@@ -3,7 +3,7 @@ prefix: au-waparl
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: "2026-06-12"
+  start: "2026-06-16"
 load_statements: true
 ci_test: false
 

--- a/datasets/ba/parliament/ba_parliament.yml
+++ b/datasets/ba/parliament/ba_parliament.yml
@@ -3,7 +3,7 @@ prefix: ba-parl
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: "2026-06-15"
+  start: "2026-06-16"
 load_statements: true
 ci_test: false
 

--- a/datasets/be/senate/be_senate.yml
+++ b/datasets/be/senate/be_senate.yml
@@ -3,7 +3,7 @@ prefix: be-sen
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: 2026-06-15
+  start: 2026-06-16
 load_statements: true
 summary: >-
   Members of the Belgian Federal Senate, the upper house of the parliament.

--- a/datasets/ph/house_representatives/ph_house_representatives.yml
+++ b/datasets/ph/house_representatives/ph_house_representatives.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ph-hrep
 coverage:
   frequency: monthly
-  start: 2026-06-08
+  start: 2026-06-16
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/ph/senate/ph_senate.yml
+++ b/datasets/ph/senate/ph_senate.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ph-sen
 coverage:
   frequency: monthly
-  start: 2025-06-30
+  start: 2026-06-16
 load_statements: true
 ci_test: false  # uses Zyte to bypass Cloudflare; API key unavailable in CI
 summary: >-

--- a/datasets/ro/cdep_deputies/ro_cdep_deputies.yml
+++ b/datasets/ro/cdep_deputies/ro_cdep_deputies.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ro-cdep
 coverage:
   frequency: monthly
-  start: 2025-06-09
+  start: 2026-06-16
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/ro/senate/ro_senate.yml
+++ b/datasets/ro/senate/ro_senate.yml
@@ -3,7 +3,7 @@ prefix: ro-senate
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-06-09
+  start: 2026-06-16
 load_statements: true
 # Each historical legislature exposes ~120-170 senators on their own detail pages,
 # so a full crawl issues well over a thousand requests -- too large for CI.

--- a/datasets/sk/nrsr_poslanci/sk_nrsr_poslanci.yml
+++ b/datasets/sk/nrsr_poslanci/sk_nrsr_poslanci.yml
@@ -3,7 +3,7 @@ prefix: sk-nrsr
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: 2026-06-15
+  start: 2026-06-16
 load_statements: true
 ci_test: false
 summary: >-

--- a/zavod/docs/best_practices/merge_checklist.md
+++ b/zavod/docs/best_practices/merge_checklist.md
@@ -6,7 +6,7 @@ Some things that are easy to forget but critical for new crawlers. Scope and per
     - required fields for crawlers that are often forgotten:
         - `coverage`
             - `frequency` (normally `daily`, but `weekly` for gpt crawlers, and `monthly` for company registers)
-            - `start` (updated to the current day when releasing)
+            - `start` - set when the dataset is released, not at merge time. Once the dataset has passed QA and initial de-duplication, it can be [released](release.md).
         - `load_statements`: `true` for normal crawlers, `false` for KYB data.
         - `assertions` - see [Data Assertions](../metadata.md#data-assertions)
     - dataset `name` is clear and conforms to convention. It's fine if it's just the yaml file name and not included in the file.

--- a/zavod/docs/best_practices/release.md
+++ b/zavod/docs/best_practices/release.md
@@ -1,0 +1,87 @@
+# Releasing a dataset
+
+A crawler that has been merged still only runs in isolation — it produces data,
+but that data is not yet part of any published OpenSanctions product. A dataset
+is **released** once it is added to a collection. This usually happens after the
+crawler has passed [review](merge_checklist.md), an initial run, and de-duplication
+against existing data.
+
+## How collections work
+
+Collections are datasets that combine the entities of other datasets. They are
+defined as YAML files in
+[`datasets/_collections/`](https://github.com/opensanctions/opensanctions/tree/main/datasets/_collections),
+each with a `children:` list naming its member datasets:
+
+```yaml
+type: collection
+title: Politically Exposed Persons Datasets
+children:
+  - ad_consell_general
+  - al_kuvendi
+  - am_hetq_officials
+  # ...
+```
+
+Membership is declared **only** in the collection's `children:` list. There is no
+reverse key on the dataset itself — to release a dataset you edit the collection,
+not the dataset's own metadata.
+
+Collections nest: the `default` collection lists the *topical* collections
+(`sanctions`, `peps`, `crime`, …) as its children, and those in turn list the
+individual datasets. Membership rolls up recursively, so adding a dataset to a
+topical collection automatically includes it in `default` (the broadest public
+distribution) as well. **You normally only edit a topical collection** — never
+add an ordinary dataset directly to `default`.
+
+## Choosing a collection
+
+Add the dataset to the most appropriate topical collection based on the
+[kind of entities](https://www.opensanctions.org/docs/topics/) it produces. The
+quickest way to decide is to find a
+[similar dataset](https://www.opensanctions.org/datasets/) and see which
+collection it is included in.
+
+| Collection         | Holds                                                       |
+|--------------------|-------------------------------------------------------------|
+| `peps`             | Parliaments, elected officials, PEP/asset declarations      |
+| `sanctions`        | Consolidated sanctions lists                                |
+| `eu_sanctions`     | EU-specific sanctions sources                               |
+| `crime`            | Criminal / investigative / leaked-records entities          |
+| `wanted`           | Wanted-persons lists                                        |
+| `debarment`        | Debarred companies and individuals                          |
+| `regulatory`       | Regulatory watchlists, investor alerts                      |
+| `enforcement`      | Enforcement actions, litigation, regulatory notices         |
+| `maritime`         | Vessels, port-state-control and other maritime sources      |
+| `securities`       | Sanctioned/flagged securities issuers                       |
+| `special_interest` | Special-interest watchlists                                 |
+
+A dataset may belong to more than one collection if it genuinely fits. If the
+topic is ambiguous, ask the team rather than guessing.
+
+## Steps
+
+1. **Add the dataset name** to the chosen collection's `children:` list in
+   `datasets/_collections/<collection>.yml`. Keep the list alphabetically sorted.
+
+2. **Bump `coverage.start`** in the dataset's own YAML to the release date (today).
+   This field records the date the dataset first entered the `default` collection
+   — i.e. the release date, which is usually later than when the crawler was
+   scaffolded. Do **not** set it to the date the source data begins covering.
+
+3. **Verify** that the dataset is now part of a collection:
+
+   ```bash
+   python contrib/check_hierarchy.py datasets
+   ```
+
+   This warns `"<name> has no collections"` for any non-collection dataset that
+   is not a child of any collection. After releasing, the dataset you added
+   should no longer appear in the output. Warnings for other unreleased datasets
+   are expected — release only the datasets you intend to.
+
+## What not to release
+
+- Test or scratch datasets.
+- `_externals/` and `_analysis/` datasets, which are wired into the pipeline
+  differently — leave these to the maintainers.

--- a/zavod/docs/best_practices/release.md
+++ b/zavod/docs/best_practices/release.md
@@ -1,17 +1,12 @@
 # Releasing a dataset
 
-A crawler that has been merged still only runs in isolation — it produces data,
-but that data is not yet part of any published OpenSanctions product. A dataset
-is **released** once it is added to a collection. This usually happens after the
-crawler has passed [review](merge_checklist.md), an initial run, and de-duplication
-against existing data.
+A dataset becomes part of a published OpenSanctions distribution by being added to a collection's `children:` list.
+
+A merged crawler runs in isolation: it produces data, but that data reaches no published product until the dataset joins a collection. Release a dataset once its crawler has passed [review](merge_checklist.md), an initial run, and deduplication against existing data.
 
 ## How collections work
 
-Collections are datasets that combine the entities of other datasets. They are
-defined as YAML files in
-[`datasets/_collections/`](https://github.com/opensanctions/opensanctions/tree/main/datasets/_collections),
-each with a `children:` list naming its member datasets:
+Collections are datasets that combine the entities of other datasets. They are defined as YAML files in `datasets/_collections/`, each with a `children:` list naming its member datasets:
 
 ```yaml
 type: collection
@@ -23,51 +18,35 @@ children:
   # ...
 ```
 
-Membership is declared **only** in the collection's `children:` list. There is no
-reverse key on the dataset itself — to release a dataset you edit the collection,
-not the dataset's own metadata.
+Membership is declared in the collection's `children:` list, and nowhere else. The dataset's own metadata carries no reverse pointer, so releasing a dataset means editing the collection rather than the dataset.
 
-Collections nest: the `default` collection lists the *topical* collections
-(`sanctions`, `peps`, `crime`, …) as its children, and those in turn list the
-individual datasets. Membership rolls up recursively, so adding a dataset to a
-topical collection automatically includes it in `default` (the broadest public
-distribution) as well. **You normally only edit a topical collection** — never
-add an ordinary dataset directly to `default`.
+Collections nest. The `default` collection lists the topical collections (`sanctions`, `peps`, `crime`, and so on) as its children, and those in turn list the individual datasets. Membership rolls up recursively, so adding a dataset to a topical collection also includes it in `default`, the broadest public distribution. Edit a topical collection; do not add an ordinary dataset directly to `default`.
 
 ## Choosing a collection
 
-Add the dataset to the most appropriate topical collection based on the
-[kind of entities](https://www.opensanctions.org/docs/topics/) it produces. The
-quickest way to decide is to find a
-[similar dataset](https://www.opensanctions.org/datasets/) and see which
-collection it is included in.
+Add the dataset to the most appropriate topical collection based on the [kind of entities](https://www.opensanctions.org/docs/topics/) it produces. The quickest way to decide is to find a [similar dataset](https://www.opensanctions.org/datasets/) and see which collection it is included in.
 
 | Collection         | Holds                                                       |
 |--------------------|-------------------------------------------------------------|
 | `peps`             | Parliaments, elected officials, PEP/asset declarations      |
 | `sanctions`        | Consolidated sanctions lists                                |
-| `eu_sanctions`     | EU-specific sanctions sources                               |
-| `crime`            | Criminal / investigative / leaked-records entities          |
+| `eu_sanctions`     | European Union sanctions sources                            |
+| `crime`            | Criminal, investigative, and leaked-records entities        |
 | `wanted`           | Wanted-persons lists                                        |
 | `debarment`        | Debarred companies and individuals                          |
-| `regulatory`       | Regulatory watchlists, investor alerts                      |
-| `enforcement`      | Enforcement actions, litigation, regulatory notices         |
-| `maritime`         | Vessels, port-state-control and other maritime sources      |
-| `securities`       | Sanctioned/flagged securities issuers                       |
+| `regulatory`       | Regulatory watchlists and investor alerts                   |
+| `enforcement`      | Enforcement actions, litigation, and regulatory notices     |
+| `maritime`         | Vessels, port-state-control, and other maritime sources     |
+| `securities`       | Sanctioned or flagged securities issuers                    |
 | `special_interest` | Special-interest watchlists                                 |
 
-A dataset may belong to more than one collection if it genuinely fits. If the
-topic is ambiguous, ask the team rather than guessing.
+A dataset may belong to more than one collection if it genuinely fits. If the topic is ambiguous, ask the team rather than guessing.
 
 ## Steps
 
-1. **Add the dataset name** to the chosen collection's `children:` list in
-   `datasets/_collections/<collection>.yml`. Keep the list alphabetically sorted.
+1. **Add the dataset name** to the chosen collection's `children:` list in `datasets/_collections/<COLLECTION>.yml`. Replace `<COLLECTION>` with the collection name, and keep the list alphabetically sorted.
 
-2. **Bump `coverage.start`** in the dataset's own YAML to the release date (today).
-   This field records the date the dataset first entered the `default` collection
-   — i.e. the release date, which is usually later than when the crawler was
-   scaffolded. Do **not** set it to the date the source data begins covering.
+2. **Bump `coverage.start`** in the dataset's own YAML to the release date (today). This field records the date the dataset first entered the `default` collection, which is usually later than when the crawler was scaffolded. Do not set it to the date the source data begins covering.
 
 3. **Verify** that the dataset is now part of a collection:
 
@@ -75,13 +54,9 @@ topic is ambiguous, ask the team rather than guessing.
    python contrib/check_hierarchy.py datasets
    ```
 
-   This warns `"<name> has no collections"` for any non-collection dataset that
-   is not a child of any collection. After releasing, the dataset you added
-   should no longer appear in the output. Warnings for other unreleased datasets
-   are expected — release only the datasets you intend to.
+   The check warns `"<name> has no collections"` for any non-collection dataset that is not a child of any collection. After releasing, the dataset you added no longer appears in the output. Warnings for other unreleased datasets are expected, so release only the datasets you intend to.
 
 ## What not to release
 
 - Test or scratch datasets.
-- `_externals/` and `_analysis/` datasets, which are wired into the pipeline
-  differently — leave these to the maintainers.
+- `_externals/` and `_analysis/` datasets, which are wired into the pipeline differently. Leave these to the maintainers.

--- a/zavod/docs/tutorial.md
+++ b/zavod/docs/tutorial.md
@@ -232,6 +232,9 @@ and see which collection they are directly included in.
 
 Broader collections include more specific collections and/or specific crawlers.
 
+See the [release guide](best_practices/release.md) for the full process of
+releasing a dataset into a collection.
+
 ### Next steps
 
 You may now want to level up your crawler by looking at

--- a/zavod/mkdocs.yml
+++ b/zavod/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - best_practices/http_operations.md
       - best_practices/priorities.md
       - best_practices/merge_checklist.md
+      - best_practices/release.md
       - best_practices/xpath_and_html.md
   - Sanctions Programs: programs.md
   - PEPs: peps.md


### PR DESCRIPTION
Releases the parliament / elected-officials datasets listed below by adding them to the `peps` collection's `children:` list and bumping each dataset's `coverage.start` to the release date (`2026-06-16`).

After this change, `python contrib/check_hierarchy.py datasets` reports no `"has no collections"` warning for any of them.

### Datasets released
- `al_kuvendi`
- `au_act_parliament`, `au_nt_parliament`, `au_qld_parliament`, `au_sa_parliament`, `au_wa_parliament` (completing the AU state/territory set alongside the already-released NSW/TAS/VIC and federal datasets)
- `ba_parliament`
- `be_senate`
- `ph_house_representatives`, `ph_senate`
- `ro_cdep_deputies`, `ro_senate`
- `sk_nrsr_poslanci`

Topical collections roll up into `default` automatically, so no `default.yml` edit is needed.

### Docs & tooling
- New **`zavod/docs/best_practices/release.md`** — the authoritative guide to releasing a dataset (collection mechanics, choosing a collection, `coverage.start`, `check_hierarchy` verification). Registered in the mkdocs nav and linked from the tutorial.
- **`merge_checklist.md`** — replaced the inline `coverage.start` note with a pointer to the release guide ("Once the dataset has passed QA and initial de-duplication, it can be released").
- New **`release-datasets`** Claude Code skill that documents *that* datasets can be released and defers the process to `release.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)