### PR TITLE
Bundle small crawler bug fixes (lt_seimas, kr_assembly)

### DIFF
--- a/datasets/kr/assembly/kr_assembly.yml
+++ b/datasets/kr/assembly/kr_assembly.yml
@@ -33,12 +33,14 @@ data:
   lang: kor
 http:
   # The member search is fetched via POST, which urllib3 excludes from retries by
-  # default. The endpoint is slow and the source zone has a flaky authoritative DNS
-  # setup (several dead/bogus nameservers), causing intermittent resolution failures.
-  # The crawl makes a single request, so retries are cheap: allow POST to be retried
-  # and raise the count so one attempt lands on a live nameserver and primes the cache.
+  # default. The source zone has a flaky authoritative DNS setup (several dead/bogus
+  # nameservers), causing intermittent resolution failures that can persist for longer
+  # than the default ~15s retry window, so all retries fail together. The crawl makes a
+  # single request, so retries are cheap: allow POST to be retried and widen the backoff
+  # so the retries span several minutes, giving resolution time to recover.
   retry_methods: [GET, POST]
-  total_retries: 5
+  total_retries: 8
+  backoff_factor: 5
 tags:
   - list.pep
 

--- a/datasets/lt/seimas/crawler.py
+++ b/datasets/lt/seimas/crawler.py
@@ -185,7 +185,7 @@ def crawl_old_member_bio(context: Context, url: str) -> None:
         lang="eng",
     )
 
-    categorisation = categorise(context, position, is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
 


### PR DESCRIPTION
Bundles two small, independent crawler fixes.

### `[lt_seimas]` Drop obsolete `is_pep` arg to `categorise()`
The `categorise()` keyword was renamed to `default_is_pep` and now defaults to `True`. The crawler still passed `is_pep=True`, raising a `TypeError` and failing the crawl. Since `True` is already the default, the argument is simply dropped.

### `[kr_assembly]` Widen DNS retry window
The source's authoritative DNS has several dead/bogus nameservers, causing intermittent resolution failures that can persist longer than the default ~15s retry window — so all retries failed together and the crawl errored with a `ConnectionError` ("Temporary failure in name resolution").

This raises `total_retries` to 8 and `backoff_factor` to 5, spreading the retries across ~6.5 min so a fresh resolution attempt is likely to land during a good window.

This is a **stopgap**. The proper fix is a pod `dnsConfig` pointing at reliable resolvers (Quad9/Cloudflare) on the crawl runner, tracked separately in the operations repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)