### PR TITLE
publish: Allow archive_failure for collections

### DIFF
--- a/zavod/zavod/cli/etl.py
+++ b/zavod/zavod/cli/etl.py
@@ -137,11 +137,7 @@ def run(
         set_last_successful_version(dataset, settings.RUN_VERSION)
     except Exception:
         log.exception("Failed to export: %s" % dataset_path)
-        # archive_failure currently does not support collections
-        # see https://github.com/opensanctions/opensanctions/issues/2459 for context
-        # and an effort to change this.
-        if not dataset.is_collection:
-            archive_failure(dataset)
+        archive_failure(dataset)
         store.close()
         sys.exit(1)
 

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -115,11 +115,14 @@ def _warn_about_stale_latest_files(dataset: Dataset, published_files: set[str]) 
 
 def archive_failure(dataset: Dataset) -> None:
     """Upload failure information about a dataset to the archive."""
-    # Collections currently should never call archive_failure (as that only gets called for crawl and validate).
-    # But if they ever did (for example to publish a failure in the export stage), we should think very well about
-    # what exactly a failed index.json for default should look like. Currently, it would have empty resources,
-    # and our clients likely wouldn't appreciate that.
-    assert not dataset.is_collection
+    # For collections, we used to refuse to archive_failure because we were worried about a failed
+    # `default/index.json` ending up at `/datasets/latest/default/index.json` with empty resources.
+    # That's no longer a concern: we stopped publishing failed `index.json` to `/datasets` in
+    # https://github.com/opensanctions/opensanctions/commit/476dcbc0088d5f92b9258244644e61754e85ffdb,
+    # and `index.json` carries an explicit `result: failure` since
+    # https://github.com/opensanctions/opensanctions/commit/ff9c602c66668393b66e79850fc1fb8810b899fa.
+    # So archiving a failed collection just lands a `result: failure` version in `/artifacts`,
+    # which is exactly what we want for surfacing the `issues.log`.
     # Clear out interim artifacts so they cannot pollute the metadata we're
     # generating.
     dataset_resource_path(dataset.name, STATEMENTS_FILE).unlink(missing_ok=True)

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -19,6 +19,14 @@ from zavod.integration import get_dataset_linker
 from zavod.publish import publish_dataset, archive_failure
 from zavod.exc import RunFailedException
 
+STANDARD_EXPORTS = {
+    "entities.ftm.json",
+    "targets.simple.csv",
+    "names.txt",
+    "targets.nested.json",
+    "senzing.json",
+}
+
 
 def _read_history(dataset_name: str) -> Optional[VersionHistory]:
     fn = settings.ARCHIVE_PATH / ARTIFACTS / dataset_name / VERSIONS_FILE
@@ -61,36 +69,33 @@ def test_publish_dataset(testdataset1: Dataset):
     assert history.latest is not None
     assert history.latest.id is not None
     artifact_path = artifacts_path / testdataset1.name / history.latest.id
-    assert artifact_path.exists()
-    # Everything gets archived
-    assert artifact_path.joinpath(INDEX_FILE).exists()
-    assert artifact_path.joinpath(ISSUES_FILE).exists()
-    assert artifact_path.joinpath(ISSUES_LOG).exists()
-    assert artifact_path.joinpath(VERSIONS_FILE).exists()
-    assert artifact_path.joinpath(RESOURCES_FILE).exists()
-    assert artifact_path.joinpath(HASH_FILE).exists()
-    assert artifact_path.joinpath(DELTA_INDEX_FILE).exists()
-    assert artifact_path.joinpath(STATEMENTS_FILE).exists()
-    assert artifact_path.joinpath(STATISTICS_FILE).exists()
-    assert artifact_path.joinpath("entities.ftm.json").exists()
-    assert artifact_path.joinpath(DELTA_EXPORT_FILE).exists()
-    # Collections-only:
-    assert not artifact_path.joinpath(CATALOG_FILE).exists()
+    artifacts = {str(p.name) for p in artifact_path.glob("*")}
+    assert artifacts == {
+        # Everything gets archived
+        INDEX_FILE,
+        ISSUES_FILE,
+        ISSUES_LOG,
+        VERSIONS_FILE,
+        RESOURCES_FILE,
+        HASH_FILE,
+        DELTA_INDEX_FILE,
+        DELTA_EXPORT_FILE,
+        STATEMENTS_FILE,
+        STATISTICS_FILE,
+        "source.csv",
+        # Collections-only:
+        # CATALOG_FILE,
+    } | STANDARD_EXPORTS  # fmt: skip
 
     # Only index and real resources get published.
-    assert release_path.joinpath(INDEX_FILE).exists()
-    assert release_path.joinpath("entities.ftm.json").exists()
-    assert not release_path.joinpath(STATEMENTS_FILE).exists()
-    assert not release_path.joinpath(STATISTICS_FILE).exists()
-    assert not release_path.joinpath(ISSUES_LOG).exists()
-    assert not release_path.joinpath(VERSIONS_FILE).exists()
-    assert not release_path.joinpath(RESOURCES_FILE).exists()
-    assert not release_path.joinpath(HASH_FILE).exists()
-    assert not release_path.joinpath(DELTA_INDEX_FILE).exists()
-    assert not release_path.joinpath(DELTA_EXPORT_FILE).exists()
-    assert not release_path.joinpath(CATALOG_FILE).exists()
-
-    assert not latest_path.joinpath(INDEX_FILE).exists()
+    release_artifacts = {str(p.name) for p in release_path.glob("*")}
+    assert release_artifacts == {
+        INDEX_FILE,
+        "source.csv",
+    } | STANDARD_EXPORTS  # fmt: skip
+    # Nothing's published to 'latest'
+    latest_artifacts = {str(p.name) for p in latest_path.glob("*")}
+    assert latest_artifacts == set()
 
     publish_dataset(testdataset1, republish_to_latest=True)
     assert latest_path.joinpath(INDEX_FILE).exists()
@@ -147,35 +152,38 @@ def test_publish_collection(testdataset1: Dataset, collection: Dataset):
     assert history is not None
     assert history.latest is not None
     artifact_path = artifacts_path / collection.name / history.latest.id
-    assert artifact_path.exists()
-    # Everything gets archived
-    assert artifact_path.joinpath(INDEX_FILE).exists()
-    assert artifact_path.joinpath("entities.ftm.json").exists()
-    assert artifact_path.joinpath(ISSUES_FILE).exists()
-    assert artifact_path.joinpath(VERSIONS_FILE).exists()
-    assert artifact_path.joinpath(RESOURCES_FILE).exists()
-    assert artifact_path.joinpath(HASH_FILE).exists()
-    assert artifact_path.joinpath(DELTA_INDEX_FILE).exists()
-    assert artifact_path.joinpath(STATISTICS_FILE).exists()
-    # Collections get a catalog.json
-    assert artifact_path.joinpath(CATALOG_FILE).exists()
-    # Collections don't crawl, so statements.pack is never produced.
-    assert not artifact_path.joinpath(STATEMENTS_FILE).exists()
-    # No issue was logged during this export, so the lazily-created
-    # issues.log was never written.
-    assert not artifact_path.joinpath(ISSUES_LOG).exists()
+    artifacts = {str(p.name) for p in artifact_path.glob("*")}
+    assert artifacts == {
+        # Everything gets archived
+        INDEX_FILE,
+        ISSUES_FILE,
+        VERSIONS_FILE,
+        RESOURCES_FILE,
+        HASH_FILE,
+        DELTA_INDEX_FILE,
+        DELTA_EXPORT_FILE,
+        STATISTICS_FILE,
+        # Collections get a catalog.json
+        CATALOG_FILE,
+        # Collections don't crawl, so statements.pack is never produced.
+        # STATEMENTS_FILE
+        # No issue was logged during this export, so the lazily-created
+        # issues.log was never written.
+        # ISSUES_LOG
+    } | STANDARD_EXPORTS  # fmt: skip
 
+    release_artifacts = {str(p.name) for p in release_path.glob("*")}
     # Only index, catalog, and real resources get published.
-    assert release_path.joinpath(INDEX_FILE).exists()
-    assert release_path.joinpath(CATALOG_FILE).exists()
-    assert release_path.joinpath("entities.ftm.json").exists()
-    assert latest_path.joinpath(INDEX_FILE).exists()
-    assert latest_path.joinpath(CATALOG_FILE).exists()
-    assert latest_path.joinpath("entities.ftm.json").exists()
     # Artifact-only files don't leak into /datasets/.
-    assert not release_path.joinpath(ISSUES_LOG).exists()
-    assert not release_path.joinpath(VERSIONS_FILE).exists()
-    assert not release_path.joinpath(HASH_FILE).exists()
+    assert release_artifacts == {
+        INDEX_FILE,
+        CATALOG_FILE,
+    } | STANDARD_EXPORTS  # fmt: skip
+    latest_artifacts = {str(p.name) for p in latest_path.glob("*")}
+    assert latest_artifacts == {
+        INDEX_FILE,
+        CATALOG_FILE,
+    } | STANDARD_EXPORTS  # fmt: skip
 
 
 def test_archive_failure(testdataset1: Dataset):
@@ -218,7 +226,7 @@ def test_archive_failure(testdataset1: Dataset):
         # RESOURCES_FILE,
         # HASH_FILE,
         # DELTA_INDEX_FILE,
-    }
+    }  # fmt: skip
 
     # We don't want failed runs to end up in /datasets
     assert len(list(latest_path.glob("*"))) == 0
@@ -269,7 +277,7 @@ def test_archive_collection_failure(
         # RESOURCES_FILE,
         # HASH_FILE,
         # DELTA_INDEX_FILE,
-    }
+    }  # fmt: skip
 
     assert len(list(latest_path.glob("*"))) == 0
     assert len(list(release_path.glob("*"))) == 0

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -2,6 +2,7 @@ import json
 from typing import Optional
 from followthemoney.dataset import VersionHistory
 from structlog.testing import capture_logs
+from logging import Logger
 
 from zavod import settings
 from zavod.meta import Dataset
@@ -201,20 +202,74 @@ def test_archive_failure(testdataset1: Dataset):
     assert history.latest.id is not None
     artifact_path = artifacts_path / testdataset1.name / history.latest.id
 
+    artifacts = {str(p.name) for p in artifact_path.glob("*")}
+
     # Only very specific files get archived.
-    assert artifact_path.joinpath(INDEX_FILE).exists()
-    assert artifact_path.joinpath(ISSUES_FILE).exists()
-    assert artifact_path.joinpath(ISSUES_LOG).exists()
-    assert artifact_path.joinpath(VERSIONS_FILE).exists()
     # We want to be really, really sure we'll never backfill from failed runs
-    assert not artifact_path.joinpath(STATEMENTS_FILE).exists()
-    assert not artifact_path.joinpath(RESOURCES_FILE).exists()
-    assert not artifact_path.joinpath(HASH_FILE).exists()
-    assert not artifact_path.joinpath(DELTA_INDEX_FILE).exists()
+    assert artifacts == {
+        INDEX_FILE,
+        ISSUES_FILE,
+        ISSUES_LOG,
+        VERSIONS_FILE,
+        # We want to be really, really sure we'll never backfill from failed runs
+        # so specifically not:
+        #
+        # STATEMENTS_FILE,
+        # RESOURCES_FILE,
+        # HASH_FILE,
+        # DELTA_INDEX_FILE,
+    }
 
     # We don't want failed runs to end up in /datasets
-    assert not latest_path.joinpath(INDEX_FILE).exists()
-    assert not latest_path.joinpath(STATEMENTS_FILE).exists()
-    assert not latest_path.joinpath(ISSUES_FILE).exists()
+    assert len(list(latest_path.glob("*"))) == 0
+    assert len(list(release_path.glob("*"))) == 0
+
+
+def test_archive_collection_failure(
+    testdataset1: Dataset, collection: Dataset, logger: Logger
+):
+    """Effectively a 'zavod run' on a collection, checking that the the files
+    expected to be archived and published are present in the right locations."""
+    linker = get_dataset_linker(testdataset1)
+    artifacts_path = settings.ARCHIVE_PATH / ARTIFACTS
+    published_path = settings.ARCHIVE_PATH / DATASETS
+    release_path = published_path / settings.RELEASE / collection.name
+    latest_path = published_path / "latest" / collection.name
+
+    # Simulate something that logs results in an issue log during a collection run
+    collection.model.exports.add("missing.exp")
+
+    crawl_dataset(testdataset1)
+    store = get_store(testdataset1, linker)
+    store.sync()
+    view = store.view(testdataset1)
+    export_dataset(testdataset1, view)
+
+    export_dataset(collection, view)
+    # let's imagine there was an exception causing abort
+    archive_failure(collection)
+
+    history = _read_history(collection.name)
+    assert history is not None
+    assert history.latest is not None
+    assert history.latest.id is not None
+    artifact_path = artifacts_path / collection.name / history.latest.id
+
+    artifacts = {str(p.name) for p in artifact_path.glob("*")}
+
+    assert artifacts == {
+        INDEX_FILE,
+        ISSUES_FILE,
+        ISSUES_LOG,
+        VERSIONS_FILE,
+        # We want to be really, really sure we won't see exports from failed runs.
+        # Specifically not:
+        #
+        # STATEMENTS_FILE,
+        # RESOURCES_FILE,
+        # HASH_FILE,
+        # DELTA_INDEX_FILE,
+    }
+
     assert len(list(latest_path.glob("*"))) == 0
     assert len(list(release_path.glob("*"))) == 0


### PR DESCRIPTION
## Summary

Stacked on https://github.com/opensanctions/opensanctions/pull/4550.

Allow `archive_failure` to be called for collections, and stop skipping the archive step when an export fails on a collection. Together with https://github.com/opensanctions/opensanctions/pull/4550, this closes out https://github.com/opensanctions/opensanctions/issues/2459.

## Why

We used to refuse to `archive_failure` for collections because we were worried about a failed `default/index.json` with empty resources ending up at `/datasets/latest/default/`. Two things have changed since:

- https://github.com/opensanctions/opensanctions/commit/476dcbc0088d5f92b9258244644e61754e85ffdb — we no longer publish failed `index.json` to `/datasets` at all.
- https://github.com/opensanctions/opensanctions/commit/ff9c602c66668393b66e79850fc1fb8810b899fa — `index.json` now carries an explicit `result: failure` field, so failed runs are recognizable rather than ambiguous.

With both of those in place, archiving a failed collection just lands a `result: failure` version in `/artifacts`. That's exactly what we want — the `issues.log` for the failed run becomes visible rather than disappearing. (See https://github.com/opensanctions/opensanctions/issues/2459#issuecomment-4709412306 for the analysis.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)