### PR TITLE
[py_senado] Add Paraguay Chamber of Senators PEP crawler

### DIFF
--- a/datasets/py/senado/crawler.py
+++ b/datasets/py/senado/crawler.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The current legislative term. The open-data endpoint URL is stable across terms,
+# so we assert the period on every record to fail loudly when the next term lands
+# (and the source starts returning 2028-2033 senators).
+EXPECTED_PERIOD = "2023-2028"
+
+IGNORE_FIELDS = [
+    "camaraParlamentario",  # constant "CAMARA DE SENADORES"
+    "telefonoParlamentario",  # private contact detail
+    "fotoURL",
+]
+
+
+def crawl_member(
+    context: Context,
+    row: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    period = row.pop("periodoLegislativo")
+    if period != EXPECTED_PERIOD:
+        raise ValueError(f"Unexpected legislative period: {period!r}")
+
+    # The endpoint returns one record per seat — the senator currently occupying it.
+    # tipoParlamentario flags whether that occupant is the elected titular or a
+    # suplente who has taken over a vacated seat; both are sitting senators, so we
+    # emit either. (We don't filter to TITULAR, which would drop seated replacements.)
+    person = context.make("Person")
+    person.id = context.make_slug(str(row.pop("idParlamentario")))
+    h.apply_name(
+        person, first_name=row.pop("nombres"), last_name=row.pop("apellidos")
+    )
+    # Senators must hold natural Paraguayan nationality; naturalised citizens are not
+    # eligible (Constitution of Paraguay, Art. 223).
+    # https://www.constituteproject.org/constitution/Paraguay_2011?lang=es
+    person.add("citizenship", "py")
+    person.add("political", row.pop("partidoPolitico"))
+    person.add("email", row.pop("emailParlamentario"))
+    person.add("sourceUrl", row.pop("appURL"))
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    # All senators are elected from a single nationwide constituency ("NACIONAL").
+    occupancy.add("constituency", row.pop("departamento"))
+    # The parliamentary bloc (bancada) is distinct from party membership.
+    occupancy.add("politicalGroup", row.pop("bancada"))
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(
+        row,
+        ignore=[
+            "tipoParlamentario",  # titular vs seated suplente — both emitted
+            "cargoBancada",  # role within the parliamentary bloc
+            *IGNORE_FIELDS,
+        ],
+    )
+
+
+def crawl(context: Context) -> None:
+    senators = context.fetch_json(context.data_url)
+    if not isinstance(senators, list) or len(senators) == 0:
+        raise ValueError("Expected a non-empty list of senators")
+
+    position = h.make_position(
+        context,
+        name="Member of the Chamber of Senators of Paraguay",
+        country="py",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q20058559",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    for row in senators:
+        crawl_member(context, row, position, categorisation)

--- a/datasets/py/senado/py_senado.yml
+++ b/datasets/py/senado/py_senado.yml
@@ -1,0 +1,50 @@
+title: Paraguay Members of the Chamber of Senators
+entry_point: crawler.py
+prefix: py-senado
+coverage:
+  frequency: monthly
+  start: 2026-06-18
+load_statements: true
+ci_test: false # Live external government API, not available in CI
+summary: >-
+  Senators of the Cámara de Senadores, the upper chamber of the National
+  Congress of Paraguay
+description: |
+  Current senators of the Cámara de Senadores (Chamber of Senators), the upper
+  chamber of the bicameral National Congress of Paraguay. Its 45 senators are
+  elected from a single nationwide constituency for five-year terms.
+
+  This dataset records each sitting senator with their name, party (partido
+  político) and parliamentary group (bancada), sourced from the Congress
+  open-data API. The source lists the current occupant of each of the 45 seats,
+  whether the elected senator or a suplente who has taken over a vacated seat.
+url: https://www.senado.gov.py/
+publisher:
+  name: Cámara de Senadores del Paraguay
+  name_en: Chamber of Senators of Paraguay
+  acronym: HCS
+  description: >
+    The Chamber of Senators is the upper chamber of the National Congress
+    (Congreso Nacional), the bicameral national legislature of Paraguay.
+  url: https://www.senado.gov.py/
+  country: py
+  official: true
+data:
+  url: https://datos.congreso.gov.py/opendata/api/data/parlamentario/camara/S
+  format: JSON
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 36
+      Position: 1
+    country_entities:
+      py: 36
+  max:
+    schema_entities:
+      Person: 60
+      Position: 1


### PR DESCRIPTION
Adds a PEP crawler for the **Cámara de Senadores of Paraguay** (upper chamber of the National Congress), sourced from the Congress open-data JSON API.

Ref opensanctions/crawler-planning#733 (milestone: South America PEPs: Legislative Bodies)

## Source
`https://datos.congreso.gov.py/opendata/api/data/parlamentario/camara/S` — official Congress open-data API (JSON, CC-BY 4.0).

## Notes
- Emits the **current occupant of each of the 45 seats**. The endpoint returns exactly chamber-size records, one per seat: currently 42 elected `TITULAR` + 3 `SUPLENTE` who have taken over vacated seats (the seated suplentes hold active bloc roles, e.g. VICELIDER, so they are sitting senators and are emitted). We deliberately do **not** filter to TITULAR, which would drop seated replacements.
- Per senator: name, party (`partidoPolitico` → `political`), parliamentary group (`bancada` → `politicalGroup`), constituency (`departamento`, all "NACIONAL"), email, source profile URL.
- `citizenship: py` — senators must hold natural Paraguayan nationality (Constitution art. 223).
- Position uses Wikidata `Q20058559` ("senator of Paraguay").
- Freshness: the crawler asserts `periodoLegislativo == "2023-2028"` so it fails loudly when the next term lands.

## Validation
- `zavod crawl` clean (`issues.json` empty); 45 Person + 45 Occupancy + 1 Position.
- `zavod validate` passes assertions; `mypy --strict` clean.
- All four PEP integrity checks (dangling post/holder, role.pep without occupancy, PEP without citizenship) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)