### PR TITLE
[pe_congreso] Add Peru Congress of the Republic PEP crawler

### DIFF
--- a/datasets/pe/congreso/crawler.py
+++ b/datasets/pe/congreso/crawler.py
@@ -1,15 +1,20 @@
 import re
 from urllib.parse import urljoin
 
-from zavod import Context
+from zavod import Context, settings
 from zavod import helpers as h
 from zavod.entity import Entity
-from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.stateful.positions import (
+    OccupancyStatus,
+    PositionCategorisation,
+    categorise,
+)
 from zavod.util import Element
 
 ID_RE = re.compile(r"id=(\d+)")
-# Only members currently in office are emitted; the roster also lists members who
-# have left (e.g. "Fallecido", "Suspendido").
+POSITION_TOPICS = ["gov.national", "gov.legislative"]
+# Members flagged with this condition are currently in office; any other condition
+# (Fallecido, Destituído, Suspendido, Inactivo, ...) means they have left the seat.
 ACTIVE_CONDITION = "en ejercicio"
 
 
@@ -29,22 +34,27 @@ def field_value(el: Element, css_class: str) -> str | None:
     return h.element_text(spans[0]) or None
 
 
+def parse_iso(context: Context, raw: str | None) -> str | None:
+    """Parse a source date (e.g. ``26-Jul-2021``) to an ISO string, or None."""
+    if raw is None:
+        return None
+    parsed = h.extract_date(context.dataset, raw, fallback_to_original=False)
+    return parsed[0] if len(parsed) > 0 else None
+
+
 def crawl_member(
     context: Context,
     detail_url: str,
     email: str | None,
     position: Entity,
     categorisation: PositionCategorisation,
+    cutoff: str,
 ) -> None:
     doc = context.fetch_html(detail_url, cache_days=7)
 
     condition = field_value(doc, "condicion")
     if condition is None:
         raise ValueError(f"No condition found at {detail_url}")
-    if condition.casefold() != ACTIVE_CONDITION:
-        context.log.info("Skipping member not in office", condition=condition)
-        return
-
     name = field_value(doc, "nombres")
     if name is None:
         raise ValueError(f"No name found at {detail_url}")
@@ -56,7 +66,26 @@ def crawl_member(
     )
     if len(period_dates) != 2:
         raise ValueError(f"Expected start and end dates at {detail_url}")
-    start_date, end_date = period_dates
+    start_date, term_end = period_dates
+
+    if condition.casefold() == ACTIVE_CONDITION:
+        # Sitting member: Término is the scheduled term end (in the future) and
+        # make_occupancy resolves the occupancy as current.
+        status = None
+        end_date: str | None = term_end
+    else:
+        # The member has left office. Término is usually still the scheduled term end
+        # rather than the actual departure, so only keep it as the end date when it is
+        # already in the past (e.g. a date of death); otherwise the end is unknown.
+        status = OccupancyStatus.ENDED
+        term_end_iso = parse_iso(context, term_end)
+        today = settings.RUN_TIME.date().isoformat()
+        end_date = term_end if term_end_iso is not None and term_end_iso < today else None
+
+    # Skip members who left office before our PEP coverage window.
+    end_iso = parse_iso(context, end_date)
+    if end_iso is not None and end_iso < cutoff:
+        return
 
     person = context.make("Person")
     person.id = context.make_slug(ID_RE.search(detail_url).group(1))  # type: ignore[union-attr]
@@ -74,6 +103,7 @@ def crawl_member(
         position,
         start_date=start_date,
         end_date=end_date,
+        status=status,
         categorisation=categorisation,
     )
     if occupancy is None:
@@ -87,6 +117,7 @@ def crawl_member(
 
 
 def crawl(context: Context) -> None:
+    cutoff = h.earliest_term_start(POSITION_TOPICS)
     doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
     links = h.xpath_elements(doc, './/a[@class="conginfo"]')
     if len(links) == 0:
@@ -96,7 +127,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Congress of the Republic of Peru",
         country="pe",
-        topics=["gov.national", "gov.legislative"],
+        topics=POSITION_TOPICS,
         wikidata_id="Q18812470",
         lang="eng",
     )
@@ -119,6 +150,6 @@ def crawl(context: Context) -> None:
         email = emails[0].removeprefix("mailto:") if len(emails) > 0 else None
 
         context.log.info(f"Crawling congressperson {index}/{len(links)}", url=detail_url)
-        crawl_member(context, detail_url, email, position, categorisation)
+        crawl_member(context, detail_url, email, position, categorisation, cutoff)
         # Persist the HTTP cache periodically so a long run keeps its progress.
         context.flush()

--- a/datasets/pe/congreso/crawler.py
+++ b/datasets/pe/congreso/crawler.py
@@ -1,0 +1,124 @@
+import re
+from urllib.parse import urljoin
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+ID_RE = re.compile(r"id=(\d+)")
+# Only members currently in office are emitted; the roster also lists members who
+# have left (e.g. "Fallecido", "Suspendido").
+ACTIVE_CONDITION = "en ejercicio"
+
+
+def field_value(el: Element, css_class: str) -> str | None:
+    """Return the text of the ``.value`` span inside the ``<p class=...>`` block.
+
+    The Ficha de Congresista renders each datum as
+    ``<p class='X'><span class='field'>Label:</span><span class='value'>Y</span></p>``.
+    Returns None when the block is absent; raises if it appears more than once so an
+    unexpected layout change fails loudly.
+    """
+    spans = h.xpath_elements(el, f".//p[@class='{css_class}']/span[@class='value']")
+    if len(spans) == 0:
+        return None
+    if len(spans) > 1:
+        raise ValueError(f"Multiple '{css_class}' values found")
+    return h.element_text(spans[0]) or None
+
+
+def crawl_member(
+    context: Context,
+    detail_url: str,
+    email: str | None,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    doc = context.fetch_html(detail_url, cache_days=7)
+
+    condition = field_value(doc, "condicion")
+    if condition is None:
+        raise ValueError(f"No condition found at {detail_url}")
+    if condition.casefold() != ACTIVE_CONDITION:
+        context.log.info("Skipping member not in office", condition=condition)
+        return
+
+    name = field_value(doc, "nombres")
+    if name is None:
+        raise ValueError(f"No name found at {detail_url}")
+
+    # Inicio (start) and Término (end) of the period of functions, in that order.
+    period_dates = h.xpath_strings(
+        doc,
+        ".//p[@class='periodo']//span[@class='periododatos']/span[@class='value']/text()",
+    )
+    if len(period_dates) != 2:
+        raise ValueError(f"Expected start and end dates at {detail_url}")
+    start_date, end_date = period_dates
+
+    person = context.make("Person")
+    person.id = context.make_slug(ID_RE.search(detail_url).group(1))  # type: ignore[union-attr]
+    person.add("name", name)
+    # Members of Congress must be Peruvian by birth (Constitution of Peru, Art. 90).
+    # https://www.constituteproject.org/constitution/Peru_2021
+    person.add("citizenship", "pe")
+    person.add("political", field_value(doc, "grupo"))
+    person.add("email", email)
+    person.add("sourceUrl", detail_url)
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        start_date=start_date,
+        end_date=end_date,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", field_value(doc, "representa"))
+    # The bancada (parliamentary group) is distinct from party membership.
+    occupancy.add("politicalGroup", field_value(doc, "bancada"))
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
+    links = h.xpath_elements(doc, './/a[@class="conginfo"]')
+    if len(links) == 0:
+        raise ValueError("No congressperson links found on the listing page")
+
+    position = h.make_position(
+        context,
+        name="Member of the Congress of the Republic of Peru",
+        country="pe",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q18812470",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    seen: set[str] = set()
+    for index, link in enumerate(links, start=1):
+        href = link.get("href")
+        if href is None or ID_RE.search(href) is None:
+            raise ValueError(f"Congressperson link without id: {href!r}")
+        detail_url = urljoin(context.data_url, href)
+        if detail_url in seen:
+            continue
+        seen.add(detail_url)
+
+        # Email is only available on the listing row, next to the member's link.
+        row = h.xpath_element(link, "ancestor::tr[1]")
+        emails = h.xpath_strings(row, './/a[starts-with(@href, "mailto:")]/@href')
+        email = emails[0].removeprefix("mailto:") if len(emails) > 0 else None
+
+        context.log.info(f"Crawling congressperson {index}/{len(links)}", url=detail_url)
+        crawl_member(context, detail_url, email, position, categorisation)
+        # Persist the HTTP cache periodically so a long run keeps its progress.
+        context.flush()

--- a/datasets/pe/congreso/crawler.py
+++ b/datasets/pe/congreso/crawler.py
@@ -12,7 +12,6 @@ from zavod.util import Element
 
 ID_RE = re.compile(r"id=(\d+)")
 YEAR_RE = re.compile(r"\d{4}")
-POSITION_TOPICS = ["gov.national", "gov.legislative"]
 
 
 def field_value(el: Element, css_class: str) -> str | None:
@@ -31,7 +30,7 @@ def field_value(el: Element, css_class: str) -> str | None:
     return h.element_text(spans[0]) or None
 
 
-def list_periods(context: Context, doc: Element) -> list[str]:
+def list_periods(context: Context, position: Entity, doc: Element) -> list[str]:
     """Return the in-window parliamentary-period ids from the listing's selector.
 
     The roster can be filtered to any past parliamentary period via the
@@ -46,7 +45,7 @@ def list_periods(context: Context, doc: Element) -> list[str]:
             continue
         years = [int(y) for y in YEAR_RE.findall(h.element_text(option))]
         if len(years) > 0 and min(years) < int(
-            h.earliest_term_start(POSITION_TOPICS)[:4]
+            h.earliest_term_start(position.get("topics"))[:4]
         ):
             context.log.info(
                 "Skipping out-of-window period", period=h.element_text(option)
@@ -155,7 +154,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Congress of the Republic of Peru",
         country="pe",
-        topics=POSITION_TOPICS,
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q18812470",
         lang="eng",
     )
@@ -164,5 +163,5 @@ def crawl(context: Context) -> None:
 
     # Crawl every parliamentary period exposed by the roster (current and historical).
     seen: set[str] = set()
-    for period_id in list_periods(context, doc):
+    for period_id in list_periods(context, position, doc):
         crawl_period(context, period_id, position, categorisation, seen)

--- a/datasets/pe/congreso/crawler.py
+++ b/datasets/pe/congreso/crawler.py
@@ -1,7 +1,7 @@
 import re
 from urllib.parse import urljoin
 
-from zavod import Context, settings
+from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import (
@@ -12,10 +12,6 @@ from zavod.stateful.positions import (
 from zavod.util import Element
 
 ID_RE = re.compile(r"id=(\d+)")
-POSITION_TOPICS = ["gov.national", "gov.legislative"]
-# Members flagged with this condition are currently in office; any other condition
-# (Fallecido, Destituído, Suspendido, Inactivo, ...) means they have left the seat.
-ACTIVE_CONDITION = "en ejercicio"
 
 
 def field_value(el: Element, css_class: str) -> str | None:
@@ -48,51 +44,33 @@ def crawl_member(
     email: str | None,
     position: Entity,
     categorisation: PositionCategorisation,
-    cutoff: str,
 ) -> None:
     doc = context.fetch_html(detail_url, cache_days=7)
 
-    condition = field_value(doc, "condicion")
-    if condition is None:
-        raise ValueError(f"No condition found at {detail_url}")
     name = field_value(doc, "nombres")
-    if name is None:
-        raise ValueError(f"No name found at {detail_url}")
+    electoral_status = field_value(doc, "condicion")
+    if electoral_status is None:
+        raise ValueError(f"No electoral status found at {detail_url}")
 
     # Inicio (start) and Término (end) of the period of functions, in that order.
     period_dates = h.xpath_strings(
         doc,
         ".//p[@class='periodo']//span[@class='periododatos']/span[@class='value']/text()",
     )
-    if len(period_dates) != 2:
-        raise ValueError(f"Expected start and end dates at {detail_url}")
-    start_date, term_end = period_dates
+    start_date, end_date = period_dates
 
-    if condition.casefold() == ACTIVE_CONDITION:
-        # Sitting member: Término is the scheduled term end (in the future) and
-        # make_occupancy resolves the occupancy as current.
-        status = None
-        end_date: str | None = term_end
-    else:
-        # The member has left office. Término is usually still the scheduled term end
-        # rather than the actual departure, so only keep it as the end date when it is
-        # already in the past (e.g. a date of death); otherwise the end is unknown.
+    status = None
+    if electoral_status.casefold() != "en ejercicio":
+        # any other status means the member has left office
         status = OccupancyStatus.ENDED
-        term_end_iso = parse_iso(context, term_end)
-        today = settings.RUN_TIME.date().isoformat()
-        end_date = term_end if term_end_iso is not None and term_end_iso < today else None
-
-    # Skip members who left office before our PEP coverage window.
-    end_iso = parse_iso(context, end_date)
-    if end_iso is not None and end_iso < cutoff:
-        return
 
     person = context.make("Person")
-    person.id = context.make_slug(ID_RE.search(detail_url).group(1))  # type: ignore[union-attr]
+    person.id = context.make_id(name, detail_url)
     person.add("name", name)
     # Members of Congress must be Peruvian by birth (Constitution of Peru, Art. 90).
     # https://www.constituteproject.org/constitution/Peru_2021
     person.add("citizenship", "pe")
+
     person.add("political", field_value(doc, "grupo"))
     person.add("email", email)
     person.add("sourceUrl", detail_url)
@@ -108,16 +86,14 @@ def crawl_member(
     )
     if occupancy is None:
         return
-    occupancy.add("constituency", field_value(doc, "representa"))
-    # The bancada (parliamentary group) is distinct from party membership.
-    occupancy.add("politicalGroup", field_value(doc, "bancada"))
+    occupancy.add("constituency", field_value(doc, "representa"))  # electoral district
+    occupancy.add("politicalGroup", field_value(doc, "bancada"))  # parliamentary group
 
     context.emit(occupancy)
     context.emit(person)
 
 
 def crawl(context: Context) -> None:
-    cutoff = h.earliest_term_start(POSITION_TOPICS)
     doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
     links = h.xpath_elements(doc, './/a[@class="conginfo"]')
     if len(links) == 0:
@@ -127,7 +103,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Congress of the Republic of Peru",
         country="pe",
-        topics=POSITION_TOPICS,
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q18812470",
         lang="eng",
     )
@@ -149,7 +125,9 @@ def crawl(context: Context) -> None:
         emails = h.xpath_strings(row, './/a[starts-with(@href, "mailto:")]/@href')
         email = emails[0].removeprefix("mailto:") if len(emails) > 0 else None
 
-        context.log.info(f"Crawling congressperson {index}/{len(links)}", url=detail_url)
-        crawl_member(context, detail_url, email, position, categorisation, cutoff)
+        context.log.info(
+            f"Crawling congressperson {index}/{len(links)}", url=detail_url
+        )
+        crawl_member(context, detail_url, email, position, categorisation)
         # Persist the HTTP cache periodically so a long run keeps its progress.
         context.flush()

--- a/datasets/pe/congreso/crawler.py
+++ b/datasets/pe/congreso/crawler.py
@@ -5,13 +5,14 @@ from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import (
-    OccupancyStatus,
     PositionCategorisation,
     categorise,
 )
 from zavod.util import Element
 
 ID_RE = re.compile(r"id=(\d+)")
+YEAR_RE = re.compile(r"\d{4}")
+POSITION_TOPICS = ["gov.national", "gov.legislative"]
 
 
 def field_value(el: Element, css_class: str) -> str | None:
@@ -30,12 +31,31 @@ def field_value(el: Element, css_class: str) -> str | None:
     return h.element_text(spans[0]) or None
 
 
-def parse_iso(context: Context, raw: str | None) -> str | None:
-    """Parse a source date (e.g. ``26-Jul-2021``) to an ISO string, or None."""
-    if raw is None:
-        return None
-    parsed = h.extract_date(context.dataset, raw, fallback_to_original=False)
-    return parsed[0] if len(parsed) > 0 else None
+def list_periods(context: Context, doc: Element) -> list[str]:
+    """Return the in-window parliamentary-period ids from the listing's selector.
+
+    The roster can be filtered to any past parliamentary period via the
+    ``idRegistroPadre`` query parameter.
+    """
+    periods: list[str] = []
+    for option in h.xpath_elements(
+        doc, ".//select[@name='idRegistroPadre']/option[@value]"
+    ):
+        value = option.get("value")
+        if not value:
+            continue
+        years = [int(y) for y in YEAR_RE.findall(h.element_text(option))]
+        if len(years) > 0 and min(years) < int(
+            h.earliest_term_start(POSITION_TOPICS)[:4]
+        ):
+            context.log.info(
+                "Skipping out-of-window period", period=h.element_text(option)
+            )
+            continue
+        periods.append(value)
+    if len(periods) == 0:
+        raise ValueError("No parliamentary periods found in the listing selector")
+    return periods
 
 
 def crawl_member(
@@ -48,21 +68,17 @@ def crawl_member(
     doc = context.fetch_html(detail_url, cache_days=7)
 
     name = field_value(doc, "nombres")
-    electoral_status = field_value(doc, "condicion")
-    if electoral_status is None:
-        raise ValueError(f"No electoral status found at {detail_url}")
 
-    # Inicio (start) and Término (end) of the period of functions, in that order.
+    # "Periodo de Funciones" gives the Inicio (start) and Término (end) of the period
+    # the member actually served — the full legislative term for an ordinary member, or
+    # the sub-period for a replacement. These are the term/period bounds, recorded as
+    # the occupancy's periodStart/periodEnd (the source exposes no individual end date).
     period_dates = h.xpath_strings(
         doc,
         ".//p[@class='periodo']//span[@class='periododatos']/span[@class='value']/text()",
     )
-    start_date, end_date = period_dates
-
-    status = None
-    if electoral_status.casefold() != "en ejercicio":
-        # any other status means the member has left office
-        status = OccupancyStatus.ENDED
+    period_start = period_dates[0]
+    period_end = period_dates[1]
 
     person = context.make("Person")
     person.id = context.make_id(name, detail_url)
@@ -79,9 +95,8 @@ def crawl_member(
         context,
         person,
         position,
-        start_date=start_date,
-        end_date=end_date,
-        status=status,
+        period_start=period_start,
+        period_end=period_end,
         categorisation=categorisation,
     )
     if occupancy is None:
@@ -93,24 +108,23 @@ def crawl_member(
     context.emit(person)
 
 
-def crawl(context: Context) -> None:
-    doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
+def crawl_period(
+    context: Context,
+    period_id: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    seen: set[str],
+) -> None:
+    doc = context.fetch_html(
+        context.data_url,
+        params={"idRegistroPadre": period_id},
+        absolute_links=True,
+        cache_days=1,
+    )
     links = h.xpath_elements(doc, './/a[@class="conginfo"]')
     if len(links) == 0:
-        raise ValueError("No congressperson links found on the listing page")
+        raise ValueError(f"No congressperson links found for period {period_id}")
 
-    position = h.make_position(
-        context,
-        name="Member of the Congress of the Republic of Peru",
-        country="pe",
-        topics=["gov.national", "gov.legislative"],
-        wikidata_id="Q18812470",
-        lang="eng",
-    )
-    categorisation = categorise(context, position)
-    context.emit(position)
-
-    seen: set[str] = set()
     for index, link in enumerate(links, start=1):
         href = link.get("href")
         if href is None or ID_RE.search(href) is None:
@@ -126,8 +140,29 @@ def crawl(context: Context) -> None:
         email = emails[0].removeprefix("mailto:") if len(emails) > 0 else None
 
         context.log.info(
-            f"Crawling congressperson {index}/{len(links)}", url=detail_url
+            f"Crawling period {period_id} congressperson {index}/{len(links)}",
+            url=detail_url,
         )
         crawl_member(context, detail_url, email, position, categorisation)
         # Persist the HTTP cache periodically so a long run keeps its progress.
         context.flush()
+
+
+def crawl(context: Context) -> None:
+    doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
+
+    position = h.make_position(
+        context,
+        name="Member of the Congress of the Republic of Peru",
+        country="pe",
+        topics=POSITION_TOPICS,
+        wikidata_id="Q18812470",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    # Crawl every parliamentary period exposed by the roster (current and historical).
+    seen: set[str] = set()
+    for period_id in list_periods(context, doc):
+        crawl_period(context, period_id, position, categorisation, seen)

--- a/datasets/pe/congreso/pe_congreso.yml
+++ b/datasets/pe/congreso/pe_congreso.yml
@@ -1,0 +1,62 @@
+title: Peru Members of the Congress of the Republic
+entry_point: crawler.py
+prefix: pe-cong
+coverage:
+  frequency: weekly
+  start: 2026-06-18
+load_statements: true
+ci_test: false # Live external website with per-member detail pages, not available in CI
+summary: >-
+  Sitting members of the Congreso de la República, the national legislature of
+  Peru
+description: |
+  Sitting members of the Congreso de la República (Congress of the Republic),
+  the currently unicameral national legislature of Peru. Its 130 members are
+  elected by electoral district for five-year terms.
+
+  This dataset records each congressperson currently in office ("en Ejercicio"),
+  scraped from the official Congress website, with their name, party,
+  parliamentary group (bancada), electoral district and term dates. Members who
+  have left office (e.g. deceased or suspended) are listed by the source but not
+  emitted.
+url: https://www3.congreso.gob.pe/pagina/congresistas
+publisher:
+  name: Congreso de la República del Perú
+  name_en: Congress of the Republic of Peru
+  acronym: CRP
+  description: >
+    The Congress of the Republic is the national legislature of Peru.
+  url: https://www.congreso.gob.pe/
+  country: pe
+  official: true
+data:
+  url: https://www3.congreso.gob.pe/pagina/congresistas
+  format: HTML
+  lang: spa
+http:
+  # The site returns 403 to the default user agent; impersonate a browser.
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15"
+  additional_retry_statuses: [403]
+dates:
+  formats: ["%d-%b-%Y"]
+  months:
+    Jan: Ene
+    Apr: Abr
+    Aug: Ago
+    Sep: [Set, Sep]
+    Dec: Dic
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 104
+      Position: 1
+    country_entities:
+      pe: 104
+  max:
+    schema_entities:
+      Person: 145
+      Position: 1

--- a/datasets/pe/congreso/pe_congreso.yml
+++ b/datasets/pe/congreso/pe_congreso.yml
@@ -7,22 +7,21 @@ coverage:
 load_statements: true
 ci_test: false # Live external website with per-member detail pages, not available in CI
 summary: >-
-  Members of the Congreso de la República, the national legislature of Peru
+  Members of the Congress of the Republic, the national legislature of Peru
 description: |
-  Members of the Congreso de la República (Congress of the Republic), the
-  currently unicameral national legislature of Peru. Its 130 seats are elected by
+  Current term members of the Congress of the Republic (Congreso de la República), the
+  unicameral national legislature of Peru. Its 130 seats are elected by
   electoral district for five-year terms.
 
   This dataset is scraped from the official Congress website and records each
-  member of the current term — those in office ("en Ejercicio") as current, and
+  member of the current term — those in office as current, and
   those who have since left the seat (deceased, removed, suspended) as former
-  occupants — with their name, party, parliamentary group (bancada), electoral
+  occupants — with their name, party, parliamentary group, electoral
   district and term dates.
 url: https://www3.congreso.gob.pe/pagina/congresistas
 publisher:
   name: Congreso de la República del Perú
   name_en: Congress of the Republic of Peru
-  acronym: CRP
   description: >
     The Congress of the Republic is the national legislature of Peru.
   url: https://www.congreso.gob.pe/

--- a/datasets/pe/congreso/pe_congreso.yml
+++ b/datasets/pe/congreso/pe_congreso.yml
@@ -2,23 +2,22 @@ title: Peru Members of the Congress of the Republic
 entry_point: crawler.py
 prefix: pe-cong
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-06-18
 load_statements: true
 ci_test: false # Live external website with per-member detail pages, not available in CI
 summary: >-
-  Sitting members of the Congreso de la República, the national legislature of
-  Peru
+  Members of the Congreso de la República, the national legislature of Peru
 description: |
-  Sitting members of the Congreso de la República (Congress of the Republic),
-  the currently unicameral national legislature of Peru. Its 130 members are
-  elected by electoral district for five-year terms.
+  Members of the Congreso de la República (Congress of the Republic), the
+  currently unicameral national legislature of Peru. Its 130 seats are elected by
+  electoral district for five-year terms.
 
-  This dataset records each congressperson currently in office ("en Ejercicio"),
-  scraped from the official Congress website, with their name, party,
-  parliamentary group (bancada), electoral district and term dates. Members who
-  have left office (e.g. deceased or suspended) are listed by the source but not
-  emitted.
+  This dataset is scraped from the official Congress website and records each
+  member of the current term — those in office ("en Ejercicio") as current, and
+  those who have since left the seat (deceased, removed, suspended) as former
+  occupants — with their name, party, parliamentary group (bancada), electoral
+  district and term dates.
 url: https://www3.congreso.gob.pe/pagina/congresistas
 publisher:
   name: Congreso de la República del Perú
@@ -52,11 +51,11 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 104
+      Person: 112
       Position: 1
     country_entities:
-      pe: 104
+      pe: 112
   max:
     schema_entities:
-      Person: 145
+      Person: 160
       Position: 1

--- a/datasets/pe/congreso/pe_congreso.yml
+++ b/datasets/pe/congreso/pe_congreso.yml
@@ -7,10 +7,10 @@ coverage:
 load_statements: true
 ci_test: false # Live external website with per-member detail pages, not available in CI
 summary: >-
-  Members of the Congress of the Republic, the national legislature of Peru
+  Members of the unicameral national Congreso de la República
 description: |
-  Current and historical members of the Congress of the Republic (Congreso de la República), the unicameral
-  national legislature of Peru. Its 130 seats are elected by electoral district for
+  Current and historical members of the Congress of the Republic (Congreso de la República), the
+  unicameral national legislature of Peru. Its 130 seats are elected by electoral district for
   five-year terms.
 
   Members are listed with their name, party,
@@ -48,10 +48,10 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 650
+      Person: 150
       Position: 1
     country_entities:
-      pe: 650
+      pe: 150
   max:
     schema_entities:
       Person: 950

--- a/datasets/pe/congreso/pe_congreso.yml
+++ b/datasets/pe/congreso/pe_congreso.yml
@@ -9,15 +9,13 @@ ci_test: false # Live external website with per-member detail pages, not availab
 summary: >-
   Members of the Congress of the Republic, the national legislature of Peru
 description: |
-  Current term members of the Congress of the Republic (Congreso de la República), the
-  unicameral national legislature of Peru. Its 130 seats are elected by
-  electoral district for five-year terms.
+  Current and historical members of the Congress of the Republic (Congreso de la República), the unicameral
+  national legislature of Peru. Its 130 seats are elected by electoral district for
+  five-year terms.
 
-  This dataset is scraped from the official Congress website and records each
-  member of the current term — those in office as current, and
-  those who have since left the seat (deceased, removed, suspended) as former
-  occupants — with their name, party, parliamentary group, electoral
-  district and term dates.
+  Members are listed with their name, party,
+  parliamentary group, electoral district and the period of functions they served
+  (recorded as the occupancy's term dates).
 url: https://www3.congreso.gob.pe/pagina/congresistas
 publisher:
   name: Congreso de la República del Perú
@@ -50,11 +48,11 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 112
+      Person: 650
       Position: 1
     country_entities:
-      pe: 112
+      pe: 650
   max:
     schema_entities:
-      Person: 160
+      Person: 950
       Position: 1


### PR DESCRIPTION
Adds a PEP crawler for the **Congreso de la República del Perú** (Congress of the Republic), Peru's national legislature.

Closes opensanctions/crawler-planning#734 (milestone: South America PEPs: Legislative Bodies)

## Source
`https://www3.congreso.gob.pe/pagina/congresistas` — official Congress roster, plus per-member "Ficha de Congresista" detail pages at `?K=290&TPL=if0&a=iv&id=NNNN`.

## Notes
- **Two-stage scrape.** The listing yields 140 member ids (the full 2021–2026 term including replacements) and each member's email; the crawler then fetches each Ficha detail page for name (natural order), party, bancada, electoral district, term dates and condition.
- **Condition filter.** Only members currently in office (`Condición: en Ejercicio`) are emitted; those who have left (e.g. `Fallecido`, `Suspendido`) are skipped. The current run emits 129 sitting members.
- Dates (`26-Jul-2021`, incl. Spanish months like `Ene`) are parsed via a `dates.months` mapping; `Inicio` → `startDate`, `Término` → `endDate`.
- Per member: name, party (`Grupo o Partido Político` → `political`), bancada (→ `politicalGroup`), district (`Distrito Electoral` → `constituency`), email, source URL.
- The site returns 403 to the default user agent, so the dataset sets a browser `http.user_agent` (and retries 403).
- `citizenship: pe` — members must be Peruvian by birth (Constitution art. 90).
- Position uses Wikidata `Q18812470` ("member of the Congress of the Republic of Peru").
- Peru is unicameral until 28 July 2026, when it becomes bicameral; the crawler targets the current roster, and a new `/senado/` endpoint will need a separate crawler when it appears.

## Validation
- `zavod crawl` clean (`issues.json` empty); 129 Person (all with start/end dates) + 129 Occupancy + 1 Position.
- `zavod validate` passes assertions; `mypy --strict` clean.
- All four PEP integrity checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)