### PR TITLE
publish: Drop unused `latest` arg from archive_failure

### DIFF
--- a/zavod/zavod/cli/etl.py
+++ b/zavod/zavod/cli/etl.py
@@ -103,14 +103,14 @@ def run(
 
     if dataset.model.disabled:
         log.info("Dataset is disabled, skipping: %s" % dataset.name)
-        archive_failure(dataset, latest=latest)
+        archive_failure(dataset)
         sys.exit(0)
     # crawl if it's a dataset, just create a new version if it's a collection
     if dataset.model.entry_point is not None and not dataset.is_collection:
         try:
             crawl_dataset(dataset, dry_run=False)
         except RunFailedException:
-            archive_failure(dataset, latest=latest)
+            archive_failure(dataset)
             sys.exit(1)
     else:
         # crawl_dataset -> Context.begin does this in the case above
@@ -126,7 +126,7 @@ def run(
             validate_dataset(dataset, view)
     except Exception:
         log.exception("Validation failed for %r" % dataset.name)
-        archive_failure(dataset, latest=latest)
+        archive_failure(dataset)
         store.close()
         sys.exit(1)
     # Export and Publish

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -97,7 +97,7 @@ def _warn_about_stale_latest_files(dataset: Dataset, published_files: set[str]) 
             )
 
 
-def archive_failure(dataset: Dataset, latest: bool = True) -> None:
+def archive_failure(dataset: Dataset) -> None:
     """Upload failure information about a dataset to the archive."""
     # Collections currently should never call publish_failure (as that only gets called for crawl and validate).
     # But if they ever did (for example to publish a failure in the export stage), we should think very well about

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -79,7 +79,7 @@ def test_publish_failure(testdataset1: Dataset):
     try:
         crawl_dataset(testdataset1)
     except RunFailedException:
-        archive_failure(testdataset1, latest=True)
+        archive_failure(testdataset1)
     clear_data_path(testdataset1.name)
 
     history = _read_history(testdataset1.name)


### PR DESCRIPTION
## Summary

Drops the `latest` parameter from `archive_failure`. It's in the signature with a default of `True` and threaded through from every caller in `zavod.cli.etl`, but the function body never actually reads it.

It used to be load-bearing: `archive_failure` would publish a failed `index.json` to `/datasets/latest/<dataset>/` so clients could see the failure, and `latest` controlled whether that republish-to-latest happened. We stopped publishing failed runs to `/datasets` at all in https://github.com/opensanctions/opensanctions/commit/476dcbc0088d5f92b9258244644e61754e85ffdb — now `archive_failure` only writes to `/artifacts/`, so the flag has nothing left to gate.

Just cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)