### PR TITLE
[ui] Add subnational_areas to position table schema

### DIFF
--- a/ui/lib/db.ts
+++ b/ui/lib/db.ts
@@ -39,6 +39,7 @@ const expectedPositionColumns = new Set<string>([
   'entity_id',
   'caption',
   'countries',
+  'subnational_areas',
   'is_pep',
   'topics',
   'dataset',
@@ -82,6 +83,7 @@ export interface PositionTable {
   entity_id: string
   caption: string
   countries: JSONColumnType<string[], string[], string[]>
+  subnational_areas: JSONColumnType<string[], string[], string[]> | null
   is_pep: boolean | null
   topics: JSONColumnType<string[], string[], string[]>
   dataset: string
@@ -510,6 +512,7 @@ export async function softDeleteAndCreatePosition({ entityId, positionUpdate, mo
         // NOTE(Leon Handreke): I don't know how else to make it work than to stringify
         // the lists manually.
         countries: JSON.stringify(updatedData.countries) as unknown as string[],
+        subnational_areas: JSON.stringify(updatedData.subnational_areas ?? []) as unknown as string[],
         topics: JSON.stringify(updatedData.topics) as unknown as string[],
       })
       .returningAll()


### PR DESCRIPTION
## Summary

Mirrors the new column added in https://github.com/opensanctions/opensanctions/pull/4585. The UI's startup schema check (`checkTableSchema` in `lib/db.ts`) throws on unexpected columns, so the UI has to learn about `subnational_areas` as soon as the column lands in the database.

Also threads it through `softDeleteAndCreatePosition`'s manual JSON stringify trick alongside `countries`/`topics`.

## Rollout

Land in this order:
1. `ALTER TABLE position ADD COLUMN subnational_areas JSON` on the prod DB
2. Merge https://github.com/opensanctions/opensanctions/pull/4585 (backend writes the column)
3. Merge this PR (UI accepts the column)

Steps 2 and 3 can happen back-to-back once the column exists; doing either without the other will break the corresponding side.

This is just the schema bookkeeping — actually surfacing subnationalArea in the classification table UI (https://github.com/opensanctions/opensanctions/issues/3843) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)