### PR TITLE
Persist subnationalArea on position records

### DIFF
--- a/ui/lib/db.ts
+++ b/ui/lib/db.ts
@@ -39,6 +39,7 @@ const expectedPositionColumns = new Set<string>([
   'entity_id',
   'caption',
   'countries',
+  'subnational_areas',
   'is_pep',
   'topics',
   'dataset',
@@ -82,6 +83,7 @@ export interface PositionTable {
   entity_id: string
   caption: string
   countries: JSONColumnType<string[], string[], string[]>
+  subnational_areas: JSONColumnType<string[], string[], string[]> | null
   is_pep: boolean | null
   topics: JSONColumnType<string[], string[], string[]>
   dataset: string
@@ -510,6 +512,7 @@ export async function softDeleteAndCreatePosition({ entityId, positionUpdate, mo
         // NOTE(Leon Handreke): I don't know how else to make it work than to stringify
         // the lists manually.
         countries: JSON.stringify(updatedData.countries) as unknown as string[],
+        subnational_areas: JSON.stringify(updatedData.subnational_areas ?? []) as unknown as string[],
         topics: JSON.stringify(updatedData.topics) as unknown as string[],
       })
       .returningAll()

--- a/zavod/zavod/stateful/model.py
+++ b/zavod/zavod/stateful/model.py
@@ -24,6 +24,7 @@ position_table = Table(
     Column("caption", Unicode(VALUE_LEN), nullable=False),
     # SQLite doesn't support arrays so we use JSON
     Column("countries", JSON, nullable=False),
+    Column("subnational_areas", JSON, nullable=True),
     Column("is_pep", Boolean, nullable=True),
     Column("topics", JSON, nullable=False),
     Column("dataset", Unicode(VALUE_LEN), nullable=False),

--- a/zavod/zavod/stateful/positions.py
+++ b/zavod/zavod/stateful/positions.py
@@ -58,23 +58,30 @@ def categorise(
     returned; later calls will pick up any edits made through the UI.
     """
     countries = sorted(position.get("country"))
+    subnational_areas = sorted(position.get("subnationalArea"))
     stmt = position_table.select()
     stmt = stmt.filter(position_table.c.entity_id == position.id)
     stmt = stmt.filter(position_table.c.deleted_at.is_(None))
     for row in context.conn.execute(stmt).fetchall():
-        if row.caption != position.caption or sorted(row.countries) != countries:
+        if (
+            row.caption != position.caption
+            or sorted(row.countries) != countries
+            or sorted(row.subnational_areas or []) != subnational_areas
+        ):
             # If the caption or countries have changed, we need to update the row.
             context.log.info(
                 "Updating position metadata",
                 entity_id=position.id,
                 caption=position.caption,
                 countries=countries,
+                subnational_areas=subnational_areas,
             )
             ustmt = position_table.update()
             ustmt = ustmt.where(position_table.c.id == row.id)
             updates = {
                 "caption": position.caption,
                 "countries": countries,
+                "subnational_areas": subnational_areas,
                 # "modified_at": settings.RUN_TIME,
             }
             ustmt = ustmt.values(updates)
@@ -88,6 +95,7 @@ def categorise(
         "entity_id": position.id,
         "caption": position.caption,
         "countries": countries,
+        "subnational_areas": subnational_areas,
         "topics": position.get("topics"),
         "dataset": position.dataset.name,
         "created_at": settings.RUN_TIME,

--- a/zavod/zavod/tests/stateful/test_positions.py
+++ b/zavod/zavod/tests/stateful/test_positions.py
@@ -165,7 +165,9 @@ def test_occupancy_status(testdataset1: Dataset):
 
 def test_categorise_flow(testdataset1: Dataset):
     context = Context(testdataset1)
-    position = make_position(context, "A position", country="ls")
+    position = make_position(
+        context, "A position", country="ls", subnational_area="Maseru"
+    )
     assert len(context.conn.execute(position_table.select()).fetchall()) == 0
     categorisation = categorise(context, position, default_is_pep=None)
     assert categorisation.is_pep is None
@@ -175,6 +177,7 @@ def test_categorise_flow(testdataset1: Dataset):
     assert pos.entity_id == position.id
     assert pos.caption == position.caption
     assert pos.countries == ["ls"]
+    assert pos.subnational_areas == ["Maseru"]
     assert pos.topics == []
     assert pos.is_pep is None
     categorise.cache_clear()
@@ -196,4 +199,37 @@ def test_categorise_flow(testdataset1: Dataset):
     categorisation = categorise(context, position2, default_is_pep=True)
     assert categorisation.is_pep is True
     assert categorisation.topics == ["gov.igo"]
+    context.close()
+
+
+def test_categorise_updates_changed_metadata(testdataset1: Dataset):
+    """When caption/countries/subnationalArea on a position change, the
+    existing row is updated in place rather than a new one being inserted."""
+    context = Context(testdataset1)
+
+    position = make_position(
+        context, "Minister of Health", country="us", subnational_area="California"
+    )
+    categorise(context, position, default_is_pep=None)
+    [row] = context.conn.execute(position_table.select()).fetchall()
+    original_id = row.id
+    assert row.caption == "Minister of Health"
+    assert row.countries == ["us"]
+    assert row.subnational_areas == ["California"]
+
+    # Same entity id, but renamed and moved to a different subnational area.
+    # categorise() should update the existing row, not insert a second one.
+    renamed = make_position(
+        context, "Secretary of Health", country="ca", subnational_area="Texas"
+    )
+    renamed.id = position.id
+    categorise.cache_clear()
+    categorise(context, renamed, default_is_pep=None)
+
+    [row] = context.conn.execute(position_table.select()).fetchall()
+    assert row.id == original_id
+    assert row.caption == "Secretary of Health"
+    assert row.countries == ["ca"]
+    assert row.subnational_areas == ["Texas"]
+
     context.close()


### PR DESCRIPTION
## Summary

Groundwork for https://github.com/opensanctions/opensanctions/issues/3843. Adds a `subnational_areas` JSON column to the `position` table and persists/refreshes it in `categorise()` alongside `countries`, so the positions classification UI can later surface it.

## Rollout

- The `subnational_areas` column has to be added to the prod `position` table (manual `ALTER TABLE`) **before** deploying this — `meta.create_all` only creates missing tables, it won't add columns to an existing one.
- Once the column exists, the UI needs to land in lockstep: `ui/lib/db.ts` does an exact-set schema check on startup (throws on both missing and unexpected columns), so adding the column on the DB without updating `expectedPositionColumns` + the `PositionTable` interface will break the UI, and vice versa. UI PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)