### PR TITLE
[statements] truth maintenance

### DIFF
--- a/contrib/dead_statements.py
+++ b/contrib/dead_statements.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+from typing import Any
+
+import click
+import requests
+from sqlalchemy import delete, func, select
+
+from zavod.db import get_engine
+from zavod.stateful.model import statement_table
+
+CATALOG_URL = "https://data.opensanctions.org/datasets/latest/default/catalog.json"
+
+
+def fetch_default_datasets() -> set[str]:
+    """Fetch the dataset names included in the published default collection."""
+    response = requests.get(CATALOG_URL, timeout=120)
+    response.raise_for_status()
+    catalog: dict[str, Any] = response.json()
+    return {
+        dataset["name"]
+        for dataset in catalog.get("datasets", [])
+        if isinstance(dataset.get("name"), str)
+    }
+
+
+def find_dead_datasets(default_datasets: set[str]) -> list[tuple[str, int]]:
+    """Find stored statements belonging to datasets outside the default collection."""
+    query = (
+        select(statement_table.c.dataset, func.count())
+        .where(statement_table.c.dataset.not_in(default_datasets))
+        .group_by(statement_table.c.dataset)
+        .order_by(func.count().desc())
+    )
+    with get_engine().connect() as conn:
+        return [(dataset, count) for dataset, count in conn.execute(query)]
+
+
+def delete_dataset(dataset: str) -> int:
+    """Delete all statements belonging to one confirmed obsolete dataset."""
+    query = delete(statement_table).where(statement_table.c.dataset == dataset)
+    with get_engine().begin() as conn:
+        result = conn.execute(query)
+        return result.rowcount
+
+
+@click.command()
+def main() -> None:
+    """Offer to delete statements absent from the published default collection."""
+    default_datasets = fetch_default_datasets()
+    dead_datasets = find_dead_datasets(default_datasets)
+    if not dead_datasets:
+        click.echo("No dead statement datasets found.")
+        return
+
+    click.echo(f"Found {len(dead_datasets)} dead statement datasets:")
+    for dataset, count in dead_datasets:
+        click.echo(f"{count:>12,}  {dataset}")
+
+    for dataset, count in dead_datasets:
+        if click.confirm(f"Delete {count:,} statements for {dataset!r}?"):
+            deleted = delete_dataset(dataset)
+            click.echo(f"Deleted {deleted:,} statements for {dataset!r}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -63,6 +63,7 @@ from followthemoney import registry
 
 from zavod import Context, Entity
 from zavod.meta import get_multi_dataset
+from zavod.constants import ORIGIN_INFERRED
 from zavod.store import get_store, View
 from zavod.integration import get_dataset_linker
 
@@ -94,7 +95,7 @@ def emit_patch(
         schema = related_entity.schema.name
     patch = context.make(schema)
     patch.id = related_entity.id
-    patch.add("topics", topic)
+    patch.add("topics", topic, origin=ORIGIN_INFERRED)
     context.emit(patch, external=related_entity.external)
 
 
@@ -119,6 +120,7 @@ def analyze_entity(context: Context, view: View, entity: Entity) -> None:
 
         # Tag role.rca for family relations of PEPs
         if "role.pep" in topics and adjacent.schema.is_a("Family"):
+            assert other_prop is not None
             for other_id in adjacent.get(other_prop):
                 other = view.get_entity(other_id)
                 if other is None or not other.schema.is_a("Person"):
@@ -149,6 +151,7 @@ def analyze_entity(context: Context, view: View, entity: Entity) -> None:
                 "Succession",
             ):
                 continue
+            assert other_prop is not None
             for other_id in adjacent.get(other_prop):
                 other = view.get_entity(other_id)
                 if other is None:
@@ -166,8 +169,10 @@ def analyze_entity(context: Context, view: View, entity: Entity) -> None:
         if (
             "sanction.linked" in topics
             and adjacent.schema.is_a("Ownership")
+            and prop.reverse is not None
             and prop.reverse.name == "owner"
         ):
+            assert other_prop is not None
             for other_id in adjacent.get(other_prop):
                 other = view.get_entity(other_id)
                 if other is None:

--- a/datasets/_analysis/ann_pep_positions/analyzer.py
+++ b/datasets/_analysis/ann_pep_positions/analyzer.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import Dict, Set, Optional
 
 from zavod import Context, Entity
+from zavod.constants import ORIGIN_INFERRED
 from zavod.integration import get_dataset_linker
 from zavod.meta import get_multi_dataset
 from zavod.stateful.positions import OccupancyStatus, categorise_many
@@ -99,7 +100,7 @@ def analyze_position(context: Context, entity: Entity) -> Set[str]:
         proxy = context.make("Position")
         proxy.id = entity.id
         # emit the topics for each referent under that ID
-        proxy.add("topics", categorisation.topics)
+        proxy.add("topics", categorisation.topics, origin=ORIGIN_INFERRED)
         if proxy.get("topics"):
             context.emit(proxy)
 
@@ -161,5 +162,5 @@ def crawl(context: Context) -> None:
             continue
         person_proxy = context.make("Person")
         person_proxy.id = entity.id
-        person_proxy.add("classification", influence_labels)
+        person_proxy.add("classification", influence_labels, origin=ORIGIN_INFERRED)
         context.emit(person_proxy)


### PR DESCRIPTION
## Summary

- add an interactive tool to identify and delete statement rows for datasets no longer published in the `default` collection
- mark graph-topic, position-topic, and PEP classification annotations as inferred
- guard optional reverse properties while traversing analysis graph edges

## Checks

- repository pre-commit hooks
- `pytest datasets/_analysis/ann_pep_positions/test_analyzer.py -q`