### PR TITLE
Friday afternoon typechecker happiness

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -67,9 +67,6 @@ repos:
           datasets/_global/un_1718_vessels|
           datasets/_global/un_ga_protocol|
           datasets/_global/un_sc_sanctions|
-          datasets/_global/worldbank|
-          datasets/_global/tokyo_mou|
-          datasets/_global/abuja_mou|
           datasets/_wikidata|
           datasets/ae|
           datasets/bg/jud_declarations|
@@ -109,11 +106,8 @@ repos:
           datasets/us/cftc_enforcement_actions|
           datasets/us/occ_enfact|
           datasets/us/ddtc_enforcements|
-          datasets/us/ddtc_debarred|
-          datasets/us/sam_exclusions|
           datasets/us/nk_jointventures|
           datasets/us/cia_world_factbook|
-          datasets/us/fara_filings|
           datasets/us/fincen_msb|
           datasets/us/fbi_lazarus_crypto|
           datasets/us/sec_litigation_releases|

--- a/datasets/_global/abuja_mou/detention/crawler.py
+++ b/datasets/_global/abuja_mou/detention/crawler.py
@@ -53,7 +53,9 @@ def crawl_row(context: Context, row: dict[str, str | None]) -> None:
     vessel.add("imoNumber", imo)
     vessel.add("flag", row.pop("Flag"))
     vessel.add("buildDate", row.pop("Year of build"))
-    h.apply_number(vessel, "grossRegisteredTonnage", row.pop("Tonnage"))
+    tonnage = row.pop("Tonnage")
+    if tonnage is not None:
+        h.apply_number(vessel, "grossRegisteredTonnage", tonnage)
     vessel.add("type", row.pop("Type"))
     vessel.add("topics", "mare.detained")
 
@@ -97,6 +99,7 @@ def crawl_row(context: Context, row: dict[str, str | None]) -> None:
         end_date=end_date,
     )
     reasons = row.pop("Nature of deficiencies")
+    assert reasons is not None, "Nature of deficiencies is required"
     for reason in reasons.split(";"):
         sanction.add("reason", reason.strip())
     # Most of the ships (even from 2019) have no end_date, most of them will be marked as active

--- a/datasets/_global/tokyo_mou/detention/crawler.py
+++ b/datasets/_global/tokyo_mou/detention/crawler.py
@@ -56,7 +56,9 @@ def crawl_row(
     vessel.add("imoNumber", imo)
     vessel.add("flag", row.pop("Ship Flag"))
     vessel.add("buildDate", row.pop("Year of build"))
-    h.apply_number(vessel, "grossRegisteredTonnage", row.pop("Gross Tonnage"))
+    gross_tonnage = row.pop("Gross Tonnage")
+    if gross_tonnage is not None:
+        h.apply_number(vessel, "grossRegisteredTonnage", gross_tonnage)
     vessel.add("type", row.pop("Ship Type"))
     vessel.add("topics", "mare.detained")
 
@@ -98,12 +100,13 @@ def crawl_row(
     for br in reasons_cell.xpath(".//br"):
         br.tail = br.tail + "\n" if br.tail else "\n"
     reason = reasons_cell.text_content().split("\n")
+    # key is type-ignored to avoid a re-key
     sanction = h.make_sanction(
         context,
         vessel,
         start_date=start_date,
         end_date=end_date,
-        key=[start_date, end_date, sorted(reason)],
+        key=[start_date, end_date, sorted(reason)],  # type: ignore
     )
     sanction.add("reason", reason)
 

--- a/datasets/_global/worldbank/crawler.py
+++ b/datasets/_global/worldbank/crawler.py
@@ -33,7 +33,10 @@ def clean_name(text: str) -> list[str]:
 
 def crawl(context: Context) -> None:
     url = context.data_url
-    headers = {"apikey": context.dataset.data.api_key}
+    assert (
+        context.dataset.data is not None and context.dataset.data.api_key is not None
+    ), "API key is required for this dataset"
+    headers: dict[str, str] = {"apikey": context.dataset.data.api_key}
     data = context.fetch_json(url, headers=headers)
     # TODO write this out to a source.json
     for data in data["response"]["ZPROCSUPP"]:

--- a/datasets/eu/travel_bans/crawler.py
+++ b/datasets/eu/travel_bans/crawler.py
@@ -2,7 +2,7 @@ from zavod import Context
 from zavod import helpers as h
 from zavod.shed.fsf import parse_entry, parse_sanctions
 from zavod.stateful.review import assert_all_accepted
-from zavod.util import Element
+from zavod.util import Element, ElementOrTree
 
 URL = "https://www.sanctionsmap.eu/api/v1/travelbans/file/%s"
 
@@ -11,6 +11,7 @@ def salvage_entity(context: Context, entry: Element) -> None:
     texts = [t.text for t in entry.findall("./remark")]
     assert len(texts) == 2, texts
     name, details = texts
+    assert name is not None
     name = name.split("(", 1)[0]
     entity = context.make("LegalEntity")
     entity.id = context.make_id(name)
@@ -29,7 +30,7 @@ def crawl(context: Context) -> None:
         data_url = URL % ban.get("id")
         path = context.fetch_resource("source.xml", data_url)
         context.export_resource(path, "text/xml", title=context.SOURCE_TITLE)
-        doc = context.parse_resource_xml(path)
+        doc: ElementOrTree = context.parse_resource_xml(path)
         doc = h.remove_namespace(doc)
         for entry in doc.findall(".//sanctionEntity"):
             subject_type = entry.find("./subjectType")

--- a/datasets/id/regional_2018/crawler.py
+++ b/datasets/id/regional_2018/crawler.py
@@ -1,8 +1,7 @@
 import re
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any
 import openpyxl
 from rigour.mime.types import XLSX
-from normality import slugify
 
 from zavod import Context
 from zavod import helpers as h
@@ -12,16 +11,6 @@ from zavod.stateful.positions import categorise
 REGEX_TITLE = re.compile(
     r"^(Drs\. |Dr\. |Ir\. |Hj\. |PROF\. |IRJEN POL\. \(Purn\) |Dra\. )*", re.IGNORECASE
 )
-
-
-def worksheet_rows(sheet: Any) -> Generator[Dict[str, Any], None, None]:
-    headers: Optional[List[str]] = None
-    for row in sheet.iter_rows(min_row=4):
-        cells = [c.value for c in row]
-        if headers is None:
-            headers = [slugify(h, sep="_") for h in cells]
-            continue
-        yield dict(zip(headers, cells))
 
 
 def clean_name(name: str) -> str:
@@ -65,12 +54,13 @@ def crawl_person(
 
     context.emit(entity)
     context.emit(position)
-    context.emit(occupancy)
+    if occupancy is not None:
+        context.emit(occupancy)
 
 
 def crawl_pair(
     context: Context,
-    row: Dict[str, Any],
+    row: dict[str, Any],
     head_ind: str,
     head_eng: str,
     deputy_ind: str,
@@ -90,7 +80,7 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("individuals.xlsx", context.data_url)
     context.export_resource(path, XLSX, title=context.SOURCE_TITLE)
     workbook = openpyxl.load_workbook(path, read_only=True)
-    for row in worksheet_rows(workbook["Pemilihan Gubernur"]):
+    for row in h.parse_xlsx_sheet(context, workbook["Pemilihan Gubernur"], skiprows=3):
         crawl_pair(
             context,
             row,
@@ -102,7 +92,9 @@ def crawl(context: Context) -> None:
             ["gov.head", "gov.state"],
         )
 
-    for row in worksheet_rows(workbook["Pemilihan Bupati atau Walikota"]):
+    for row in h.parse_xlsx_sheet(
+        context, workbook["Pemilihan Bupati atau Walikota"], skiprows=3
+    ):
         crawl_pair(
             context,
             row,

--- a/datasets/ng/join_dots/crawler.py
+++ b/datasets/ng/join_dots/crawler.py
@@ -1,5 +1,5 @@
 import openpyxl
-from typing import Any, Iterator, cast
+from typing import Any, cast
 from normality import squash_spaces, slugify
 from rigour.mime.types import XLSX
 import re
@@ -106,7 +106,7 @@ def crawl_pep(
     """Returns (person name, entity ID), or (None, None) if the PEP was not emitted."""
     name = row.pop("name")
     birth_date = row.pop("date_of_birth", None)
-    birth_date = birth_date.isoformat()[:10] if birth_date else None
+    birth_date = birth_date[:10] if birth_date else None
     district = row.pop("district", None)
 
     entity = context.make("Person")
@@ -184,16 +184,6 @@ def crawl_relative(
     context.emit(rel)
 
 
-def worksheet_rows(sheet: Any) -> Iterator[dict[str | None, Any]]:
-    headers: list[str | None] | None = None
-    for row in sheet.rows:
-        cells = [c.value for c in row]
-        if headers is None:
-            headers = [slugify(h, sep="_") for h in cells]
-            continue
-        yield dict(zip(headers, cells))
-
-
 def crawl(context: Context) -> None:
     pep_ids: dict[str, str] = {}  # slugified name -> entity ID
     dupes = set()
@@ -203,7 +193,7 @@ def crawl(context: Context) -> None:
     )
     context.export_resource(peps_path, XLSX, title="PEPs source data")
     workbook = openpyxl.load_workbook(peps_path, read_only=True)
-    for row in worksheet_rows(workbook.worksheets[0]):
+    for row in h.parse_xlsx_sheet(context, workbook.worksheets[0]):
         name, entity_id = crawl_pep(context, row)
         if name is None:
             continue
@@ -224,6 +214,6 @@ def crawl(context: Context) -> None:
     )
     context.export_resource(peps_path, XLSX, title="PEP Relatives source data")
     workbook = openpyxl.load_workbook(peps_path, read_only=True)
-    for row in worksheet_rows(workbook.worksheets[0]):
+    for row in h.parse_xlsx_sheet(context, workbook.worksheets[0]):
         if row:
             crawl_relative(context, row, pep_ids)

--- a/datasets/ro/onpcsb_sanctions/crawler.py
+++ b/datasets/ro/onpcsb_sanctions/crawler.py
@@ -1,5 +1,4 @@
 import csv
-from typing import Dict
 
 from rigour.mime.types import PDF
 
@@ -7,7 +6,7 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     full_name = row.pop("name")
     other_name = h.multi_split(row.pop("other name"), [",", ";"])
     birth_date_1_orig = row.pop("date of birth")
@@ -42,7 +41,10 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 
     if entity_type == "Person":
         entity = context.make("Person")
-        entity.id = context.make_id(full_name, birth_date_1, birth_place)
+        # birth_date_1 is list[str] but make_id expects str|None; changing the
+        # argument type would re-key all existing entities, so keep the current
+        # runtime behaviour and suppress the type error.
+        entity.id = context.make_id(full_name, birth_date_1, birth_place)  # type: ignore[arg-type]
         entity.add("name", full_name)
         entity.add("alias", other_name)
         entity.add("birthDate", birth_date_1, original_value=birth_date_1_orig)
@@ -83,6 +85,7 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 
 def crawl(context: Context) -> None:
     url_xpath = ".//a[contains(text(), 'HG nr. 1.272/2005')]/@href"
+    assert context.dataset.url is not None
     doc = zyte_api.fetch_html(
         context,
         context.dataset.url,

--- a/datasets/sg/mas_investor_alert/crawler.py
+++ b/datasets/sg/mas_investor_alert/crawler.py
@@ -20,7 +20,9 @@ WEBSITE_KEYWORDS = [".com", ".net", ".org", "https:", "http:", "www.", ".sg", ".
 
 
 def check_num_found(context: Context, data: dict[str, Any]) -> None:
-    num_found = data.get("response").get("numFound")
+    response = data.get("response")
+    assert response is not None, "Response missing from data"
+    num_found = response.get("numFound")
     if num_found is None:
         context.log.warn("Response doesn't contain numFound field")
     else:
@@ -88,7 +90,7 @@ CrawlItemResult = namedtuple(
 )
 
 
-def crawl_item(context: Context, item: dict) -> CrawlItemResult:
+def crawl_item(context: Context, item: dict[str, Any]) -> CrawlItemResult:
     id = item.pop("id")
 
     relatedunregulatedpersonsid_s = item.pop("relatedunregulatedpersonsid_s")

--- a/datasets/ua/war_sanctions/crawler.py
+++ b/datasets/ua/war_sanctions/crawler.py
@@ -442,12 +442,16 @@ def crawl(context: Context) -> None:
         response = fetch_endpoint(context, url)
 
         data = response.get("data")
+        assert data is not None, f"No data in response for {url}"
         for entity_details in data:
             # Construct entity specific page URL: {base_url}/{endpoint}/{entity_id}
             entity_id = entity_details.get("id")
             source_url = urljoin(context.data_url, f"{link.endpoint}/{entity_id}")
 
             if link.type is WSAPIDataType.PERSON:
+                assert link.program_key is not None, (
+                    f"No program_key for {link.endpoint}"
+                )
                 crawl_person(
                     context,
                     entity_details,

--- a/datasets/us/ddtc_debarred/crawler.py
+++ b/datasets/us/ddtc_debarred/crawler.py
@@ -1,8 +1,6 @@
-from normality import slugify
 import openpyxl
-from openpyxl.worksheet.worksheet import Worksheet
 from rigour.mime.types import XLSX
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any
 
 from zavod import Context
 from zavod import helpers as h
@@ -13,25 +11,14 @@ US_DDTC_SD = "US-DDTC-SD"
 US_DDTC_AD = "US-DDTC-AD"
 
 
-def sheet_to_dicts(sheet: Worksheet) -> Iterator[Dict[str, Any]]:
-    headers: Optional[List[str]] = None
-    for row in sheet.rows:
-        cells = [c.value for c in row]
-        if headers is None:
-            headers = [slugify(h) or f"column_{i}" for i, h in enumerate(cells)]
-            continue
-        row = dict(zip(headers, cells))
-        yield row
-
-
 def crawl_debarment(
     context: Context,
-    row: Dict[str, Any],
+    row: dict[str, Any],
     program_key: str,
     name_field: str,
     notice_date_field: str,
 ) -> None:
-    date_of_birth = row.pop("date-of-birth", None)
+    date_of_birth = row.pop("date_of_birth", None)
     if date_of_birth:
         schema = "Person"
     else:
@@ -55,13 +42,13 @@ def crawl_debarment(
     )
 
     sanction = h.make_sanction(context, entity, program_key=program_key)
-    sanction.add("listingDate", row.pop(notice_date_field).isoformat()[:10])
-    sanction.add("listingDate", row.pop("corrected-notice-date", None))
+    sanction.add("listingDate", row.pop(notice_date_field))
+    sanction.add("listingDate", row.pop("corrected_notice_date", None))
     sanction.add(
         "description",
-        "Federal register notice: " + row.pop("federal-register-notice"),
+        "Federal register notice: " + row.pop("federal_register_notice"),
     )
-    corrected_notice_number = row.pop("corrected-notice", None)
+    corrected_notice_number = row.pop("corrected_notice", None)
     if corrected_notice_number:
         sanction.add(
             "description",
@@ -71,18 +58,18 @@ def crawl_debarment(
     context.emit(entity)
     context.emit(sanction)
 
-    context.audit_data(row, ["charging-letter", "debarment-order"])
+    context.audit_data(row, ["charging_letter", "debarment_order"])
 
 
 def crawl(context: Context) -> None:
     path = context.fetch_resource("statutory.xlsx", STATUTORY_XLSX_URL)
     context.export_resource(path, XLSX, title="Statutory Debarments")
-    rows = sheet_to_dicts(openpyxl.load_workbook(path, read_only=True).worksheets[0])
-    for row in rows:
-        crawl_debarment(context, row, US_DDTC_SD, "party-name", "notice-date")
+    wb = openpyxl.load_workbook(path, read_only=True)
+    for row in h.parse_xlsx_sheet(context, wb.worksheets[0]):
+        crawl_debarment(context, row, US_DDTC_SD, "party_name", "notice_date")
 
     path = context.fetch_resource("administrative.xlsx", ADMINISTRATIVE_XLSX_URL)
     context.export_resource(path, XLSX, title="Administrative Debarments")
-    rows = sheet_to_dicts(openpyxl.load_workbook(path, read_only=True).worksheets[0])
-    for row in rows:
+    wb = openpyxl.load_workbook(path, read_only=True)
+    for row in h.parse_xlsx_sheet(context, wb.worksheets[0]):
         crawl_debarment(context, row, US_DDTC_AD, "name", "date")

--- a/datasets/us/fara_filings/crawler.py
+++ b/datasets/us/fara_filings/crawler.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from lxml import etree
 from rigour.mime.types import ZIP
 from pathlib import Path
-from typing import Any, Dict, Generator
+from typing import Iterator
 from zipfile import ZipFile
 
 from zavod import Context, helpers as h
@@ -16,7 +16,7 @@ PRINCIPALS_NAME = "FARA_All_ForeignPrincipals.xml"
 
 def read_rows(
     context: Context, zip_path: Path, file_name: str
-) -> Generator[Dict[str, Any], None, None]:
+) -> Iterator[dict[str, str | None]]:
     with ZipFile(zip_path, "r") as zip:
         with zip.open(file_name) as zfh:
             fh = io.TextIOWrapper(zfh, encoding="iso-8859-1")
@@ -25,11 +25,11 @@ def read_rows(
                 yield {el.tag: el.text for el in node}
 
 
-def registrant_id(context: Context, registration_number: str) -> str:
+def registrant_id(context: Context, registration_number: str) -> str | None:
     return context.make_slug("reg", registration_number)
 
 
-def crawl_registrant(context: Context, item: Dict[str, Any]) -> None:
+def crawl_registrant(context: Context, item: dict[str, str | None]) -> None:
     # Extract relevant fields from each item
     address = h.make_address(
         context,
@@ -43,10 +43,12 @@ def crawl_registrant(context: Context, item: Dict[str, Any]) -> None:
         context.dataset, item.pop("Termination_Date", None)
     )
     registration_number = item.pop("Registration_Number")
+    assert registration_number is not None
 
     entity = context.make("LegalEntity")
     entity.id = registrant_id(context, registration_number)
-    entity.add("name", item.pop("Name").strip() or None)
+    name = item.pop("Name")
+    entity.add("name", name.strip() if name else None)
     entity.add("topics", "role.lobby")
     h.apply_address(context, entity, address)
     entity.add("registrationNumber", registration_number)
@@ -56,7 +58,7 @@ def crawl_registrant(context: Context, item: Dict[str, Any]) -> None:
         entity.add("description", f"Terminated registration {termination_date[0]}")
     context.emit(entity)
 
-    business_name = item.pop("Business_Name", "").strip()
+    business_name = (item.pop("Business_Name", None) or "").strip()
     if business_name:
         business_entity = context.make("LegalEntity")
         business_entity.id = context.make_slug(
@@ -77,7 +79,7 @@ def crawl_registrant(context: Context, item: Dict[str, Any]) -> None:
     context.audit_data(item)
 
 
-def crawl_principal(context: Context, item: Dict[str, Any]) -> None:
+def crawl_principal(context: Context, item: dict[str, str | None]) -> None:
     # Add relevant agency client information to the company entity
     p_name = item.pop("Foreign_principal")
     address = h.make_address(
@@ -89,10 +91,12 @@ def crawl_principal(context: Context, item: Dict[str, Any]) -> None:
         state=item.pop("State", None),
     )
     registration_number = item.pop("Registration_number")
+    assert registration_number is not None
 
     # Now create a new Company entity for the agency client
     principal = context.make("LegalEntity")
-    full_address = address.get("full") if address else None
+    full_address_parts = address.get("full") if address else []
+    full_address = full_address_parts[0] if full_address_parts else None
     principal.id = context.make_id("principal", p_name, full_address)
     principal.add("name", p_name)
     principal.add("country", item.pop("Country_location_represented"))

--- a/datasets/us/sam_exclusions/crawler.py
+++ b/datasets/us/sam_exclusions/crawler.py
@@ -35,10 +35,10 @@ def parse_date(date: Optional[str]) -> str | None:
 def clean_address_part(part: Any) -> Optional[str]:
     if part is None:
         return None
-    part = str(part).strip()
-    if len(part) == 0 or part == "-" or part == "XX":
+    cleaned: str = str(part).strip()
+    if len(cleaned) == 0 or cleaned == "-" or cleaned == "XX":
         return None
-    return part
+    return cleaned
 
 
 def read_rows(zip_path: Path) -> Generator[Tuple[str, Dict[str, str]], None, None]:
@@ -57,7 +57,7 @@ def crawl_data_url(context: Context) -> str:
     metadata = context.fetch_json(url)
     objects = metadata.pop("_embedded").pop("customS3ObjectSummaryList")
     for obj in objects:
-        data_url = urljoin(DOWNLOAD_URL, obj["key"])
+        data_url: str = urljoin(DOWNLOAD_URL, obj["key"])
         if data_url.endswith(".ZIP"):
             return data_url
     raise RuntimeError("No ZIP file found")

--- a/datasets/za/fic_sanctions/crawler.py
+++ b/datasets/za/fic_sanctions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict, List
 import re
 
 from zavod import Context
@@ -42,7 +41,8 @@ ADDRESS_SPLITS = [
 ]
 
 
-def clean_passports(context: Context, text: str) -> List[str]:
+def clean_passports(context: Context, text: str) -> tuple[list[str], list[str]]:
+    # Returns (passport_numbers, national_id_numbers)
     values = text.split(", ")
     passports = []
     ids = []
@@ -66,7 +66,7 @@ def clean_passports(context: Context, text: str) -> List[str]:
     return passports, ids
 
 
-def crawl_row(context: Context, data: Dict[str, str]) -> None:
+def crawl_row(context: Context, data: dict[str, str | None]) -> None:
     full_name = data.pop("FullName", None)
     if full_name is not None:
         ent_id = data.pop("IndividualID")
@@ -97,7 +97,8 @@ def crawl_row(context: Context, data: Dict[str, str]) -> None:
             entity.add("alias", alias)
             if any(["?" in a for a in entity.get("alias")]):
                 context.log.warning("Alias contains '?'", alias=alias)
-        passports, ids = clean_passports(context, data.pop("IndividualDocument", ""))
+        individual_document = data.pop("IndividualDocument", None) or ""
+        passports, ids = clean_passports(context, individual_document)
         entity.add("passportNumber", passports)
         entity.add("idNumber", ids)
 
@@ -140,7 +141,7 @@ def crawl(context: Context) -> None:
     for table in tables:
         for row in doc.findall(table):
             data = {}
-            for field in row.getchildren():
+            for field in row:
                 value = field.text
                 if value == "NA":
                     continue


### PR DESCRIPTION
Several crawlers had hand-rolled Excel parsing loops (`worksheet_rows`, `sheet_to_dicts`, etc.) that duplicated what `h.parse_xlsx_sheet` already does. This replaces them all with the standard helper, cleans up a bunch of pre-existing type errors, and removes the now-passing crawlers from the mypy pre-commit exclude list.

- `id_regional_2018` — removed custom `worksheet_rows`, `skiprows=3`
- `us_ddtc_debarred` — removed custom `sheet_to_dicts`; note: re-keys 2 Person entities whose birthDate was previously hashed as `"1967-10-01 00:00:00"` (raw datetime object passed to `make_id`), now correctly `"1967-10-01"`
- `ng_join_dots` — removed custom `worksheet_rows`
- Various other crawlers — pre-existing mypy/type annotation fixes
- `.pre-commit-config.yml` — removed 6 dedicated exclude entries for crawlers that now pass `mypy --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)