### PR TITLE
[ar_senado] Add Argentina Senate PEP crawler

### DIFF
--- a/datasets/ar/senado/ar_senado.yml
+++ b/datasets/ar/senado/ar_senado.yml
@@ -2,22 +2,25 @@ title: Argentina Members of the Senate
 entry_point: crawler.py
 prefix: ar-sen
 coverage:
-  frequency: daily
+  frequency: monthly
   start: 2026-06-18
 load_statements: true
 ci_test: false # Live external government source, not available in CI
 summary: >-
-  Current members of the Honorable Senate of the Nation, the upper house of the
-  National Congress of Argentina
+  Members of the Honorable Senate of the Nation, the upper house of the National
+  Congress of Argentina
 description: |
-  Current senators of the Honorable Senado de la Nación (Senate of the Nation),
-  the upper house of the bicameral National Congress of Argentina. Its 72 members
-  are elected directly, three per province across the 23 provinces and the
-  Autonomous City of Buenos Aires, for six-year terms.
+  Senators of the Honorable Senado de la Nación (Senate of the Nation), the upper
+  house of the bicameral National Congress of Argentina. Its 72 seats are elected
+  directly, three per province across the 23 provinces and the Autonomous City of
+  Buenos Aires, for six-year terms.
 
-  This dataset is sourced from the Senate's official open-data portal and records
-  each sitting senator with their name, party, parliamentary group (bloque),
-  province and term dates. It complements the ar_parliament dataset, which covers
+  This dataset is sourced from the Senate's official open-data portal. It uses the
+  historical roster so it spans multiple legislative terms — both sitting senators
+  and those who left office recently enough to remain politically exposed — and
+  records each with their name, party, province and term dates. Sitting senators
+  are additionally enriched with their email and parliamentary group (bloque) from
+  the current-members feed. It complements the ar_parliament dataset, which covers
   the lower house (Chamber of Deputies).
 url: https://www.senado.gob.ar/micrositios/DatosAbiertos/
 publisher:
@@ -31,7 +34,7 @@ publisher:
   country: ar
   official: true
 data:
-  url: https://www.senado.gob.ar/micrositios/DatosAbiertos/ExportarListadoSenadores/json
+  url: https://www.senado.gob.ar/micrositios/DatosAbiertos/ExportarListadoSenadoresHistorico/json
   format: JSON
   lang: spa
 dates:
@@ -43,11 +46,11 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 57
+      Person: 130
       Position: 1
     country_entities:
-      ar: 57
+      ar: 130
   max:
     schema_entities:
-      Person: 100
+      Person: 400
       Position: 1

--- a/datasets/ar/senado/ar_senado.yml
+++ b/datasets/ar/senado/ar_senado.yml
@@ -1,0 +1,53 @@
+title: Argentina Members of the Senate
+entry_point: crawler.py
+prefix: ar-sen
+coverage:
+  frequency: daily
+  start: 2026-06-18
+load_statements: true
+ci_test: false # Live external government source, not available in CI
+summary: >-
+  Current members of the Honorable Senate of the Nation, the upper house of the
+  National Congress of Argentina
+description: |
+  Current senators of the Honorable Senado de la Nación (Senate of the Nation),
+  the upper house of the bicameral National Congress of Argentina. Its 72 members
+  are elected directly, three per province across the 23 provinces and the
+  Autonomous City of Buenos Aires, for six-year terms.
+
+  This dataset is sourced from the Senate's official open-data portal and records
+  each sitting senator with their name, party, parliamentary group (bloque),
+  province and term dates. It complements the ar_parliament dataset, which covers
+  the lower house (Chamber of Deputies).
+url: https://www.senado.gob.ar/micrositios/DatosAbiertos/
+publisher:
+  name: Honorable Senado de la Nación Argentina
+  name_en: Honorable Senate of the Argentine Nation
+  acronym: HSN
+  description: >
+    The Honorable Senate of the Nation is the upper house of the National
+    Congress, the bicameral national legislature of Argentina.
+  url: https://www.senado.gob.ar/
+  country: ar
+  official: true
+data:
+  url: https://www.senado.gob.ar/micrositios/DatosAbiertos/ExportarListadoSenadores/json
+  format: JSON
+  lang: spa
+dates:
+  formats: ["%Y-%m-%d"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 57
+      Position: 1
+    country_entities:
+      ar: 57
+  max:
+    schema_entities:
+      Person: 100
+      Position: 1

--- a/datasets/ar/senado/ar_senado.yml
+++ b/datasets/ar/senado/ar_senado.yml
@@ -7,21 +7,20 @@ coverage:
 load_statements: true
 ci_test: false # Live external government source, not available in CI
 summary: >-
-  Members of the Honorable Senate of the Nation, the upper house of the National
-  Congress of Argentina
+  Upper house of Argentina's National Congress: three senators per province,
+  serving six-year terms
 description: |
   Senators of the Honorable Senado de la Nación (Senate of the Nation), the upper
   house of the bicameral National Congress of Argentina. Its 72 seats are elected
   directly, three per province across the 23 provinces and the Autonomous City of
   Buenos Aires, for six-year terms.
 
-  This dataset is sourced from the Senate's official open-data portal. It uses the
-  historical roster so it spans multiple legislative terms — both sitting senators
-  and those who left office recently enough to remain politically exposed — and
-  records each with their name, party, province and term dates. Sitting senators
-  are additionally enriched with their email and parliamentary group (bloque) from
-  the current-members feed. It complements the ar_parliament dataset, which covers
-  the lower house (Chamber of Deputies).
+  The dataset covers the chamber's full historical roster, spanning many
+  legislative terms: both sitting senators and those who left office recently
+  enough to remain politically exposed. Each senator is recorded with their name,
+  party, province and term dates; sitting senators additionally carry an email
+  address and their parliamentary group (bloque). It complements the ar_parliament
+  dataset, which covers the lower house (Chamber of Deputies).
 url: https://www.senado.gob.ar/micrositios/DatosAbiertos/
 publisher:
   name: Honorable Senado de la Nación Argentina

--- a/datasets/ar/senado/crawler.py
+++ b/datasets/ar/senado/crawler.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# C_REAL (actual end of mandate) holds this placeholder while a senator is serving.
+NO_DATE = "Sin Datos"
+
+IGNORE_FIELDS = [
+    "D_LEGAL",  # scheduled term start; we use D_REAL (actual swearing-in)
+    "C_LEGAL",  # scheduled term end; we use C_REAL (actual end of mandate)
+    "TELEFONO",  # private contact detail
+    "FOTO",
+    "FACEBOOK",
+    "TWITTER",
+    "INSTAGRAM",
+    "YOUTUBE",
+]
+
+
+def crawl_senator(
+    context: Context,
+    row: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug(row.pop("ID"))
+    h.apply_name(
+        person, first_name=row.pop("NOMBRE"), last_name=row.pop("APELLIDO")
+    )
+    # Senators must have been citizens of the Nation for six years (Constitution of
+    # Argentina, Art. 55). https://www.constituteproject.org/constitution/Argentina_1994
+    person.add("citizenship", "ar")
+    person.add("political", row.pop("PARTIDO O ALIANZA"))
+    person.add("email", row.pop("EMAIL"))
+
+    # C_REAL is the actual end of mandate; "Sin Datos" means the senator is serving.
+    end_date = row.pop("C_REAL")
+    if end_date == NO_DATE:
+        end_date = None
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        start_date=row.pop("D_REAL"),
+        end_date=end_date,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", row.pop("PROVINCIA"))
+    # The parliamentary bloc (bloque) is distinct from party membership.
+    occupancy.add("politicalGroup", row.pop("BLOQUE"))
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(row, ignore=IGNORE_FIELDS)
+
+
+def crawl(context: Context) -> None:
+    data = context.fetch_json(context.data_url)
+    rows = data["table"]["rows"]
+    if not isinstance(rows, list) or len(rows) == 0:
+        raise ValueError("Expected a non-empty list of senators")
+
+    position = h.make_position(
+        context,
+        name="Member of the Argentine Chamber of Senators",
+        country="ar",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q18711738",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    for row in rows:
+        crawl_senator(context, row, position, categorisation)

--- a/datasets/ar/senado/crawler.py
+++ b/datasets/ar/senado/crawler.py
@@ -5,78 +5,115 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# C_REAL (actual end of mandate) holds this placeholder while a senator is serving.
+POSITION_TOPICS = ["gov.national", "gov.legislative"]
+# CESE (end of mandate) fields hold this placeholder while a senator is serving.
 NO_DATE = "Sin Datos"
+# Current-members feed, used to enrich sitting senators with email + group (bloque).
+CURRENT_URL = (
+    "https://www.senado.gob.ar/micrositios/DatosAbiertos/ExportarListadoSenadores/json"
+)
 
-IGNORE_FIELDS = [
-    "D_LEGAL",  # scheduled term start; we use D_REAL (actual swearing-in)
-    "C_LEGAL",  # scheduled term end; we use C_REAL (actual end of mandate)
-    "TELEFONO",  # private contact detail
-    "FOTO",
-    "FACEBOOK",
-    "TWITTER",
-    "INSTAGRAM",
-    "YOUTUBE",
-]
+
+def fetch_rows(context: Context, url: str) -> list[dict[str, Any]]:
+    data = context.fetch_json(url)
+    rows = data["table"]["rows"]
+    if not isinstance(rows, list) or len(rows) == 0:
+        raise ValueError(f"Expected a non-empty list of senators from {url}")
+    return rows
+
+
+def clean_date(value: str | None) -> str | None:
+    if value is None or value == "" or value == NO_DATE:
+        return None
+    return value
 
 
 def crawl_senator(
     context: Context,
     row: dict[str, Any],
+    current: dict[str, Any] | None,
     position: Entity,
     categorisation: PositionCategorisation,
+    cutoff: str,
 ) -> None:
+    senator_id = row.pop("ID")
+    name = row.pop("SENADOR")
+    start_date = clean_date(row.pop("INICIO PERIODO REAL"))
+    end_date = clean_date(row.pop("CESE PERIODO REAL"))
+    # The legal period is the senator's full mandate; the real dates are when they
+    # actually took and left the seat (earlier/later for replacements).
+    period_start = clean_date(row.pop("INICIO PERIODO LEGAL"))
+    period_end = clean_date(row.pop("CESE PERIODO LEGAL"))
+    province = row.pop("PROVINCIA")
+    party = row.pop("PARTIDO POLITICO O ALIANZA")
+
+    # Skip senators who left office before our PEP coverage window. Senators still in
+    # office have no real end date and are always kept.
+    if end_date is not None and end_date < cutoff:
+        return
+
     person = context.make("Person")
-    person.id = context.make_slug(row.pop("ID"))
-    h.apply_name(
-        person, first_name=row.pop("NOMBRE"), last_name=row.pop("APELLIDO")
-    )
+    person.id = context.make_slug(senator_id)
+    if current is not None:
+        # The current-members feed has properly-cased names and an email.
+        h.apply_name(
+            person,
+            first_name=current["NOMBRE"],
+            last_name=current["APELLIDO"],
+        )
+        person.add("email", current["EMAIL"])
+    else:
+        # The historical feed gives "APELLIDO, NOMBRE" in upper case.
+        last_name, _, first_name = name.partition(",")
+        h.apply_name(
+            person,
+            first_name=first_name.strip() or None,
+            last_name=last_name.strip(),
+        )
     # Senators must have been citizens of the Nation for six years (Constitution of
     # Argentina, Art. 55). https://www.constituteproject.org/constitution/Argentina_1994
     person.add("citizenship", "ar")
-    person.add("political", row.pop("PARTIDO O ALIANZA"))
-    person.add("email", row.pop("EMAIL"))
-
-    # C_REAL is the actual end of mandate; "Sin Datos" means the senator is serving.
-    end_date = row.pop("C_REAL")
-    if end_date == NO_DATE:
-        end_date = None
+    person.add("political", party)
 
     occupancy = h.make_occupancy(
         context,
         person,
         position,
-        start_date=row.pop("D_REAL"),
+        start_date=start_date,
         end_date=end_date,
+        period_start=period_start,
+        period_end=period_end,
         categorisation=categorisation,
     )
     if occupancy is None:
         return
-    occupancy.add("constituency", row.pop("PROVINCIA"))
-    # The parliamentary bloc (bloque) is distinct from party membership.
-    occupancy.add("politicalGroup", row.pop("BLOQUE"))
+    occupancy.add("constituency", province)
+    if current is not None:
+        # The bloque (parliamentary group) is distinct from party membership.
+        occupancy.add("politicalGroup", current["BLOQUE"])
 
     context.emit(occupancy)
     context.emit(person)
-    context.audit_data(row, ignore=IGNORE_FIELDS)
+    context.audit_data(row, ignore=["REEMPLAZO", "OBSERVACIONES"])
 
 
 def crawl(context: Context) -> None:
-    data = context.fetch_json(context.data_url)
-    rows = data["table"]["rows"]
-    if not isinstance(rows, list) or len(rows) == 0:
-        raise ValueError("Expected a non-empty list of senators")
+    cutoff = h.earliest_term_start(POSITION_TOPICS)
+    current = {row["ID"]: row for row in fetch_rows(context, CURRENT_URL)}
+    historico = fetch_rows(context, context.data_url)
 
     position = h.make_position(
         context,
         name="Member of the Argentine Chamber of Senators",
         country="ar",
-        topics=["gov.national", "gov.legislative"],
+        topics=POSITION_TOPICS,
         wikidata_id="Q18711738",
         lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)
 
-    for row in rows:
-        crawl_senator(context, row, position, categorisation)
+    for row in historico:
+        crawl_senator(
+            context, row, current.get(row["ID"]), position, categorisation, cutoff
+        )

--- a/datasets/ar/senado/crawler.py
+++ b/datasets/ar/senado/crawler.py
@@ -22,10 +22,16 @@ def fetch_rows(context: Context, url: str) -> list[dict[str, Any]]:
     return rows
 
 
-def clean_date(value: str | None) -> str | None:
+def clean_date(context: Context, value: str | None) -> str | None:
+    """Normalize a source date to an ISO string, or None for empty/placeholder values.
+
+    Parses through the dataset's configured date formats so an unexpected format
+    raises rather than silently corrupting the downstream cutoff comparison.
+    """
     if value is None or value == "" or value == NO_DATE:
         return None
-    return value
+    dates = h.extract_date(context.dataset, value, fallback_to_original=False)
+    return dates[0]
 
 
 def crawl_senator(
@@ -38,12 +44,12 @@ def crawl_senator(
 ) -> None:
     senator_id = row.pop("ID")
     name = row.pop("SENADOR")
-    start_date = clean_date(row.pop("INICIO PERIODO REAL"))
-    end_date = clean_date(row.pop("CESE PERIODO REAL"))
+    start_date = clean_date(context, row.pop("INICIO PERIODO REAL"))
+    end_date = clean_date(context, row.pop("CESE PERIODO REAL"))
     # The legal period is the senator's full mandate; the real dates are when they
     # actually took and left the seat (earlier/later for replacements).
-    period_start = clean_date(row.pop("INICIO PERIODO LEGAL"))
-    period_end = clean_date(row.pop("CESE PERIODO LEGAL"))
+    period_start = clean_date(context, row.pop("INICIO PERIODO LEGAL"))
+    period_end = clean_date(context, row.pop("CESE PERIODO LEGAL"))
     province = row.pop("PROVINCIA")
     party = row.pop("PARTIDO POLITICO O ALIANZA")
 
@@ -88,8 +94,10 @@ def crawl_senator(
     if occupancy is None:
         return
     occupancy.add("constituency", province)
-    if current is not None:
-        # The bloque (parliamentary group) is distinct from party membership.
+    # The bloque (parliamentary group) is distinct from party membership. The current
+    # feed only reflects the present group, so apply it to the sitting term (no real
+    # end date); past terms have no bloque source and keep politicalGroup empty.
+    if current is not None and end_date is None:
         occupancy.add("politicalGroup", current["BLOQUE"])
 
     context.emit(occupancy)
@@ -101,6 +109,12 @@ def crawl(context: Context) -> None:
     cutoff = h.earliest_term_start(POSITION_TOPICS)
     current = {row["ID"]: row for row in fetch_rows(context, CURRENT_URL)}
     historico = fetch_rows(context, context.data_url)
+
+    # The two feeds are joined on ID to enrich sitting senators; if that overlap ever
+    # disappears, the join is broken and every senator silently loses email + bloque.
+    historico_ids = {row["ID"] for row in historico}
+    if not current.keys() & historico_ids:
+        raise ValueError("No ID overlap between current and historical senator feeds")
 
     position = h.make_position(
         context,


### PR DESCRIPTION
Adds a PEP crawler for the **Honorable Senado de la Nación of Argentina** (upper house of the National Congress), sourced from the Senate's official open-data portal. Complements the existing `ar_parliament` dataset, which covers the lower house (Chamber of Deputies).

Ref opensanctions/crawler-planning#634 (milestone: South America PEPs: Legislative Bodies)

## Sources
- **Historical roster** (primary): `https://www.senado.gob.ar/micrositios/DatosAbiertos/ExportarListadoSenadoresHistorico/json` — `.table.rows`, ~1380 term records spanning many legislatures.
- **Current members** (enrichment): `https://www.senado.gob.ar/micrositios/DatosAbiertos/ExportarListadoSenadores/json` — 72 sitting senators, joined to the historical roster on `ID` to add email and parliamentary group.

## Modeling
- One `Person` per senator, keyed on the source `ID` via `make_slug`, so a senator who served several terms deduplicates to a single person with multiple `Occupancy` entities.
- Per term: `INICIO/CESE PERIODO REAL` (actual swearing-in / end) → `startDate`/`endDate`; `INICIO/CESE PERIODO LEGAL` (scheduled mandate) → `periodStart`/`periodEnd`. The "Sin Datos" placeholder maps to none.
- `PARTIDO POLITICO O ALIANZA` → `political` (party). For sitting senators only, `BLOQUE` → `politicalGroup` on the current term's occupancy (the feed reflects only the present group, so it is not applied to past terms). `PROVINCIA` → `constituency`.
- Sitting senators additionally get name (properly cased) and email from the current-members feed.
- `citizenship: ar` — senators must have been citizens of the Nation for six years (Constitution art. 55).
- Position uses Wikidata `Q18711738`, name "Member of the Argentine Chamber of Senators".
- Historical rows are filtered against `earliest_term_start` so only people recent enough to remain politically exposed are emitted.

## Robustness
- Dates are parsed through the dataset's configured formats, so an unexpected format raises rather than silently breaking the coverage-cutoff comparison.
- The crawler asserts the two feeds still share senator IDs, so a broken join surfaces instead of silently dropping email + bloque.

## Validation
- `zavod crawl` clean (`issues.log` empty); `zavod validate` passes assertions.
- 290 `Person` + 349 `Occupancy` + 1 `Position`; 72 occupancies carry `politicalGroup` (one per sitting term).
- `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)