### PR TITLE
[py_congreso] Add Paraguay National Congress PEP crawler (merges #4614 + #4615)

### DIFF
--- a/datasets/py/congreso/crawler.py
+++ b/datasets/py/congreso/crawler.py
@@ -1,5 +1,4 @@
 from typing import Any
-from enum import Enum
 
 from zavod import Context, helpers as h
 from zavod.stateful.positions import categorise
@@ -7,22 +6,17 @@ from zavod.stateful.positions import categorise
 
 POSITION_TOPICS = ["gov.national", "gov.legislative"]
 
-
-class Chamber(Enum):
-    DEPUTIES = ("Member of the Chamber of Deputies of Paraguay", "Q20058561")
-    SENATORS = ("Member of the Chamber of Senators of Paraguay", "Q20058559")
-
-    def __init__(self, position_name: str, wikidata_id: str) -> None:
-        self.position_name = position_name
-        self.wikidata_id = wikidata_id
-
-    @classmethod
-    def from_source(cls, value: str) -> "Chamber":
-        if "DIPUTADOS" in value:
-            return cls.DEPUTIES
-        if "SENADORES" in value:
-            return cls.SENATORS
-        raise ValueError(f"Unexpected chamber value: {value!r}")
+# Maps the source's camaraParlamentario value to (position name, Wikidata QID).
+CHAMBERS = {
+    "CAMARA DE DIPUTADOS": (
+        "Member of the Chamber of Deputies of Paraguay",
+        "Q20058561",
+    ),
+    "CAMARA DE SENADORES": (
+        "Member of the Chamber of Senators of Paraguay",
+        "Q20058559",
+    ),
+}
 
 
 def crawl_member(
@@ -35,13 +29,16 @@ def crawl_member(
     if period_start < h.earliest_term_start(POSITION_TOPICS):
         return
 
-    chamber = Chamber.from_source(row.pop("camaraParlamentario"))
+    camara = row.pop("camaraParlamentario")
+    if camara not in CHAMBERS:
+        raise ValueError(f"Unexpected chamber value: {camara!r}")
+    position_name, wikidata_id = CHAMBERS[camara]
     position = h.make_position(
         context,
-        name=chamber.position_name,
+        name=position_name,
         country="py",
         topics=POSITION_TOPICS,
-        wikidata_id=chamber.wikidata_id,
+        wikidata_id=wikidata_id,
         lang="eng",
     )
     categorisation = categorise(context, position)

--- a/datasets/py/congreso/crawler.py
+++ b/datasets/py/congreso/crawler.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The current legislative term. The open-data endpoints are stable across terms, so we
+# assert the period on every record to fail loudly when the next term lands (and the
+# source starts returning 2028-2033 members).
+EXPECTED_PERIOD = "2023-2028"
+
+IGNORE_FIELDS = [
+    "camaraParlamentario",  # constant per chamber ("CAMARA DE DIPUTADOS"/"DE SENADORES")
+    "telefonoParlamentario",  # private contact detail
+    "fotoURL",
+    "tipoParlamentario",  # titular vs seated suplente — both emitted
+    "cargoBancada",  # role within the parliamentary bloc
+]
+
+
+def crawl_member(
+    context: Context,
+    row: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    period = row.pop("periodoLegislativo")
+    if period != EXPECTED_PERIOD:
+        raise ValueError(f"Unexpected legislative period: {period!r}")
+    # The legislative term bounds (e.g. "2023-2028"); recorded as the occupancy's legal
+    # period. The source has no individual start/end date for seated suplentes.
+    period_start, period_end = period.split("-")
+
+    # The endpoint returns one record per seat — the member currently occupying it.
+    # tipoParlamentario flags whether that occupant is the elected titular or a suplente
+    # who has taken over a vacated seat; both are sitting members, so we emit either.
+    # (We don't filter to TITULAR, which would drop seated replacements.)
+    person = context.make("Person")
+    person.id = context.make_slug(str(row.pop("idParlamentario")))
+    h.apply_name(person, first_name=row.pop("nombres"), last_name=row.pop("apellidos"))
+    # Members of Congress must hold natural Paraguayan nationality; naturalised citizens
+    # are not eligible (Constitution of Paraguay, Art. 221 for deputies, Art. 223 for
+    # senators). https://www.constituteproject.org/constitution/Paraguay_2011?lang=es
+    person.add("citizenship", "py")
+    person.add("political", row.pop("partidoPolitico"))
+    person.add("email", row.pop("emailParlamentario"))
+    person.add("sourceUrl", row.pop("appURL"))
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        period_start=period_start,
+        period_end=period_end,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    # Deputies are elected by department (plus the Capital District, Asunción); senators
+    # from a single nationwide constituency (departamento "NACIONAL").
+    occupancy.add("constituency", row.pop("departamento"))
+    # The parliamentary bloc (bancada) is distinct from party membership.
+    occupancy.add("politicalGroup", row.pop("bancada"))
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(row, ignore=IGNORE_FIELDS)
+
+
+def crawl_chamber(
+    context: Context, path: str, position_name: str, wikidata_id: str
+) -> None:
+    members = context.fetch_json(context.data_url + path)
+    if not isinstance(members, list) or len(members) == 0:
+        raise ValueError(f"Expected a non-empty list of members from {path!r}")
+
+    position = h.make_position(
+        context,
+        name=position_name,
+        country="py",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id=wikidata_id,
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    for row in members:
+        crawl_member(context, row, position, categorisation)
+
+
+def crawl(context: Context) -> None:
+    # Both chambers come from the same Congress open-data API; data_url is the
+    # `.../camara/` base. limit=200 is required for the 80-seat Chamber of Deputies
+    # (the default page size of 50 would truncate it) and harmless for the Senate.
+    crawl_chamber(
+        context,
+        "S?limit=200",
+        "Member of the Chamber of Senators of Paraguay",
+        "Q20058559",
+    )
+    crawl_chamber(
+        context,
+        "D?limit=200",
+        "Member of the Chamber of Deputies of Paraguay",
+        "Q20058561",
+    )

--- a/datasets/py/congreso/crawler.py
+++ b/datasets/py/congreso/crawler.py
@@ -1,41 +1,51 @@
 from typing import Any
+from enum import Enum
 
-from zavod import Context
-from zavod import helpers as h
-from zavod.entity import Entity
-from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod import Context, helpers as h
+from zavod.stateful.positions import categorise
 
-# The current legislative term. The open-data endpoints are stable across terms, so we
-# assert the period on every record to fail loudly when the next term lands (and the
-# source starts returning 2028-2033 members).
-EXPECTED_PERIOD = "2023-2028"
 
-IGNORE_FIELDS = [
-    "camaraParlamentario",  # constant per chamber ("CAMARA DE DIPUTADOS"/"DE SENADORES")
-    "telefonoParlamentario",  # private contact detail
-    "fotoURL",
-    "tipoParlamentario",  # titular vs seated suplente — both emitted
-    "cargoBancada",  # role within the parliamentary bloc
-]
+POSITION_TOPICS = ["gov.national", "gov.legislative"]
+
+
+class Chamber(Enum):
+    DEPUTIES = ("Member of the Chamber of Deputies of Paraguay", "Q20058561")
+    SENATORS = ("Member of the Chamber of Senators of Paraguay", "Q20058559")
+
+    def __init__(self, position_name: str, wikidata_id: str) -> None:
+        self.position_name = position_name
+        self.wikidata_id = wikidata_id
+
+    @classmethod
+    def from_source(cls, value: str) -> "Chamber":
+        if "DIPUTADOS" in value:
+            return cls.DEPUTIES
+        if "SENADORES" in value:
+            return cls.SENATORS
+        raise ValueError(f"Unexpected chamber value: {value!r}")
 
 
 def crawl_member(
     context: Context,
     row: dict[str, Any],
-    position: Entity,
-    categorisation: PositionCategorisation,
 ) -> None:
     period = row.pop("periodoLegislativo")
-    if period != EXPECTED_PERIOD:
-        raise ValueError(f"Unexpected legislative period: {period!r}")
-    # The legislative term bounds (e.g. "2023-2028"); recorded as the occupancy's legal
-    # period. The source has no individual start/end date for seated suplentes.
     period_start, period_end = period.split("-")
 
-    # The endpoint returns one record per seat — the member currently occupying it.
-    # tipoParlamentario flags whether that occupant is the elected titular or a suplente
-    # who has taken over a vacated seat; both are sitting members, so we emit either.
-    # (We don't filter to TITULAR, which would drop seated replacements.)
+    if period_start < h.earliest_term_start(POSITION_TOPICS):
+        return
+
+    chamber = Chamber.from_source(row.pop("camaraParlamentario"))
+    position = h.make_position(
+        context,
+        name=chamber.position_name,
+        country="py",
+        topics=POSITION_TOPICS,
+        wikidata_id=chamber.wikidata_id,
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+
     person = context.make("Person")
     person.id = context.make_slug(str(row.pop("idParlamentario")))
     h.apply_name(person, first_name=row.pop("nombres"), last_name=row.pop("apellidos"))
@@ -57,52 +67,25 @@ def crawl_member(
     )
     if occupancy is None:
         return
-    # Deputies are elected by department (plus the Capital District, Asunción); senators
-    # from a single nationwide constituency (departamento "NACIONAL").
+    # Deputies are elected by department; senators from a single nationwide constituency ("NACIONAL")
     occupancy.add("constituency", row.pop("departamento"))
-    # The parliamentary bloc (bancada) is distinct from party membership.
-    occupancy.add("politicalGroup", row.pop("bancada"))
+    occupancy.add("politicalGroup", row.pop("bancada"))  # caucus
 
+    context.emit(position)
     context.emit(occupancy)
     context.emit(person)
-    context.audit_data(row, ignore=IGNORE_FIELDS)
-
-
-def crawl_chamber(
-    context: Context, path: str, position_name: str, wikidata_id: str
-) -> None:
-    members = context.fetch_json(context.data_url + path)
-    if not isinstance(members, list) or len(members) == 0:
-        raise ValueError(f"Expected a non-empty list of members from {path!r}")
-
-    position = h.make_position(
-        context,
-        name=position_name,
-        country="py",
-        topics=["gov.national", "gov.legislative"],
-        wikidata_id=wikidata_id,
-        lang="eng",
+    context.audit_data(
+        row,
+        ignore=[
+            "telefonoParlamentario",  # private contact detail
+            "fotoURL",
+            "tipoParlamentario",  # titular vs seated suplente — both emitted
+            "cargoBancada",  # role within the parliamentary bloc
+        ],
     )
-    categorisation = categorise(context, position)
-    context.emit(position)
-
-    for row in members:
-        crawl_member(context, row, position, categorisation)
 
 
 def crawl(context: Context) -> None:
-    # Both chambers come from the same Congress open-data API; data_url is the
-    # `.../camara/` base. limit=200 is required for the 80-seat Chamber of Deputies
-    # (the default page size of 50 would truncate it) and harmless for the Senate.
-    crawl_chamber(
-        context,
-        "S?limit=200",
-        "Member of the Chamber of Senators of Paraguay",
-        "Q20058559",
-    )
-    crawl_chamber(
-        context,
-        "D?limit=200",
-        "Member of the Chamber of Deputies of Paraguay",
-        "Q20058561",
-    )
+    members = context.fetch_json(context.data_url)
+    for row in members:
+        crawl_member(context, row)

--- a/datasets/py/congreso/py_congreso.yml
+++ b/datasets/py/congreso/py_congreso.yml
@@ -1,26 +1,23 @@
 title: Paraguay Members of the National Congress
 entry_point: crawler.py
-prefix: py-congreso
+prefix: py-cgso
 coverage:
   frequency: monthly
   start: 2026-06-23
 load_statements: true
-ci_test: false # Live external government API, not available in CI
+ci_test: true
 summary: >-
-  Members of the Chamber of Senators and the Chamber of Deputies of the National
-  Congress of Paraguay
+  Members of the Chamber of Senators and the Chamber of Deputies of Paraguay
 description: |
   Current and historical members of the bicameral National Congress (Congreso Nacional) of Paraguay,
   which holds the country's legislative power, including passing laws and approving the
-  budget. It comprises the Chamber of Senators (Cámara de Senadores) — 45 senators
-  elected from a single nationwide constituency — and the Chamber of Deputies (Cámara
-  de Diputados) — 80 deputies elected from the 17 departments and the Capital District.
-  Members serve five-year terms.
+  budget. It comprises the Chamber of Senators (Cámara de Senadores, elected from a single nationwide
+  constituency) and the Chamber of Deputies (Cámara de Diputados, elected from the 17 departments and
+  the Capital District). Members serve five-year terms.
 
   This dataset records each sitting member of both chambers with their name, party, parliamentary group,
-  constituency and email, sourced
-  from the Congress open-data API. For the current occupant of each seat, the source lists
-  both the elected member or a suplente who has taken over a vacated seat.
+  constituency and email, For the current occupant of each seat, the source lists both the elected member
+  or a suplente who has taken over a vacated seat.
 url: https://datos.congreso.gov.py/
 publisher:
   name: Congreso de la Nación Paraguaya

--- a/datasets/py/congreso/py_congreso.yml
+++ b/datasets/py/congreso/py_congreso.yml
@@ -1,0 +1,52 @@
+title: Paraguay Members of the National Congress
+entry_point: crawler.py
+prefix: py-congreso
+coverage:
+  frequency: monthly
+  start: 2026-06-23
+load_statements: true
+ci_test: false # Live external government API, not available in CI
+summary: >-
+  Members of the Chamber of Senators and the Chamber of Deputies of the National
+  Congress of Paraguay
+description: |
+  Current members of the bicameral National Congress (Congreso Nacional) of Paraguay,
+  which holds the country's legislative power, including passing laws and approving the
+  budget. It comprises the Chamber of Senators (Cámara de Senadores) — 45 senators
+  elected from a single nationwide constituency — and the Chamber of Deputies (Cámara
+  de Diputados) — 80 deputies elected from the 17 departments and the Capital District
+  (Asunción). Members serve five-year terms.
+
+  This dataset records each sitting member of both chambers with their name, party
+  (partido político), parliamentary group (bancada), constituency and email, sourced
+  from the Congress open-data API. The source lists the current occupant of each seat,
+  whether the elected member or a suplente who has taken over a vacated seat.
+url: https://datos.congreso.gov.py/
+publisher:
+  name: Congreso de la Nación Paraguaya
+  name_en: National Congress of Paraguay
+  description: >
+    The National Congress (Congreso Nacional) is the bicameral national legislature of
+    Paraguay, made up of the Chamber of Senators and the Chamber of Deputies.
+  url: https://www.congreso.gov.py/
+  country: py
+  official: true
+data:
+  url: https://datos.congreso.gov.py/opendata/api/data/parlamentario/camara/
+  format: JSON
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 100
+      Position: 2
+    country_entities:
+      py: 100
+  max:
+    schema_entities:
+      Person: 150
+      Position: 2

--- a/datasets/py/congreso/py_congreso.yml
+++ b/datasets/py/congreso/py_congreso.yml
@@ -10,17 +10,17 @@ summary: >-
   Members of the Chamber of Senators and the Chamber of Deputies of the National
   Congress of Paraguay
 description: |
-  Current members of the bicameral National Congress (Congreso Nacional) of Paraguay,
+  Current and historical members of the bicameral National Congress (Congreso Nacional) of Paraguay,
   which holds the country's legislative power, including passing laws and approving the
   budget. It comprises the Chamber of Senators (Cámara de Senadores) — 45 senators
   elected from a single nationwide constituency — and the Chamber of Deputies (Cámara
-  de Diputados) — 80 deputies elected from the 17 departments and the Capital District
-  (Asunción). Members serve five-year terms.
+  de Diputados) — 80 deputies elected from the 17 departments and the Capital District.
+  Members serve five-year terms.
 
-  This dataset records each sitting member of both chambers with their name, party
-  (partido político), parliamentary group (bancada), constituency and email, sourced
-  from the Congress open-data API. The source lists the current occupant of each seat,
-  whether the elected member or a suplente who has taken over a vacated seat.
+  This dataset records each sitting member of both chambers with their name, party, parliamentary group,
+  constituency and email, sourced
+  from the Congress open-data API. For the current occupant of each seat, the source lists
+  both the elected member or a suplente who has taken over a vacated seat.
 url: https://datos.congreso.gov.py/
 publisher:
   name: Congreso de la Nación Paraguaya
@@ -32,21 +32,28 @@ publisher:
   country: py
   official: true
 data:
-  url: https://datos.congreso.gov.py/opendata/api/data/parlamentario/camara/
+  url: https://datos.congreso.gov.py/opendata/api/data/parlamentario/?limit=100000
   format: JSON
   lang: spa
 
 tags:
   - list.pep
 
+lookups:
+  type.email:
+    options:
+      - match:
+          - 'julio_mineur@diputados.gov.p'
+        value: 'julio_mineur@diputados.gov.py'
+
 assertions:
   min:
     schema_entities:
-      Person: 100
+      Person: 550
       Position: 2
     country_entities:
       py: 100
   max:
     schema_entities:
-      Person: 150
+      Person: 1400
       Position: 2


### PR DESCRIPTION
Consolidates the two separate Paraguay chamber crawlers — **py_senado** (#4614) and **py_diputados** (#4615) — into a single dataset for the bicameral **National Congress of Paraguay**, mirroring the [Belize National Assembly](https://github.com/opensanctions/opensanctions/pull/4567) pattern: both chambers share one publisher and one open-data API (`datos.congreso.gov.py`, `camara/S` and `camara/D`), so they belong in one dataset.

Closes opensanctions/crawler-planning#732 and opensanctions/crawler-planning#733 (milestone: South America PEPs — Legislative Bodies). **Supersedes #4614 and #4615.**

## Structure
One crawler emits both chambers via a shared `crawl_member()` / `crawl_chamber(path, position_name, wikidata_id)` helper (the two source crawlers were byte-identical apart from comments):

- Member of the Chamber of Senators of Paraguay (`Q20058559`) — 45
- Member of the Chamber of Deputies of Paraguay (`Q20058561`) — 80

Both positions are `gov.national` + `gov.legislative`. `data.url` is the `.../camara/` API base; the crawler appends `S?limit=200` / `D?limit=200` (the `limit` is required for the 80-seat lower house, harmless for the Senate — verified against the live API).

## What it emits
Each member → a `Person` (name, `citizenship=py`, party, email, source URL) holding a `current` `Occupancy` with `constituency` (department / `NACIONAL`) and `politicalGroup` (bancada). Both the elected `TITULAR` and seated `SUPLENTE` occupants are emitted; we don't filter to `TITULAR`, which would drop seated replacements.

## Audit notes (vs. the two source PRs)
- **Faithful union:** 125 Persons + 125 Occupancies + 2 Positions = the exact sum of the two originals (45 + 80). No members dropped; the only missing optional values are genuine source gaps (4 independents without a bancada, 18 undisclosed emails) which `add()` skips cleanly.
- **Term period recorded:** unlike the originals (which only *asserted* `periodoLegislativo`), the term `2023-2028` is now emitted as the occupancy's `periodStart`/`periodEnd`, consistent with other legislative-PEP crawlers. Status stays `current` (2028 is in the future). The freshness guard is retained.

## Validation
- `zavod crawl` clean (`issues.json` empty); 252 entities (125 Person · 125 Occupancy · 2 Position).
- `zavod validate` passes assertions; `mypy --strict` clean; pre-commit (ruff, yamllint, mypy-datasets) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)