### PR TITLE
[peps] Release 12 legislature/parliament datasets

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -34,6 +34,7 @@ children:
   - am_hetq_officials
   - ann_pep_positions
   - ar_parliament
+  - ar_senado
   - at_meine_abgeordneten
   - at_parlament
   - au_act_parliament
@@ -54,6 +55,7 @@ children:
   - bg_jud_declarations
   - bg_parliament
   - br_pep
+  - bz_national_assembly
   - ca_commons
   - ca_foreign_reps
   - ca_senate
@@ -62,6 +64,7 @@ children:
   - cn_peoples_congress_wikipedia
   - co_funcion_publica
   - co_join_dots
+  - cr_legislature
   - cu_inventario_legislatura
   - cy_parliament
   - cz_pep_declarations
@@ -87,6 +90,7 @@ children:
   - gr_parliament
   - hk_legco
   - hk_principal_officials
+  - hn_legislature
   - hr_public_officials
   - hu_national_assembly
   - id_regional_2018
@@ -96,7 +100,9 @@ children:
   - is_althingi
   - it_deputies
   - it_senate
+  - jp_sangiin
   - jp_shugiin
+  - kr_assembly
   - ky_judicial
   - ky_parliament
   - li_landtag
@@ -109,17 +115,20 @@ children:
   - me_skupstina
   - mk_officials
   - mn_parliament
+  - mo_legislature
   - mt_parlament
   - mx_deputies
   - mx_governors
   - mx_senators
   - ng_chipper_peps
   - ng_join_dots
+  - ni_legislature
   - nl_house_of_representatives
   - nl_senate
   - no_brreg
   - no_storting
   - nz_parliament
+  - pa_asamblea
   - ph_house_representatives
   - ph_senate
   - pl_sejm
@@ -136,8 +145,10 @@ children:
   - si_zvezoskop
   - sk_nrsr_poslanci
   - sk_public_officials
+  - sv_legislature
   - th_cabinet
   - tr_parliament
+  - tw_legislature
   - ua_rada
   - un_ga_protocol
   - us_cia_world_leaders
@@ -151,5 +162,6 @@ children:
   - vn_national_assembly
   - wd_categories
   - wd_peps
+  - xk_assembly
   - za_mm_officials
   - za_pmg_legislators

--- a/datasets/ar/senado/ar_senado.yml
+++ b/datasets/ar/senado/ar_senado.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ar-sen
 coverage:
   frequency: monthly
-  start: 2026-06-18
+  start: 2026-06-22
 load_statements: true
 ci_test: false # Live external government source, not available in CI
 summary: >-

--- a/datasets/bz/national_assembly/bz_national_assembly.yml
+++ b/datasets/bz/national_assembly/bz_national_assembly.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: bz-na
 coverage:
   frequency: monthly
-  start: 2026-06-16
+  start: 2026-06-22
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/cr/legislature/cr_legislature.yml
+++ b/datasets/cr/legislature/cr_legislature.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: cr-al
 coverage:
   frequency: monthly
-  start: 2026-06-16
+  start: 2026-06-22
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/hn/legislature/hn_legislature.yml
+++ b/datasets/hn/legislature/hn_legislature.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: hn-cn
 coverage:
   frequency: monthly
-  start: 2026-06-16
+  start: 2026-06-22
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/jp/sangiin/jp_sangiin.yml
+++ b/datasets/jp/sangiin/jp_sangiin.yml
@@ -5,7 +5,7 @@ load_statements: true
 ci_test: false
 coverage:
   frequency: monthly
-  start: 2026-06-15
+  start: 2026-06-22
 summary: >-
   Japanese House of Councillors (Sangiin), the upper house of the National Diet of Japan.
 description: |

--- a/datasets/kr/assembly/kr_assembly.yml
+++ b/datasets/kr/assembly/kr_assembly.yml
@@ -5,7 +5,7 @@ load_statements: true
 ci_test: false
 coverage:
   frequency: monthly
-  start: "2026-06-15"
+  start: "2026-06-22"
 summary: >-
   Current members of the unicameral National Assembly of the Republic of Korea.
 description: |

--- a/datasets/mo/legislature/mo_legislature.yml
+++ b/datasets/mo/legislature/mo_legislature.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: mo-al
 coverage:
   frequency: monthly
-  start: 2026-06-15
+  start: 2026-06-22
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/ni/legislature/ni_legislature.yml
+++ b/datasets/ni/legislature/ni_legislature.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ni-an
 coverage:
   frequency: monthly
-  start: 2026-06-16
+  start: 2026-06-22
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/pa/asamblea/pa_asamblea.yml
+++ b/datasets/pa/asamblea/pa_asamblea.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: pa-asm
 coverage:
   frequency: monthly
-  start: 2026-06-17
+  start: 2026-06-22
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/sv/legislature/sv_legislature.yml
+++ b/datasets/sv/legislature/sv_legislature.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: sv-al
 coverage:
   frequency: monthly
-  start: 2026-06-16
+  start: 2026-06-22
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/tw/legislature/tw_legislature.yml
+++ b/datasets/tw/legislature/tw_legislature.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: tw-ly
 coverage:
   frequency: monthly
-  start: 2026-06-15
+  start: 2026-06-22
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/xk/assembly/xk_assembly.yml
+++ b/datasets/xk/assembly/xk_assembly.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: xk-kuv
 coverage:
   frequency: weekly
-  start: "2026-06-13"
+  start: "2026-06-22"
 load_statements: true
 ci_test: false
 summary: >-


### PR DESCRIPTION
Releases 12 legislature/parliament PEP datasets into the `peps` collection (and thereby `default`):

`ar_senado`, `bz_national_assembly`, `cr_legislature`, `hn_legislature`, `jp_sangiin`, `kr_assembly`, `mo_legislature`, `ni_legislature`, `pa_asamblea`, `sv_legislature`, `tw_legislature`, `xk_assembly`

- Added each to `datasets/_collections/peps.yml` `children:` (alphabetically sorted).
- Bumped each dataset's `coverage.start` to `2026-06-22`.

`python contrib/check_hierarchy.py datasets` confirms none of the 12 remain orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)