### PR TITLE
[uz_legislative_chamber] Add Uzbekistan Legislative Chamber PEP crawler

### DIFF
--- a/datasets/uz/legislative_chamber/crawler.py
+++ b/datasets/uz/legislative_chamber/crawler.py
@@ -1,0 +1,106 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The list endpoint serves names in the locale chosen by Accept-Language (default is
+# Uzbek Latin); we fetch the Cyrillic (oz) and Russian (ru) variants too and merge by
+# id. Per-deputy birth details live on the detail endpoint.
+DETAIL_URL = "https://parliament.gov.uz/api/v1/structure/deputy/detail/"
+
+IGNORE = [
+    "first_name",  # consumed via .get() (also read from the oz/ru locale rows)
+    "last_name",
+    "middle_name",
+    "image",
+    "work_place",  # free-text prior workplace
+    "deputy_assistant",
+    "deputy_assistant_phone",
+    "committee",  # committee membership — no entity field
+]
+
+
+def apply_names(person: Entity, row: dict[str, Any], lang: str, alias: bool) -> None:
+    h.apply_name(
+        person,
+        first_name=row.get("first_name"),
+        patronymic=row.get("middle_name"),
+        last_name=row.get("last_name"),
+        lang=lang,
+        alias=alias,
+    )
+
+
+def crawl_deputy(
+    context: Context,
+    row: dict[str, Any],
+    oz: dict[str, Any] | None,
+    ru: dict[str, Any] | None,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    slug = row.pop("slug")
+    person = context.make("Person")
+    person.id = context.make_slug("deputy", str(row.pop("id")))
+    apply_names(person, row, lang="uzb", alias=False)  # Uzbek Latin (default)
+    if oz is not None:
+        apply_names(person, oz, lang="uzb", alias=True)  # Uzbek Cyrillic
+    if ru is not None:
+        apply_names(person, ru, lang="rus", alias=True)  # Russian
+
+    detail = context.fetch_json(f"{DETAIL_URL}{slug}/", cache_days=7)
+    h.apply_date(person, "birthDate", detail.get("birth_date"))
+    person.add("birthPlace", detail.get("birth_place"), lang="uzb")
+    # Deputies of the Legislative Chamber must be citizens of Uzbekistan (Constitution
+    # art. 77). https://www.constituteproject.org/constitution/Uzbekistan_2011
+    person.add("citizenship", "uz")
+
+    okrug = row.pop("okrug")
+    fraction = row.pop("fraction")
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    # Single-mandate deputies carry an electoral district (okrug); party-list do not.
+    if okrug is not None:
+        occupancy.add("constituency", okrug.get("title"), lang="uzb")
+    if fraction is not None:
+        occupancy.add("politicalGroup", fraction.get("title"), lang="uzb")
+        if ru is not None and ru.get("fraction") is not None:
+            occupancy.add("politicalGroup", ru["fraction"].get("title"), lang="rus")
+
+    context.emit(occupancy)
+    context.emit(person)
+    context.audit_data(row, ignore=IGNORE)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Legislative Chamber of the Oliy Majlis of Uzbekistan",
+        country="uz",
+        topics=["gov.national", "gov.legislative"],
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    deputies = context.fetch_json(context.data_url, cache_days=1)
+    # Other locales sit at the same URL behind Accept-Language; zavod's cache keys on
+    # URL only, so fetch them uncached to avoid colliding with the default response.
+    oz = {
+        r["id"]: r
+        for r in context.fetch_json(context.data_url, headers={"Accept-Language": "oz"})
+    }
+    ru = {
+        r["id"]: r
+        for r in context.fetch_json(context.data_url, headers={"Accept-Language": "ru"})
+    }
+
+    for row in deputies:
+        crawl_deputy(
+            context, row, oz.get(row["id"]), ru.get(row["id"]), position, categorisation
+        )

--- a/datasets/uz/legislative_chamber/crawler.py
+++ b/datasets/uz/legislative_chamber/crawler.py
@@ -5,76 +5,49 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The list endpoint serves names in the locale chosen by Accept-Language (default is
-# Uzbek Latin); we fetch the Cyrillic (oz) and Russian (ru) variants too and merge by
-# id. Per-deputy birth details live on the detail endpoint.
-DETAIL_URL = "https://parliament.gov.uz/api/v1/structure/deputy/detail/"
-
-IGNORE = [
-    "first_name",  # consumed via .get() (also read from the oz/ru locale rows)
-    "last_name",
-    "middle_name",
-    "image",
-    "work_place",  # free-text prior workplace
-    "deputy_assistant",
-    "deputy_assistant_phone",
-    "committee",  # committee membership — no entity field
-]
-
-
-def apply_names(person: Entity, row: dict[str, Any], lang: str, alias: bool) -> None:
-    h.apply_name(
-        person,
-        first_name=row.get("first_name"),
-        patronymic=row.get("middle_name"),
-        last_name=row.get("last_name"),
-        lang=lang,
-        alias=alias,
-    )
-
 
 def crawl_deputy(
     context: Context,
     row: dict[str, Any],
-    oz: dict[str, Any] | None,
-    ru: dict[str, Any] | None,
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
     slug = row.pop("slug")
     person = context.make("Person")
     person.id = context.make_slug("deputy", str(row.pop("id")))
-    apply_names(person, row, lang="uzb", alias=False)  # Uzbek Latin (default)
-    if oz is not None:
-        apply_names(person, oz, lang="uzb", alias=True)  # Uzbek Cyrillic
-    if ru is not None:
-        apply_names(person, ru, lang="rus", alias=True)  # Russian
+    h.apply_name(
+        person,
+        first_name=row.pop("first_name"),
+        patronymic=row.pop("middle_name"),
+        last_name=row.pop("last_name"),
+        lang="eng",
+    )
 
-    detail = context.fetch_json(f"{DETAIL_URL}{slug}/", cache_days=7)
-    h.apply_date(person, "birthDate", detail.get("birth_date"))
-    person.add("birthPlace", detail.get("birth_place"), lang="uzb")
+    detail = context.fetch_json(
+        f"{context.data_url.replace('list/', 'detail/')}{slug}/", cache_days=7
+    )
+    h.apply_date(person, "birthDate", detail.pop("birth_date"))
+    person.add("birthPlace", detail.pop("birth_place"), lang="uzb")
+    person.add("email", detail.pop("email"))
     # Deputies of the Legislative Chamber must be citizens of Uzbekistan (Constitution
     # art. 77). https://www.constituteproject.org/constitution/Uzbekistan_2011
     person.add("citizenship", "uz")
 
-    okrug = row.pop("okrug")
-    fraction = row.pop("fraction")
     occupancy = h.make_occupancy(
         context, person, position, categorisation=categorisation
     )
     if occupancy is None:
         return
+
+    okrug = row.pop("okrug")
+    fraction = row.pop("fraction")
     # Single-mandate deputies carry an electoral district (okrug); party-list do not.
     if okrug is not None:
-        occupancy.add("constituency", okrug.get("title"), lang="uzb")
+        occupancy.add("constituency", okrug.pop("title"), lang="uzb")
     if fraction is not None:
-        occupancy.add("politicalGroup", fraction.get("title"), lang="uzb")
-        if ru is not None and ru.get("fraction") is not None:
-            occupancy.add("politicalGroup", ru["fraction"].get("title"), lang="rus")
-
+        occupancy.add("politicalGroup", fraction.pop("title"), lang="uzb")
     context.emit(occupancy)
     context.emit(person)
-    context.audit_data(row, ignore=IGNORE)
 
 
 def crawl(context: Context) -> None:
@@ -89,18 +62,5 @@ def crawl(context: Context) -> None:
     context.emit(position)
 
     deputies = context.fetch_json(context.data_url, cache_days=1)
-    # Other locales sit at the same URL behind Accept-Language; zavod's cache keys on
-    # URL only, so fetch them uncached to avoid colliding with the default response.
-    oz = {
-        r["id"]: r
-        for r in context.fetch_json(context.data_url, headers={"Accept-Language": "oz"})
-    }
-    ru = {
-        r["id"]: r
-        for r in context.fetch_json(context.data_url, headers={"Accept-Language": "ru"})
-    }
-
     for row in deputies:
-        crawl_deputy(
-            context, row, oz.get(row["id"]), ru.get(row["id"]), position, categorisation
-        )
+        crawl_deputy(context, row, position, categorisation)

--- a/datasets/uz/legislative_chamber/uz_legislative_chamber.yml
+++ b/datasets/uz/legislative_chamber/uz_legislative_chamber.yml
@@ -5,10 +5,9 @@ coverage:
   frequency: monthly
   start: 2026-06-24
 load_statements: true
-ci_test: false # Live external government API, not available in CI
+ci_test: true
 summary: >-
-  Deputies of the Legislative Chamber, the lower house of the Oliy Majlis of the
-  Republic of Uzbekistan
+  Deputies of the lower house of the Oliy Majlis of the Republic of Uzbekistan
 description: |
   Deputies of the Legislative Chamber (Qonunchilik palatasi), the lower house of the
   bicameral Oliy Majlis of the Republic of Uzbekistan. It has 150 deputies — 75 elected
@@ -19,7 +18,7 @@ description: |
   faction, sourced from the Oliy Majlis open JSON API.
 url: https://parliament.gov.uz/
 publisher:
-  name: Oʻzbekiston Respublikasi Oliy Majlisi Qonunchilik palatasi
+  name: "Oʻzbekiston Respublikasi Oliy Majlisi Qonunchilik palatasi"
   name_en: Legislative Chamber of the Oliy Majlis of the Republic of Uzbekistan
   description: >
     The Legislative Chamber is the lower house of the Oliy Majlis, the bicameral

--- a/datasets/uz/legislative_chamber/uz_legislative_chamber.yml
+++ b/datasets/uz/legislative_chamber/uz_legislative_chamber.yml
@@ -1,0 +1,51 @@
+title: Uzbekistan Members of the Legislative Chamber
+entry_point: crawler.py
+prefix: uz-legch
+coverage:
+  frequency: monthly
+  start: 2026-06-24
+load_statements: true
+ci_test: false # Live external government API, not available in CI
+summary: >-
+  Deputies of the Legislative Chamber, the lower house of the Oliy Majlis of the
+  Republic of Uzbekistan
+description: |
+  Deputies of the Legislative Chamber (Qonunchilik palatasi), the lower house of the
+  bicameral Oliy Majlis of the Republic of Uzbekistan. It has 150 deputies — 75 elected
+  in single-mandate districts and 75 by party list — for a five-year term.
+
+  This dataset records each sitting deputy with their name (Uzbek Latin, Uzbek Cyrillic
+  and Russian forms), date and place of birth, electoral district and parliamentary
+  faction, sourced from the Oliy Majlis open JSON API.
+url: https://parliament.gov.uz/
+publisher:
+  name: Oʻzbekiston Respublikasi Oliy Majlisi Qonunchilik palatasi
+  name_en: Legislative Chamber of the Oliy Majlis of the Republic of Uzbekistan
+  description: >
+    The Legislative Chamber is the lower house of the Oliy Majlis, the bicameral
+    national legislature of the Republic of Uzbekistan.
+  url: https://parliament.gov.uz/
+  country: uz
+  official: true
+data:
+  url: https://parliament.gov.uz/api/v1/structure/deputy/list/
+  format: JSON
+  lang: uzb
+
+dates:
+  formats: ["%Y-%m-%d"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 110
+      Position: 1
+    country_entities:
+      uz: 110
+  max:
+    schema_entities:
+      Person: 170
+      Position: 1


### PR DESCRIPTION
PEP crawler for the **Legislative Chamber** (Qonunchilik palatasi), the lower house of the Oliy Majlis of Uzbekistan.

Closes opensanctions/crawler-planning#748 (milestone: Central Asia — Legislative Bodies).

## Source
`https://parliament.gov.uz/api/v1/structure/deputy/list/` — official JSON API behind the Nuxt SPA. Returns 146 deputies (of the 150-seat cap; 4 mid-term vacancies). Per-deputy birth details from `/structure/deputy/detail/{slug}/`.

## What it emits
Each deputy → a `Person` holding a `current` `Occupancy` on one Position — Member of the Legislative Chamber of the Oliy Majlis of Uzbekistan (`gov.national` + `gov.legislative`; no distinct Wikidata QID, so none is set).

- **Names in three scripts:** the list endpoint serves names per `Accept-Language` — Uzbek Latin (default, `name`), Uzbek Cyrillic (`oz`) and Russian (`ru`) as aliases, merged by id. (zavod caches on URL only, so the secondary locales are fetched uncached.)
- `birthDate` + `birthPlace` from the detail endpoint; electoral district (`okrug`) → `constituency` (single-mandate only); faction → `politicalGroup` (Uzbek + Russian).
- `citizenship=uz` — Legislative Chamber deputies must be Uzbek citizens (Constitution art. 77).
- The detail `email` is a shared parliament address (not personal) and is not captured; phone/assistant fields are skipped.

## Validation
- `zavod crawl` clean (`issues.json` empty); 293 entities (146 Person · 146 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.
- PEP integrity checks pass: no dangling post/holder, every `role.pep` person has `citizenship`; name + Cyrillic + Russian alias on all 146; DOB on all 146, birthPlace on 145, faction on 143, district on 71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)