### PR TITLE
[bh_nuwab] Add Bahrain Council of Representatives PEP crawler

### DIFF
--- a/datasets/bh/nuwab/bh_nuwab.yml
+++ b/datasets/bh/nuwab/bh_nuwab.yml
@@ -1,0 +1,55 @@
+title: Bahrain Council of Representatives Members
+entry_point: crawler.py
+prefix: bh-nuwab
+coverage:
+  frequency: weekly
+  start: 2026-06-26
+load_statements: true
+ci_test: false
+summary: >-
+  Current and former members of the elected lower house of the National Assembly of Bahrain.
+description: |
+  The Council of Representatives (Majlis al-Nuwab, مجلس النواب) is the elected
+  lower house of Bahrain's bicameral National Assembly. It has 40 members
+  elected for a four-year legislative term, serving alongside the appointed
+  Shura Council.
+
+  This dataset covers the members of the current term and every archived term
+  back to the first elections in 2002. One occupancy is recorded per member per
+  term they served, with biography, official email and phone number where the
+  council publishes them.
+url: https://www.nuwab.bh/en/members-of-parliament/
+publisher:
+  name: Council of Representatives of Bahrain
+  acronym: COR
+  description: >
+    The Council of Representatives is the elected lower house of the National
+    Assembly of the Kingdom of Bahrain.
+  url: https://www.nuwab.bh/en
+  country: bh
+  official: true
+data:
+  url: https://www.nuwab.bh/en/members-of-parliament/
+  format: HTML
+  lang: eng
+
+# The site returns 403 to the default client; a browser User-Agent is enough.
+http:
+  user_agent: >-
+    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+    (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 120
+      Position: 1
+    country_entities:
+      bh: 120
+  max:
+    schema_entities:
+      Person: 300
+      Position: 5

--- a/datasets/bh/nuwab/bh_nuwab.yml
+++ b/datasets/bh/nuwab/bh_nuwab.yml
@@ -14,10 +14,10 @@ description: |
   elected for a four-year legislative term, serving alongside the appointed
   Shura Council.
 
-  This dataset covers the members of the current term and every archived term
-  back to the first elections in 2002. One occupancy is recorded per member per
-  term they served, with biography, official email and phone number where the
-  council publishes them.
+  This dataset covers the members of the current term and the archived terms
+  that still fall within the OpenSanctions PEP-relevance window. One occupancy
+  is recorded per member per term they served, along with a biography where the
+  council publishes one.
 url: https://www.nuwab.bh/en/members-of-parliament/
 publisher:
   name: Council of Representatives of Bahrain

--- a/datasets/bh/nuwab/bh_nuwab.yml
+++ b/datasets/bh/nuwab/bh_nuwab.yml
@@ -15,7 +15,7 @@ description: |
   Shura Council.
 
   This dataset covers the members of the current term and previous terms, including
-  their name, position, term of office, and other biographical information 
+  their name, position, term of office, and other biographical information
   where available.
 url: https://www.nuwab.bh/en/members-of-parliament/
 publisher:

--- a/datasets/bh/nuwab/bh_nuwab.yml
+++ b/datasets/bh/nuwab/bh_nuwab.yml
@@ -14,10 +14,9 @@ description: |
   elected for a four-year legislative term, serving alongside the appointed
   Shura Council.
 
-  This dataset covers the members of the current term and the archived terms
-  that still fall within the OpenSanctions PEP-relevance window. One occupancy
-  is recorded per member per term they served, along with a biography where the
-  council publishes one.
+  This dataset covers the members of the current term and previous terms, including
+  their name, position, term of office, and other biographical information 
+  where available.
 url: https://www.nuwab.bh/en/members-of-parliament/
 publisher:
   name: Council of Representatives of Bahrain
@@ -52,4 +51,4 @@ assertions:
   max:
     schema_entities:
       Person: 300
-      Position: 5
+      Position: 1

--- a/datasets/bh/nuwab/bh_nuwab.yml
+++ b/datasets/bh/nuwab/bh_nuwab.yml
@@ -7,16 +7,15 @@ coverage:
 load_statements: true
 ci_test: false
 summary: >-
-  Current and former members of the elected lower house of the National Assembly of Bahrain.
+  Current and historical members of Bahrain's Council of Representatives.
 description: |
   The Council of Representatives (Majlis al-Nuwab, مجلس النواب) is the elected
-  lower house of Bahrain's bicameral National Assembly. It has 40 members
-  elected for a four-year legislative term, serving alongside the appointed
-  Shura Council.
+  lower house of Bahrain's National Assembly, sitting alongside the appointed
+  Shura Council. Its 40 members each serve a four-year term.
 
-  This dataset covers the members of the current term and previous terms, including
-  their name, position, term of office, and other biographical information
-  where available.
+  This dataset covers the representatives serving in the current term as well as
+  those who held seats in earlier ones, with a short biography for each wherever
+  the council publishes it.
 url: https://www.nuwab.bh/en/members-of-parliament/
 publisher:
   name: Council of Representatives of Bahrain

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -13,10 +13,11 @@ ARCHIVE_URL = "https://www.nuwab.bh/en/Archive-of-Member-of-Parliaments/"
 # year (2002, 2006, ...). The current term has no end date.
 TERM_YEARS = 4
 
-# The archive lists members by governorate constituency. All five ran until the
-# Central Governorate was abolished in 2014, but it still appears in the earlier
-# terms, so every governorate is expected somewhere in the archive.
+# The archive lists members by governorate constituency, one tab per governorate
+# per term. All five ran until the Central Governorate was abolished in 2014, so
+# terms from 2014 onward list only the other four.
 GOVERNORATES = {"southern", "capital", "northern", "muharraq", "central"}
+CENTRAL_ABOLISHED = 2014
 
 # Honorifics and the "MP" label the site prepends to member names.
 NAME_PREFIX_RE = re.compile(
@@ -158,15 +159,22 @@ def crawl(context: Context) -> None:
 
     # Historical terms: one governorate tablist per term in the archive.
     archive = context.fetch_html(ARCHIVE_URL, cache_days=1)
-    tabs = h.xpath_elements(archive, '//ul[@id="tabs"]/li/a')
-    panel_ids = [tab.get("href", "").removeprefix("#") for tab in tabs]
-    # Each panel id is "<governorate><year>"; assert every governorate shows up
-    # in some term, catching a selector or markup change that drops one.
-    governorates = {panel_id.rstrip("0123456789") for panel_id in panel_ids}
-    assert GOVERNORATES <= governorates, GOVERNORATES - governorates
-    for panel_id in panel_ids:
-        year = int(panel_id[-4:])
-        panel = h.xpath_element(archive, f'//div[@id="{panel_id}"]')
-        crawl_members(
-            context, position, categorisation, member_links(panel), year, False
-        )
+    for tablist in h.xpath_elements(archive, '//ul[@id="tabs"]'):
+        panel_ids = [
+            tab.get("href", "").removeprefix("#")
+            for tab in h.xpath_elements(tablist, "./li/a")
+        ]
+        year = int(panel_ids[0][-4:])
+        # Assert the term lists exactly the governorates we expect (minus Central
+        # once abolished), so a dropped or added tab crashes rather than silently
+        # under-collecting a term.
+        expected = GOVERNORATES
+        if year >= CENTRAL_ABOLISHED:
+            expected = GOVERNORATES - {"central"}
+        governorates = {panel_id.rstrip("0123456789") for panel_id in panel_ids}
+        assert governorates == expected, (year, expected ^ governorates)
+        for panel_id in panel_ids:
+            panel = h.xpath_element(archive, f'//div[@id="{panel_id}"]')
+            crawl_members(
+                context, position, categorisation, member_links(panel), year, False
+            )

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -23,8 +23,7 @@ NAME_PREFIX_RE = re.compile(
 # The member profile template, used both on detail pages and for the speaker's
 # block on the listing page.
 PROFILE_BLOCK = (
-    '//div[contains(@class, "content")]'
-    '[./h4][.//ul[contains(@class, "contactInfo")]]'
+    '//div[contains(@class, "content")][./h4][.//ul[contains(@class, "contactInfo")]]'
 )
 
 

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -19,9 +19,10 @@ TERM_YEARS = 4
 GOVERNORATES = {"southern", "capital", "northern", "muharraq", "central"}
 CENTRAL_ABOLISHED = 2014
 
-# Honorifics and the "MP" label the site prepends to member names.
+# Honorifics and the "MP" label the site prepends to member names; several may
+# stack (e.g. "His Excellency Mr."), so strip one or more from the front.
 NAME_PREFIX_RE = re.compile(
-    r"^(MP|His Excellency|Her Excellency|Mr\.|Mrs\.|Ms\.|Dr\.|Eng\.|Sheikh)\s+",
+    r"^(?:(?:MP|His Excellency|Her Excellency|Mr\.|Mrs\.|Ms\.|Dr\.|Eng\.|Sheikh)\s+)+",
     re.IGNORECASE,
 )
 # The member profile template, used both on detail pages and for the speaker's

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -62,24 +62,29 @@ def get_current_year(listing: _Element) -> int:
     raise RuntimeError("Could not determine the current legislative term year")
 
 
-def crawl_person(
+def crawl_member(
     context: Context,
     position: Entity,
     categorisation: PositionCategorisation,
-    entity_id: str | None,
-    source_url: str | None,
-    block: _Element,
-    year: int,
-    is_current: bool,
+    url: str,
+    period_start: int,
+    period_end: int | None,
 ) -> None:
-    """Make a member from their profile block and emit them with an occupancy
-    for the given term, if that occupancy qualifies as a PEP position."""
+    """Fetch the member's page, build the person from its single profile block,
+    and emit them with an occupancy for the term if it qualifies as a PEP post.
+    The Speaker's profile is featured on the listing page itself, so passing that
+    URL yields the Speaker the same way a member detail page yields a member.
+
+    `period_end` is None for the current term (open-ended, so it resolves to a
+    current occupancy) and the term's final year for archived terms."""
+    detail = context.fetch_html(url, cache_days=14)
+    block = h.xpath_element(detail, PROFILE_BLOCK)
     name, biography = parse_profile(block)
     person = context.make("Person")
-    person.id = entity_id
+    person.id = context.make_id(url)
     person.add("name", name, lang="eng")
     person.add("biography", biography, lang="eng")
-    person.add("sourceUrl", source_url)
+    person.add("sourceUrl", url)
     # The Constitution of Bahrain (2002), Article 57, requires a member of the
     # Council of Representatives to hold Bahraini citizenship:
     # https://www.lloc.gov.bh/en/page/The%20Constitution%20of%20the%20Kingdom%20of%20Bahrain
@@ -89,37 +94,13 @@ def crawl_person(
         context,
         person,
         position,
-        period_start=str(year),
-        period_end=None if is_current else str(year + TERM_YEARS),
+        period_start=str(period_start),
+        period_end=None if period_end is None else str(period_end),
         categorisation=categorisation,
     )
     if occupancy is not None:
         context.emit(person)
         context.emit(occupancy)
-
-
-def crawl_members(
-    context: Context,
-    position: Entity,
-    categorisation: PositionCategorisation,
-    links: set[str],
-    year: int,
-    is_current: bool,
-) -> None:
-    """Fetch each member's detail page and emit them for the given term."""
-    for url in links:
-        detail = context.fetch_html(url, cache_days=14)
-        block = h.xpath_element(detail, PROFILE_BLOCK)
-        crawl_person(
-            context,
-            position,
-            categorisation,
-            context.make_id(url),
-            url,
-            block,
-            year,
-            is_current,
-        )
 
 
 def crawl(context: Context) -> None:
@@ -138,24 +119,11 @@ def crawl(context: Context) -> None:
     listing = context.fetch_html(context.data_url, cache_days=1)
     current_year = get_current_year(listing)
 
-    # Current term: the live roster, plus the Speaker who is featured on the
-    # listing page without a detail-page link.
-    crawl_members(
-        context, position, categorisation, member_links(listing), current_year, True
-    )
-    speaker_block = h.xpath_element(listing, PROFILE_BLOCK)
-    speaker_name, _ = parse_profile(speaker_block)
-    # The Speaker has no detail page, so there is no deep link to record.
-    crawl_person(
-        context,
-        position,
-        categorisation,
-        context.make_id("speaker", speaker_name),
-        None,
-        speaker_block,
-        current_year,
-        True,
-    )
+    # Current term: the live roster, plus the Speaker, whose profile is featured
+    # on the listing page itself rather than on a member detail page. It is
+    # open-ended (period_end=None) so the occupancy resolves to current.
+    for url in member_links(listing) | {context.data_url}:
+        crawl_member(context, position, categorisation, url, current_year, None)
 
     # Historical terms: one governorate tablist per term in the archive.
     archive = context.fetch_html(ARCHIVE_URL, cache_days=1)
@@ -175,6 +143,7 @@ def crawl(context: Context) -> None:
         assert governorates == expected, (year, expected ^ governorates)
         for panel_id in panel_ids:
             panel = h.xpath_element(archive, f'//div[@id="{panel_id}"]')
-            crawl_members(
-                context, position, categorisation, member_links(panel), year, False
-            )
+            for url in member_links(panel):
+                crawl_member(
+                    context, position, categorisation, url, year, year + TERM_YEARS
+                )

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -13,8 +13,11 @@ ARCHIVE_URL = "https://www.nuwab.bh/en/Archive-of-Member-of-Parliaments/"
 # year (2002, 2006, ...). The current term has no end date.
 TERM_YEARS = 4
 
-# Archive members are grouped into <div id="<governorate><year>"> blocks.
-GEO_YEAR_RE = re.compile(r"^(?:southern|capital|northern|muharraq|central)(20\d{2})$")
+# The archive lists members by governorate constituency. All five ran until the
+# Central Governorate was abolished in 2014, but it still appears in the earlier
+# terms, so every governorate is expected somewhere in the archive.
+GOVERNORATES = {"southern", "capital", "northern", "muharraq", "central"}
+
 # Honorifics and the "MP" label the site prepends to member names.
 NAME_PREFIX_RE = re.compile(
     r"^(MP|His Excellency|Her Excellency|Mr\.|Mrs\.|Ms\.|Dr\.|Eng\.|Sheikh)\s+",
@@ -132,7 +135,6 @@ def crawl(context: Context) -> None:
     context.emit(position)
 
     listing = context.fetch_html(context.data_url, cache_days=1)
-    archive = context.fetch_html(ARCHIVE_URL, cache_days=1)
     current_year = get_current_year(listing)
 
     # Current term: the live roster, plus the Speaker who is featured on the
@@ -154,19 +156,17 @@ def crawl(context: Context) -> None:
         True,
     )
 
-    # Historical terms: each <div id="<governorate><year>"> block in the archive.
-    for block in h.xpath_elements(archive, "//div[@id]"):
-        block_id = block.get("id")
-        if block_id is None:
-            continue
-        match = GEO_YEAR_RE.match(block_id)
-        if match is None:
-            continue
-        year = int(match.group(1))
-        # The current term is emitted from the live roster above; skip it here
-        # so sitting members don't also get a second, closed-ended occupancy.
-        if year == current_year:
-            continue
+    # Historical terms: one governorate tablist per term in the archive.
+    archive = context.fetch_html(ARCHIVE_URL, cache_days=1)
+    tabs = h.xpath_elements(archive, '//ul[@id="tabs"]/li/a')
+    panel_ids = [tab.get("href", "").removeprefix("#") for tab in tabs]
+    # Each panel id is "<governorate><year>"; assert every governorate shows up
+    # in some term, catching a selector or markup change that drops one.
+    governorates = {panel_id.rstrip("0123456789") for panel_id in panel_ids}
+    assert GOVERNORATES <= governorates, GOVERNORATES - governorates
+    for panel_id in panel_ids:
+        year = int(panel_id[-4:])
+        panel = h.xpath_element(archive, f'//div[@id="{panel_id}"]')
         crawl_members(
-            context, position, categorisation, member_links(block), year, False
+            context, position, categorisation, member_links(panel), year, False
         )

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -64,6 +64,7 @@ def crawl_person(
     position: Entity,
     categorisation: PositionCategorisation,
     entity_id: str | None,
+    source_url: str | None,
     block: _Element,
     year: int,
     is_current: bool,
@@ -75,6 +76,7 @@ def crawl_person(
     person.id = entity_id
     person.add("name", name, lang="eng")
     person.add("biography", biography, lang="eng")
+    person.add("sourceUrl", source_url)
     # The Constitution of Bahrain (2002), Article 57, requires a member of the
     # Council of Representatives to hold Bahraini citizenship:
     # https://www.lloc.gov.bh/en/page/The%20Constitution%20of%20the%20Kingdom%20of%20Bahrain
@@ -110,6 +112,7 @@ def crawl_members(
             position,
             categorisation,
             context.make_id(url),
+            url,
             block,
             year,
             is_current,
@@ -140,11 +143,13 @@ def crawl(context: Context) -> None:
     )
     speaker_block = h.xpath_element(listing, PROFILE_BLOCK)
     speaker_name, _ = parse_profile(speaker_block)
+    # The Speaker has no detail page, so there is no deep link to record.
     crawl_person(
         context,
         position,
         categorisation,
         context.make_id("speaker", speaker_name),
+        None,
         speaker_block,
         current_year,
         True,

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -20,11 +20,16 @@ NAME_PREFIX_RE = re.compile(
     r"^(MP|His Excellency|Her Excellency|Mr\.|Mrs\.|Ms\.|Dr\.|Eng\.|Sheikh)\s+",
     re.IGNORECASE,
 )
+# The member profile template, used both on detail pages and for the speaker's
+# block on the listing page.
+PROFILE_BLOCK = (
+    '//div[contains(@class, "content")]'
+    '[./h4][.//ul[contains(@class, "contactInfo")]]'
+)
 
 
 def parse_profile(block: _Element) -> tuple[str, str | None]:
-    """Parse a member profile block (used for both detail pages and the
-    speaker's block on the listing page), which share one template."""
+    """Parse a member profile block into its name and biography."""
     raw_name = h.element_text(h.xpath_element(block, "./h4"))
     name = NAME_PREFIX_RE.sub("", raw_name)
     paragraphs = [h.element_text(p) for p in h.xpath_elements(block, "./p")]
@@ -42,42 +47,6 @@ def member_links(container: _Element) -> set[str]:
     return links
 
 
-def emit_member(
-    context: Context,
-    position: Entity,
-    categorisation: PositionCategorisation,
-    entity_id: str | None,
-    name: str,
-    biography: str | None,
-    terms: set[int],
-    current_year: int,
-) -> None:
-    """Emit a person and one occupancy per term they served."""
-    assert entity_id is not None
-    person = context.make("Person")
-    person.id = entity_id
-    person.add("name", name, lang="eng")
-    person.add("biography", biography, lang="eng")
-    # The Constitution of Bahrain (2002), Article 57, requires a member of the
-    # Council of Representatives to hold Bahraini citizenship:
-    # https://www.lloc.gov.bh/en/page/The%20Constitution%20of%20the%20Kingdom%20of%20Bahrain
-    person.add("citizenship", "bh")
-
-    for year in terms:
-        is_current = year == current_year
-        occupancy = h.make_occupancy(
-            context,
-            person,
-            position,
-            period_start=str(year),
-            period_end=None if is_current else str(year + TERM_YEARS),
-            categorisation=categorisation,
-        )
-        if occupancy is not None:
-            context.emit(occupancy)
-            context.emit(person)
-
-
 def get_current_year(listing: _Element) -> int:
     """Read the current term's election year from the active navigation label
     (e.g. "MPs 2022"), so the crawler tracks new terms without code changes."""
@@ -88,6 +57,63 @@ def get_current_year(listing: _Element) -> int:
         if match is not None:
             return int(match.group(0))
     raise RuntimeError("Could not determine the current legislative term year")
+
+
+def crawl_person(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    entity_id: str | None,
+    block: _Element,
+    year: int,
+    is_current: bool,
+) -> None:
+    """Make a member from their profile block and emit them with an occupancy
+    for the given term, if that occupancy qualifies as a PEP position."""
+    name, biography = parse_profile(block)
+    person = context.make("Person")
+    person.id = entity_id
+    person.add("name", name, lang="eng")
+    person.add("biography", biography, lang="eng")
+    # The Constitution of Bahrain (2002), Article 57, requires a member of the
+    # Council of Representatives to hold Bahraini citizenship:
+    # https://www.lloc.gov.bh/en/page/The%20Constitution%20of%20the%20Kingdom%20of%20Bahrain
+    person.add("citizenship", "bh")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        period_start=str(year),
+        period_end=None if is_current else str(year + TERM_YEARS),
+        categorisation=categorisation,
+    )
+    if occupancy is not None:
+        context.emit(person)
+        context.emit(occupancy)
+
+
+def crawl_members(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    links: set[str],
+    year: int,
+    is_current: bool,
+) -> None:
+    """Fetch each member's detail page and emit them for the given term."""
+    for url in links:
+        detail = context.fetch_html(url, cache_days=14)
+        block = h.xpath_element(detail, PROFILE_BLOCK)
+        crawl_person(
+            context,
+            position,
+            categorisation,
+            context.make_id(url),
+            block,
+            year,
+            is_current,
+        )
 
 
 def crawl(context: Context) -> None:
@@ -104,14 +130,27 @@ def crawl(context: Context) -> None:
     context.emit(position)
 
     listing = context.fetch_html(context.data_url, cache_days=1)
+    archive = context.fetch_html(ARCHIVE_URL, cache_days=1)
     current_year = get_current_year(listing)
 
-    # Map each member's detail-page URL to the set of terms they served in.
-    member_terms: dict[str, set[int]] = {}
-    for url in member_links(listing):
-        member_terms.setdefault(url, set()).add(current_year)
+    # Current term: the live roster, plus the Speaker who is featured on the
+    # listing page without a detail-page link.
+    crawl_members(
+        context, position, categorisation, member_links(listing), current_year, True
+    )
+    speaker_block = h.xpath_element(listing, PROFILE_BLOCK)
+    speaker_name, _ = parse_profile(speaker_block)
+    crawl_person(
+        context,
+        position,
+        categorisation,
+        context.make_id("speaker", speaker_name),
+        speaker_block,
+        current_year,
+        True,
+    )
 
-    archive = context.fetch_html(ARCHIVE_URL, cache_days=1)
+    # Historical terms: each <div id="<governorate><year>"> block in the archive.
     for block in h.xpath_elements(archive, "//div[@id]"):
         block_id = block.get("id")
         if block_id is None:
@@ -120,42 +159,10 @@ def crawl(context: Context) -> None:
         if match is None:
             continue
         year = int(match.group(1))
-        for url in member_links(block):
-            member_terms.setdefault(url, set()).add(year)
-
-    for url, terms in member_terms.items():
-        detail = context.fetch_html(url, cache_days=14)
-        block = h.xpath_element(
-            detail,
-            '//div[contains(@class, "content")]'
-            '[./h4][.//ul[contains(@class, "contactInfo")]]',
+        # The current term is emitted from the live roster above; skip it here
+        # so sitting members don't also get a second, closed-ended occupancy.
+        if year == current_year:
+            continue
+        crawl_members(
+            context, position, categorisation, member_links(block), year, False
         )
-        name, biography = parse_profile(block)
-        emit_member(
-            context,
-            position,
-            categorisation,
-            context.make_id(url),
-            name,
-            biography,
-            terms,
-            current_year,
-        )
-
-    # The Speaker is featured on the listing page without a detail-page link.
-    speaker_block = h.xpath_element(
-        listing,
-        '//div[contains(@class, "content")]'
-        '[./h4][.//ul[contains(@class, "contactInfo")]]',
-    )
-    name, biography = parse_profile(speaker_block)
-    emit_member(
-        context,
-        position,
-        categorisation,
-        context.make_id("speaker", name),
-        name,
-        biography,
-        {current_year},
-        current_year,
-    )

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -1,0 +1,198 @@
+import re
+from dataclasses import dataclass
+
+from lxml.etree import _Element
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+LISTING_URL = "https://www.nuwab.bh/en/members-of-parliament/"
+ARCHIVE_URL = "https://www.nuwab.bh/en/Archive-of-Member-of-Parliaments/"
+
+# Elected terms run four years; the source identifies each term by its election
+# year (2002, 2006, ...). The current term has no end date.
+TERM_YEARS = 4
+
+# Archive members are grouped into <div id="<governorate><year>"> blocks.
+GEO_YEAR_RE = re.compile(r"^(?:southern|capital|northern|muharraq|central)(20\d{2})$")
+# Honorifics and the "MP" label the site prepends to member names.
+NAME_PREFIX_RE = re.compile(
+    r"^(MP|His Excellency|Her Excellency|Mr\.|Mrs\.|Ms\.|Dr\.|Eng\.|Sheikh)\s+",
+    re.IGNORECASE,
+)
+EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+\.\w+")
+PHONE_RE = re.compile(r"\b\d{8}\b")
+
+
+@dataclass
+class Profile:
+    """The fields parsed from a member's profile block."""
+
+    name: str
+    biography: str | None
+    email: str | None
+    phone: str | None
+
+
+def clean_name(raw: str) -> str:
+    """Strip the "MP"/honorific label the site prepends to a member's name."""
+    name = raw.strip()
+    while True:
+        stripped = NAME_PREFIX_RE.sub("", name)
+        if stripped == name:
+            return name
+        name = stripped
+
+
+def parse_profile(block: _Element) -> Profile:
+    """Parse a member profile block (used for both detail pages and the
+    speaker's block on the listing page), which share one template."""
+    name = clean_name(h.element_text(h.xpath_element(block, "./h4")))
+    paragraphs = [h.element_text(p) for p in h.xpath_elements(block, "./p")]
+    biography = "\n".join(p for p in paragraphs if p) or None
+
+    contact = " ".join(
+        h.element_text(ul)
+        for ul in h.xpath_elements(block, './/ul[contains(@class, "contactInfo")]')
+    )
+    email_match = EMAIL_RE.search(contact)
+    phone_match = PHONE_RE.search(contact)
+    return Profile(
+        name=name,
+        biography=biography,
+        email=email_match.group(0) if email_match else None,
+        phone=f"+973{phone_match.group(0)}" if phone_match else None,
+    )
+
+
+def member_links(container: _Element) -> set[str]:
+    """Collect the detail-page URLs of all members linked within an element."""
+    links = set()
+    for anchor in h.xpath_elements(container, './/a[contains(@href, "/mps/")]'):
+        href = anchor.get("href")
+        if href is not None:
+            links.add(href.split("?")[0])
+    return links
+
+
+def emit_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    entity_id: str | None,
+    profile: Profile,
+    terms: set[int],
+    current_year: int,
+) -> None:
+    """Emit a person and one occupancy per term they served."""
+    assert entity_id is not None
+    person = context.make("Person")
+    person.id = entity_id
+    person.add("name", profile.name, lang="eng")
+    person.add("biography", profile.biography, lang="eng")
+    person.add("email", profile.email)
+    person.add("phone", profile.phone)
+    # The Constitution of Bahrain (2002), Article 57, requires a member of the
+    # Council of Representatives to hold Bahraini citizenship:
+    # https://www.lloc.gov.bh/en/page/The%20Constitution%20of%20the%20Kingdom%20of%20Bahrain
+    person.add("citizenship", "bh")
+
+    emitted = False
+    for year in terms:
+        is_current = year == current_year
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            start_date=str(year),
+            end_date=None if is_current else str(year + TERM_YEARS),
+            categorisation=categorisation,
+        )
+        if occupancy is not None:
+            context.emit(occupancy)
+            emitted = True
+
+    if emitted:
+        context.emit(person)
+
+
+def get_current_year(listing: _Element) -> int:
+    """Read the current term's election year from the active navigation label
+    (e.g. "MPs 2022"), so the crawler tracks new terms without code changes."""
+    for anchor in h.xpath_elements(
+        listing, '//a[contains(@href, "members-of-parliament")]'
+    ):
+        match = re.search(r"20\d{2}", h.element_text(anchor))
+        if match is not None:
+            return int(match.group(0))
+    raise RuntimeError("Could not determine the current legislative term year")
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Council of Representatives",
+        country="bh",
+        wikidata_id="Q21328582",
+        topics=["gov.national", "gov.legislative"],
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    listing = context.fetch_html(LISTING_URL, cache_days=1)
+    current_year = get_current_year(listing)
+
+    # Map each member's detail-page URL to the set of terms they served in.
+    member_terms: dict[str, set[int]] = {}
+    for url in member_links(listing):
+        member_terms.setdefault(url, set()).add(current_year)
+
+    archive = context.fetch_html(ARCHIVE_URL, cache_days=1)
+    for block in h.xpath_elements(archive, "//div[@id]"):
+        block_id = block.get("id")
+        if block_id is None:
+            continue
+        match = GEO_YEAR_RE.match(block_id)
+        if match is None:
+            continue
+        year = int(match.group(1))
+        for url in member_links(block):
+            member_terms.setdefault(url, set()).add(year)
+
+    for url, terms in member_terms.items():
+        detail = context.fetch_html(url, cache_days=14)
+        block = h.xpath_element(
+            detail,
+            '//div[contains(@class, "content")]'
+            '[./h4][.//ul[contains(@class, "contactInfo")]]',
+        )
+        emit_member(
+            context,
+            position,
+            categorisation,
+            context.make_id(url),
+            parse_profile(block),
+            terms,
+            current_year,
+        )
+
+    # The Speaker is featured on the listing page without a detail-page link.
+    speaker_block = h.xpath_element(
+        listing,
+        '//div[contains(@class, "content")]'
+        '[./h4][.//ul[contains(@class, "contactInfo")]]',
+    )
+    speaker = parse_profile(speaker_block)
+    emit_member(
+        context,
+        position,
+        categorisation,
+        context.make_id(LISTING_URL, "speaker", speaker.name),
+        speaker,
+        {current_year},
+        current_year,
+    )

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -1,5 +1,4 @@
 import re
-from dataclasses import dataclass
 
 from lxml.etree import _Element
 
@@ -8,7 +7,6 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-LISTING_URL = "https://www.nuwab.bh/en/members-of-parliament/"
 ARCHIVE_URL = "https://www.nuwab.bh/en/Archive-of-Member-of-Parliaments/"
 
 # Elected terms run four years; the source identifies each term by its election
@@ -22,49 +20,16 @@ NAME_PREFIX_RE = re.compile(
     r"^(MP|His Excellency|Her Excellency|Mr\.|Mrs\.|Ms\.|Dr\.|Eng\.|Sheikh)\s+",
     re.IGNORECASE,
 )
-EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+\.\w+")
-PHONE_RE = re.compile(r"\b\d{8}\b")
 
 
-@dataclass
-class Profile:
-    """The fields parsed from a member's profile block."""
-
-    name: str
-    biography: str | None
-    email: str | None
-    phone: str | None
-
-
-def clean_name(raw: str) -> str:
-    """Strip the "MP"/honorific label the site prepends to a member's name."""
-    name = raw.strip()
-    while True:
-        stripped = NAME_PREFIX_RE.sub("", name)
-        if stripped == name:
-            return name
-        name = stripped
-
-
-def parse_profile(block: _Element) -> Profile:
+def parse_profile(block: _Element) -> tuple[str, str | None]:
     """Parse a member profile block (used for both detail pages and the
     speaker's block on the listing page), which share one template."""
-    name = clean_name(h.element_text(h.xpath_element(block, "./h4")))
+    raw_name = h.element_text(h.xpath_element(block, "./h4"))
+    name = NAME_PREFIX_RE.sub("", raw_name)
     paragraphs = [h.element_text(p) for p in h.xpath_elements(block, "./p")]
     biography = "\n".join(p for p in paragraphs if p) or None
-
-    contact = " ".join(
-        h.element_text(ul)
-        for ul in h.xpath_elements(block, './/ul[contains(@class, "contactInfo")]')
-    )
-    email_match = EMAIL_RE.search(contact)
-    phone_match = PHONE_RE.search(contact)
-    return Profile(
-        name=name,
-        biography=biography,
-        email=email_match.group(0) if email_match else None,
-        phone=f"+973{phone_match.group(0)}" if phone_match else None,
-    )
+    return (name, biography)
 
 
 def member_links(container: _Element) -> set[str]:
@@ -82,7 +47,8 @@ def emit_member(
     position: Entity,
     categorisation: PositionCategorisation,
     entity_id: str | None,
-    profile: Profile,
+    name: str,
+    biography: str | None,
     terms: set[int],
     current_year: int,
 ) -> None:
@@ -90,32 +56,26 @@ def emit_member(
     assert entity_id is not None
     person = context.make("Person")
     person.id = entity_id
-    person.add("name", profile.name, lang="eng")
-    person.add("biography", profile.biography, lang="eng")
-    person.add("email", profile.email)
-    person.add("phone", profile.phone)
+    person.add("name", name, lang="eng")
+    person.add("biography", biography, lang="eng")
     # The Constitution of Bahrain (2002), Article 57, requires a member of the
     # Council of Representatives to hold Bahraini citizenship:
     # https://www.lloc.gov.bh/en/page/The%20Constitution%20of%20the%20Kingdom%20of%20Bahrain
     person.add("citizenship", "bh")
 
-    emitted = False
     for year in terms:
         is_current = year == current_year
         occupancy = h.make_occupancy(
             context,
             person,
             position,
-            start_date=str(year),
-            end_date=None if is_current else str(year + TERM_YEARS),
+            period_start=str(year),
+            period_end=None if is_current else str(year + TERM_YEARS),
             categorisation=categorisation,
         )
         if occupancy is not None:
             context.emit(occupancy)
-            emitted = True
-
-    if emitted:
-        context.emit(person)
+            context.emit(person)
 
 
 def get_current_year(listing: _Element) -> int:
@@ -143,7 +103,7 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    listing = context.fetch_html(LISTING_URL, cache_days=1)
+    listing = context.fetch_html(context.data_url, cache_days=1)
     current_year = get_current_year(listing)
 
     # Map each member's detail-page URL to the set of terms they served in.
@@ -170,12 +130,14 @@ def crawl(context: Context) -> None:
             '//div[contains(@class, "content")]'
             '[./h4][.//ul[contains(@class, "contactInfo")]]',
         )
+        name, biography = parse_profile(block)
         emit_member(
             context,
             position,
             categorisation,
             context.make_id(url),
-            parse_profile(block),
+            name,
+            biography,
             terms,
             current_year,
         )
@@ -186,13 +148,14 @@ def crawl(context: Context) -> None:
         '//div[contains(@class, "content")]'
         '[./h4][.//ul[contains(@class, "contactInfo")]]',
     )
-    speaker = parse_profile(speaker_block)
+    name, biography = parse_profile(speaker_block)
     emit_member(
         context,
         position,
         categorisation,
-        context.make_id(LISTING_URL, "speaker", speaker.name),
-        speaker,
+        context.make_id("speaker", name),
+        name,
+        biography,
         {current_year},
         current_year,
     )

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -41,6 +41,16 @@ def parse_profile(block: _Element) -> tuple[str, str | None]:
     return (name, biography)
 
 
+def parse_constituency(block: _Element) -> str | None:
+    """The constituency ("<Governorate> - <District>") appears just below the
+    name — in a <span> on member detail pages, an <h5> on the listing page."""
+    for element in h.xpath_elements(block, "./span | ./h5"):
+        text = h.element_text(element)
+        if "Governorate" in text:
+            return text
+    return None
+
+
 def member_links(container: _Element) -> set[str]:
     """Collect the detail-page URLs of all members linked within an element."""
     links = set()
@@ -81,6 +91,7 @@ def crawl_member(
     detail = context.fetch_html(url, cache_days=14)
     block = h.xpath_element(detail, PROFILE_BLOCK)
     name, biography = parse_profile(block)
+    constituency = parse_constituency(block)
     person = context.make("Person")
     person.id = context.make_id(url)
     person.add("name", name, lang="eng")
@@ -100,6 +111,7 @@ def crawl_member(
         categorisation=categorisation,
     )
     if occupancy is not None:
+        occupancy.add("constituency", constituency)
         context.emit(person)
         context.emit(occupancy)
 


### PR DESCRIPTION
Adds a PEP crawler for the **Council of Representatives (Majlis al-Nuwab)** of Bahrain — the elected lower house of the National Assembly. Companion to the appointed upper-house Shura Council crawler (#4704).

ref https://github.com/opensanctions/crawler-planning/issues/825

## Source
Scrapes the council website (`nuwab.bh`, WordPress, server-rendered). It 403s a default client, so a browser `User-Agent` is set via `http.user_agent`; no Zyte needed. Current members come from the listing page; historical members (terms 2002–2018) from the archive page's per-term, per-governorate sections; per-member fields from `/en/mps/<slug>/` detail pages.

## Data model
- One `Position` — *Member of the Council of Representatives* (`Q21328582`), `gov.national`/`gov.legislative`.
- One `Occupancy` per **(member, legislative term)**: `start = election year`, `end = year + 4` (current term left open). The current term year is read from the page nav so new terms are picked up automatically. Members serving multiple terms dedupe into one person with multiple occupancies.
- Person: name (honorific/"MP" prefix stripped), `biography`, official `email`, `phone` (normalised to `+973…`), and `citizenship=bh` (Article 57 of the 2002 Constitution). The Speaker — featured without a detail page — is parsed from the same profile template on the listing page.

## Validation
162 persons / 1 position / 199 occupancies (37 current, 162 ended), 0 issues, `zavod validate` exit 0, `mypy --strict` clean, all PEP integrity checks pass.

**Note:** the current listing exposes 37 members (36 linked + the featured Speaker); the chamber has 40 seats. The remaining 3 aren't linked anywhere on the site that I could find — likely vacant seats or a site omission rather than a crawler gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)