### PR TITLE
make_position translate_if_required (+ util.LangText, position translate helper)

### DIFF
--- a/datasets/cz/pep_declarations/crawler.py
+++ b/datasets/cz/pep_declarations/crawler.py
@@ -81,6 +81,7 @@ def crawl_person(context: Context, item: Dict[str, Any]) -> None:
             name=position_name,
             country="cz",
             lang="ces",
+            translate_name=True,
         )
         entity.add("position", position_name)
 

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -8,6 +8,7 @@ from zavod import settings
 from zavod.constants import ORIGIN_INFERRED
 from zavod.context import Context
 from zavod.entity import Entity
+from zavod.util import LangText
 from zavod.stateful.positions import (
     DEFAULT_AFTER_OFFICE,
     OccupancyStatus,
@@ -33,6 +34,7 @@ def make_position(
     source_url: Optional[str] = None,
     lang: Optional[str] = None,
     id_hash_prefix: Optional[str] = None,
+    translate_name: bool = False,
 ) -> Entity:
     """Creates a Position entity.
 
@@ -53,6 +55,11 @@ def make_position(
         wikidata_id: The Wikidata QID of the position.
         source_url: The URL of the source the position was found in.
         lang: The language of the position details.
+        translate_name: If True and `lang` is a non-English language, the
+            position name is translated to English via an LLM and stored as the
+            `name` (with the original kept as the value's original_value). The
+            entity id is always derived from the untranslated `name`, so it stays
+            stable and independent of the (LLM-produced) translation.
 
     Returns:
         A new entity of type `Position`."""
@@ -74,7 +81,30 @@ def make_position(
     else:
         position.id = context.make_id(*parts, hash_prefix=id_hash_prefix)
 
-    position.add("name", name, lang=lang)
+    # Optionally translate the name to English. The id above is keyed on the
+    # untranslated name, so it stays stable regardless of the LLM output.
+    if translate_name and lang is not None and lang != "eng":
+        # Local import to break the cycle: zavod.shed.trans imports the helpers
+        # package, which imports this module. TODO: move the translation core to
+        # a helpers-free zavod.helpers.translate in a followup so this can become
+        # a top-level import.
+        from zavod.shed.trans import translate_position_name
+
+        result = translate_position_name(context, LangText(text=name, lang=lang))
+        translated = result.get_english()
+        if translated is not None:
+            position.add(
+                "name",
+                translated.text,
+                lang=translated.lang,
+                original_value=name,
+                origin=result.origin,
+            )
+        else:
+            position.add("name", name, lang=lang)
+    else:
+        position.add("name", name, lang=lang)
+
     position.add("summary", summary, lang=lang)
     position.add("description", description, lang=lang)
     position.add("country", country)

--- a/zavod/zavod/shed/trans.py
+++ b/zavod/zavod/shed/trans.py
@@ -83,6 +83,16 @@ class TranslationResult(NamedTuple):
     the response was parsed and accepted. Callers that do additional
     per-result validation can drop this entry via context.cache.delete()
     so a later run can retry."""
+    origin: str
+    """The model that produced the translation. Suitable for passing as the
+    ``origin`` when applying the resulting values to an entity."""
+
+    def get_english(self) -> Optional[LangText]:
+        """Return the English ``LangText`` from ``texts``, or None if absent."""
+        for text in self.texts:
+            if text.lang == "eng":
+                return text
+        return None
 
 
 def run_translation_prompt(
@@ -113,7 +123,7 @@ def run_translation_prompt(
         response = run_text_prompt(context, prompt, text, model=model)
     except ConfigurationException as ce:
         context.log.error("LLM translation skipped: %s" % ce.message)
-        return TranslationResult([], None)
+        return TranslationResult([], None, model)
     try:
         trans_by_lang = orjson.loads(response.content)
     except orjson.JSONDecodeError:
@@ -125,7 +135,7 @@ def run_translation_prompt(
             model=model,
             response_content=response.content,
         )
-        return TranslationResult([], None)
+        return TranslationResult([], None, model)
     if not set(trans_by_lang.keys()).issubset(output_langs):
         context.cache.delete(response.cache_key)
         context.log.warning(
@@ -136,14 +146,33 @@ def run_translation_prompt(
             response_content=response.content,
             expected=sorted(output_langs),
         )
-        return TranslationResult([], None)
+        return TranslationResult([], None, model)
     results: List[LangText] = []
     for lang in output_langs:
         value = trans_by_lang.get(lang)
         if not isinstance(value, str) or not value.strip():
             continue
         results.append(LangText(text=value, lang=lang))
-    return TranslationResult(results, response.cache_key)
+    return TranslationResult(results, response.cache_key, model)
+
+
+def translate_position_name(
+    context: Context,
+    label: LangText,
+    *,
+    model: str = DEFAULT_MODEL,
+) -> TranslationResult:
+    """Translate a public office position label into English.
+
+    ``label`` carries the source text and its language in ``label.lang``,
+    which must be set. Builds the position-translation prompt for that
+    language and runs it. Use ``result.get_english()`` to read the English
+    ``LangText`` (None if none was produced) and ``result.origin`` as the
+    ``origin`` when applying it to an entity.
+    """
+    assert label.lang is not None, "Source language is required for translation"
+    prompt = make_position_translation_prompt(label.lang)
+    return run_translation_prompt(context, prompt=prompt, text=label.text, model=model)
 
 
 def apply_translit_names(

--- a/zavod/zavod/shed/trans.py
+++ b/zavod/zavod/shed/trans.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Optional, NamedTuple, List
 import orjson
 
@@ -76,7 +77,8 @@ def make_position_translation_prompt(input_code: str) -> str:
     return POSITION_TRANS_PROMPT.format(code=input_code)
 
 
-class TranslationResult(NamedTuple):
+@dataclass(frozen=True, kw_only=True)
+class TranslationResult:
     texts: List[LangText]
     cache_key: Optional[str]
     """Cache key of the underlying run_text_prompt response, set only when
@@ -123,7 +125,7 @@ def run_translation_prompt(
         response = run_text_prompt(context, prompt, text, model=model)
     except ConfigurationException as ce:
         context.log.error("LLM translation skipped: %s" % ce.message)
-        return TranslationResult([], None, model)
+        return TranslationResult(texts=[], cache_key=None, origin=model)
     try:
         trans_by_lang = orjson.loads(response.content)
     except orjson.JSONDecodeError:
@@ -135,7 +137,7 @@ def run_translation_prompt(
             model=model,
             response_content=response.content,
         )
-        return TranslationResult([], None, model)
+        return TranslationResult(texts=[], cache_key=None, origin=model)
     if not set(trans_by_lang.keys()).issubset(output_langs):
         context.cache.delete(response.cache_key)
         context.log.warning(
@@ -146,14 +148,14 @@ def run_translation_prompt(
             response_content=response.content,
             expected=sorted(output_langs),
         )
-        return TranslationResult([], None, model)
+        return TranslationResult(texts=[], cache_key=None, origin=model)
     results: List[LangText] = []
     for lang in output_langs:
         value = trans_by_lang.get(lang)
         if not isinstance(value, str) or not value.strip():
             continue
         results.append(LangText(text=value, lang=lang))
-    return TranslationResult(results, response.cache_key, model)
+    return TranslationResult(texts=results, cache_key=response.cache_key, origin=model)
 
 
 def translate_position_name(

--- a/zavod/zavod/shed/trans.py
+++ b/zavod/zavod/shed/trans.py
@@ -5,7 +5,7 @@ from zavod.context import Context
 from zavod.entity import Entity
 from zavod.exc import ConfigurationException
 from zavod.extract.llm import run_text_prompt, DEFAULT_MODEL
-from zavod.extract.names.clean import LangText
+from zavod.util import LangText
 from zavod import helpers as h
 
 

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -9,11 +9,8 @@ from rigour.territories import get_territory_by_qid
 from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.constants import ORIGIN_INFERRED
-from zavod.extract.llm import DEFAULT_MODEL
-from zavod.shed.trans import (
-    make_position_translation_prompt,
-    run_translation_prompt,
-)
+from zavod.shed.trans import translate_position_name
+from zavod.util import LangText
 from zavod.stateful.positions import categorise
 from zavod.shed.wikidata.country import is_historical_country, item_countries
 
@@ -140,22 +137,22 @@ def wikidata_position(
             clean_label_text = clean_wikidata_name(item.label.text)
             if clean_label_text is not None and clean_label_text.strip() != "":
                 assert item.label.lang is not None
-                prompt = make_position_translation_prompt(item.label.lang)
-                translations = run_translation_prompt(
-                    context, prompt=prompt, text=item.label.text
-                ).texts
+                result = translate_position_name(
+                    context,
+                    LangText(text=item.label.text, lang=item.label.lang),
+                )
+                translated = result.get_english()
                 # if for some reason the translation fails, fall back to the original
-                if len(translations) == 0:
+                if translated is None:
                     item.label.apply(position, "name", clean=clean_wikidata_name)
                 else:
-                    for translated in translations:
-                        position.add(
-                            "name",
-                            translated.text,
-                            lang=translated.lang,
-                            original_value=item.label.text,
-                            origin=DEFAULT_MODEL,
-                        )
+                    position.add(
+                        "name",
+                        translated.text,
+                        lang=translated.lang,
+                        original_value=item.label.text,
+                        origin=result.origin,
+                    )
 
     for claim in item.claims:
         if claim.property in ("P1001", "P17", "P27") and claim.qid is not None:

--- a/zavod/zavod/tests/helpers/test_positions.py
+++ b/zavod/zavod/tests/helpers/test_positions.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from zavod import settings
 from zavod.context import Context
 from zavod.meta import Dataset
+from zavod.util import LangText
+from zavod.shed.trans import TranslationResult
 from zavod.helpers.positions import make_position, make_occupancy, earliest_term_start
 
 
@@ -56,6 +59,76 @@ def test_make_position_full(testdataset1: Dataset):
     assert one_with_everything.get("numberOfSeats") == ["5"]
     assert one_with_everything.get("wikidataId") == ["Q123"]
     assert one_with_everything.get("sourceUrl") == ["http://example.com/"]
+    context.close()
+
+
+def test_make_position_translate_name(testdataset1: Dataset):
+    """With translate_name, a non-English name is translated to English
+    and stored as the name (original kept as original_value), while the id stays
+    keyed on the untranslated name so it's stable regardless of the LLM output."""
+    context = Context(testdataset1)
+    with patch(
+        "zavod.shed.trans.translate_position_name",
+        return_value=TranslationResult(
+            texts=[LangText(text="Member of Parliament", lang="eng")],
+            cache_key="cache-key",
+            origin="test-model",
+        ),
+    ) as mock_translate:
+        position = make_position(
+            context,
+            name="Poslanec",
+            country="cz",
+            lang="ces",
+            translate_name=True,
+        )
+    mock_translate.assert_called_once()
+    assert position.get("name") == ["Member of Parliament"]
+    name_statement = next(s for s in position.statements if s.prop == "name")
+    assert name_statement.lang == "eng"
+    assert name_statement.original_value == "Poslanec"
+    assert name_statement.origin == "test-model"
+    # id is keyed on the original name, so it matches the untranslated position.
+    untranslated = make_position(context, name="Poslanec", country="cz", lang="ces")
+    assert position.id == untranslated.id
+    context.close()
+
+
+def test_make_position_translate_fallback(testdataset1: Dataset):
+    """When translation yields no English text, the original name is kept."""
+    context = Context(testdataset1)
+    with patch(
+        "zavod.shed.trans.translate_position_name",
+        return_value=TranslationResult(texts=[], cache_key=None, origin="test-model"),
+    ):
+        position = make_position(
+            context,
+            name="Poslanec",
+            country="cz",
+            lang="ces",
+            translate_name=True,
+        )
+    assert position.get("name") == ["Poslanec"]
+    context.close()
+
+
+def test_make_position_translate_skipped_for_english(testdataset1: Dataset):
+    """Translation is skipped when the language is already English or unset."""
+    context = Context(testdataset1)
+    with patch("zavod.shed.trans.translate_position_name") as mock_translate:
+        eng = make_position(
+            context,
+            name="Speaker",
+            country="gb",
+            lang="eng",
+            translate_name=True,
+        )
+        no_lang = make_position(
+            context, name="Speaker", country="gb", translate_name=True
+        )
+    mock_translate.assert_not_called()
+    assert eng.get("name") == ["Speaker"]
+    assert no_lang.get("name") == ["Speaker"]
     context.close()
 
 

--- a/zavod/zavod/util.py
+++ b/zavod/zavod/util.py
@@ -1,5 +1,6 @@
 import orjson
 import logging
+from dataclasses import dataclass
 from lxml import etree
 from functools import cache
 from typing import Optional, Union, IO, Any, Dict
@@ -10,6 +11,19 @@ log = logging.getLogger(__name__)
 Element = etree._Element
 ElementOrTree = Union[etree._Element, etree._ElementTree]
 ID_SEP = "-"
+
+
+@dataclass(frozen=True)
+class LangText:
+    """A piece of text together with its ISO 639-2 language code.
+
+    Use this as the general-purpose carrier for translated/transliterated
+    strings across zavod (e.g. ``shed/trans.py``).
+    """
+
+    text: str
+    lang: Optional[str]
+    """ISO 639-2 (3-letter) language code, or None if not known."""
 
 
 @cache


### PR DESCRIPTION
Stacked on #4514 — based on the `leonhandreke/wikidata-position-llm-translation` branch, not main, so review/merge that one first.

Pulls the Wikidata position-label translation logic out into something reusable and uses it in another crawler:

- **`zavod.util.LangText`** — a general-purpose `NamedTuple` (text + lang) for translated/transliterated strings, kept separate from the pydantic `LangText` in `zavod.extract.names.clean` (that one's part of the persisted name-cleaning review model and has to stay stable). `TranslationResult` uses this one now.
- **`translate_position_name`** in `shed/trans.py` — takes a `LangText`, builds the position prompt, runs the translation, and returns a `TranslationResult`. Callers read the English value via `result.get_english()` and use `result.origin` (the model) as the statement origin. `wikidata/position.py` just calls it.
- **`make_position(..., translate_if_required=True)`** — translates a non-English position name to English (original kept as `original_value`), but keys the entity id on the *untranslated* name so ids stay stable and independent of the LLM output. `cz_pep_declarations` opts in, so Czech labels surface in English.

### On the `translate_if_required` design

An alternative would have been to let `make_position` take `LangText`s instead, and call `translate_position_name` at the callsite. That would have been the better design from a composition-over-inheritance standpoint — `make_position` stays dumb about translation, and crawlers compose the translate step themselves. But here I opted for the minimal change to the widely-used `make_position` instead, since threading translation through every callsite (and re-keying concerns) felt like more churn than it's worth right now. WDYT?

🤖 Generated with [Claude Code](https://claude.com/claude-code)