### PR TITLE
[tj_majlisi_milli] Add Tajikistan Majlisi Milli PEP crawler

### DIFF
--- a/datasets/tj/majlisi_milli/crawler.py
+++ b/datasets/tj/majlisi_milli/crawler.py
@@ -1,0 +1,107 @@
+import re
+
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Listing names sometimes run together without spaces (e.g. "давлаталӣСаид"); insert a
+# space at each lower→upper case transition, then capitalise the first letter.
+CASE_SPLIT = re.compile(r"(?<=[а-яёҷҳӣқғӯ])(?=[А-ЯЁҶҲӢҚҒӮ])")
+# Detail pages give the birth date in a "Санаи/Соли таваллуд:" field, usually as
+# dd.mm.yyyy but sometimes as Tajik text (year extracted as a fallback). Leadership
+# role pages instead state the year in prose ("соли YYYY … таваллуд шудааст").
+BIRTH_FIELD = re.compile(r"(?:Санаи|Соли) таваллуд:\s*([^*\n]+)")
+NUM_DATE = re.compile(r"(\d{1,2})\.(\d{1,2})\.(\d{4})")
+YEAR = re.compile(r"\d{4}")
+BIRTH_YEAR_PROSE = re.compile(r"соли\s+(\d{4})[^.]{0,40}таваллуд")
+BIRTH_PLACE = re.compile(r"Ҷойи таваллуд:\s*([^*\n]+)")
+
+
+def extract_birth_date(text: str) -> str | None:
+    field = BIRTH_FIELD.search(text)
+    if field is not None:
+        num = NUM_DATE.search(field.group(1))
+        if num is not None:
+            day, month, year = num.groups()
+            return f"{year}-{int(month):02d}-{int(day):02d}"
+        year = YEAR.search(field.group(1))
+        if year is not None:
+            return year.group(0)
+    prose = BIRTH_YEAR_PROSE.search(text)
+    return prose.group(1) if prose is not None else None
+
+
+def clean_name(raw: str) -> str:
+    name = CASE_SPLIT.sub(" ", " ".join(raw.split())).strip()
+    return name[:1].upper() + name[1:]
+
+
+def crawl_member(
+    context: Context,
+    name: str,
+    url: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    person = context.make("Person")
+    # Leadership cards link to a role page (one holder each), members to a personal
+    # page; the final path segment is a stable per-person key either way.
+    person.id = context.make_slug(url.rstrip("/").split("/")[-1])
+    person.add("name", name, lang="tgk")
+
+    text = h.element_text(context.fetch_html(url, cache_days=7))
+    h.apply_date(person, "birthDate", extract_birth_date(text))
+    place_match = BIRTH_PLACE.search(text)
+    if place_match is not None:
+        person.add("birthPlace", place_match.group(1).strip(), lang="tgk")
+    # Members must hold only Tajik citizenship (Constitution art. 49).
+    # https://www.constituteproject.org/constitution/Tajikistan_2016
+    person.add("citizenship", "tj")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Majlisi Milli of Tajikistan",
+        country="tj",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21296003",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    seen: set[str] = set()
+    for box in h.xpath_elements(
+        doc, "//div[contains(@class, 'elementor-image-box-content')]"
+    ):
+        titles = h.xpath_elements(
+            box, ".//*[contains(@class, 'elementor-image-box-title')]"
+        )
+        links = h.xpath_elements(box, ".//a[@href]")
+        if not titles or not links:
+            continue
+        url = links[0].get("href")
+        # Skip the page-title card (no member link) and dedupe the chairman, who is
+        # listed both as a header and as a member.
+        if url is None or url in seen or context.data_url.rstrip("/") in url:
+            continue
+        seen.add(url)
+        crawl_member(
+            context,
+            clean_name(h.element_text(titles[0])),
+            url,
+            position,
+            categorisation,
+        )

--- a/datasets/tj/majlisi_milli/tj_majlisi_milli.yml
+++ b/datasets/tj/majlisi_milli/tj_majlisi_milli.yml
@@ -1,0 +1,51 @@
+title: Tajikistan Members of the Majlisi Milli
+entry_point: crawler.py
+prefix: tj-milli
+coverage:
+  frequency: monthly
+  start: 2026-06-24
+load_statements: true
+ci_test: false # Live external government website, not available in CI
+summary: >-
+  Members of the Majlisi Milli, the upper chamber of the Supreme Assembly of the
+  Republic of Tajikistan
+description: |
+  Members of the Majlisi Milli (Маҷлиси миллӣ), the upper chamber of the bicameral
+  Supreme Assembly (Majlisi Oli) of the Republic of Tajikistan. It has 33 members — 25
+  elected indirectly by the regional and city assemblies and 8 appointed by the
+  President; former presidents are ex-officio members for life.
+
+  This dataset records each sitting member with their name, date and place of birth,
+  sourced from the chamber's official website.
+url: https://majmilli.tj/azoi-majlisi-milli/
+publisher:
+  name: Маҷлиси миллии Маҷлиси Олии Ҷумҳурии Тоҷикистон
+  name_en: Majlisi Milli of the Supreme Assembly of the Republic of Tajikistan
+  description: >
+    The Majlisi Milli is the upper chamber of the Supreme Assembly (Majlisi Oli), the
+    bicameral national legislature of the Republic of Tajikistan.
+  url: https://majmilli.tj/
+  country: tj
+  official: true
+data:
+  url: https://majmilli.tj/azoi-majlisi-milli/
+  format: HTML
+  lang: tgk
+
+dates:
+  formats: ["%Y-%m-%d", "%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 25
+      Position: 1
+    country_entities:
+      tj: 25
+  max:
+    schema_entities:
+      Person: 40
+      Position: 1

--- a/datasets/tj/majlisi_milli/tj_majlisi_milli.yml
+++ b/datasets/tj/majlisi_milli/tj_majlisi_milli.yml
@@ -5,15 +5,14 @@ coverage:
   frequency: monthly
   start: 2026-06-24
 load_statements: true
-ci_test: false # Live external government website, not available in CI
+ci_test: true
 summary: >-
-  Members of the Majlisi Milli, the upper chamber of the Supreme Assembly of the
-  Republic of Tajikistan
+  Members of the upper chamber of the Supreme Assembly of the Republic of Tajikistan
 description: |
   Members of the Majlisi Milli (Маҷлиси миллӣ), the upper chamber of the bicameral
-  Supreme Assembly (Majlisi Oli) of the Republic of Tajikistan. It has 33 members — 25
+  Supreme Assembly (Majlisi Oli) of the Republic of Tajikistan. It has 33 members: 25
   elected indirectly by the regional and city assemblies and 8 appointed by the
-  President; former presidents are ex-officio members for life.
+  President. Former presidents are ex-officio members for life.
 
   This dataset records each sitting member with their name, date and place of birth,
   sourced from the chamber's official website.


### PR DESCRIPTION
PEP crawler for the **Majlisi Milli**, the upper chamber of the Supreme Assembly (Majlisi Oli) of Tajikistan.

Closes opensanctions/crawler-planning#746 (milestone: Central Asia — Legislative Bodies).

## Source
`https://majmilli.tj/azoi-majlisi-milli/` — official site (HTML, Tajik Cyrillic). Members are Elementor image-box cards linking to per-member (or, for leadership, per-role) detail pages.

## What it emits
Each member → a `Person` holding a `current` `Occupancy` on Member of the Majlisi Milli of Tajikistan (`Q21296003`, `gov.national` + `gov.legislative`).

- **Name** from the listing card. Member names run together without spaces (e.g. `давлаталӣСаид`), so they're split at lower→upper case transitions and capitalised (→ `Давлаталӣ Саид`, matching the detail-page titles).
- **Dedup:** the chairman is listed twice (header + member block); cards are deduped by their detail-page URL (the final path segment is also the person id).
- `birthDate` + `birthPlace` parsed from each detail page (`Санаи/Соли таваллуд:` and `Ҷойи таваллуд:`; date as `dd.mm.yyyy`, year-only fallback for Tajik-text dates and leadership prose).
- `citizenship=tj` — members must hold only Tajik citizenship (Constitution art. 49).

## Notes
- The listing currently exposes 31 of the 33 seats; the assertion floor is set accordingly.
- The 25-elected-vs-8-appointed split and region assignments are not on the site in a structured form, so they're not captured.

## Validation
- `zavod crawl` clean (`issues.json` empty); 63 entities (31 Person · 31 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.
- PEP integrity: every `role.pep` person has `citizenship`; name on all 31, DOB on 31, birthPlace on 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)