### PR TITLE
[ph_gppb_debarred] Release into debarment

### DIFF
--- a/datasets/_collections/debarment.yml
+++ b/datasets/_collections/debarment.yml
@@ -26,6 +26,7 @@ children:
   - iadb_sanctions
   - li_entsg
   - md_interdictie
+  - ph_gppb_debarred
   - ps_ohchr_settlement
   - si_conflicts
   - us_ak_med_exclusions

--- a/datasets/_collections/debarment.yml
+++ b/datasets/_collections/debarment.yml
@@ -31,16 +31,16 @@ children:
   - si_conflicts
   - us_ak_med_exclusions
   - us_al_med_exclusions
-  - us_az_med_exclusions
   - us_ar_med_exclusions
+  - us_az_med_exclusions
   - us_ca_med_exclusions
   - us_co_med_exclusions
-  - us_ddtc_debarred
   - us_dc_exclusions
+  - us_ddtc_debarred
   - us_de_med_exclusions
   - us_dod_chinese_milcorps
-  - us_fda_restricted
   - us_fcc_covered_list
+  - us_fda_restricted
   - us_ga_med_exclusions
   - us_hhs_exclusions
   - us_hi_med_exclusions

--- a/datasets/ph/gppb_debarred/ph_gppb_debarred.yml
+++ b/datasets/ph/gppb_debarred/ph_gppb_debarred.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ph-gppb
 coverage:
   frequency: daily
-  start: 2026-06-03
+  start: 2026-06-22
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/ph/gppb_debarred/ph_gppb_debarred.yml
+++ b/datasets/ph/gppb_debarred/ph_gppb_debarred.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ph-gppb
 coverage:
   frequency: daily
-  start: 2026-06-22
+  start: 2026-06-25
 load_statements: true
 ci_test: true
 summary: >-


### PR DESCRIPTION
Release the Philippines GPPB Consolidated Blacklisting Report crawler into the product.

- **[ph_gppb_debarred]** Added to the `debarment` collection's `children:` (it emits `Organization` entities debarred from Philippine government procurement; tagged `list.debarment`). Bumped `coverage.start` to the release date.
- **[debarment]** Sorted the collection's `children:` list alphabetically — it had three pre-existing out-of-order `us_*` entries.

Verified with `python contrib/check_hierarchy.py datasets` (no longer flagged as having no collection) and a sort/dupe check on the children list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)