### PR TITLE
[issues_agent] Handle present-but-null project field values

### DIFF
--- a/contrib/issues_agent/tasks.py
+++ b/contrib/issues_agent/tasks.py
@@ -119,10 +119,15 @@ def get_outage_datasets() -> set[str]:
             dataset: str | None = None
             status: str | None = None
             for field in item.get("fields", []):
+                # `value` is present-but-null when a field exists on the board
+                # but is unset for this item (e.g. a fresh outage report with no
+                # Dataset assigned), so `.get("value", {})` won't shield us — the
+                # key is there, just null. Coerce each level with `or {}`.
                 if field["id"] == FIELD_DATASET:
-                    dataset = field.get("value", {}).get("raw")
+                    dataset = (field.get("value") or {}).get("raw")
                 elif field["id"] == FIELD_STATUS:
-                    status = field.get("value", {}).get("name", {}).get("raw")
+                    name = (field.get("value") or {}).get("name") or {}
+                    status = name.get("raw")
             if dataset is not None and status == OUTAGE_STATUS:
                 outages.add(dataset)
 


### PR DESCRIPTION
## Problem

The matrix-generation step of the issues agent ([failing run](https://github.com/opensanctions/opensanctions/actions/runs/27672500779/job/81839895885)) crashed with:

```
AttributeError: 'NoneType' object has no attribute 'get'
  File ".../contrib/issues_agent/tasks.py", line 123, in get_outage_datasets
    dataset = field.get("value", {}).get("raw")
```

A fresh outage report on the Projects v2 board #6 has no `Dataset` field assigned, so the API returns that field with an explicit `value: null`. `dict.get("value", {})` only falls back to `{}` when the key is *absent* — here the key is present with a `null` value, so it returns `None` and `.get("raw")` throws.

## Fix

Coerce each nullable level with `or {}`. The `Status` field's chain (`value` → `name`) had the same latent bug and is fixed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)