### PR TITLE
[gh_parliament] Add Ghana Parliament PEP crawler

### DIFF
--- a/datasets/gh/parliament/crawler.py
+++ b/datasets/gh/parliament/crawler.py
@@ -27,7 +27,7 @@ def crawl_member(
 
     person = context.make("Person")
     person.id = context.make_slug("mp", match.group(1))
-    h.apply_name(person, full=name, lang="eng")
+    h.apply_name(person, full=name)
     # Members of Parliament must be citizens of Ghana (Constitution art. 94(1)(a)) and
     # may not owe allegiance to another country (art. 94(2)(a)).
     # https://www.constituteproject.org/constitution/Ghana_1996
@@ -60,7 +60,6 @@ def crawl(context: Context) -> None:
         country="gh",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21290881",
-        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)

--- a/datasets/gh/parliament/crawler.py
+++ b/datasets/gh/parliament/crawler.py
@@ -1,0 +1,83 @@
+import re
+from itertools import count
+
+from lxml.html import HtmlElement
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+MP_RE = re.compile(r"mp=(\d+)")
+
+
+def crawl_member(
+    context: Context,
+    card: HtmlElement,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    match = MP_RE.search(card.get("href") or "")
+    if match is None:
+        return
+    names = h.xpath_elements(card, ".//h5")
+    name = h.element_text(names[0]) if names else None
+    if name is None or len(name) == 0:
+        return
+
+    person = context.make("Person")
+    person.id = context.make_slug("mp", match.group(1))
+    h.apply_name(person, full=name, lang="eng")
+    # Members of Parliament must be citizens of Ghana (Constitution art. 94(1)(a)) and
+    # may not owe allegiance to another country (art. 94(2)(a)).
+    # https://www.constituteproject.org/constitution/Ghana_1996
+    person.add("citizenship", "gh")
+
+    # The card's <p> holds "<constituency><br><party>".
+    paragraphs = h.xpath_elements(card, ".//p")
+    constituency = party = None
+    if paragraphs:
+        constituency = (paragraphs[0].text or "").strip() or None
+        breaks = h.xpath_elements(paragraphs[0], ".//br")
+        if breaks and breaks[0].tail is not None:
+            party = breaks[0].tail.strip() or None
+    person.add("political", party)
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", constituency)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Parliament of Ghana",
+        country="gh",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21290881",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    seen: set[str] = set()
+    for page in count(1):
+        doc = context.fetch_html(
+            context.data_url, params={"page": page}, cache_days=1, absolute_links=True
+        )
+        cards = h.xpath_elements(doc, "//a[contains(@href, 'members?mp=')]")
+        fresh = 0
+        for card in cards:
+            match = MP_RE.search(card.get("href") or "")
+            if match is None or match.group(1) in seen:
+                continue
+            seen.add(match.group(1))
+            fresh += 1
+            crawl_member(context, card, position, categorisation)
+        if fresh == 0:
+            break

--- a/datasets/gh/parliament/gh_parliament.yml
+++ b/datasets/gh/parliament/gh_parliament.yml
@@ -5,7 +5,6 @@ coverage:
   frequency: monthly
   start: 2026-06-25
 load_statements: true
-ci_test: false # Live external government website, not available in CI
 summary: >-
   Members of the Parliament of Ghana, the unicameral national legislature
 description: |

--- a/datasets/gh/parliament/gh_parliament.yml
+++ b/datasets/gh/parliament/gh_parliament.yml
@@ -1,0 +1,44 @@
+title: Ghana Members of Parliament
+entry_point: crawler.py
+prefix: gh-mp
+coverage:
+  frequency: monthly
+  start: 2026-06-25
+load_statements: true
+ci_test: false # Live external government website, not available in CI
+summary: >-
+  Members of the Parliament of Ghana, the unicameral national legislature
+description: |
+  Members of Parliament of Ghana, the unicameral national legislature. It has 275
+  members elected one per constituency for four-year terms.
+
+  This dataset records each sitting member with their name, constituency and political
+  party, sourced from the Parliament of Ghana's official website.
+url: https://www.parliament.gh/members
+publisher:
+  name: Parliament of Ghana
+  description: >
+    The Parliament of Ghana is the unicameral national legislature of the Republic of
+    Ghana.
+  url: https://www.parliament.gh/
+  country: gh
+  official: true
+data:
+  url: https://www.parliament.gh/members
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 220
+      Position: 1
+    country_entities:
+      gh: 220
+  max:
+    schema_entities:
+      Person: 290
+      Position: 1


### PR DESCRIPTION
PEP crawler for the unicameral **Parliament of Ghana**.

Closes opensanctions/crawler-planning#753 (milestone: Africa PEPs — Legislative Bodies).

## Source
`https://www.parliament.gh/members` — official Parliament site, Bootstrap cards paginated `?page=1..7`.

## What it emits
Each MP → a `Person` holding a `current` `Occupancy` on Member of the Parliament of Ghana (`Q21290881`, gov.national + gov.legislative).

- Name, `constituency` and party → `political` (the card's `<p>` separates constituency and party with a `<br>`).
- `citizenship=gh` — MPs must be citizens of Ghana (Constitution art. 94(1)(a)) and may not owe allegiance to another country (art. 94(2)(a)).

## Notes
- 270 MPs scraped vs 275 seats — the site paginates a few short / omits vacant seats (party tally NDC 181 / NPP 85 / Independent 4 aligns with the published composition). Assertion floor set with tolerance.

## Validation
- `zavod crawl` clean (issues.json empty); 541 entities (270 Person · 270 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.
- PEP integrity passes: every role.pep person has citizenship; name, party, constituency on all 270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)