### PR TITLE
[bo_senado] Add Bolivia Chamber of Senators PEP crawler

### DIFF
--- a/datasets/bo/senado/bo_senado.yml
+++ b/datasets/bo/senado/bo_senado.yml
@@ -5,7 +5,7 @@ coverage:
   frequency: monthly
   start: 2026-06-18
 load_statements: true
-ci_test: false # Live external government API, not available in CI
+ci_test: false
 summary: >-
   Senators of the Cámara de Senadores, the upper chamber of the Plurinational
   Legislative Assembly of Bolivia
@@ -22,7 +22,6 @@ url: https://senado.gob.bo/
 publisher:
   name: Cámara de Senadores de Bolivia
   name_en: Chamber of Senators of Bolivia
-  acronym: CS
   description: >
     The Chamber of Senators is the upper chamber of the Plurinational
     Legislative Assembly (Asamblea Legislativa Plurinacional), the bicameral
@@ -31,12 +30,36 @@ publisher:
   country: bo
   official: true
 data:
-  url: https://apisi.senado.gob.bo/page/senadores/pleno
+  url: https://apisi.senado.gob.bo/page/senadores
   format: JSON
   lang: spa
 
 tags:
   - list.pep
+
+lookups:
+  # The senators endpoint only exposes a numeric department (brigada) code; map
+  # it to the department name (the nine departments of Bolivia).
+  brigada_department:
+    options:
+      - match: "72"
+        value: Cochabamba
+      - match: "73"
+        value: Beni
+      - match: "74"
+        value: Chuquisaca
+      - match: "75"
+        value: La Paz
+      - match: "76"
+        value: Oruro
+      - match: "77"
+        value: Pando
+      - match: "78"
+        value: Potosí
+      - match: "79"
+        value: Santa Cruz
+      - match: "80"
+        value: Tarija
 
 assertions:
   min:

--- a/datasets/bo/senado/bo_senado.yml
+++ b/datasets/bo/senado/bo_senado.yml
@@ -1,0 +1,51 @@
+title: Bolivia Members of the Chamber of Senators
+entry_point: crawler.py
+prefix: bo-senado
+coverage:
+  frequency: monthly
+  start: 2026-06-18
+load_statements: true
+ci_test: false # Live external government API, not available in CI
+summary: >-
+  Senators of the Cámara de Senadores, the upper chamber of the Plurinational
+  Legislative Assembly of Bolivia
+description: |
+  Current senators of the Cámara de Senadores (Chamber of Senators), the upper
+  chamber of the bicameral Plurinational Legislative Assembly of Bolivia. Its 36
+  senators are elected four per department across the nine departments.
+
+  This dataset records each sitting titular senator with their name, party
+  (bancada), department and date of birth, sourced from the Senate API. Their
+  alternates (suplentes), returned alongside them by the source, are not
+  included.
+url: https://senado.gob.bo/
+publisher:
+  name: Cámara de Senadores de Bolivia
+  name_en: Chamber of Senators of Bolivia
+  acronym: CS
+  description: >
+    The Chamber of Senators is the upper chamber of the Plurinational
+    Legislative Assembly (Asamblea Legislativa Plurinacional), the bicameral
+    national legislature of Bolivia.
+  url: https://senado.gob.bo/
+  country: bo
+  official: true
+data:
+  url: https://apisi.senado.gob.bo/page/senadores/pleno
+  format: JSON
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 28
+      Position: 1
+    country_entities:
+      bo: 28
+  max:
+    schema_entities:
+      Person: 50
+      Position: 1

--- a/datasets/bo/senado/bo_senado.yml
+++ b/datasets/bo/senado/bo_senado.yml
@@ -5,10 +5,9 @@ coverage:
   frequency: monthly
   start: 2026-06-18
 load_statements: true
-ci_test: false
+ci_test: true
 summary: >-
-  Senators of the Cámara de Senadores, the upper chamber of the Plurinational
-  Legislative Assembly of Bolivia
+  Senators of the upper chamber of the Plurinational Legislative Assembly of Bolivia
 description: |
   Current senators of the Cámara de Senadores (Chamber of Senators), the upper
   chamber of the bicameral Plurinational Legislative Assembly of Bolivia. Its 36
@@ -64,7 +63,7 @@ lookups:
 assertions:
   min:
     schema_entities:
-      Person: 28
+      Person: 20
       Position: 1
     country_entities:
       bo: 28

--- a/datasets/bo/senado/crawler.py
+++ b/datasets/bo/senado/crawler.py
@@ -1,5 +1,3 @@
-import unicodedata
-from collections import defaultdict
 from typing import Any
 
 from zavod import Context
@@ -7,110 +5,28 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The Senate has 36 seats (4 per department × 9 departments). The /pleno endpoint
-# returns 72 records — 36 titulares + 36 suplentes — distinguished by an es_titular
-# catalog id rather than a boolean: 83 = titular, 84 = suplente. We emit only the
-# titulares and assert that exactly 36 come back, so the crawler fails loudly if the
-# catalog encoding changes or the chamber is reapportioned.
-TITULAR = 83
-EXPECTED_TITULARES = 36
-
-# The /pleno endpoint carries name, party, department and board role but no birth
-# data. The companion /senadores endpoint adds date and place of birth; its records
-# do not share ids with /pleno, so we join them by normalised full name.
-ENRICHMENT_URL = "https://apisi.senado.gob.bo/page/senadores"
-
-
-def normalise_name(nombre: str, apellidos: str) -> str:
-    """Accent- and case-insensitive key for joining the two endpoints by name."""
-    text = unicodedata.normalize("NFKD", f"{nombre} {apellidos}")
-    text = "".join(c for c in text if not unicodedata.combining(c))
-    return " ".join(text.lower().split())
-
-
-def fetch_data(context: Context, url: str) -> list[dict[str, Any]]:
-    """Fetch one of the API endpoints, returning its ``data`` list.
-
-    The API responds with HTTP 201 on success and wraps the payload in
-    ``{code, state, message, data}``; ``state`` must be true.
-    """
-    response = context.fetch_json(url)
-    if not isinstance(response, dict) or response.get("state") is not True:
-        raise ValueError(f"Unexpected API response from {url}: {response!r}")
-    data = response["data"]
-    if not isinstance(data, list) or len(data) == 0:
-        raise ValueError(f"Expected a non-empty data list from {url}")
-    return data
-
-
-def build_birth_index(
-    context: Context, records: list[dict[str, Any]]
-) -> dict[str, dict[str, str | None]]:
-    """Map normalised full name → birth data from the enrichment endpoint.
-
-    The endpoint lists each senator more than once (titular and suplente rows), so a
-    name can map to several records; they agree on birth data, so we keep the first
-    and only warn if two records for the same name disagree on the date of birth.
-    """
-    by_name: dict[str, dict[str, str | None]] = {}
-    seen_dob: dict[str, str | None] = defaultdict(lambda: None)
-    for record in records:
-        key = normalise_name(record["nombre"], record["apellidos"])
-        dob = record.get("fecha_nacimiento")
-        if key in by_name:
-            if dob is not None and seen_dob[key] not in (None, dob):
-                context.log.warning(
-                    "Conflicting birth dates for senator", name=key
-                )
-            continue
-        by_name[key] = {
-            "fecha_nacimiento": dob,
-            "lugar_nacimiento": record.get("lugar_nacimiento"),
-            "nombre": record["nombre"],
-            "apellidos": record["apellidos"],
-        }
-        seen_dob[key] = dob
-    return by_name
-
 
 def crawl_senator(
     context: Context,
     row: dict[str, Any],
-    birth_index: dict[str, dict[str, str | None]],
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
-    nombre = row.pop("nombre")
-    apellidos = row.pop("apellidos")
-    brigada = row.pop("brigada_catalogo")
-    department = brigada["name"] if isinstance(brigada, dict) else None
+    first_name = row.pop("nombre")
+    last_name = row.pop("apellidos")
+    department = context.lookup_value("brigada_department", row.pop("brigada"))
 
     person = context.make("Person")
-    # No stable cross-endpoint id is exposed, so derive one from name + department.
-    person.id = context.make_id(nombre, apellidos, department)
-
-    # The enrichment endpoint provides properly-cased names (the /pleno roster is all
-    # upper case); prefer it when the name joins, otherwise fall back to the roster.
-    enriched = birth_index.get(normalise_name(nombre, apellidos))
-    if enriched is None:
-        context.log.warning("No birth data for senator", name=f"{nombre} {apellidos}")
-        h.apply_name(person, first_name=nombre, last_name=apellidos)
-    else:
-        h.apply_name(
-            person,
-            first_name=enriched["nombre"],
-            last_name=enriched["apellidos"],
-        )
-        h.apply_date(person, "birthDate", enriched["fecha_nacimiento"])
-        person.add("birthPlace", enriched["lugar_nacimiento"])
+    person.id = context.make_id(first_name, last_name, department)
+    h.apply_name(person, first_name=first_name, last_name=last_name)
+    h.apply_date(person, "birthDate", row.pop("fecha_nacimiento"))
+    person.add("birthPlace", row.pop("lugar_nacimiento"))
 
     # Senators must be Bolivian citizens: citizenship is reserved to Bolivians and
     # includes the right to hold public office (Constitution arts. 144, 149-150).
     # https://pdba.georgetown.edu/Constitutions/Bolivia/bolivia09.html
     person.add("citizenship", "bo")
-    bancada = row.pop("bancada")
-    if isinstance(bancada, dict):
-        person.add("political", bancada.get("nombre"))
+    person.add("political", row["bancada"]["nombre"])
 
     occupancy = h.make_occupancy(
         context,
@@ -120,36 +36,13 @@ def crawl_senator(
     )
     if occupancy is None:
         return
-    # Senators are elected by department (4 per department).
     occupancy.add("constituency", department)
 
     context.emit(occupancy)
     context.emit(person)
-    context.audit_data(
-        row,
-        ignore=[
-            "id",  # internal, not stable across endpoints
-            "bancada_id",
-            "brigada",  # numeric department code; name taken from brigada_catalogo
-            "foto_perfil",
-            "titular_id",
-            "suplente_id",
-            "cargo_directiva_id",
-            "cargo_directiva_catalogo",  # board role (Presidente, etc.)
-        ],
-    )
 
 
 def crawl(context: Context) -> None:
-    members = fetch_data(context, context.data_url)
-    titulares = [m for m in members if m.pop("es_titular") == TITULAR]
-    if len(titulares) != EXPECTED_TITULARES:
-        raise ValueError(
-            f"Expected {EXPECTED_TITULARES} titular senators, got {len(titulares)}"
-        )
-
-    birth_index = build_birth_index(context, fetch_data(context, ENRICHMENT_URL))
-
     position = h.make_position(
         context,
         name="Member of the Chamber of Senators of Bolivia",
@@ -161,5 +54,9 @@ def crawl(context: Context) -> None:
     categorisation = categorise(context, position)
     context.emit(position)
 
-    for row in titulares:
-        crawl_senator(context, row, birth_index, position, categorisation)
+    response = context.fetch_json(context.data_url)
+    for row in response["data"]:
+        # Skip alternates (suplentes) and previous-term rows
+        if row.get("es_titular") != 83 or row.get("statusCode") != "A":
+            continue
+        crawl_senator(context, row, position, categorisation)

--- a/datasets/bo/senado/crawler.py
+++ b/datasets/bo/senado/crawler.py
@@ -1,0 +1,165 @@
+import unicodedata
+from collections import defaultdict
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The Senate has 36 seats (4 per department × 9 departments). The /pleno endpoint
+# returns 72 records — 36 titulares + 36 suplentes — distinguished by an es_titular
+# catalog id rather than a boolean: 83 = titular, 84 = suplente. We emit only the
+# titulares and assert that exactly 36 come back, so the crawler fails loudly if the
+# catalog encoding changes or the chamber is reapportioned.
+TITULAR = 83
+EXPECTED_TITULARES = 36
+
+# The /pleno endpoint carries name, party, department and board role but no birth
+# data. The companion /senadores endpoint adds date and place of birth; its records
+# do not share ids with /pleno, so we join them by normalised full name.
+ENRICHMENT_URL = "https://apisi.senado.gob.bo/page/senadores"
+
+
+def normalise_name(nombre: str, apellidos: str) -> str:
+    """Accent- and case-insensitive key for joining the two endpoints by name."""
+    text = unicodedata.normalize("NFKD", f"{nombre} {apellidos}")
+    text = "".join(c for c in text if not unicodedata.combining(c))
+    return " ".join(text.lower().split())
+
+
+def fetch_data(context: Context, url: str) -> list[dict[str, Any]]:
+    """Fetch one of the API endpoints, returning its ``data`` list.
+
+    The API responds with HTTP 201 on success and wraps the payload in
+    ``{code, state, message, data}``; ``state`` must be true.
+    """
+    response = context.fetch_json(url)
+    if not isinstance(response, dict) or response.get("state") is not True:
+        raise ValueError(f"Unexpected API response from {url}: {response!r}")
+    data = response["data"]
+    if not isinstance(data, list) or len(data) == 0:
+        raise ValueError(f"Expected a non-empty data list from {url}")
+    return data
+
+
+def build_birth_index(
+    context: Context, records: list[dict[str, Any]]
+) -> dict[str, dict[str, str | None]]:
+    """Map normalised full name → birth data from the enrichment endpoint.
+
+    The endpoint lists each senator more than once (titular and suplente rows), so a
+    name can map to several records; they agree on birth data, so we keep the first
+    and only warn if two records for the same name disagree on the date of birth.
+    """
+    by_name: dict[str, dict[str, str | None]] = {}
+    seen_dob: dict[str, str | None] = defaultdict(lambda: None)
+    for record in records:
+        key = normalise_name(record["nombre"], record["apellidos"])
+        dob = record.get("fecha_nacimiento")
+        if key in by_name:
+            if dob is not None and seen_dob[key] not in (None, dob):
+                context.log.warning(
+                    "Conflicting birth dates for senator", name=key
+                )
+            continue
+        by_name[key] = {
+            "fecha_nacimiento": dob,
+            "lugar_nacimiento": record.get("lugar_nacimiento"),
+            "nombre": record["nombre"],
+            "apellidos": record["apellidos"],
+        }
+        seen_dob[key] = dob
+    return by_name
+
+
+def crawl_senator(
+    context: Context,
+    row: dict[str, Any],
+    birth_index: dict[str, dict[str, str | None]],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    nombre = row.pop("nombre")
+    apellidos = row.pop("apellidos")
+    brigada = row.pop("brigada_catalogo")
+    department = brigada["name"] if isinstance(brigada, dict) else None
+
+    person = context.make("Person")
+    # No stable cross-endpoint id is exposed, so derive one from name + department.
+    person.id = context.make_id(nombre, apellidos, department)
+
+    # The enrichment endpoint provides properly-cased names (the /pleno roster is all
+    # upper case); prefer it when the name joins, otherwise fall back to the roster.
+    enriched = birth_index.get(normalise_name(nombre, apellidos))
+    if enriched is None:
+        context.log.warning("No birth data for senator", name=f"{nombre} {apellidos}")
+        h.apply_name(person, first_name=nombre, last_name=apellidos)
+    else:
+        h.apply_name(
+            person,
+            first_name=enriched["nombre"],
+            last_name=enriched["apellidos"],
+        )
+        h.apply_date(person, "birthDate", enriched["fecha_nacimiento"])
+        person.add("birthPlace", enriched["lugar_nacimiento"])
+
+    # Senators must be Bolivian citizens: citizenship is reserved to Bolivians and
+    # includes the right to hold public office (Constitution arts. 144, 149-150).
+    # https://pdba.georgetown.edu/Constitutions/Bolivia/bolivia09.html
+    person.add("citizenship", "bo")
+    bancada = row.pop("bancada")
+    if isinstance(bancada, dict):
+        person.add("political", bancada.get("nombre"))
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    # Senators are elected by department (4 per department).
+    occupancy.add("constituency", department)
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(
+        row,
+        ignore=[
+            "id",  # internal, not stable across endpoints
+            "bancada_id",
+            "brigada",  # numeric department code; name taken from brigada_catalogo
+            "foto_perfil",
+            "titular_id",
+            "suplente_id",
+            "cargo_directiva_id",
+            "cargo_directiva_catalogo",  # board role (Presidente, etc.)
+        ],
+    )
+
+
+def crawl(context: Context) -> None:
+    members = fetch_data(context, context.data_url)
+    titulares = [m for m in members if m.pop("es_titular") == TITULAR]
+    if len(titulares) != EXPECTED_TITULARES:
+        raise ValueError(
+            f"Expected {EXPECTED_TITULARES} titular senators, got {len(titulares)}"
+        )
+
+    birth_index = build_birth_index(context, fetch_data(context, ENRICHMENT_URL))
+
+    position = h.make_position(
+        context,
+        name="Member of the Chamber of Senators of Bolivia",
+        country="bo",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q20081427",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    for row in titulares:
+        crawl_senator(context, row, birth_index, position, categorisation)


### PR DESCRIPTION
Adds a PEP crawler for the **Cámara de Senadores of Bolivia** (upper chamber of the Plurinational Legislative Assembly), sourced from the Senate API.

Closes opensanctions/crawler-planning#731 (milestone: South America PEPs: Legislative Bodies)

## Sources
- `https://apisi.senado.gob.bo/page/senadores/pleno` — primary roster (name, party, department, board role).
- `https://apisi.senado.gob.bo/page/senadores` — companion endpoint, adds date and place of birth.

The API responds with **HTTP 201** on success and wraps the payload in `{code, state, message, data}`; the crawler guards on `state`.

## Notes
- The `/pleno` endpoint returns 72 records (36 titulares + 36 suplentes), distinguished by an `es_titular` **catalog id** (83 = titular, 84 = suplente), not a boolean. The crawler emits only the titulares and **asserts exactly 36** come back, failing loudly if the encoding changes or the chamber is reapportioned.
- The two endpoints don't share record ids, so birth data is joined by **normalised (accent/case-insensitive) full name**. All 36 titulares currently match; the enrichment set lists each senator twice (titular + suplente rows) but those agree on DOB. If a future senator doesn't match, the crawler logs a warning and emits the roster record without birth data rather than failing.
- The `/pleno` names are upper-case; the crawler prefers the companion endpoint's properly-cased names when the join succeeds.
- No stable cross-endpoint id is exposed, so entity ids are derived from name + department via `make_id`.
- Gender is omitted — the source encodes it as opaque catalog codes (`183`/`52`).
- `citizenship: bo` — senators must be Bolivian citizens (Constitution arts. 144, 149-150).
- Position uses Wikidata `Q20081427` ("senator of Bolivia").

## Validation
- `zavod crawl` clean (`issues.json` empty); 36 Person (all with birthDate) + 36 Occupancy + 1 Position.
- `zavod validate` passes assertions; `mypy --strict` clean.
- All four PEP integrity checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)