### PR TITLE
Rare examples where religious roles result in PEP status

### DIFF
--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -254,6 +254,7 @@ lookups:
           - "Q20801619" # secrétaire général du ministère de la Justice
           - "Q20900278" # Island Administrator
           - "Q20995522" # title of nobility in the United Kingdom
+          - "Q19808790" # Episcopal Co-Prince (one of two joint heads of state of Andorra)
           - "Q21028311" # White House Cabinet Secretary
           - "Q23307026" # Shadow minister
           - "Q23541196" # Queen mothers in Africa

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -444,7 +444,10 @@ lookups:
           - "Q108466181" # judicial position
           - "Q107363151" # central bank governor
           - "Q5785176" # auditor general
-          - "Q19816651" # Order of Cardinals (members of the College of Cardinals are recognised by Holy See as being PEPs)
+          - "Q45722" # cardinal (members of the College of Cardinals are recognised by the Holy See as being PEPs)
+          - "Q1729113" # cardinal-bishop (members of the College of Cardinals are recognised by the Holy See as being PEPs)
+          - "Q2033341" # cardinal priest (members of the College of Cardinals are recognised by the Holy See as being PEPs)
+          - "Q2361374" # cardinal-deacon (members of the College of Cardinals are recognised by the Holy See as being PEPs)
       - maybe_pep: false
         match:
           - "Q8191099" # affiliate

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -443,6 +443,7 @@ lookups:
           - "Q108466181" # judicial position
           - "Q107363151" # central bank governor
           - "Q5785176" # auditor general
+          - "Q19816651" # Order of Cardinals (members of the College of Cardinals are recognised by Holy See as being PEPs)
       - maybe_pep: false
         match:
           - "Q8191099" # affiliate
@@ -487,7 +488,6 @@ lookups:
           - "Q15140392" # founding member
           - "Q15143900" # United Nations Special Rapporteur
           - "Q15726407" # President of the World Esperanto Youth Organization
-          - "Q19816651" # Order of Cardinals
           - "Q21114371" # episcopal title
           - "Q23685787" # working student
           - "Q28689677" # honorary secretary


### PR DESCRIPTION
(1) Holders of religious offices are not normally regarded as PEPs as a result of holding those positions in this case however the Vatican recognises that Members of the College of Cardinals are PEPs of the Holy See.

https://www.asif.va/ENG/pdf/Regolamenti/EN-Instruction_no.5_Annex.pdf

(2) Andorra has two joint heads of state known as "Co-princes" - both are PEPs. One is the President of France, the other is the Episcopal Co-Prince (the Bishop of Urgel).

https://en.wikipedia.org/wiki/Co-princes_of_Andorra