### PR TITLE
[ci_senate] Add Côte d'Ivoire Senate PEP crawler

### DIFF
--- a/datasets/ci/senate/ci_senate.yml
+++ b/datasets/ci/senate/ci_senate.yml
@@ -5,7 +5,6 @@ coverage:
   frequency: monthly
   start: 2026-06-25
 load_statements: true
-ci_test: false # Live external government website, not available in CI
 summary: >-
   Senators of the Senate of Côte d'Ivoire, the upper house of Parliament
 description: |

--- a/datasets/ci/senate/ci_senate.yml
+++ b/datasets/ci/senate/ci_senate.yml
@@ -1,0 +1,45 @@
+title: Côte d'Ivoire Members of the Senate
+entry_point: crawler.py
+prefix: ci-senate
+coverage:
+  frequency: monthly
+  start: 2026-06-25
+load_statements: true
+ci_test: false # Live external government website, not available in CI
+summary: >-
+  Senators of the Senate of Côte d'Ivoire, the upper house of Parliament
+description: |
+  Members of the Senate (Sénat), the upper house of the bicameral Parliament of Côte
+  d'Ivoire. It has 99 senators — two thirds elected indirectly and one third appointed
+  by the President — serving five-year terms.
+
+  This dataset records each sitting senator by name, sourced from the Senate's official
+  website. The site lists names only (no party or region in a structured form).
+url: https://www.senat.ci/les-senateurs
+publisher:
+  name: Sénat de Côte d'Ivoire
+  name_en: Senate of Côte d'Ivoire
+  description: >
+    The Senate is the upper house of the bicameral Parliament of Côte d'Ivoire.
+  url: https://www.senat.ci/
+  country: ci
+  official: true
+data:
+  url: https://www.senat.ci/les-senateurs
+  format: HTML
+  lang: fra
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 85
+      Position: 1
+    country_entities:
+      ci: 85
+  max:
+    schema_entities:
+      Person: 110
+      Position: 1

--- a/datasets/ci/senate/crawler.py
+++ b/datasets/ci/senate/crawler.py
@@ -1,0 +1,47 @@
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Senate of Côte d'Ivoire",
+        country="ci",
+        topics=["gov.national", "gov.legislative"],
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    # Senators are rendered as cards; the same senator recurs under each commission
+    # section they sit on, so dedupe by name.
+    cards = h.xpath_elements(doc, "//div[contains(@class, 'tof-card')]")
+    seen: set[str] = set()
+    for card in cards:
+        titles = h.xpath_elements(card, ".//h6[contains(@class, 'card-title')]")
+        if not titles:
+            continue
+        name = h.element_text(titles[0])
+        if len(name) == 0 or name in seen:
+            continue
+        seen.add(name)
+
+        person = context.make("Person")
+        person.id = context.make_id("ci-senator", name)
+        person.add("name", name)
+        # Senators must be Ivorian nationals (Constitution art. 87; Electoral Code
+        # art. 112). https://www.constituteproject.org/constitution/Cote_DIvoire_2016
+        person.add("citizenship", "ci")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(occupancy)
+        context.emit(person)
+
+    if len(seen) == 0:
+        raise ValueError("No senators found on the listing page")

--- a/datasets/ci/senate/crawler.py
+++ b/datasets/ci/senate/crawler.py
@@ -2,6 +2,12 @@ from zavod import Context
 from zavod import helpers as h
 from zavod.stateful.positions import categorise
 
+CARD_TITLE_XPATH = """
+    .//section[@id='main-container']
+    //*[self::h5 or self::h6]
+      [contains(concat(' ', normalize-space(@class), ' '), ' card-title ')]
+"""
+
 
 def crawl(context: Context) -> None:
     position = h.make_position(
@@ -12,18 +18,16 @@ def crawl(context: Context) -> None:
         lang="eng",
     )
     categorisation = categorise(context, position)
+    if not categorisation.is_pep:
+        return
     context.emit(position)
 
     doc = context.fetch_html(context.data_url, cache_days=1)
-    # Senators are rendered as cards; the same senator recurs under each commission
-    # section they sit on, so dedupe by name.
-    cards = h.xpath_elements(doc, "//div[contains(@class, 'tof-card')]")
+    # Senators recur across the page's organ and commission sections.
     seen: set[str] = set()
-    for card in cards:
-        titles = h.xpath_elements(card, ".//h6[contains(@class, 'card-title')]")
-        if not titles:
-            continue
-        name = h.element_text(titles[0])
+    titles = h.xpath_elements(doc, CARD_TITLE_XPATH)
+    for title in titles:
+        name = h.element_text(title)
         if len(name) == 0 or name in seen:
             continue
         seen.add(name)


### PR DESCRIPTION
PEP crawler for the **Senate**, the upper house of the Parliament of Côte d'Ivoire.

Closes opensanctions/crawler-planning#763 (milestone: Africa PEPs — Legislative Bodies).

## Source
`https://www.senat.ci/les-senateurs` — official Senate site. Senators render as cards grouped by commission, so the same senator recurs under each commission they sit on; the crawler dedupes by name.

## What it emits
Each senator → a `Person` holding a `current` `Occupancy` on Member of the Senate of Côte d'Ivoire (gov.national + gov.legislative; no distinct Wikidata QID exists).

- `citizenship=ci` — senators must be Ivorian nationals (Constitution art. 87; Electoral Code art. 112).
- **Name only**: the listing exposes names without party or region in structured form.

## Validation
- `zavod crawl` clean (issues.json empty); 197 entities (98 Person · 98 Occupancy · 1 Position).
- `zavod validate` passes; `mypy --strict` + pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)