### PR TITLE
Format Excel datetimes directly to silence rigour UTC warning

### DIFF
--- a/zavod/zavod/helpers/excel.py
+++ b/zavod/zavod/helpers/excel.py
@@ -12,7 +12,6 @@ from xlrd import (
 from xlrd.book import Book
 from xlrd.sheet import Cell, Sheet
 from xlrd.xldate import xldate_as_datetime
-from rigour.time import datetime_iso
 from openpyxl.worksheet.worksheet import Worksheet
 
 from zavod.context import Context
@@ -36,7 +35,8 @@ def convert_excel_cell(book: Book, cell: Cell) -> Optional[str]:
     if cell.ctype == XL_CELL_DATE:
         assert isinstance(cell.value, float)
         dt = xldate_as_datetime(cell.value, book.datemode)
-        return datetime_iso(dt)
+        # Naive ISO 8601, e.g. "2023-07-26T00:00:00" — Excel cells carry no timezone.
+        return dt.isoformat(sep="T", timespec="seconds")
     else:
         if cell.value is None:
             return None
@@ -64,7 +64,8 @@ def convert_excel_date(value: Optional[Union[str, int, float]]) -> Optional[str]
     if value < 4_000 or value > 100_000:
         return None
     dt = datetime.fromordinal(datetime(1900, 1, 1).toordinal() + value - 2)
-    return datetime_iso(dt)
+    # Naive ISO 8601, e.g. "2022-11-11T00:00:00" — Excel dates carry no timezone.
+    return dt.isoformat(sep="T", timespec="seconds")
 
 
 def parse_xls_sheet(


### PR DESCRIPTION
## Summary

`rigour.time.datetime_iso` now warns when it receives a non-UTC datetime, which fires on every Excel date cell parsed by `convert_excel_cell` / `convert_excel_date`:

```
UserWarning: datetime_iso expects UTC timezone, but got None.
Consider using utc_now() or converting to UTC first.
```

It surfaces visibly in `test_excel`, but it's a runtime warning for any crawler using these helpers (currently `ae/local_terrorists`, `ca/dfatd`, `jp/mof_sanctions`).

Fixed by formatting the naive datetime directly with `dt.isoformat(sep="T", timespec="seconds")`. Output is byte-for-byte identical to before — no downstream crawler data changes.

Why not just attach `timezone.utc` and move on: Excel cells genuinely don't carry timezone info. A `2023-07-26 14:00` cell in a Russian agency's spreadsheet means `14:00 Moscow`, not `14:00 UTC`, and we have no way to know. Tagging it `+00:00` would be a quiet lie. `datetime_iso`'s contract is "datetimes are UTC, with explicit offset" — right tool for `utc_now()`, wrong tool for naive Excel data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)