### PR TITLE
[wd_categories] Tag our position names as
  English

### DIFF
--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -150,7 +150,11 @@ def crawl_category(state: CrawlState, category_crawl_spec: Dict[str, Any]) -> No
     position: Optional[Entity] = None
     if "name" in position_data:
         position = h.make_position(
-            state.context, **position_data, id_hash_prefix="wd-cat"
+            state.context,
+            **position_data,
+            # Our position specs in the metadata are always in English
+            lang="eng",
+            id_hash_prefix="wd-cat",
         )
 
     query_string = urlencode(query)

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -248,6 +248,8 @@ config:
     - Q5234712 # Came in via Dallas categories under Category:George_M._Dallas
     - Q546195 # Khuit II, Queen Consort of Ancient Egypt
   categories:
+    # Position names defined here (the `position.name` field) should be written
+    # in English — make_position tags them with lang="eng".
     # Mega collections:
     - category: Political_office-holders_in_Asia
       depth: 8

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -2974,7 +2974,7 @@ config:
       country: ru
       language: ru
       position:
-        name: Глава парламента субъекта Российской Федерации
+        name: Chairman of a Regional Parliament of Russia
         topics:
           - gov.legislative
           - gov.state


### PR DESCRIPTION
The position names we define ourselves in the wd_categories config are always
written in English, so we now tag them with `lang="eng"` in `make_position`.

While doing that I went through all 273 position names we define and found
exactly one that was actually written in Russian:
`Глава парламента субъекта Российской Федерации`. Translated it to
"Chairman of a Regional Parliament of Russia" — matches the common Wikipedia
term [Regional parliaments of Russia](https://en.wikipedia.org/wiki/Regional_parliaments_of_Russia)
and the "Chairman" convention used by the other federal-level entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
