### PR TITLE
[hr_sabor] Add Croatian Parliament PEP crawler

### DIFF
--- a/datasets/hr/sabor/crawler.py
+++ b/datasets/hr/sabor/crawler.py
@@ -1,0 +1,107 @@
+import re
+from itertools import count
+
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# MP profile links look like /en/members-parliament/<name-slug>-<n>-term (the party and
+# deputy-club links under /members-parliament/ are excluded).
+MP_LINK = re.compile(r"/members-parliament/[^/]+-\d+-term/?$")
+TERM_SUFFIX = re.compile(r"-\d+-term$")
+# Biographies open with "Born on <d Month yyyy> in <place>."
+BORN = re.compile(r"Born on (\d{1,2} \w+ \d{4})(?: in ([^.]+))?")
+CONSTITUENCY = re.compile(r"Constituency:\s*(.+?)\s*(?:Overview|Education|Contact|$)")
+
+
+def is_mp_link(href: str) -> bool:
+    return (
+        MP_LINK.search(href) is not None
+        and "/party/" not in href
+        and "/club/" not in href
+    )
+
+
+def crawl_member(
+    context: Context,
+    name: str,
+    url: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    slug = url.rstrip("/").split("/")[-1]
+    person = context.make("Person")
+    # Drop the term suffix so a re-elected MP keeps one entity across terms.
+    person.id = context.make_slug("mp", TERM_SUFFIX.sub("", slug))
+    # Names are listed "Last, First" (the surname may be multi-word).
+    last_name, _, first_name = name.partition(",")
+    h.apply_name(
+        person,
+        first_name=first_name.strip() or None,
+        last_name=last_name.strip(),
+        lang="hrv",
+    )
+
+    doc = context.fetch_html(url, cache_days=7)
+    text = h.element_text(doc)
+    born = BORN.search(text)
+    if born is not None:
+        h.apply_date(person, "birthDate", born.group(1))
+        if born.group(2) is not None:
+            person.add("birthPlace", born.group(2).strip())
+    for party in h.xpath_elements(
+        doc, ".//a[contains(@href, '/members-parliament/party/')]"
+    ):
+        person.add("political", h.element_text(party))
+        break
+    # Suffrage in Croatian Parliament elections is reserved to Croatian citizens
+    # (Constitution art. 45). https://www.constituteproject.org/constitution/Croatia_2013
+    person.add("citizenship", "hr")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    constituency = CONSTITUENCY.search(text)
+    if constituency is not None:
+        occupancy.add("constituency", constituency.group(1))
+    for club in h.xpath_elements(
+        doc, ".//a[contains(@href, '/members-parliament/club/')]"
+    ):
+        occupancy.add("politicalGroup", h.element_text(club))
+        break
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Croatian Parliament",
+        country="hr",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q18643511",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    seen: set[str] = set()
+    for page in count(0):
+        doc = context.fetch_html(
+            context.data_url, params={"page": page}, cache_days=1, absolute_links=True
+        )
+        fresh = 0
+        for link in h.xpath_elements(doc, "//a[@href]"):
+            href = (link.get("href") or "").strip()
+            if not is_mp_link(href) or href in seen:
+                continue
+            seen.add(href)
+            fresh += 1
+            crawl_member(context, h.element_text(link), href, position, categorisation)
+        if fresh == 0:
+            break

--- a/datasets/hr/sabor/hr_sabor.yml
+++ b/datasets/hr/sabor/hr_sabor.yml
@@ -5,10 +5,9 @@ coverage:
   frequency: monthly
   start: 2026-06-24
 load_statements: true
-ci_test: false # Live external government website, not available in CI
+ci_test: true
 summary: >-
-  Members of the Croatian Parliament (Hrvatski sabor), the unicameral national
-  legislature of Croatia
+  Members of the Hrvatski sabor, the unicameral national legislature of Croatia
 description: |
   Members of the Croatian Parliament (Hrvatski sabor), the unicameral national
   legislature of Croatia, which has up to 151 representatives elected for four-year

--- a/datasets/hr/sabor/hr_sabor.yml
+++ b/datasets/hr/sabor/hr_sabor.yml
@@ -1,4 +1,4 @@
-title: Croatia Members of the Croatian Parliament
+title: Croatia Members of the Parliament
 entry_point: crawler.py
 prefix: hr-sabor
 coverage:

--- a/datasets/hr/sabor/hr_sabor.yml
+++ b/datasets/hr/sabor/hr_sabor.yml
@@ -1,0 +1,51 @@
+title: Croatia Members of the Croatian Parliament
+entry_point: crawler.py
+prefix: hr-sabor
+coverage:
+  frequency: monthly
+  start: 2026-06-24
+load_statements: true
+ci_test: false # Live external government website, not available in CI
+summary: >-
+  Members of the Croatian Parliament (Hrvatski sabor), the unicameral national
+  legislature of Croatia
+description: |
+  Members of the Croatian Parliament (Hrvatski sabor), the unicameral national
+  legislature of Croatia, which has up to 151 representatives elected for four-year
+  terms from territorial constituencies, the diaspora and the national-minority seats.
+
+  This dataset records each sitting representative with their name, date and place of
+  birth, constituency, political party and deputy club, sourced from the Parliament's
+  official website.
+url: https://www.sabor.hr/en/mps
+publisher:
+  name: Hrvatski sabor
+  name_en: Croatian Parliament
+  description: >
+    The Croatian Parliament (Hrvatski sabor) is the unicameral national legislature of
+    the Republic of Croatia.
+  url: https://www.sabor.hr/
+  country: hr
+  official: true
+data:
+  url: https://www.sabor.hr/en/mps
+  format: HTML
+  lang: eng
+
+dates:
+  formats: ["%d %B %Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 120
+      Position: 1
+    country_entities:
+      hr: 120
+  max:
+    schema_entities:
+      Person: 170
+      Position: 1


### PR DESCRIPTION
PEP crawler for the **Croatian Parliament** (Hrvatski sabor), the unicameral national legislature of Croatia.

Closes opensanctions/crawler-planning#618 (milestone: European Union PEPs — Legislative Bodies).

## Source
`https://www.sabor.hr/en/mps` — official site (HTML), paginated (`?page=0..2`); each row links to an MP profile page at `/en/members-parliament/<slug>-<n>-term`.

## What it emits
Each MP → a `Person` holding a `current` `Occupancy` on Member of the Croatian Parliament (`Q18643511`, `gov.national` + `gov.legislative`).

- Name (split from the listing's "Last, First"); `birthDate` + `birthPlace` ("Born on … in …"), `political` (party) and the deputy club → `politicalGroup`, `constituency` — all from the profile page.
- Entity id drops the `-<n>-term` URL suffix so a re-elected MP stays one entity across terms.
- `citizenship=hr` — suffrage in Sabor elections is reserved to Croatian citizens (Constitution art. 45).

## Validation
- `zavod crawl` clean (`issues.json` empty); 299 entities (149 Person · 149 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.
- PEP integrity: every `role.pep` person has `citizenship`; name on all 149, DOB on 148, birthPlace on 147, party on 137, constituency on 149, deputy club on 148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)