### PR TITLE
[py_diputados] Add Paraguay Chamber of Deputies PEP crawler

### DIFF
--- a/datasets/py/diputados/crawler.py
+++ b/datasets/py/diputados/crawler.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The current legislative term. The open-data endpoint URL is stable across terms,
+# so we assert the period on every record to fail loudly when the next term lands
+# (and the source starts returning 2028-2033 deputies).
+EXPECTED_PERIOD = "2023-2028"
+
+IGNORE_FIELDS = [
+    "camaraParlamentario",  # constant "CAMARA DE DIPUTADOS"
+    "telefonoParlamentario",  # private contact detail
+    "fotoURL",
+]
+
+
+def crawl_member(
+    context: Context,
+    row: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    period = row.pop("periodoLegislativo")
+    if period != EXPECTED_PERIOD:
+        raise ValueError(f"Unexpected legislative period: {period!r}")
+
+    # The endpoint returns one record per seat — the deputy currently occupying it.
+    # tipoParlamentario flags whether that occupant is the elected titular or a
+    # suplente who has taken over a vacated seat; both are sitting deputies, so we
+    # emit either. (We don't filter to TITULAR, which would drop seated replacements.)
+    person = context.make("Person")
+    person.id = context.make_slug(str(row.pop("idParlamentario")))
+    h.apply_name(
+        person, first_name=row.pop("nombres"), last_name=row.pop("apellidos")
+    )
+    # Deputies must hold natural Paraguayan nationality; naturalised citizens are not
+    # eligible (Constitution of Paraguay, Art. 221).
+    # https://www.constituteproject.org/constitution/Paraguay_2011?lang=es
+    person.add("citizenship", "py")
+    person.add("political", row.pop("partidoPolitico"))
+    person.add("email", row.pop("emailParlamentario"))
+    person.add("sourceUrl", row.pop("appURL"))
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    # Deputies are elected by department (plus the Capital District, Asunción).
+    occupancy.add("constituency", row.pop("departamento"))
+    # The parliamentary bloc (bancada) is distinct from party membership.
+    occupancy.add("politicalGroup", row.pop("bancada"))
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(
+        row,
+        ignore=[
+            "tipoParlamentario",  # titular vs seated suplente — both emitted
+            "cargoBancada",  # role within the parliamentary bloc
+            *IGNORE_FIELDS,
+        ],
+    )
+
+
+def crawl(context: Context) -> None:
+    deputies = context.fetch_json(context.data_url)
+    if not isinstance(deputies, list) or len(deputies) == 0:
+        raise ValueError("Expected a non-empty list of deputies")
+
+    position = h.make_position(
+        context,
+        name="Member of the Chamber of Deputies of Paraguay",
+        country="py",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q20058561",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    for row in deputies:
+        crawl_member(context, row, position, categorisation)

--- a/datasets/py/diputados/py_diputados.yml
+++ b/datasets/py/diputados/py_diputados.yml
@@ -1,0 +1,52 @@
+title: Paraguay Members of the Chamber of Deputies
+entry_point: crawler.py
+prefix: py-diput
+coverage:
+  frequency: monthly
+  start: 2026-06-18
+load_statements: true
+ci_test: false # Live external government API, not available in CI
+summary: >-
+  Deputies of the Cámara de Diputados, the lower chamber of the National
+  Congress of Paraguay
+description: |
+  Current deputies of the Cámara de Diputados (Chamber of Deputies), the lower
+  chamber of the bicameral National Congress of Paraguay. Its 80 deputies are
+  elected from the 17 departments and the Capital District (Asunción) via
+  departmental party-list proportional representation for five-year terms.
+
+  This dataset records each sitting deputy with their name, party (partido
+  político), parliamentary group (bancada) and department, sourced from the
+  Congress open-data API. The source lists the current occupant of each of the
+  80 seats, whether the elected deputy or a suplente who has taken over a
+  vacated seat.
+url: https://www.diputados.gov.py/
+publisher:
+  name: Cámara de Diputados del Paraguay
+  name_en: Chamber of Deputies of Paraguay
+  acronym: HCD
+  description: >
+    The Chamber of Deputies is the lower chamber of the National Congress
+    (Congreso Nacional), the bicameral national legislature of Paraguay.
+  url: https://www.diputados.gov.py/
+  country: py
+  official: true
+data:
+  url: https://datos.congreso.gov.py/opendata/api/data/parlamentario/camara/D?limit=200
+  format: JSON
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 60
+      Position: 1
+    country_entities:
+      py: 60
+  max:
+    schema_entities:
+      Person: 120
+      Position: 1


### PR DESCRIPTION
Adds a PEP crawler for the **Cámara de Diputados of Paraguay** (lower chamber of the National Congress), sourced from the Congress open-data JSON API.

Ref opensanctions/crawler-planning#732 (milestone: South America PEPs: Legislative Bodies)

## Source
`https://datos.congreso.gov.py/opendata/api/data/parlamentario/camara/D?limit=200` — official Congress open-data API (JSON, CC-BY 4.0). The `limit=200` is required; the default page size of 50 would truncate the 80-seat chamber.

## Notes
- Emits the **current occupant of each of the 80 seats**. The endpoint returns exactly chamber-size records, one per seat: currently 78 elected `TITULAR` + 2 `SUPLENTE` who have taken over vacated seats. Both are sitting deputies and are emitted; we deliberately do **not** filter to TITULAR, which would drop seated replacements.
- Per deputy: name, party (`partidoPolitico` → `political`), parliamentary group (`bancada` → `politicalGroup`), department (`departamento` → `constituency`), email, source profile URL.
- `citizenship: py` — deputies must hold natural Paraguayan nationality (Constitution art. 221).
- Position uses Wikidata `Q20058561` ("deputy of Paraguay").
- Freshness: asserts `periodoLegislativo == "2023-2028"` so it fails loudly when the next term lands.

## Validation
- `zavod crawl` clean (`issues.json` empty); 80 Person + 80 Occupancy + 1 Position.
- `zavod validate` passes assertions; `mypy --strict` clean.
- All four PEP integrity checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)