### PR TITLE
[sr_national_assembly] Add Suriname National Assembly PEP crawler

### DIFF
--- a/datasets/sr/national_assembly/crawler.py
+++ b/datasets/sr/national_assembly/crawler.py
@@ -1,0 +1,91 @@
+from urllib.parse import urljoin
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+# The roster page renders every member as a Bootstrap modal carrying their full
+# profile, so the whole dataset comes from a single page — no per-member fetches.
+MODAL_XPATH = './/div[contains(@class, "ledenModal")]'
+
+
+def crawl_member(
+    context: Context,
+    modal: Element,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    # The modal id ("modalLid-10222") carries a stable numeric member id; the
+    # data-url slug is name-derived and must not be used as an entity id.
+    modal_id = modal.get("id")
+    if modal_id is None or not modal_id.startswith("modalLid-"):
+        raise ValueError(f"Unexpected member modal id: {modal_id!r}")
+    member_id = modal_id.removeprefix("modalLid-")
+
+    name = h.element_text(h.xpath_element(modal, ".//h4"))
+    party = h.element_text(
+        h.xpath_element(
+            modal, './/th[normalize-space()="Partij"]/following-sibling::td[1]'
+        )
+    )
+    fractie = h.element_text(
+        h.xpath_element(
+            modal, './/th[normalize-space()="Fractie"]/following-sibling::td[1]'
+        )
+    )
+    emails = h.xpath_strings(modal, './/a[starts-with(@href, "mailto:")]/@href')
+    data_url = modal.get("data-url")
+
+    person = context.make("Person")
+    person.id = context.make_slug(member_id)
+    # Names carry Dutch academic honorifics (dr., drs., mr., ir.) and degree suffixes
+    # (MSc, LLB, PhD, ...) mixed in; defer cleaning to the name-review workflow, which
+    # applies the original string until a reviewed split is accepted.
+    h.apply_reviewed_name_string(
+        context, person, string=name, lang="nld", llm_cleaning=True
+    )
+    # Members must hold Surinamese nationality (Constitution of Suriname, Art. 59).
+    # https://www.constituteproject.org/constitution/Surinam_1992
+    person.add("citizenship", "sr")
+    person.add("political", party)
+    if len(emails) > 0:
+        person.add("email", emails[0].removeprefix("mailto:"))
+    if data_url is not None:
+        person.add("sourceUrl", urljoin(context.data_url, data_url))
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    # The fractie (parliamentary group) is distinct from party membership.
+    occupancy.add("politicalGroup", fractie)
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    modals = h.xpath_elements(doc, MODAL_XPATH)
+    if len(modals) == 0:
+        raise ValueError("No member modals found on the roster page")
+
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of Suriname",
+        country="sr",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q17268790",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    for modal in modals:
+        crawl_member(context, modal, position, categorisation)

--- a/datasets/sr/national_assembly/crawler.py
+++ b/datasets/sr/national_assembly/crawler.py
@@ -6,10 +6,6 @@ from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import Element
 
-# The roster page renders every member as a Bootstrap modal carrying their full
-# profile, so the whole dataset comes from a single page — no per-member fetches.
-MODAL_XPATH = './/div[contains(@class, "ledenModal")]'
-
 
 def crawl_member(
     context: Context,
@@ -17,44 +13,37 @@ def crawl_member(
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
-    # The modal id ("modalLid-10222") carries a stable numeric member id; the
-    # data-url slug is name-derived and must not be used as an entity id.
-    modal_id = modal.get("id")
-    if modal_id is None or not modal_id.startswith("modalLid-"):
-        raise ValueError(f"Unexpected member modal id: {modal_id!r}")
-    member_id = modal_id.removeprefix("modalLid-")
-
+    member_id = modal.get("id")
     name = h.element_text(h.xpath_element(modal, ".//h4"))
-    party = h.element_text(
-        h.xpath_element(
-            modal, './/th[normalize-space()="Partij"]/following-sibling::td[1]'
-        )
-    )
-    fractie = h.element_text(
-        h.xpath_element(
-            modal, './/th[normalize-space()="Fractie"]/following-sibling::td[1]'
-        )
-    )
-    emails = h.xpath_strings(modal, './/a[starts-with(@href, "mailto:")]/@href')
-    data_url = modal.get("data-url")
 
     person = context.make("Person")
-    person.id = context.make_slug(member_id)
-    # Names carry Dutch academic honorifics (dr., drs., mr., ir.) and degree suffixes
-    # (MSc, LLB, PhD, ...) mixed in; defer cleaning to the name-review workflow, which
-    # applies the original string until a reviewed split is accepted.
+    person.id = context.make_id(member_id, name)
     h.apply_reviewed_name_string(
         context, person, string=name, lang="nld", llm_cleaning=True
     )
     # Members must hold Surinamese nationality (Constitution of Suriname, Art. 59).
     # https://www.constituteproject.org/constitution/Surinam_1992
     person.add("citizenship", "sr")
-    person.add("political", party)
-    if len(emails) > 0:
-        person.add("email", emails[0].removeprefix("mailto:"))
-    if data_url is not None:
-        person.add("sourceUrl", urljoin(context.data_url, data_url))
 
+    party = h.element_text(
+        h.xpath_element(
+            modal, './/th[normalize-space()="Partij"]/following-sibling::td[1]'
+        )
+    )
+    person.add("political", party)
+
+    emails = h.xpath_strings(modal, './/a[starts-with(@href, "mailto:")]/@href')
+    if emails != []:
+        person.add("email", emails[0].removeprefix("mailto:").strip())
+
+    data_url = modal.get("data-url")
+    person.add("sourceUrl", urljoin(context.data_url, data_url))
+
+    faction = h.element_text(
+        h.xpath_element(
+            modal, './/th[normalize-space()="Fractie"]/following-sibling::td[1]'
+        )
+    )
     occupancy = h.make_occupancy(
         context,
         person,
@@ -63,8 +52,7 @@ def crawl_member(
     )
     if occupancy is None:
         return
-    # The fractie (parliamentary group) is distinct from party membership.
-    occupancy.add("politicalGroup", fractie)
+    occupancy.add("politicalGroup", faction)
 
     context.emit(occupancy)
     context.emit(person)
@@ -72,9 +60,9 @@ def crawl_member(
 
 def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url, cache_days=1)
-    modals = h.xpath_elements(doc, MODAL_XPATH)
-    if len(modals) == 0:
-        raise ValueError("No member modals found on the roster page")
+    # The roster page renders every member as a Bootstrap modal carrying their full
+    # profile, so the whole dataset comes from a single page
+    modals = h.xpath_elements(doc, './/div[contains(@class, "ledenModal")]')
 
     position = h.make_position(
         context,

--- a/datasets/sr/national_assembly/sr_national_assembly.yml
+++ b/datasets/sr/national_assembly/sr_national_assembly.yml
@@ -2,7 +2,7 @@ title: Suriname De Nationale Assemblée
 entry_point: crawler.py
 prefix: sr-dna
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-18
 load_statements: true
 ci_test: false # Live external website, not available in CI

--- a/datasets/sr/national_assembly/sr_national_assembly.yml
+++ b/datasets/sr/national_assembly/sr_national_assembly.yml
@@ -5,10 +5,9 @@ coverage:
   frequency: monthly
   start: 2026-06-18
 load_statements: true
-ci_test: false # Live external website, not available in CI
+ci_test: true
 summary: >-
-  Members of the National Assembly (De Nationale Assemblée), the unicameral national legislature of
-  Suriname
+  Members of De Nationale Assemblée, the unicameral national legislature of Suriname
 description: |
   Current members of the National Assembly (De Nationale Assemblée), the
   unicameral national legislature of Suriname. Its 51 members are elected from

--- a/datasets/sr/national_assembly/sr_national_assembly.yml
+++ b/datasets/sr/national_assembly/sr_national_assembly.yml
@@ -1,4 +1,4 @@
-title: Suriname De Nationale Assemblée
+title: Suriname Members of National Assembly
 entry_point: crawler.py
 prefix: sr-dna
 coverage:
@@ -7,20 +7,19 @@ coverage:
 load_statements: true
 ci_test: false # Live external website, not available in CI
 summary: >-
-  Members of De Nationale Assemblée, the unicameral national legislature of
+  Members of the National Assembly (De Nationale Assemblée), the unicameral national legislature of
   Suriname
 description: |
-  Current members of De Nationale Assemblée (DNA, National Assembly), the
+  Current members of the National Assembly (De Nationale Assemblée), the
   unicameral national legislature of Suriname. Its 51 members are elected from
   the ten districts via proportional representation for five-year terms.
 
-  This dataset records each sitting member with their name, party (partij) and
-  parliamentary group (fractie), scraped from the official Assembly website.
+  This dataset records each sitting member with their name, party, and
+  parliamentary group, scraped from the official Assembly website.
 url: https://www.dna.sr/politiek-college/leden-2025-2030/
 publisher:
   name: De Nationale Assemblée
   name_en: National Assembly of Suriname
-  acronym: DNA
   description: >
     De Nationale Assemblée is the unicameral national legislature of Suriname.
   url: https://www.dna.sr/

--- a/datasets/sr/national_assembly/sr_national_assembly.yml
+++ b/datasets/sr/national_assembly/sr_national_assembly.yml
@@ -1,0 +1,47 @@
+title: Suriname De Nationale Assemblée
+entry_point: crawler.py
+prefix: sr-dna
+coverage:
+  frequency: weekly
+  start: 2026-06-18
+load_statements: true
+ci_test: false # Live external website, not available in CI
+summary: >-
+  Members of De Nationale Assemblée, the unicameral national legislature of
+  Suriname
+description: |
+  Current members of De Nationale Assemblée (DNA, National Assembly), the
+  unicameral national legislature of Suriname. Its 51 members are elected from
+  the ten districts via proportional representation for five-year terms.
+
+  This dataset records each sitting member with their name, party (partij) and
+  parliamentary group (fractie), scraped from the official Assembly website.
+url: https://www.dna.sr/politiek-college/leden-2025-2030/
+publisher:
+  name: De Nationale Assemblée
+  name_en: National Assembly of Suriname
+  acronym: DNA
+  description: >
+    De Nationale Assemblée is the unicameral national legislature of Suriname.
+  url: https://www.dna.sr/
+  country: sr
+  official: true
+data:
+  url: https://www.dna.sr/politiek-college/leden-2025-2030/
+  format: HTML
+  lang: nld
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 40
+      Position: 1
+    country_entities:
+      sr: 40
+  max:
+    schema_entities:
+      Person: 65
+      Position: 1


### PR DESCRIPTION
Adds a PEP crawler for **De Nationale Assemblée** (DNA), the unicameral national legislature of Suriname.

Closes opensanctions/crawler-planning#735 (milestone: South America PEPs: Legislative Bodies)

## Source
`https://www.dna.sr/politiek-college/leden-2025-2030/` — official Assembly roster page.

## Notes
- **Single-page scrape, no per-member fetches.** Each of the 51 members is rendered as a Bootstrap modal on the roster page carrying their full profile (name, party, parliamentary group, email). The per-member detail pages add nothing the modals don't already have (no district/DOB), so the crawler reads only the roster page.
- Per member: name, party (`Partij` → `political`), parliamentary group (`Fractie` → `politicalGroup`), email (50 of 51 list one), source profile URL.
- Entity ids come from the stable numeric modal id (`modalLid-NNNN`), not the name-derived URL slug.
- **Name cleaning:** source names mix in Dutch academic honorifics (`dr.`, `drs.`, `mr.`, `ir.`) and degree suffixes (`MSc`, `LLB`, `PhD`, ...). The crawler uses `h.apply_reviewed_name_string(..., llm_cleaning=True)`, which applies the original string now and proposes a cleaned split through the name-review workflow.
- `citizenship: sr` — members must hold Surinamese nationality (Constitution art. 59).
- Position uses Wikidata `Q17268790` ("member of the National Assembly of Suriname").

## Validation
- `zavod crawl` clean (`issues.json` empty); 51 Person + 51 Occupancy + 1 Position.
- `zavod validate` passes assertions; `mypy --strict` clean.
- All four PEP integrity checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)