### PR TITLE
Reclassifying some old/religious/junior offices as non-PEP etc

### DIFF
--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -373,7 +373,6 @@ lookups:
           - "Q1802914" # Landgerichtsrat
           - "Q2038497" # Q2038497
           - "Q2101555" # Politischer Leiter
-          - "Q2246543" # Ruwaard
           - "Q2276758" # Q2276758
           - "Q2305417" # inspector general
           - "Q2324526" # Garpon
@@ -642,5 +641,6 @@ lookups:
           - "Q116878625" # Appellationsgerichtsrat (abolished at around the time of German unification in the 1800s)
           - "Q117458668" # Oberappellationsgerichtsrat (abolished at around the time of German unification in the 1800s)
           - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
+          - "Q2246543" # Ruwaard (title used in medieval times)
           - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)
           - "Q5928980" # jefe político superior (Spanish office not used after the 1800s)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -221,7 +221,6 @@ lookups:
           - "Q30056203" # ambassador to Qatar
           - "Q30081888" # ambassador to Belarus
           - "Q5663887" # alcaide
-          - "Q5928980" # jefe político superior
           - "Q6857706" # military profession
           - "Q6888512" # moderator
           - "Q7210354" # Political officer
@@ -644,3 +643,4 @@ lookups:
           - "Q117458668" # Oberappellationsgerichtsrat (abolished at around the time of German unification in the 1800s)
           - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
           - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)
+          - "Q5928980" # jefe político superior (Spanish office not used after the 1800s)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -395,7 +395,6 @@ lookups:
           - "Q7886633" # centenier
           - "Q9325187" # Q9325187
           - "Q10312791" #  juiz de direito
-          - "Q10342662" # ouvidor-mor
           - "Q10544194" # Q10544194
           - "Q13142904" # Sechser
           - "Q14173978" # Q14173978
@@ -642,5 +641,6 @@ lookups:
           - "Q16931516" # Muhandiram (colonial-era honour not awarded after 1956)
           - "Q1654355" # Interior Minister of Prussia (Prussia was dissolved after World War II)
           - "Q1555246" # Supreme commanders of the Imperial and Royal Armed Forces (office in Austro-Hungarian Empire)
+          - "Q10342662" # ouvidor-mor (office in colonial-era Brazil)
           - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
           - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -432,7 +432,6 @@ lookups:
           - "Q117458668" # Oberappellationsgerichtsrat
           - "Q118109623" # Q118109623
           - "Q118278814" # président de l'Assemblée commune
-          - "Q120633697" # antiabbot
           - "Q121620135" # Q121620135
           - "Q56669297" # superintendent
           - "Q60832272" # Grand voyer
@@ -450,6 +449,7 @@ lookups:
           - "Q11271" # Benevolent Dictator for Life
           - "Q29182" # bishop
           - "Q212071" # rector
+          - "Q120633697" # antiabbot
           - "Q368620" # Chief Apostle
           - "Q381136" # shareholder
           - "Q383865" # executive sponsor

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -427,6 +427,7 @@ lookups:
           - "Q108466181" # judicial position
           - "Q107363151" # central bank governor
           - "Q5785176" # auditor general
+          - "Q7074545" # Oba of Lagos (traditional monarch, the AML rules in Nigeria cover 'members of royal families')
       - maybe_pep: false
         match:
           - "Q8191099" # affiliate
@@ -459,7 +460,6 @@ lookups:
           - "Q4048723" # SEO specialist
           - "Q4102597" # job vacancy
           - "Q5428874" # faculty member
-          - "Q7074545" # Oba of Lagos
           - "Q7140693" # partner
           - "Q7200276" # placeholder
           - "Q10438271" # office manager

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -187,8 +187,6 @@ lookups:
           - "Q1500391" # chief of municipal
           - "Q1513949" # Returning officer
           - "Q1516453" # lieutenant governor
-          - "Q1555246" # Supreme commanders of the Imperial and Royal Armed Forces
-          - "Q1654355" # Interior Minister of Prussia
           - "Q1758037" # speaker
           - "Q1837955" # Chief Minister of Punjab
           - "Q1890052" # president of the court
@@ -397,14 +395,12 @@ lookups:
           - "Q7886633" # centenier
           - "Q9325187" # Q9325187
           - "Q10312791" #  juiz de direito
-          - "Q10312792" # juiz de fora
           - "Q10342662" # ouvidor-mor
           - "Q10544194" # Q10544194
           - "Q13142904" # Sechser
           - "Q14173978" # Q14173978
           - "Q14418847" # Q14418847
           - "Q15913260" # Q15913260
-          - "Q16931516" # Muhandiram
           - "Q18677341" # Procurator
           - "Q20025378" # Q20025378
           - "Q20169991" # Kreisausschussinspektor
@@ -641,6 +637,10 @@ lookups:
           - "Q15110009" # Ministerial Diary Secretary
           - "Q37110" # Pharaoh (ruler of ancient Egypt)
           - "Q104492321" # copeiro-mor (chief cupbearer, office in the Kingdom of Portugal that has not existed for over 100 years)
+          - "Q10312792" # juiz de fora (magistrate, office in the Kingdom of Portugal that has not existed for over 100 years)
           - "Q81641582" # intendant of the généralité de Valenciennes (position existed before French Revolution)
+          - "Q16931516" # Muhandiram (colonial-era honour not awarded after 1956)
+          - "Q1654355" # Interior Minister of Prussia (Prussia was dissolved after World War II)
+          - "Q1555246" # Supreme commanders of the Imperial and Royal Armed Forces (office in Austro-Hungarian Empire)
           - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
           - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -219,7 +219,6 @@ lookups:
           - "Q5390229" # ambassador of Costa Rica
           - "Q30056203" # ambassador to Qatar
           - "Q30081888" # ambassador to Belarus
-          - "Q5663887" # alcaide
           - "Q6857706" # military profession
           - "Q6888512" # moderator
           - "Q7210354" # Political officer
@@ -295,7 +294,6 @@ lookups:
           - "Q103838820" # elected position
           - "Q103888080" # audit committee member
           - "Q104178983" # municipal judge
-          - "Q104180972" # alcaide-mor
           - "Q105116421" # treasurer
           - "Q106090919" # Deputy Mayor of London for Policing and Crime
           - "Q107419604" # honorary consul of Ireland
@@ -642,5 +640,7 @@ lookups:
           - "Q117458668" # Oberappellationsgerichtsrat (abolished at around the time of German unification in the 1800s)
           - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
           - "Q2246543" # Ruwaard (title used in medieval times)
+          - "Q5663887" # alcaide (captain of a fortress, title used in around 1500s)
+          - "Q104180972" # alcaide-mor (captain of a fortress, title used in around 1500s)
           - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)
           - "Q5928980" # jefe político superior (Spanish office not used after the 1800s)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -157,7 +157,6 @@ lookups:
       - maybe_pep: true
         match:
           - "Q116" # monarch
-          - "Q26718" # Continental Congress
           - "Q30461" # president
           - "Q42841" # incumbent
           - "Q58333" # Police and Crime Commissioner
@@ -642,5 +641,6 @@ lookups:
           - "Q1654355" # Interior Minister of Prussia (Prussia was dissolved after World War II)
           - "Q1555246" # Supreme commanders of the Imperial and Royal Armed Forces (office in Austro-Hungarian Empire)
           - "Q10342662" # ouvidor-mor (office in colonial-era Brazil)
+          - "Q26718" # Continental Congress (body from the 1700s)
           - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
           - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -166,7 +166,6 @@ lookups:
           - "Q294414" # public office
           - "Q303618" # diplomatic rank
           - "Q334473" # division manager
-          - "Q337902" # naval rating
           - "Q524778" # commissioner
           - "Q620110" # Leader of the Opposition
           - "Q740126" # President of the European Parliament
@@ -629,6 +628,7 @@ lookups:
           - "Q1757970" # elder
           - "Q138412833" # Kurdirektor (spa/health resort director)
           - "Q15110009" # Ministerial Diary Secretary
+           - "Q337902" # naval rating (junior naval rank)
           - "Q37110" # Pharaoh (ruler of ancient Egypt)
           - "Q104492321" # copeiro-mor (chief cupbearer, office in the Kingdom of Portugal that has not existed for over 100 years)
           - "Q10312792" # juiz de fora (magistrate, office in the Kingdom of Portugal that has not existed for over 100 years)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -221,6 +221,8 @@ lookups:
           - "Q5123536" # city attorney
           - "Q5124691" # civil servant of the People's Republic of China
           - "Q5390229" # ambassador of Costa Rica
+          - "Q30056203" # ambassador to Qatar
+          - "Q30081888" # ambassador to Belarus
           - "Q5663887" # alcaide
           - "Q5928980" # jefe político superior
           - "Q6857706" # military profession
@@ -490,8 +492,6 @@ lookups:
           - "Q23685787" # working student
           - "Q28689677" # honorary secretary
           - "Q29982545" # function in the Evangelical Church of Czech Brethren
-          - "Q30056203" # ambassador to Qatar
-          - "Q30081888" # ambassador to Belarus
           - "Q30582382" # excavation director
           - "Q30682903" # data protection officer
           - "Q51321989" # Professional engineer

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -427,7 +427,8 @@ lookups:
           - "Q108466181" # judicial position
           - "Q107363151" # central bank governor
           - "Q5785176" # auditor general
-          - "Q7074545" # Oba of Lagos (traditional monarch, the AML rules in Nigeria cover 'members of royal families')
+          - "Q7074545" # Oba of Lagos (traditional monarch, the AML rules in Nigeria cover members of royal families)
+          - "Q3643105" # Rain Queen (traditional monarch, the AML rules in South Africa cover traditional leaders)
       - maybe_pep: false
         match:
           - "Q8191099" # affiliate
@@ -456,7 +457,6 @@ lookups:
           - "Q3149494" # printer to the King
           - "Q3290825" # churchwarden
           - "Q3504856" # substitute
-          - "Q3643105" # Rain Queen
           - "Q4048723" # SEO specialist
           - "Q4102597" # job vacancy
           - "Q5428874" # faculty member

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -416,13 +416,11 @@ lookups:
           - "Q38267249" # Q38267249
           - "Q47529145" # Stationsleiter
           - "Q56500108" # Consejero de Gobierno
-          - "Q81641582" # intendant of the généralité de Valenciennes
           - "Q84418077" # Q84418077
           - "Q98092253" # Q98092253
           - "Q102088897" # President of Vox Asturias
           - "Q104006894" # subprefeito
           - "Q104008340" # 1.º prefeito
-          - "Q104492321" # copeiro-mor
           - "Q104540886" # jurisdição do crime
           - "Q104871400" # Q104871400
           - "Q106581314" # Q106581314
@@ -642,5 +640,7 @@ lookups:
           - "Q138412833" # Kurdirektor (spa/health resort director)
           - "Q15110009" # Ministerial Diary Secretary
           - "Q37110" # Pharaoh (ruler of ancient Egypt)
+          - "Q104492321" # copeiro-mor (chief cupbearer, office in the Kingdom of Portugal that has not existed for over 100 years)
+          - "Q81641582" # intendant of the généralité de Valenciennes (position existed before French Revolution)
           - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
           - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -420,9 +420,7 @@ lookups:
           - "Q106581314" # Q106581314
           - "Q112660316" # Q112660316
           - "Q114850321" # Collector of Customs
-          - "Q116878625" # Appellationsgerichtsrat
           - "Q116908879" # Community Board member
-          - "Q117458668" # Oberappellationsgerichtsrat
           - "Q118109623" # Q118109623
           - "Q118278814" # président de l'Assemblée commune
           - "Q121620135" # Q121620135
@@ -642,5 +640,7 @@ lookups:
           - "Q1555246" # Supreme commanders of the Imperial and Royal Armed Forces (office in Austro-Hungarian Empire)
           - "Q10342662" # ouvidor-mor (office in colonial-era Brazil)
           - "Q26718" # Continental Congress (body from the 1700s)
+          - "Q116878625" # Appellationsgerichtsrat (abolished at around the time of German unification in the 1800s)
+          - "Q117458668" # Oberappellationsgerichtsrat (abolished at around the time of German unification in the 1800s)
           - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
           - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -385,7 +385,6 @@ lookups:
           - "Q3043452" # Délégué interministériel à la sécurité routière
           - "Q3043455" # délégué militaire départemental
           - "Q3043456" # Délégué militaire régional
-          - "Q3401661" # Premier bouteiller de Bretagne
           - "Q3933467" # responsible
           - "Q3969776" # Q3969776
           - "Q4498939" # Hokim
@@ -434,7 +433,6 @@ lookups:
           - "Q118278814" # président de l'Assemblée commune
           - "Q121620135" # Q121620135
           - "Q56669297" # superintendent
-          - "Q60832272" # Grand voyer
           - "Q65238772" # intendant
           - "Q480319" # title of authority
           - "Q135842653" # directeur de cabinet du ministre des Outre-mer
@@ -644,3 +642,5 @@ lookups:
           - "Q138412833" # Kurdirektor (spa/health resort director)
           - "Q15110009" # Ministerial Diary Secretary
           - "Q37110" # Pharaoh (ruler of ancient Egypt)
+          - "Q60832272" # Grand voyer (Quebec title, office abolished in 1840)
+          - "Q3401661" # Premier bouteiller de Bretagne (not used since the 1500s)


### PR DESCRIPTION
== Religious roles that are not PEPs ==

(1) Abbot is a religious office - antiabbot is basically where some people say they are the abbot but others disagree - either way not likely to be a PEP role.

==Historical roles that are not PEPs in modern times ==
(2) Premier bouteiller de Bretagne - this was a Duchy of Brittany office, the Duchy became united with the French Crown in the 1500s and this office ceased to exist.
(3) Grand Voyer is a Quebec title - the office was abolished in 1840.
(4) Copeiro-mor - chief cupbearer, office in the Kingdom of Portugal that has not existed for over 100 years.
(5) Intendant of the généralité de Valenciennes was a position existed before French Revolution.
(6) Supreme commanders of the Imperial and Royal Armed Forces was an office in Austro-Hungarian Empire.
(7) Interior Minister of Prussia - Prussia was dissolved after World War II.
(8) Muhandiram was colonial-era honour not awarded after 1956.
(9) Juiz de fora was an office (similar to magistrate) in the Kingdom of Portugal that has not existed for over 100 years)
(10) Ouvidor-mor was an office in colonial-era Brazil (i.e. pre-1824).
(11) The Continental Congress is body from the 1700s.
(12) Appellationsgerichtsrat and Oberappellationsgerichtsrat were each abolished at around the time of German unification in the 1800s.
(13) Jefe político superior is a Spanish office not used after the 1800s.
(14) Ruwaard was a title used in medieval times.
(15)   Alcaide and alcaide-mor is a title used for the captain of a fortress in around the 1500s - see https://brill.com/display/book/9789004753488/BP000019.xml

== Very junior roles that are not PEPs ==
(16) Naval rating is a junior position often entry-level.

==Roles that are PEPs ==
(17) Reclassified two ambassadors as PEPs in line with FATF definition.
(18) The Oba of Lagos is a traditional monarch. Under section 29 of the regulations that apply in Nigeria, "members of royal families" are classed as PEPs: https://www.stanbicibtcbank.com/static_file/Nigeria/nigeriabank/Personal/Products/Ways%20To%20Bank/Self%20service%20banking/Agency%20Banking/AML%20CIRCULAR%20AND%20REGULATIONS%20MERGED%202022---.pdf
(19) The Rain Queen is a traditional monarch of Balobedu a people of the Limpopo of South Africa. Under the rules set by the main stock exchange in South Africa, 'a member of a royal family or senior traditional leader' is a PEP.
https://resource.capetown.gov.za/documentcentre/Documents/Financial%20documents/JSE_Register%20of_Domestic_Prominent_Influential_Persons.pdf
