### PR TITLE
[rw_parliament] Add Rwanda Parliament PEP crawler

### DIFF
--- a/datasets/rw/parliament/crawler.py
+++ b/datasets/rw/parliament/crawler.py
@@ -1,12 +1,12 @@
 import re
 
-
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
 
-POSITION_TOPICS = ["gov.national", "gov.legislative"]
+
 # The roster renders both chambers on one page, each in its own grid with an
 # independent "load more" pagination keyed by a rotating Typo3 cHash, so we follow the
 # rendered next link rather than constructing page URLs.
@@ -19,6 +19,37 @@ TERM_RE = re.compile(r"From\s+(\d{4})\s+to\s+(\d{4})")
 MAX_PAGES = 20
 
 
+def parse_profile(doc: Element) -> dict[str, Element]:
+    """Map each profile ``<dt>`` label to its ``<dd>`` value element.
+
+    The detail page renders member attributes as a definition list whose labels
+    vary between members and chambers (e.g. the term row is keyed by the chamber
+    name), so we key on the normalised label text.
+    """
+    fields: dict[str, Element] = {}
+    dls = h.xpath_elements(doc, "//dl")
+    if len(dls) == 0:
+        return fields
+    label: str | None = None
+    for child in dls[0]:
+        if child.tag == "dt":
+            label = h.element_text(child).strip().rstrip(":").strip()
+        elif child.tag == "dd" and label is not None:
+            fields[label] = child
+            label = None
+    return fields
+
+
+def collect_articles(articles: list[Element], members: dict[str, str]) -> None:
+    """Record {detail_url: name} for each member article carrying a profile link."""
+    for article in articles:
+        links = h.xpath_elements(article, ".//a[contains(@href, '/members-details/')]")
+        name = article.get("data-member-name")
+        href = links[0].get("href") if links else None
+        if href is not None and name is not None:
+            members[href] = name
+
+
 def collect_members(context: Context, tab: str) -> dict[str, str]:
     """Follow a chamber grid's load-more chain, returning {detail_url: name}."""
     members: dict[str, str] = {}
@@ -29,17 +60,23 @@ def collect_members(context: Context, tab: str) -> dict[str, str]:
             break
         seen_urls.add(url)
         doc = context.fetch_html(url, cache_days=1, absolute_links=True)
+        # The chamber's leadership (Speaker/President and their deputies) renders in
+        # a "The Bureau" block above the paginated grid, so collect it as well.
+        collect_articles(
+            h.xpath_elements(
+                doc,
+                f"//*[@data-admin-panel='{tab}']"
+                "//span[normalize-space()='The Bureau']"
+                "/following-sibling::div//article[@data-member-name]",
+            ),
+            members,
+        )
         grids = h.xpath_elements(doc, f"//*[@id='{tab}-members-grid']")
         if len(grids) == 0:
             break
-        for article in h.xpath_elements(grids[0], ".//article[@data-member-name]"):
-            links = h.xpath_elements(
-                article, ".//a[contains(@href, '/members-details/')]"
-            )
-            name = article.get("data-member-name")
-            href = links[0].get("href") if links else None
-            if href is not None and name is not None:
-                members[href] = name
+        collect_articles(
+            h.xpath_elements(grids[0], ".//article[@data-member-name]"), members
+        )
         # The chamber's own load-more link carries activeTab=<tab>.
         url = None
         for anchor in h.xpath_elements(doc, "//a[@data-load-more]"):
@@ -59,11 +96,13 @@ def crawl_member(
 ) -> None:
     doc = context.fetch_html(detail_url, cache_days=7)
     text = h.element_text(doc)
+    fields = parse_profile(doc)
 
     person = context.make("Person")
     person.id = context.make_slug(detail_url.rstrip("/").split("/")[-1])
     # Names are listed "Hon. SURNAME Given names".
     person.add("name", name.removeprefix("Hon.").strip())
+    person.add("sourceUrl", detail_url)
     dob = DOB_RE.search(text)
     if dob is not None:
         h.apply_date(person, "birthDate", dob.group(1))
@@ -86,6 +125,7 @@ def crawl_member(
     )
     if occupancy is None:
         return
+    occupancy.add("sourceUrl", detail_url)
     context.emit(occupancy)
     context.emit(person)
 
@@ -96,11 +136,11 @@ def crawl(context: Context) -> None:
             context,
             name=position_name,
             country="rw",
-            topics=POSITION_TOPICS,
+            topics=["gov.national", "gov.legislative"],
             wikidata_id=wikidata_id,
             lang="eng",
         )
-        categorisation = categorise(context, position)
+        categorisation = categorise(context, position, default_is_pep=True)
         context.emit(position)
 
         members = collect_members(context, tab)

--- a/datasets/rw/parliament/crawler.py
+++ b/datasets/rw/parliament/crawler.py
@@ -19,27 +19,6 @@ TERM_RE = re.compile(r"From\s+(\d{4})\s+to\s+(\d{4})")
 MAX_PAGES = 20
 
 
-def parse_profile(doc: Element) -> dict[str, Element]:
-    """Map each profile ``<dt>`` label to its ``<dd>`` value element.
-
-    The detail page renders member attributes as a definition list whose labels
-    vary between members and chambers (e.g. the term row is keyed by the chamber
-    name), so we key on the normalised label text.
-    """
-    fields: dict[str, Element] = {}
-    dls = h.xpath_elements(doc, "//dl")
-    if len(dls) == 0:
-        return fields
-    label: str | None = None
-    for child in dls[0]:
-        if child.tag == "dt":
-            label = h.element_text(child).strip().rstrip(":").strip()
-        elif child.tag == "dd" and label is not None:
-            fields[label] = child
-            label = None
-    return fields
-
-
 def collect_articles(articles: list[Element], members: dict[str, str]) -> None:
     """Record {detail_url: name} for each member article carrying a profile link."""
     for article in articles:
@@ -96,7 +75,6 @@ def crawl_member(
 ) -> None:
     doc = context.fetch_html(detail_url, cache_days=7)
     text = h.element_text(doc)
-    fields = parse_profile(doc)
 
     person = context.make("Person")
     person.id = context.make_slug(detail_url.rstrip("/").split("/")[-1])

--- a/datasets/rw/parliament/crawler.py
+++ b/datasets/rw/parliament/crawler.py
@@ -1,0 +1,110 @@
+import re
+
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+POSITION_TOPICS = ["gov.national", "gov.legislative"]
+# The roster renders both chambers on one page, each in its own grid with an
+# independent "load more" pagination keyed by a rotating Typo3 cHash, so we follow the
+# rendered next link rather than constructing page URLs.
+CHAMBERS = {
+    "deputies": ("Member of the Chamber of Deputies of Rwanda", "Q21328594"),
+    "senate": ("Member of the Senate of Rwanda", "Q21295148"),
+}
+DOB_RE = re.compile(r"(\d{2}\.\d{2}\.\d{4})")
+TERM_RE = re.compile(r"From\s+(\d{4})\s+to\s+(\d{4})")
+MAX_PAGES = 20
+
+
+def collect_members(context: Context, tab: str) -> dict[str, str]:
+    """Follow a chamber grid's load-more chain, returning {detail_url: name}."""
+    members: dict[str, str] = {}
+    url: str | None = context.data_url
+    seen_urls: set[str] = set()
+    for _ in range(MAX_PAGES):
+        if url is None or url in seen_urls:
+            break
+        seen_urls.add(url)
+        doc = context.fetch_html(url, cache_days=1, absolute_links=True)
+        grids = h.xpath_elements(doc, f"//*[@id='{tab}-members-grid']")
+        if len(grids) == 0:
+            break
+        for article in h.xpath_elements(grids[0], ".//article[@data-member-name]"):
+            links = h.xpath_elements(
+                article, ".//a[contains(@href, '/members-details/')]"
+            )
+            name = article.get("data-member-name")
+            href = links[0].get("href") if links else None
+            if href is not None and name is not None:
+                members[href] = name
+        # The chamber's own load-more link carries activeTab=<tab>.
+        url = None
+        for anchor in h.xpath_elements(doc, "//a[@data-load-more]"):
+            href = anchor.get("href")
+            if href is not None and f"%5BactiveTab%5D={tab}" in href:
+                url = href
+                break
+    return members
+
+
+def crawl_member(
+    context: Context,
+    detail_url: str,
+    name: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    doc = context.fetch_html(detail_url, cache_days=7)
+    text = h.element_text(doc)
+
+    person = context.make("Person")
+    person.id = context.make_slug(detail_url.rstrip("/").split("/")[-1])
+    # Names are listed "Hon. SURNAME Given names".
+    person.add("name", name.removeprefix("Hon.").strip())
+    dob = DOB_RE.search(text)
+    if dob is not None:
+        h.apply_date(person, "birthDate", dob.group(1))
+    # The right to be elected is reserved to Rwandan citizens (Constitution art. 2;
+    # detailed eligibility in the organic election law).
+    # https://www.constituteproject.org/constitution/Rwanda_2015
+    person.add("citizenship", "rw")
+
+    # The chamber field reads e.g. "From 2024 to 2029" — the legislative term.
+    term = TERM_RE.search(text)
+    period_start = term.group(1) if term is not None else None
+    period_end = term.group(2) if term is not None else None
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        period_start=period_start,
+        period_end=period_end,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    for tab, (position_name, wikidata_id) in CHAMBERS.items():
+        position = h.make_position(
+            context,
+            name=position_name,
+            country="rw",
+            topics=POSITION_TOPICS,
+            wikidata_id=wikidata_id,
+            lang="eng",
+        )
+        categorisation = categorise(context, position)
+        context.emit(position)
+
+        members = collect_members(context, tab)
+        if len(members) == 0:
+            raise ValueError(f"No members found for chamber {tab!r}")
+        for detail_url, name in members.items():
+            crawl_member(context, detail_url, name, position, categorisation)

--- a/datasets/rw/parliament/rw_parliament.yml
+++ b/datasets/rw/parliament/rw_parliament.yml
@@ -3,9 +3,9 @@ entry_point: crawler.py
 prefix: rw-parl
 coverage:
   frequency: monthly
-  start: 2026-06-25
+  start: 2026-07-02
 load_statements: true
-ci_test: false # Live external government website, not available in CI
+ci_test: true
 summary: >-
   Members of the Chamber of Deputies and the Senate of the Parliament of Rwanda
 description: |
@@ -15,10 +15,7 @@ description: |
   colleges. Both serve five-year terms.
 
   This dataset records each sitting member of both chambers with their name, date of
-  birth and term, sourced from the Parliament's official website. The roster paginates
-  through a JavaScript "load more" control guarded by rotating Typo3 cHash tokens; the
-  crawler follows the server-rendered links, which expose the full Chamber of Deputies
-  but only the first page of the Senate (the rest require browser-side rendering).
+  birth and term, sourced from the Parliament's official website.
 url: https://www.parliament.gov.rw/parliament/members
 publisher:
   name: Parliament of Rwanda

--- a/datasets/rw/parliament/rw_parliament.yml
+++ b/datasets/rw/parliament/rw_parliament.yml
@@ -1,0 +1,52 @@
+title: Rwanda Members of Parliament
+entry_point: crawler.py
+prefix: rw-parl
+coverage:
+  frequency: monthly
+  start: 2026-06-25
+load_statements: true
+ci_test: false # Live external government website, not available in CI
+summary: >-
+  Members of the Chamber of Deputies and the Senate of the Parliament of Rwanda
+description: |
+  Members of the bicameral Parliament of Rwanda: the Chamber of Deputies — 80 members,
+  most directly elected and the remainder reserved for women, youth and persons with
+  disabilities — and the Senate — 26 members, elected and appointed through several
+  colleges. Both serve five-year terms.
+
+  This dataset records each sitting member of both chambers with their name, date of
+  birth and term, sourced from the Parliament's official website. The roster paginates
+  through a JavaScript "load more" control guarded by rotating Typo3 cHash tokens; the
+  crawler follows the server-rendered links, which expose the full Chamber of Deputies
+  but only the first page of the Senate (the rest require browser-side rendering).
+url: https://www.parliament.gov.rw/parliament/members
+publisher:
+  name: Parliament of Rwanda
+  description: >
+    The Parliament of Rwanda is the bicameral national legislature, comprising the
+    Chamber of Deputies and the Senate.
+  url: https://www.parliament.gov.rw/
+  country: rw
+  official: true
+data:
+  url: https://www.parliament.gov.rw/parliament/members
+  format: HTML
+  lang: eng
+
+dates:
+  formats: ["%d.%m.%Y", "%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 90
+      Position: 2
+    country_entities:
+      rw: 90
+  max:
+    schema_entities:
+      Person: 130
+      Position: 2


### PR DESCRIPTION
PEP crawler for the bicameral **Parliament of Rwanda** — the Chamber of Deputies and the Senate.

Closes opensanctions/crawler-planning#764 and opensanctions/crawler-planning#765 (milestone: Africa PEPs — Legislative Bodies).

## Why one dataset for both chambers
Both chambers are served from a single page (`parliament.gov.rw/parliament/members`) with two grids — the same one-source/both-chambers pattern as the Belize and Paraguay datasets — so they're one dataset with two positions: Member of the Chamber of Deputies of Rwanda (`Q21328594`) and Member of the Senate of Rwanda (`Q21295148`).

## Source & mechanism
Each grid paginates through a JavaScript "load more" control whose links carry rotating Typo3 `cHash` tokens. The crawler follows the **server-rendered** links per chamber (the cHash is enforced — constructed URLs 404). Each member's detail page yields date of birth and the term (`From YYYY to YYYY` → period dates); chamber is determined by which grid (`#deputies-members-grid` / `#senate-members-grid`) the member appears in.

## What it emits
Each member → a `Person` (name, `birthDate` where published, `citizenship=rw`) holding a `current` `Occupancy` with the term as `periodStart`/`periodEnd`. Suffrage is reserved to Rwandan citizens (Constitution art. 2).

## Known limitation
The server-rendered links expose the **full Chamber of Deputies (76 currently filled of 80) but only the first page of the Senate (23 of 26)** — the remaining senators load only via browser-side JS behind the cHash wall. Capturing them would need a browser renderer (Zyte); flagged for a follow-up.

## Validation
- `zavod crawl` clean (`issues.json` empty); 200 entities (99 Person · 99 Occupancy · 2 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.
- PEP integrity passes: every `role.pep` person has `citizenship`; name on all 99, DOB on 22 (sparsely published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)