### PR TITLE
[ma_representatives] Add Morocco House of Representatives PEP crawler

### DIFF
--- a/datasets/ma/representatives/crawler.py
+++ b/datasets/ma/representatives/crawler.py
@@ -1,4 +1,5 @@
 from openpyxl import load_workbook
+from followthemoney.util import sanitize_text
 from rigour.mime.types import XLSX
 
 from zavod import Context
@@ -6,12 +7,13 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-GENDERS = {"Homme": "male", "Femme": "female"}
+MISSING_ARABIC_NAME = "Said Outghilast"
 
 
 def crawl_member(
     context: Context,
     row: dict[str, str | None],
+    name_ara: str | None,
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
@@ -24,9 +26,8 @@ def crawl_member(
     constituency = row.get("nom_de_la_circonscription")
     person.id = context.make_id(name, constituency)
     h.apply_name(person, full=name, lang="fra")
-    gender = row.get("genre")
-    if gender is not None:
-        person.add("gender", GENDERS[gender])
+    h.apply_name(person, full=name_ara, lang="ara")
+    person.add("gender", row.get("genre"))
     person.add("political", row.get("appartenance_politique"), lang="fra")
     # The right to be elected to the House of Representatives is reserved to Moroccan
     # citizens (Constitution art. 30).
@@ -62,8 +63,16 @@ def crawl(context: Context) -> None:
     categorisation = categorise(context, position)
     context.emit(position)
 
-    # Two parallel sheets ("ar"/"fr"); the French sheet is the complete Latin-script
-    # roster (the Arabic sheet is one row short and has no shared key to join on).
     workbook = load_workbook(path, read_only=True)
+    arabic_names = iter(
+        name
+        for row in workbook["ar"].iter_rows(min_row=2, max_col=5)
+        if (name := sanitize_text(row[4].value)) is not None
+    )
     for row in h.parse_xlsx_sheet(context, workbook["fr"]):
-        crawl_member(context, row, position, categorisation)
+        # The sheets have the same ordering, but Said Outghilast is absent from the
+        # Arabic sheet. Do not advance the Arabic-name iterator for that member.
+        name_ara = None
+        if row.get("prenom_et_nom") != MISSING_ARABIC_NAME:
+            name_ara = next(arabic_names)
+        crawl_member(context, row, name_ara, position, categorisation)

--- a/datasets/ma/representatives/crawler.py
+++ b/datasets/ma/representatives/crawler.py
@@ -1,0 +1,69 @@
+from openpyxl import load_workbook
+from rigour.mime.types import XLSX
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+GENDERS = {"Homme": "male", "Femme": "female"}
+
+
+def crawl_member(
+    context: Context,
+    row: dict[str, str | None],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    name = row.get("prenom_et_nom")
+    if name is None:
+        return
+
+    person = context.make("Person")
+    # The source has no stable per-deputy id; key on name and electoral district.
+    constituency = row.get("nom_de_la_circonscription")
+    person.id = context.make_id(name, constituency)
+    h.apply_name(person, full=name, lang="fra")
+    gender = row.get("genre")
+    if gender is not None:
+        person.add("gender", GENDERS[gender])
+    person.add("political", row.get("appartenance_politique"), lang="fra")
+    # The right to be elected to the House of Representatives is reserved to Moroccan
+    # citizens (Constitution art. 30).
+    # https://www.constituteproject.org/constitution/Morocco_2011
+    person.add("citizenship", "ma")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", constituency, lang="fra")
+    occupancy.add(
+        "politicalGroup", row.get("groupe_ou_groupement_parlementaire"), lang="fra"
+    )
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    path = context.fetch_resource("deputies.xlsx", context.data_url)
+    context.export_resource(path, XLSX, title=context.SOURCE_TITLE)
+
+    position = h.make_position(
+        context,
+        name="Member of the House of Representatives of Morocco",
+        country="ma",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21328583",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    # Two parallel sheets ("ar"/"fr"); the French sheet is the complete Latin-script
+    # roster (the Arabic sheet is one row short and has no shared key to join on).
+    workbook = load_workbook(path, read_only=True)
+    for row in h.parse_xlsx_sheet(context, workbook["fr"]):
+        crawl_member(context, row, position, categorisation)

--- a/datasets/ma/representatives/ma_representatives.yml
+++ b/datasets/ma/representatives/ma_representatives.yml
@@ -1,0 +1,49 @@
+title: Morocco Members of the House of Representatives
+entry_point: crawler.py
+prefix: ma-rep
+coverage:
+  frequency: monthly
+  start: 2026-06-25
+load_statements: true
+ci_test: false # Live external open-data download, not exercised in CI
+summary: >-
+  Members of the House of Representatives (Chambre des Représentants), the lower
+  house of the Parliament of Morocco
+description: |
+  Members of the House of Representatives (Chambre des Représentants / مجلس النواب), the
+  directly elected lower house of the bicameral Parliament of Morocco. It has 395 seats
+  filled for five-year terms from local and regional (women's and youth) constituencies.
+
+  This dataset records each member of the 11th Legislature (2021–2026) with their name,
+  gender, electoral district, political party and parliamentary group, sourced from the
+  official list published on Morocco's national open-data portal.
+url: https://data.gov.ma/data/fr/dataset/liste-des-depute-e-s-au-titre-de-la-11eme-legislature-2021-2026
+publisher:
+  name: مجلس النواب
+  name_en: House of Representatives of Morocco
+  description: >
+    The House of Representatives (Chambre des Représentants) is the directly elected
+    lower house of the bicameral Parliament of Morocco. The list is republished via
+    data.gov.ma, the national open-data portal.
+  url: https://www.chambredesrepresentants.ma/
+  country: ma
+  official: true
+data:
+  url: https://data.gov.ma/data/fr/dataset/cc2ed3f0-218b-4cd7-99ce-7f0d99cd5aff/resource/31a247d0-5c34-48e3-8c47-8df8dd30bf0c/download/opendata-liste-dep-v2.xlsx
+  format: XLSX
+  lang: fra
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 350
+      Position: 1
+    country_entities:
+      ma: 350
+  max:
+    schema_entities:
+      Person: 420
+      Position: 1

--- a/datasets/ma/representatives/ma_representatives.yml
+++ b/datasets/ma/representatives/ma_representatives.yml
@@ -5,10 +5,9 @@ coverage:
   frequency: monthly
   start: 2026-06-25
 load_statements: true
-ci_test: false # Live external open-data download, not exercised in CI
+ci_test: true
 summary: >-
-  Members of the House of Representatives (Chambre des Représentants), the lower
-  house of the Parliament of Morocco
+  Members of the Chambre des Représentants, the lower house of the Parliament of Morocco
 description: |
   Members of the House of Representatives (Chambre des Représentants / مجلس النواب), the
   directly elected lower house of the bicameral Parliament of Morocco. It has 395 seats
@@ -47,3 +46,11 @@ assertions:
     schema_entities:
       Person: 420
       Position: 1
+
+lookups:
+  type.gender:
+    options:
+      - match: Homme
+        value: male
+      - match: Femme
+        value: female


### PR DESCRIPTION
PEP crawler for the **House of Representatives** (Chambre des Représentants), the directly elected lower house of the Parliament of Morocco.

Closes opensanctions/crawler-planning#754 (milestone: Africa PEPs — Legislative Bodies).

## Source
The official deputies list for the 11th Legislature (2021–2026), published as an XLSX on Morocco's national open-data portal [data.gov.ma](https://data.gov.ma/data/fr/dataset/liste-des-depute-e-s-au-titre-de-la-11eme-legislature-2021-2026). The file has parallel Arabic and French sheets (394 deputies).

## What it emits
Each member → a `Person` holding a `current` `Occupancy` on Member of the House of Representatives of Morocco (`Q21328583`, `gov.national` + `gov.legislative`).

- Name (French/Latin), `gender`, `political` (party); `constituency` (electoral district) and parliamentary group → `politicalGroup`.
- `citizenship=ma` — the right to be elected is reserved to Moroccan citizens (Constitution art. 30).

## Notes
- Built from the **French sheet** (complete Latin-script roster). The Arabic sheet is one row short and shares no language-independent key to join on, so attaching Arabic names would risk mis-pairing — omitted rather than emit wrong aliases.
- The source has no per-deputy id, DOB or contact info; entity ids key on name + electoral district.
- The file is a static 2021 snapshot, so mid-term replacements may lag (documented source limitation).

## Validation
- `zavod crawl` clean (`issues.json` empty); 789 entities (394 Person · 394 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.
- PEP integrity: every `role.pep` person has `citizenship`; name, gender, party, constituency and group populated on all 394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)