### PR TITLE
Crawler bug fixes: lt_seimas data quality, kr_assembly DNS via Zyte

### DIFF
--- a/datasets/kr/assembly/crawler.py
+++ b/datasets/kr/assembly/crawler.py
@@ -1,7 +1,9 @@
+import json
 from typing import Any
 
 from zavod import Context, Entity
 from zavod import helpers as h
+from zavod.extract import zyte_api
 from zavod.stateful.positions import PositionCategorisation, categorise
 
 
@@ -68,14 +70,21 @@ def crawl(context: Context) -> None:
     categorisation = categorise(context, position)
     context.emit(position)
 
+    # The source has a flaky authoritative DNS setup that the crawl host's resolver
+    # intermittently fails to resolve (and negatively caches the failure, so retries
+    # don't help). Fetch via Zyte, which resolves the host on its own infrastructure.
     # The endpoint caps the page size silently; request all seats in one call and assert
     # the returned count matches the reported total.
-    data = context.fetch_json(
+    _, _, _, path = zyte_api.fetch_resource(
+        context,
+        "members.json",
         context.data_url,
         method="POST",
-        data={"page": "1", "rows": 500},
-        cache_days=1,
+        body=b"page=1&rows=500",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
     rows = data["data"]
     # Fail loudly if the single-request assumption breaks (paging silently re-introduced,
     # or the seat count grows past ROWS and the response is truncated).

--- a/datasets/kr/assembly/kr_assembly.yml
+++ b/datasets/kr/assembly/kr_assembly.yml
@@ -31,16 +31,6 @@ data:
   url: https://open.assembly.go.kr/portal/assm/search/searchAssmMemberSch.do
   format: JSON
   lang: kor
-http:
-  # The member search is fetched via POST, which urllib3 excludes from retries by
-  # default. The source zone has a flaky authoritative DNS setup (several dead/bogus
-  # nameservers), causing intermittent resolution failures that can persist for longer
-  # than the default ~15s retry window, so all retries fail together. The crawl makes a
-  # single request, so retries are cheap: allow POST to be retried and widen the backoff
-  # so the retries span several minutes, giving resolution time to recover.
-  retry_methods: [GET, POST]
-  total_retries: 8
-  backoff_factor: 5
 tags:
   - list.pep
 

--- a/datasets/lt/seimas/crawler.py
+++ b/datasets/lt/seimas/crawler.py
@@ -137,32 +137,28 @@ def crawl_old_member_bio(context: Context, url: str) -> None:
     )  # TODO: more robust name fetch method
     assert person_name is not None
 
-    date_of_birth = None
-    place_of_birth = None
-
-    try:
-        date_of_birth = h.xpath_string(
-            doc,
-            '//div[@class="par"][contains(text(),"Biography")]/following-sibling::div[@align="justify"][1]//table//tr[1]/td[last()]/p[1]/text()',
-        )
-
-        place_of_birth_xpaths = [
+    # Birth details are missing or differently structured on many older member
+    # pages, so extract them leniently and emit the member even when absent.
+    date_of_birth = xpath_match(
+        doc,
+        [
+            '//div[@class="par"][contains(text(),"Biography")]/following-sibling::div[@align="justify"][1]//table//tr[1]/td[last()]/p[1]/text()'
+        ],
+    )
+    place_of_birth = xpath_match(
+        doc,
+        [
             '//div[@class="par"][contains(text(),"Biography")]/following-sibling::div[@align="justify"][1]//table//tr[1]/td[last()]/p[1]//strong',
             '//div[@class="par"][contains(text(),"Biography")]/following-sibling::div[@align="justify"][1]//table//tr[1]/td[last()]/p[1]',
-        ]
-        place_of_birth = xpath_match(doc, place_of_birth_xpaths)
-
-    except ValueError:
-        context.log.warning(
-            "Could not extract birth details for old member", url=url, name=person_name
-        )
-        return None
+        ],
+    )
 
     person = context.make("Person")
     person.id = context.make_slug(person_name)
     person.add("name", person_name)
     person.add("birthPlace", place_of_birth)
-    h.apply_date(person, "birthDate", date_of_birth)
+    if date_of_birth is not None:
+        h.apply_date(person, "birthDate", date_of_birth)
 
     party_affiliation = h.xpath_strings(
         doc,

--- a/datasets/lt/seimas/lt_seimas.yml
+++ b/datasets/lt/seimas/lt_seimas.yml
@@ -42,6 +42,17 @@ data:
 
 dates:
   formats: ["%d %B %Y"]
+
+lookups:
+  # Source DOB strings carry formatting noise the date parser rejects:
+  # a missing space ("3 May1958") and a trailing period ("19 August 1951.").
+  type.date:
+    options:
+      - match: "3 May1958"
+        value: "1958-05-03"
+      - match: "19 August 1951."
+        value: "1951-08-19"
+
 assertions:
   min:
     schema_entities:

--- a/zavod/zavod/extract/zyte_api.py
+++ b/zavod/zavod/extract/zyte_api.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from lxml import html, etree
+from normality import predict_encoding
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
@@ -283,7 +284,12 @@ def fetch(
     )
     if zyte_request.scrape_type == ZyteScrapeType.HTTP_RESPONSE_BODY:
         b64_text = b64decode(text)
-        text = b64_text.decode(charset) if charset is not None else b64_text.decode()
+        # The Content-Type header often omits the charset, leaving the encoding
+        # declared only in an HTML <meta> tag (e.g. legacy windows-1257 pages).
+        # Assuming UTF-8 then raises on the first non-ASCII byte, so detect the
+        # encoding from the bytes when the header doesn't state it.
+        encoding = charset if charset is not None else predict_encoding(b64_text)
+        text = b64_text.decode(encoding)
 
     cookies = (
         api_response.json().get("responseCookies")

--- a/zavod/zavod/tests/extract/test_zyte_api.py
+++ b/zavod/zavod/tests/extract/test_zyte_api.py
@@ -84,6 +84,36 @@ def test_fetch_html_http_response_body(testdataset1: Dataset):
     context.close()
 
 
+def test_fetch_html_detects_missing_charset(testdataset1: Dataset):
+    context = Context(testdataset1)
+
+    # Legacy pages declare their encoding only in a <meta> tag, not the HTTP
+    # Content-Type header. Byte 0xf0 ('š' in windows-1257) is invalid UTF-8, so
+    # assuming UTF-8 would crash; the encoding must be detected from the bytes.
+    name = "Žemaitaitis Čmilytė Šiauliuose gegužės mėnesį Tėvynės sąjunga"
+    page = (
+        '<html><head><meta http-equiv="Content-Type" '
+        'content="text/html; charset=windows-1257"></head>'
+        f"<body><h1>{name}</h1></body></html>"
+    )
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://api.zyte.com/v1/extract",
+            json={
+                "httpResponseBody": b64encode(page.encode("windows-1257")).decode(),
+                # No charset in the header, only in the page's <meta> tag.
+                "httpResponseHeaders": [{"name": "content-type", "value": "text/html"}],
+                "statusCode": 200,
+            },
+        )
+        doc = fetch_html(
+            context, "https://test.com/bla", ".//h1", html_source="httpResponseBody"
+        )
+        assert doc.find(".//h1").text == name
+
+    context.close()
+
+
 def test_unblock_failed(testdataset1: Dataset):
     context = Context(testdataset1)
 


### PR DESCRIPTION
Second bundle of small crawler fixes, on top of #4645 (merged). Three independent changes.

### `[zavod]` Detect body encoding when Zyte response lacks a charset
`zyte_api.fetch()` decoded the response body as UTF-8 whenever the `Content-Type` header carried no charset, crashing on pages whose encoding is declared only in an HTML `<meta>` tag (e.g. legacy windows-1257 pages). It now detects the encoding from the bytes via `normality.predict_encoding`. Covered by a new unit test.

This is what unblocked the `lt_seimas` crawl, which was aborting with `UnicodeDecodeError` on the older legislature pages.

> Note: `predict_encoding` is statistical; it resolves the real pages correctly (`cp1257`). A strictly-deterministic alternative would be letting lxml parse the raw bytes (it reads the `<meta charset>` directly) — happy to switch if preferred.

### `[lt_seimas]` Tolerate missing birth details; clean two DOB strings
`crawl_old_member_bio` dropped the entire member (33 of them) whenever the date-of-birth XPath missed. It now extracts birth details leniently and emits the member regardless. Added a `type.date` lookup for two source DOB strings the parser rejected (a missing space `"3 May1958"` and a trailing dot `"19 August 1951."`).

### `[kr_assembly]` Fetch via Zyte to bypass flaky source DNS
The source's authoritative DNS intermittently fails to resolve and the failure is negatively cached, so in-process retries — even widened over ~6.5 min in #4645 — all hit the cached failure and the crawl errors with `NameResolutionError`. Switched the fetch to Zyte, which resolves the host on its own infrastructure. Dropped the now-obsolete `http` retry block.

**Validation caveat:** `kr_assembly` is `ci_test: false` (Zyte needs a key CI lacks), so this can only be verified on the next production run. The proper long-term fix remains a pod `dnsConfig` pointing at reliable resolvers in the operations repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
