### PR TITLE
[ext_ror] Expand enrichment inputs, add PublicBody, set threshold

### DIFF
--- a/datasets/_externals/ext_ror.yml
+++ b/datasets/_externals/ext_ror.yml
@@ -33,12 +33,27 @@ publisher:
 url: "https://ror.org/registry/"
 
 inputs:
+  - ann_graph_topics
+  - c4ads_xinjiang
+  - c4ads_xinjiang_mining
   - ca_named_research_orgs
+  - eiti_soe
+  - eu_edes
+  - eu_esma_sanctions
+  - eu_esma_saris
   - eu_sanctions
+  - ext_gleif
+  - gem_energy_ownership
   - no_nbim_exclusions
+  - permid
+  - research
+  - shu_uyghur_companies
   - special_interest
-  - us_bis_oac
+  - ua_war_sanctions
   - us_bis_antiboycott
+  - us_bis_denied
+  - us_bis_export
+  - us_bis_oac
   - us_ddtc_debarred
   - us_ddtc_enforcements
   - us_fcc_covered_list
@@ -48,12 +63,12 @@ inputs:
   - us_sec_pause
   - us_special_leg
   - us_trade_csl
-  - us_bis_denied
 
 config:
   topic_gated: true
   index_options:
     memory: 2000
+  threshold: 0.3
   topics:
     - role.pep
     - role.rca
@@ -72,7 +87,7 @@ config:
     - Company
     - Organization
     - LegalEntity
-    # - Person
+    - PublicBody
 
 assertions:
   min:

--- a/datasets/_global/ror/crawler.py
+++ b/datasets/_global/ror/crawler.py
@@ -20,9 +20,6 @@ def get_download_url(context: Context) -> str:
 
 
 def crawl_item(context: Context, item: Dict[str, Any]) -> None:
-    # from pprint import pprint
-
-    # pprint(item)
     ror_uri = item.pop("id")
     entity = context.make("Organization")
     entity.id = context.make_slug(ror_uri.rsplit("/", 1)[-1])


### PR DESCRIPTION
Expand the ROR external enrichment dataset:

- **More enrichment inputs** — add C4ADS Xinjiang (+ mining), ANN graph topics, EITI SOE, EU EDES / ESMA sanctions / ESMA SARIS, GLEIF, GEM energy ownership, PermID, research, SHU Uyghur companies, UA war sanctions, and BIS denied/export to the input list (alongside the existing sanctions/PEP sources).
- **`PublicBody`** added to the enriched schemata, so public bodies are matched against ROR in addition to `Company`/`Organization`/`LegalEntity`.
- **`threshold: 0.3`** set on the enrichment config.
- Drop leftover `pprint` debug code from `crawler.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
