### PR TITLE
[peps] Release 14 parliament/legislature crawlers

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -54,6 +54,7 @@ children:
   - be_walloon_parliament
   - bg_jud_declarations
   - bg_parliament
+  - bo_senado
   - br_pep
   - bz_national_assembly
   - ca_commons
@@ -88,10 +89,12 @@ children:
   - gb_lords
   - ge_declarations
   - gr_parliament
+  - gt_congress
   - hk_legco
   - hk_principal_officials
   - hn_legislature
   - hr_public_officials
+  - hr_sabor
   - hu_national_assembly
   - id_regional_2018
   - ie_parliament
@@ -102,10 +105,13 @@ children:
   - it_senate
   - jp_sangiin
   - jp_shugiin
+  - kg_jogorku_kenesh
   # Doesn't have data yet. Leads to broken catalog export.
   # - kr_assembly
   - ky_judicial
   - ky_parliament
+  - kz_mazhilis
+  - kz_senate
   - li_landtag
   - lt_pep_declarations
   - lt_seimas
@@ -130,11 +136,14 @@ children:
   - no_storting
   - nz_parliament
   - pa_asamblea
+  - pe_congreso
+  - pg_parliament
   - ph_house_representatives
   - ph_senate
   - pl_sejm
   - pl_senate
   - pt_parliament
+  - py_congreso
   - ro_cdep_deputies
   - ro_fiu_declarations
   - ro_senate
@@ -146,10 +155,13 @@ children:
   - si_zvezoskop
   - sk_nrsr_poslanci
   - sk_public_officials
+  - sr_national_assembly
   - sv_legislature
   - th_cabinet
+  - tj_majlisi_milli
   - tr_parliament
   - tw_legislature
+  - tz_bunge
   - ua_rada
   - un_ga_protocol
   - us_cia_world_leaders
@@ -159,6 +171,8 @@ children:
   - us_plural_legislators
   - us_state_dept
   - uy_pep
+  - uz_legislative_chamber
+  - uz_senate
   - ve_asamblea_nacional
   - vn_national_assembly
   - wd_categories

--- a/datasets/bo/senado/bo_senado.yml
+++ b/datasets/bo/senado/bo_senado.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: bo-senado
 coverage:
   frequency: monthly
-  start: 2026-06-18
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/gt/congress/gt_congress.yml
+++ b/datasets/gt/congress/gt_congress.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: gt-crc
 coverage:
   frequency: monthly
-  start: 2026-06-17
+  start: 2026-06-26
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/hr/sabor/hr_sabor.yml
+++ b/datasets/hr/sabor/hr_sabor.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: hr-sabor
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/kg/jogorku_kenesh/kg_jogorku_kenesh.yml
+++ b/datasets/kg/jogorku_kenesh/kg_jogorku_kenesh.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: kg-kenesh
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/kz/mazhilis/kz_mazhilis.yml
+++ b/datasets/kz/mazhilis/kz_mazhilis.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: kz-mazhilis
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/kz/senate/kz_senate.yml
+++ b/datasets/kz/senate/kz_senate.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: kz-senate
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/pe/congreso/pe_congreso.yml
+++ b/datasets/pe/congreso/pe_congreso.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: pe-cong
 coverage:
   frequency: monthly
-  start: 2026-06-18
+  start: 2026-06-26
 load_statements: true
 ci_test: false # Live external website with per-member detail pages, not available in CI
 summary: >-

--- a/datasets/pg/parliament/pg_parliament.yml
+++ b/datasets/pg/parliament/pg_parliament.yml
@@ -3,7 +3,7 @@ prefix: pg-parliament
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: 2026-06-17
+  start: 2026-06-26
 load_statements: true
 ci_test: false
 

--- a/datasets/py/congreso/py_congreso.yml
+++ b/datasets/py/congreso/py_congreso.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: py-cgso
 coverage:
   frequency: monthly
-  start: 2026-06-23
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/sr/national_assembly/sr_national_assembly.yml
+++ b/datasets/sr/national_assembly/sr_national_assembly.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: sr-dna
 coverage:
   frequency: monthly
-  start: 2026-06-18
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/tj/majlisi_milli/tj_majlisi_milli.yml
+++ b/datasets/tj/majlisi_milli/tj_majlisi_milli.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: tj-milli
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/tz/bunge/tz_bunge.yml
+++ b/datasets/tz/bunge/tz_bunge.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: tz-bunge
 coverage:
   frequency: monthly
-  start: 2026-06-25
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/uz/legislative_chamber/uz_legislative_chamber.yml
+++ b/datasets/uz/legislative_chamber/uz_legislative_chamber.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: uz-legch
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-06-26
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/uz/senate/uz_senate.yml
+++ b/datasets/uz/senate/uz_senate.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: uz-senate
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-06-26
 load_statements: true
 ci_test: false  # Cloudflare-fronted government API needing a browser UA, not in CI
 summary: >-


### PR DESCRIPTION
Add 14 parliament/legislature crawlers to the `peps` collection and bump their `coverage.start`:

- `tz_bunge`
- `kz_senate`
- `kz_mazhilis`
- `hr_sabor`
- `kg_jogorku_kenesh`
- `bo_senado`
- `sr_national_assembly`
- `pg_parliament`
- `tj_majlisi_milli`
- `gt_congress`
- `py_congreso`
- `pe_congreso`
- `uz_legislative_chamber`
- `uz_senate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
