### PR TITLE
[ug_parliament] Add Uganda Parliament PEP crawler

### DIFF
--- a/datasets/ug/parliament/crawler.py
+++ b/datasets/ug/parliament/crawler.py
@@ -10,12 +10,6 @@ from zavod.stateful.positions import PositionCategorisation, categorise
 
 # The party acronym is embedded in the photo filename as the last "(...)" token.
 PARTY_RE = re.compile(r"\(([^()]+)\)[^()]*$")
-# The filenames spell the independents inconsistently.
-INDEPENDENTS = {"INDEP", "INDEPENDENT", "IND"}
-
-
-def clean_party(value: str) -> str:
-    return "Independent" if value.upper() in INDEPENDENTS else value
 
 
 def crawl_member(
@@ -44,7 +38,7 @@ def crawl_member(
     if images:
         match = PARTY_RE.search(images[0].get("src") or "")
         if match is not None:
-            person.add("political", clean_party(match.group(1)))
+            person.add("political", match.group(1))
     # Members of Parliament must be citizens of Uganda (Constitution art. 80(1)(a)).
     # https://www.constituteproject.org/constitution/Uganda_2017
     person.add("citizenship", "ug")

--- a/datasets/ug/parliament/crawler.py
+++ b/datasets/ug/parliament/crawler.py
@@ -1,0 +1,88 @@
+import re
+from itertools import count
+
+from lxml.html import HtmlElement
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The party acronym is embedded in the photo filename as the last "(...)" token.
+PARTY_RE = re.compile(r"\(([^()]+)\)[^()]*$")
+# The filenames spell the independents inconsistently.
+INDEPENDENTS = {"INDEP", "INDEPENDENT", "IND"}
+
+
+def clean_party(value: str) -> str:
+    return "Independent" if value.upper() in INDEPENDENTS else value
+
+
+def crawl_member(
+    context: Context,
+    card: HtmlElement,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    headings = h.xpath_elements(card, ".//h5")
+    if not headings:
+        return
+    # Names are prefixed "Hon.".
+    name = h.element_text(headings[0]).removeprefix("Hon.").strip()
+    if len(name) == 0:
+        return
+    # Two location spans: the constituency/seat designation and the district.
+    spans = [h.element_text(s) for s in h.xpath_elements(card, ".//span")]
+    locations = [s for s in spans[:2] if len(s) > 0]
+    district = locations[-1] if locations else None
+
+    person = context.make("Person")
+    # The profile-link tokens rotate between runs, so key on name + district instead.
+    person.id = context.make_id(name, district)
+    h.apply_name(person, full=name, lang="eng")
+    images = h.xpath_elements(card, ".//img")
+    if images:
+        match = PARTY_RE.search(images[0].get("src") or "")
+        if match is not None:
+            person.add("political", clean_party(match.group(1)))
+    # Members of Parliament must be citizens of Uganda (Constitution art. 80(1)(a)).
+    # https://www.constituteproject.org/constitution/Uganda_2017
+    person.add("citizenship", "ug")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    for location in locations:
+        occupancy.add("constituency", location)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Parliament of Uganda",
+        country="ug",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21296005",
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    seen: set[str] = set()
+    for page in count(1):
+        doc = context.fetch_html(context.data_url, params={"page": page}, cache_days=1)
+        cards = h.xpath_elements(doc, "//a[contains(@href, '/home/mp/')]")
+        fresh = 0
+        for card in cards:
+            href = card.get("href") or ""
+            if href in seen:
+                continue
+            seen.add(href)
+            fresh += 1
+            crawl_member(context, card, position, categorisation)
+        if fresh == 0:
+            break

--- a/datasets/ug/parliament/ug_parliament.yml
+++ b/datasets/ug/parliament/ug_parliament.yml
@@ -1,0 +1,46 @@
+title: Uganda Members of Parliament
+entry_point: crawler.py
+prefix: ug-mp
+coverage:
+  frequency: monthly
+  start: 2026-06-25
+load_statements: true
+ci_test: false # Live external government website, not available in CI
+summary: >-
+  Members of the Parliament of Uganda, the unicameral national legislature
+description: |
+  Members of the Parliament of Uganda, the unicameral national legislature. It comprises
+  directly elected constituency members, district woman representatives, and members for
+  special interest groups (army, youth, persons with disabilities, workers and older
+  persons), serving five-year terms.
+
+  This dataset records each sitting member with their name, constituency/district and
+  political party, sourced from the Parliament's official MPs database.
+url: https://mpsdb.parliament.go.ug/
+publisher:
+  name: Parliament of Uganda
+  description: >
+    The Parliament of Uganda is the unicameral national legislature of the Republic of
+    Uganda; the MPs Database is its official member directory.
+  url: https://www.parliament.go.ug/
+  country: ug
+  official: true
+data:
+  url: https://mpsdb.parliament.go.ug/
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 450
+      Position: 1
+    country_entities:
+      ug: 450
+  max:
+    schema_entities:
+      Person: 620
+      Position: 1


### PR DESCRIPTION
PEP crawler for the unicameral **Parliament of Uganda**.

Closes opensanctions/crawler-planning#759 (milestone: Africa PEPs — Legislative Bodies).

## Source
`https://mpsdb.parliament.go.ug/` — the Parliament's official MPs Database (Laravel app), paginated `?page=1..24` (555 MPs).

## What it emits
Each MP → a `Person` holding a `current` `Occupancy` on Member of the Parliament of Uganda (`Q21296005`, gov.national + gov.legislative).

- Name (`Hon.` stripped); `constituency` (seat/county designation and district); party → `political`, parsed from the photo filename's trailing party token.
- `citizenship=ug` — MPs must be citizens of Uganda (Constitution art. 80(1)(a)).
- Profile-link tokens rotate between runs, so entity ids key on name + district.

## Validation
- `zavod crawl` clean (issues.json empty); 1111 entities (555 Person · 555 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.
- PEP integrity passes: every role.pep person has citizenship; name + constituency on all 555, party on 472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
