### PR TITLE
[md_companies] Fix nonprofits sheet rename and dataset URL

### DIFF
--- a/datasets/md/companies/md_companies.yml
+++ b/datasets/md/companies/md_companies.yml
@@ -21,11 +21,11 @@ summary: >-
 description: |
   This dataset combines two distinct official registers from the Republic of Moldova:
 
-  - **State Register of Legal Entities**: Covers commercial companies, providing information 
+  - **State Register of Legal Entities**: Covers commercial companies, providing information
     on founders, beneficial owners, and directors.
-  
-  - **State Register of Non-Profit Organizations**: Includes associations, foundations, 
-    and other nonprofit entities, with data on tax identification numbers, legal form, 
+
+  - **State Register of Non-Profit Organizations**: Includes associations, foundations,
+    and other nonprofit entities, with data on tax identification numbers, legal form,
     registration and liquidation dates, and directors.
 url: https://dataset.gov.md/ro/dataset/11736-date-din-registrul-de-stat-al-unitatilor-de-drept-privind-intreprinderile-inregistrate-in-repu
 publisher:
@@ -33,9 +33,9 @@ publisher:
   name_en: Public Services Agency
   acronym: ASP
   descrition: |
-    The Public Services Agency (ASP) is a government institution responsible for 
-    implementing public policies in areas such as information technology, state 
-    registration, and business licensing. It manages core national registers, including 
+    The Public Services Agency (ASP) is a government institution responsible for
+    implementing public policies in areas such as information technology, state
+    registration, and business licensing. It manages core national registers, including
     those for legal entities, non-profit organizations, and vehicles.
   country: md
   url: https://www.asp.gov.md/en
@@ -43,7 +43,7 @@ publisher:
 data:
   # Legal entities
   url: "https://dataset.gov.md/ro/dataset/11736-date-din-registrul-de-stat-al-unitatilor-de-drept-privind-intreprinderile-inregistrate-in-repu"
-  lang: ron 
+  lang: ron
 dates:
   formats: ["%d.%m.%Y"]
 
@@ -118,3 +118,7 @@ lookups:
           - G.T."TURCAN F.P."
           - "IONAS NICOLAI ION"
           - "PAVALACHE DOMENTI FEODOSEI"
+  type.address:
+    options:
+      - match: "0"
+        value: null

--- a/datasets/md/companies/parse.py
+++ b/datasets/md/companies/parse.py
@@ -19,7 +19,7 @@ IGNORE_COLUMNS = [
     "Genuri de activitate nelicentiate",
     "Genuri de activitate licentiate",
 ]
-NONPROFITS_URL = "https://dataset.gov.md/dataset/18516-date-din-registrul-de-stat-al-unitatilor-de-drept-privind-organizatiile-necomerciale"
+NONPROFITS_URL = "https://dataset.gov.md/dataset/date-din-registrul-de-stat-al-unitatilor-de-drept-privind-organizatiile-necomerciale"
 LEGAL_ENTITIES_URL = "https://dataset.gov.md/ro/dataset/11736-date-din-registrul-de-stat-al-unitatilor-de-drept-privind-intreprinderile-inregistrate-in-repu"
 REGEX_CONTAINS_WORDS = re.compile(r"\w{2}")
 
@@ -191,7 +191,7 @@ def parse_nonprofits(context: Context, wb: Workbook) -> None:
     assert set(wb.sheetnames) == {active_sheet.title}
     for row in h.parse_xlsx_sheet(
         context,
-        wb["organizations"],
+        wb["O.N."],
         skiprows=4,
         header_lookup=context.get_lookup("nonprofit_headers"),
     ):


### PR DESCRIPTION
Fixes https://github.com/opensanctions/opensanctions/issues/4403.

The source changed the shape of its data again:

- The nonprofits sheet was renamed from `organizations` to `O.N.`, which was causing the `Worksheet organizations does not exist.` runner failure.
- The nonprofits dataset URL dropped its numeric ID prefix (`18516-date-din-...` → `date-din-...`).
- Added a `type.address` lookup to drop bogus `"0"` address values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)