### PR TITLE
[sn_assembly] Add Senegal National Assembly PEP crawler

### DIFF
--- a/datasets/sn/assembly/crawler.py
+++ b/datasets/sn/assembly/crawler.py
@@ -1,0 +1,101 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The roster is a Nuxt "devalue" payload: a flat pool where container values are
+# integer indices back into the same pool. Resolving one key yields the deputies.
+DEPUTIES_KEY = "deputies"
+GENDERS = {"M": "male", "F": "female"}
+
+
+def resolve(pool: list[Any], index: Any, seen: frozenset[int] = frozenset()) -> Any:
+    """Dereference a Nuxt devalue index into its concrete value."""
+    if not isinstance(index, int) or not 0 <= index < len(pool) or index in seen:
+        return None if isinstance(index, int) else index
+    value = pool[index]
+    if isinstance(value, dict):
+        return {k: resolve(pool, v, seen | {index}) for k, v in value.items()}
+    if isinstance(value, list):
+        # devalue wraps reactive values as ["Reactive", index] etc.
+        if len(value) == 2 and value[0] in (
+            "Reactive",
+            "ShallowReactive",
+            "Ref",
+            "ShallowRef",
+        ):
+            return resolve(pool, value[1], seen | {index})
+        return [resolve(pool, v, seen | {index}) for v in value]
+    return value
+
+
+def crawl_deputy(
+    context: Context,
+    deputy: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug("deputy", str(deputy["id"]))
+    h.apply_name(
+        person,
+        first_name=deputy.get("first_name"),
+        last_name=deputy.get("last_name"),
+        lang="fra",
+    )
+    gender = deputy.get("gender")
+    if gender is not None:
+        person.add("gender", GENDERS[gender])
+    h.apply_date(person, "birthDate", deputy.get("birthdate"))
+    person.add("birthPlace", deputy.get("birthplace"))
+    person.add("notes", deputy.get("biography"))
+    # Suffrage is reserved to Senegalese nationals (Constitution art. 3).
+    # https://www.constituteproject.org/constitution/Senegal_2016
+    person.add("citizenship", "sn")
+
+    electoral_list = deputy.get("electoral_list") or {}
+    coalition = electoral_list.get("coalition") or {}
+    person.add("political", coalition.get("name"))
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    constituency = electoral_list.get("constituency") or {}
+    occupancy.add("constituency", constituency.get("name"))
+    group = deputy.get("group") or {}
+    occupancy.add("politicalGroup", group.get("name"))
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    pool = context.fetch_json(context.data_url, cache_days=1)
+    root = resolve(pool, 2)
+    if not isinstance(root, dict):
+        raise ValueError("Unexpected payload root")
+    # The deputies live under a query-parameterised key; match it by substring.
+    keys = [k for k in root if DEPUTIES_KEY in k and isinstance(root[k], dict)]
+    if len(keys) != 1:
+        raise ValueError(f"Expected one deputies key, found {keys}")
+    deputies = root[keys[0]].get("items")
+    if not isinstance(deputies, list) or len(deputies) == 0:
+        raise ValueError("No deputies resolved from payload")
+
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of Senegal",
+        country="sn",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q20757571",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    for deputy in deputies:
+        crawl_deputy(context, deputy, position, categorisation)

--- a/datasets/sn/assembly/crawler.py
+++ b/datasets/sn/assembly/crawler.py
@@ -8,7 +8,6 @@ from zavod.stateful.positions import PositionCategorisation, categorise
 # The roster is a Nuxt "devalue" payload: a flat pool where container values are
 # integer indices back into the same pool. Resolving one key yields the deputies.
 DEPUTIES_KEY = "deputies"
-GENDERS = {"M": "male", "F": "female"}
 
 
 def resolve(pool: list[Any], index: Any, seen: frozenset[int] = frozenset()) -> Any:
@@ -45,9 +44,7 @@ def crawl_deputy(
         last_name=deputy.get("last_name"),
         lang="fra",
     )
-    gender = deputy.get("gender")
-    if gender is not None:
-        person.add("gender", GENDERS[gender])
+    person.add("gender", deputy.get("gender"))
     h.apply_date(person, "birthDate", deputy.get("birthdate"))
     person.add("birthPlace", deputy.get("birthplace"))
     person.add("notes", deputy.get("biography"))

--- a/datasets/sn/assembly/sn_assembly.yml
+++ b/datasets/sn/assembly/sn_assembly.yml
@@ -1,0 +1,52 @@
+title: Senegal Members of the National Assembly
+entry_point: crawler.py
+prefix: sn-an
+coverage:
+  frequency: monthly
+  start: 2026-06-25
+load_statements: true
+ci_test: false # Live external data source, not exercised in CI
+summary: >-
+  Members of the National Assembly (Assemblée nationale), the unicameral
+  parliament of Senegal
+description: |
+  Members of the National Assembly (Assemblée nationale), the unicameral national
+  parliament of Senegal. It has 165 deputies elected for five-year terms from
+  departmental, national and diaspora lists.
+
+  This dataset records each deputy of the 15th Legislature (2024–2029) with their name,
+  gender, date and place of birth, electoral list and coalition, constituency and
+  parliamentary group, sourced from the vie-publique.sn civic-data portal.
+url: https://www.vie-publique.sn/assemblee-nationale/deputes
+publisher:
+  name: Assemblée nationale du Sénégal
+  name_en: National Assembly of Senegal
+  description: >
+    The National Assembly (Assemblée nationale) is the unicameral national parliament
+    of Senegal. The roster is republished by vie-publique.sn, a Senegalese civic-data
+    portal, which exposes it as a structured payload.
+  url: https://www.assemblee-nationale.sn/
+  country: sn
+  official: false
+data:
+  url: https://www.vie-publique.sn/assemblee-nationale/deputes/_payload.json
+  format: JSON
+  lang: fra
+
+dates:
+  formats: ["%Y-%m-%d"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 140
+      Position: 1
+    country_entities:
+      sn: 140
+  max:
+    schema_entities:
+      Person: 200
+      Position: 1

--- a/datasets/sn/assembly/sn_assembly.yml
+++ b/datasets/sn/assembly/sn_assembly.yml
@@ -5,10 +5,9 @@ coverage:
   frequency: monthly
   start: 2026-06-25
 load_statements: true
-ci_test: false # Live external data source, not exercised in CI
+ci_test: true
 summary: >-
-  Members of the National Assembly (Assemblée nationale), the unicameral
-  parliament of Senegal
+  Members of the Assemblée nationale, the unicameral parliament of Senegal
 description: |
   Members of the National Assembly (Assemblée nationale), the unicameral national
   parliament of Senegal. It has 165 deputies elected for five-year terms from
@@ -50,3 +49,11 @@ assertions:
     schema_entities:
       Person: 200
       Position: 1
+
+lookups:
+  type.gender:
+    options:
+      - match: M
+        value: male
+      - match: F
+        value: female


### PR DESCRIPTION
PEP crawler for the **National Assembly** (Assemblée nationale), the unicameral parliament of Senegal.

Closes opensanctions/crawler-planning#761 (milestone: Africa PEPs — Legislative Bodies).

## Source
`https://www.vie-publique.sn/assemblee-nationale/deputes/_payload.json` — the Nuxt SSR payload behind vie-publique.sn (a Senegalese civic-data portal; the official assemblee.sn API is non-functional). 166 deputies of the 15th Legislature (2024–2029).

The payload is a Nuxt **devalue** structure — a flat pool where container values are integer indices back into the same pool — so the crawler includes a small index dereferencer to resolve it into deputy records.

## What it emits
Each deputy → a `Person` holding a `current` `Occupancy` on Member of the National Assembly of Senegal (`Q20757571`, `gov.national` + `gov.legislative`).

- Name (French/Latin), `gender`, `birthDate`, `birthPlace`, `notes` (biography where present), `political` (electoral coalition).
- `constituency` (departmental lists; national/diaspora lists have none) and parliamentary group → `politicalGroup`.
- `citizenship=sn` — suffrage is reserved to Senegalese nationals (Constitution art. 3; the candidacy requirement lives in the electoral code).

## Notes
- vie-publique.sn is a civic-tech NGO, not the parliament itself — flagged via `publisher.official: false`; risk of staleness between elections.
- The payload key/shape is undocumented; the crawler validates the resolved structure and crashes on drift.

## Validation
- `zavod crawl` clean (`issues.json` empty); 333 entities (166 Person · 166 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.
- PEP integrity: every `role.pep` person has `citizenship`; name + gender + party on all 166, DOB/birthplace on 165, group on 166, constituency on 112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)