### PR TITLE
[bo_diputados] Add Bolivia Chamber of Deputies PEP crawler

### DIFF
--- a/datasets/bo/diputados/bo_diputados.yml
+++ b/datasets/bo/diputados/bo_diputados.yml
@@ -10,13 +10,13 @@ summary: >-
   Deputies of the Cámara de Diputados, the lower chamber of the Plurinational
   Legislative Assembly of Bolivia
 description: |
-  Deputies of the Cámara de Diputados (Chamber of Deputies), the lower chamber of the
+  Deputies of the Chamber of Deputies (Cámara de Diputados), the lower chamber of the
   bicameral Plurinational Legislative Assembly of Bolivia. Its 130 titular deputies are
   elected per department through a mixed system: single-member districts (uninominal),
   department party lists (plurinominal) and special indigenous-campesino
-  circumscriptions, each with an alternate (suplente).
+  circumscriptions, each with an alternate.
 
-  This dataset records each deputy with their name, party (bancada), department and date
+  This dataset records each deputy with their name, party, department and date
   of birth, sourced from the Chamber's website. The source does not reliably flag which
   profiles are titulares and which are their suplentes, so both are included.
 url: https://diputados.gob.bo/diputados-home/

--- a/datasets/bo/diputados/bo_diputados.yml
+++ b/datasets/bo/diputados/bo_diputados.yml
@@ -5,10 +5,9 @@ coverage:
   frequency: monthly
   start: 2026-06-24
 load_statements: true
-ci_test: false # Live government site needing a browser UA / Bolivia egress, not in CI
+ci_test: false 
 summary: >-
-  Deputies of the Cámara de Diputados, the lower chamber of the Plurinational
-  Legislative Assembly of Bolivia
+  Deputies of the lower chamber of the Plurinational Legislative Assembly of Bolivia
 description: |
   Deputies of the Chamber of Deputies (Cámara de Diputados), the lower chamber of the
   bicameral Plurinational Legislative Assembly of Bolivia. Its 130 titular deputies are

--- a/datasets/bo/diputados/bo_diputados.yml
+++ b/datasets/bo/diputados/bo_diputados.yml
@@ -5,7 +5,7 @@ coverage:
   frequency: monthly
   start: 2026-06-24
 load_statements: true
-ci_test: false 
+ci_test: false
 summary: >-
   Deputies of the lower chamber of the Plurinational Legislative Assembly of Bolivia
 description: |

--- a/datasets/bo/diputados/bo_diputados.yml
+++ b/datasets/bo/diputados/bo_diputados.yml
@@ -1,0 +1,60 @@
+title: Bolivia Members of the Chamber of Deputies
+entry_point: crawler.py
+prefix: bo-dip
+coverage:
+  frequency: monthly
+  start: 2026-06-24
+load_statements: true
+ci_test: false # Live government site needing a browser UA / Bolivia egress, not in CI
+summary: >-
+  Deputies of the Cámara de Diputados, the lower chamber of the Plurinational
+  Legislative Assembly of Bolivia
+description: |
+  Deputies of the Cámara de Diputados (Chamber of Deputies), the lower chamber of the
+  bicameral Plurinational Legislative Assembly of Bolivia. Its 130 titular deputies are
+  elected per department through a mixed system: single-member districts (uninominal),
+  department party lists (plurinominal) and special indigenous-campesino
+  circumscriptions, each with an alternate (suplente).
+
+  This dataset records each deputy with their name, party (bancada), department and date
+  of birth, sourced from the Chamber's website. The source does not reliably flag which
+  profiles are titulares and which are their suplentes, so both are included.
+url: https://diputados.gob.bo/diputados-home/
+publisher:
+  name: Cámara de Diputados de Bolivia
+  name_en: Chamber of Deputies of Bolivia
+  description: >
+    The Chamber of Deputies is the lower chamber of the Plurinational Legislative
+    Assembly (Asamblea Legislativa Plurinacional), the bicameral national legislature
+    of Bolivia.
+  url: https://diputados.gob.bo/
+  country: bo
+  official: true
+data:
+  # WordPress REST collection of deputy profiles; structured fields are scraped from
+  # each linked profile page (HTML).
+  url: https://diputados.gob.bo/wp-json/wp/v2/diputados
+  format: JSON
+  lang: spa
+
+http:
+  # The site 403s the default crawler user agent; send a browser-like one.
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+
+dates:
+  formats: ["%d/%m/%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 200
+      Position: 1
+    country_entities:
+      bo: 200
+  max:
+    schema_entities:
+      Person: 300
+      Position: 1

--- a/datasets/bo/diputados/crawler.py
+++ b/datasets/bo/diputados/crawler.py
@@ -1,0 +1,118 @@
+from itertools import count
+
+from lxml.html import HtmlElement
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Roster lives in a WordPress "diputados" custom post type; data_url is its REST
+# collection endpoint. Each post links to a profile page whose structured fields
+# (party, department, titular/suplente) are only rendered in the page HTML.
+PAGE_SIZE = 100
+
+
+def deputy_fields(doc: HtmlElement) -> dict[str, str]:
+    """Map each profile's Elementor icon-box label to its value.
+
+    Profiles render one icon-box per attribute, with the label in the box title and
+    the value in the box description (e.g. "Bancada" -> "MAS IPSP ...").
+    """
+    fields: dict[str, str] = {}
+    for box in h.xpath_elements(
+        doc, ".//div[contains(@class, 'elementor-icon-box-content')]"
+    ):
+        titles = h.xpath_elements(
+            box, ".//*[contains(@class, 'elementor-icon-box-title')]"
+        )
+        if not titles:
+            continue
+        descriptions = h.xpath_elements(
+            box, ".//*[contains(@class, 'elementor-icon-box-description')]"
+        )
+        label = h.element_text(titles[0])
+        fields[label] = h.element_text(descriptions[0]) if descriptions else ""
+    return fields
+
+
+def crawl_deputy(
+    context: Context,
+    url: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    fields = deputy_fields(context.fetch_html(url, cache_days=7))
+
+    name = fields.pop("Nombre", "").strip()
+    if len(name) == 0:
+        context.log.warning("Deputy profile missing name", url=url)
+        return
+    department = fields.pop("Brigada", None)
+
+    person = context.make("Person")
+    person.id = context.make_id(name, department)
+    h.apply_name(person, full=name)
+    h.apply_date(person, "birthDate", fields.pop("Fecha de nacimiento", None))
+    person.add("email", fields.pop("Correo electronico", None))
+    # Deputies sit in the Asamblea Legislativa Plurinacional, whose membership is
+    # reserved to Bolivian citizens (Constitution arts. 144, 149-150).
+    # https://pdba.georgetown.edu/Constitutions/Bolivia/bolivia09.html
+    person.add("citizenship", "bo")
+    person.add("political", fields.pop("Bancada", None))
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    # Deputies are elected by department, via single-member districts, party lists or
+    # special indigenous-campesino circumscriptions (the seat type, "Diputación").
+    occupancy.add("constituency", department)
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(
+        fields,
+        ignore=[
+            # The site rarely fills the titular/suplente flag (blank on ~90% of
+            # profiles), so it can't be used to limit the roster to titulares; both
+            # are emitted. The label is gendered (Legislador / Legisladora).
+            "Legislador",
+            "Legisladora",
+            "Suplente",  # the deputy's own alternate's name, where filled
+            "Diputación",  # seat type (uninominal / plurinominal / especial)
+            "Circunscripción",  # single-member district number, where applicable
+            "Comisión",  # committee assignments
+            "Comité",
+            "Cargo comisión",
+        ],
+    )
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Chamber of Deputies of Bolivia",
+        country="bo",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q20081432",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    for page in count(1):
+        records = context.fetch_json(
+            context.data_url,
+            params={"per_page": PAGE_SIZE, "page": page},
+            cache_days=1,
+        )
+        for record in records:
+            crawl_deputy(context, record["link"], position, categorisation)
+        # The REST collection is paginated; the final page is short of PAGE_SIZE.
+        if len(records) < PAGE_SIZE:
+            break


### PR DESCRIPTION
Adds a PEP crawler for the **Cámara de Diputados of Bolivia** (lower chamber of the Plurinational Legislative Assembly).

Closes opensanctions/crawler-planning#730 (milestone: South America PEPs — Legislative Bodies).

## Why a separate dataset from `bo_senado` (#4616)
The two chambers do **not** share a source, so they can't be folded into one crawl the way Paraguay's were:

| | Senate (`bo_senado`) | Deputies (this PR) |
|---|---|---|
| Host | `apisi.senado.gob.bo` | `diputados.gob.bo` (different domain) |
| Format | JSON API | WordPress site (REST enumeration + scraped HTML profiles) |

## Source & approach
- Deputies are enumerated via the site's WordPress REST collection (`wp-json/wp/v2/diputados`, 255 profiles, paginated).
- Each profile page is scraped for its Elementor "icon-box" fields: name, party (`Bancada`), department (`Brigada`), date of birth, email.
- The site **403s the default UA**, so a browser User-Agent is set; it's also intermittently unreachable from non-LATAM egress (`ci_test: false`).

## Titular vs suplente — known limitation
The source does **not** reliably distinguish the 130 titulares from their ~125 suplentes:
- the profile `Legislador/Legisladora` (Titular/Suplente) field is blank on **235 of 255** profiles;
- biographies are blank on 77 and mention both terms ambiguously otherwise;
- the listing page has no labels/grouping, and the `cargo`/`Diputado(a)` taxonomies encode committee role / gender, not seat type.

So **all current-term deputy profiles are emitted** (titulares + suplentes) rather than filtering to titulares. If we later want titulares only, the OEP "Asambleístas elegidos" electoral results are the authoritative list to cross-reference by name (separate effort).

## What it emits
Each profile → a `Person` (name, `citizenship=bo`, party, DOB and email where published) holding a `current` `Occupancy` (`constituency` = department) on one Position — Member of the Chamber of Deputies of Bolivia (`Q20081432`), `gov.national` + `gov.legislative`.

## Validation
- `zavod crawl` clean (`issues.json` empty); 511 entities (255 Person · 255 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` clean; pre-commit (ruff, yamllint, mypy-datasets) green.
- PEP integrity checks pass: no dangling post/holder, every `role.pep` person has `citizenship`; party filled on all 255, constituency on 254, DOB on 112, no duplicate names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)