### PR TITLE
Persist extra position properties in a JSONB bag

### DIFF
--- a/zavod/zavod/stateful/model.py
+++ b/zavod/zavod/stateful/model.py
@@ -24,6 +24,10 @@ position_table = Table(
     Column("caption", Unicode(VALUE_LEN), nullable=False),
     # SQLite doesn't support arrays so we use JSON
     Column("countries", JSON, nullable=False),
+    # Bag of extra position entity properties (subnationalArea,
+    # inceptionDate, dissolutionDate, ...) — lets us add fields without
+    # further schema migrations.
+    Column("properties", JSON, nullable=False, default=dict),
     Column("is_pep", Boolean, nullable=True),
     Column("topics", JSON, nullable=False),
     Column("dataset", Unicode(VALUE_LEN), nullable=False),

--- a/zavod/zavod/stateful/positions.py
+++ b/zavod/zavod/stateful/positions.py
@@ -13,6 +13,9 @@ from zavod.stateful.model import position_table
 
 NOTIFIED_SYNC_POSITIONS = False
 
+# Position entity properties mirrored into position_table.properties.
+EXTRA_PROPERTIES = ("subnationalArea",)
+
 YEAR_DAYS = 365  # days
 DEFAULT_AFTER_OFFICE = timedelta(days=5 * YEAR_DAYS)
 EXTENDED_AFTER_OFFICE_YEARS = 20
@@ -58,23 +61,29 @@ def categorise(
     returned; later calls will pick up any edits made through the UI.
     """
     countries = sorted(position.get("country"))
+    properties = {prop: sorted(position.get(prop)) for prop in EXTRA_PROPERTIES}
     stmt = position_table.select()
     stmt = stmt.filter(position_table.c.entity_id == position.id)
     stmt = stmt.filter(position_table.c.deleted_at.is_(None))
     for row in context.conn.execute(stmt).fetchall():
-        if row.caption != position.caption or sorted(row.countries) != countries:
-            # If the caption or countries have changed, we need to update the row.
+        if (
+            row.caption != position.caption
+            or sorted(row.countries) != countries
+            or (row.properties or {}) != properties
+        ):
             context.log.info(
                 "Updating position metadata",
                 entity_id=position.id,
                 caption=position.caption,
                 countries=countries,
+                properties=properties,
             )
             ustmt = position_table.update()
             ustmt = ustmt.where(position_table.c.id == row.id)
             updates = {
                 "caption": position.caption,
                 "countries": countries,
+                "properties": properties,
                 # "modified_at": settings.RUN_TIME,
             }
             ustmt = ustmt.values(updates)
@@ -88,6 +97,7 @@ def categorise(
         "entity_id": position.id,
         "caption": position.caption,
         "countries": countries,
+        "properties": properties,
         "topics": position.get("topics"),
         "dataset": position.dataset.name,
         "created_at": settings.RUN_TIME,

--- a/zavod/zavod/tests/stateful/test_positions.py
+++ b/zavod/zavod/tests/stateful/test_positions.py
@@ -165,7 +165,9 @@ def test_occupancy_status(testdataset1: Dataset):
 
 def test_categorise_flow(testdataset1: Dataset):
     context = Context(testdataset1)
-    position = make_position(context, "A position", country="ls")
+    position = make_position(
+        context, "A position", country="ls", subnational_area="Maseru"
+    )
     assert len(context.conn.execute(position_table.select()).fetchall()) == 0
     categorisation = categorise(context, position, default_is_pep=None)
     assert categorisation.is_pep is None
@@ -175,6 +177,7 @@ def test_categorise_flow(testdataset1: Dataset):
     assert pos.entity_id == position.id
     assert pos.caption == position.caption
     assert pos.countries == ["ls"]
+    assert pos.properties == {"subnationalArea": ["Maseru"]}
     assert pos.topics == []
     assert pos.is_pep is None
     categorise.cache_clear()
@@ -186,6 +189,7 @@ def test_categorise_flow(testdataset1: Dataset):
         "entity_id": position2.id,
         "caption": position2.caption,
         "countries": position2.get("country"),
+        "properties": {},
         "topics": ["gov.igo"],
         "is_pep": True,
         "dataset": "banana",
@@ -196,4 +200,37 @@ def test_categorise_flow(testdataset1: Dataset):
     categorisation = categorise(context, position2, default_is_pep=True)
     assert categorisation.is_pep is True
     assert categorisation.topics == ["gov.igo"]
+    context.close()
+
+
+def test_categorise_updates_changed_metadata(testdataset1: Dataset):
+    """When caption/countries/properties on a position change, the existing
+    row is updated in place rather than a new one being inserted."""
+    context = Context(testdataset1)
+
+    position = make_position(
+        context, "Minister of Health", country="us", subnational_area="California"
+    )
+    categorise(context, position, default_is_pep=None)
+    [row] = context.conn.execute(position_table.select()).fetchall()
+    original_id = row.id
+    assert row.caption == "Minister of Health"
+    assert row.countries == ["us"]
+    assert row.properties == {"subnationalArea": ["California"]}
+
+    # Same entity id, but renamed and moved to a different subnational area.
+    # categorise() should update the existing row, not insert a second one.
+    renamed = make_position(
+        context, "Secretary of Health", country="ca", subnational_area="Texas"
+    )
+    renamed.id = position.id
+    categorise.cache_clear()
+    categorise(context, renamed, default_is_pep=None)
+
+    [row] = context.conn.execute(position_table.select()).fetchall()
+    assert row.id == original_id
+    assert row.caption == "Secretary of Health"
+    assert row.countries == ["ca"]
+    assert row.properties == {"subnationalArea": ["Texas"]}
+
     context.close()


### PR DESCRIPTION
## Summary

Groundwork for https://github.com/opensanctions/opensanctions/issues/3843. Adds a generic `properties` JSON column to `position_table` and mirrors a configurable set of position entity properties (`EXTRA_PROPERTIES`, currently just `subnationalArea`) into it from `categorise()`, so the positions classification UI can later surface them.

Picks up Friedrich's suggestion on https://github.com/opensanctions/opensanctions/pull/4585#issuecomment-4727072298 — one JSON bag instead of a per-field column, so future additions (`inceptionDate`, `dissolutionDate`, a text-only sibling to `organization`, ...) don't each need a new ALTER. Supersedes https://github.com/opensanctions/opensanctions/pull/4585.

Also adds coverage for the previously untested `categorise()` update path that refreshes caption/countries/properties when they change on the crawler side.

## Rollout

- The `properties` column has to be added to the prod `position` table (manual `ALTER TABLE ADD COLUMN properties JSON NOT NULL DEFAULT '{}'`) **before** deploying this — `meta.create_all` only creates missing tables, it won't add columns to an existing one.
- Once the column exists, the UI needs to land in lockstep: `ui/lib/db.ts` does an exact-set schema check on startup (throws on both missing and unexpected columns), so adding the column on the DB without updating `expectedPositionColumns` + the `PositionTable` interface will break the UI, and vice versa. UI PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)