### PR TITLE
[pl_mswia_sanctions] Fix dirty identifiers in details parsing

### DIFF
--- a/datasets/pl/mswia_sanctions/crawler.py
+++ b/datasets/pl/mswia_sanctions/crawler.py
@@ -52,9 +52,9 @@ def parse_details(context: Context, entity: Entity, text: str) -> None:
         if len(parts) > 1:
             value = parts[1].strip().rstrip(",")
             if prop != "address" and re.search(r"[,:]", value):
-                clean_value = context.lookup("details", value, warn_unmatched=True)
-                if clean_value is not None:
-                    value = clean_value.props.get(prop, value)
+                result = context.lookup("details", value, warn_unmatched=True)
+                if result is not None:
+                    value = result.props.get(prop, value)
             entity.add(prop, value)
 
     if not len(text.strip()):

--- a/datasets/pl/mswia_sanctions/crawler.py
+++ b/datasets/pl/mswia_sanctions/crawler.py
@@ -9,10 +9,17 @@ from zavod import helpers as h
 TYPES = {"osoby": "Person", "podmioty": "Company"}
 CHOPSKA = [
     # "Nr" = number; NIP = Polish tax ID, KRS = Polish business register number,
-    # PESEL = Polish personal ID, "siedziba" = registered seat / headquarters
+    # REGON = Polish statistical ID, PESEL = Polish personal ID,
+    # "siedziba" = registered seat / headquarters
+    ("Nr NIP:", "taxNumber"),
     ("Nr NIP", "taxNumber"),
+    ("NIP:", "taxNumber"),
     ("NIP", "taxNumber"),
+    ("REGON:", "registrationNumber"),
+    ("REGON", "registrationNumber"),
+    ("Nr KRS:", "registrationNumber"),
     ("Nr KRS", "registrationNumber"),
+    ("KRS:", "registrationNumber"),
     ("KRS", "registrationNumber"),
     ("(PESEL:", "idNumber"),
     ("PESEL:", "idNumber"),
@@ -43,7 +50,12 @@ def parse_details(context: Context, entity: Entity, text: str) -> None:
         parts = text.rsplit(chop, 1)
         text = parts[0]
         if len(parts) > 1:
-            entity.add(prop, parts[1].strip())
+            value = parts[1].strip().rstrip(",")
+            if prop != "address" and re.search(r"[,:]", value):
+                clean_value = context.lookup("details", value, warn_unmatched=True)
+                if clean_value is not None:
+                    value = clean_value.props.get(prop, value)
+            entity.add(prop, value)
 
     if not len(text.strip()):
         return
@@ -55,10 +67,8 @@ def parse_details(context: Context, entity: Entity, text: str) -> None:
 
     if text == "":
         return
-    result = context.lookup("details", text)
-    if result is None:
-        context.log.warning("Unhandled details", details=text)
-    else:
+    result = context.lookup("details", text, warn_unmatched=True)
+    if result is not None:
         for prop, value in result.props.items():
             entity.add(prop, value)
 

--- a/datasets/pl/mswia_sanctions/pl_mswia_sanctions.yml
+++ b/datasets/pl/mswia_sanctions/pl_mswia_sanctions.yml
@@ -82,9 +82,7 @@ lookups:
   details:
     lowercase: true
     options:
-      - match:
-          - (
-          - ","
+      - match: ","
         props: {}
       - match: "0000426746, numer"
         props:
@@ -125,9 +123,7 @@ lookups:
       - match: "Plac Dąbrowskiego 1, 00-057 Warszawa "
         props:
           address: Plac Dąbrowskiego 1, 00-057 Warszawa
-      - match:
-          - "prowadzący działalność gospodarczą pod adresem: 00-844 Warszawa, ul. Grzybowska 87, REGON 147421934"
-          - "prowadzący działalność gospodarczą pod adresem: 00-844 Warszawa, ul. Grzybowska 87, "
+      - match: "prowadzący działalność gospodarczą pod adresem: 00-844 Warszawa, ul. Grzybowska 87, "
         props:
           address: "00-844 Warszawa, ul. Grzybowska 87"
           registrationNumber: 147421934
@@ -171,9 +167,6 @@ lookups:
       - match: "adres: ul. Stefana Okrzei 1A lok. 10P, 03-715 Warszawa "
         props:
           address: "ul. Stefana Okrzei 1A lok. 10P, 03-715 Warszawa"
-      - match: "adres: Lielirbes iela 17A–46, Ryga, LV-1046 Łotwa"
-        props:
-          address: "Lielirbes iela 17A–46, Ryga, LV-1046 Łotwa"
       - match: "adres: Biuro 02, Aber King Khalfan Muhammad Khalfan Al Hamli – Al Thanyah 1, Dubaj, Zjednoczone Emiraty Arabskie (nazwa arabska: مكتب 02 ملك عابر خلفان محمد خلفان الهاملىالثنية االولى) numer rejestrowy: 2823197"
         props:
           address: "Biuro 02, Aber King Khalfan Muhammad Khalfan Al Hamli – Al Thanyah 1, Dubaj, Zjednoczone Emiraty Arabskie"

--- a/datasets/pl/mswia_sanctions/pl_mswia_sanctions.yml
+++ b/datasets/pl/mswia_sanctions/pl_mswia_sanctions.yml
@@ -73,14 +73,8 @@ lookups:
   type.identifier:
     normalize: true
     options:
-      - match: 0001008314 REGON 523931831
-        values:
-          - 0001008314
-          - 523931831
       - match: 79090613232)
         value: 79090613232
-      - match: ": 7705122392 (adres w jęz. rosyjskim: 105064, г. Москва, Пер. Малый Казённый, д. 3)"
-        value: 7705122392
   type.name:
     options:
       - match: do 3.03.2022 r. – SULZER MIXPAC POLAND Sp. z o.o.
@@ -92,6 +86,17 @@ lookups:
           - (
           - ","
         props: {}
+      - match: "0000426746, numer"
+        props:
+          registrationNumber: "0000426746"
+      - match: "5273044625, REGON: 524556447"
+        props:
+          taxNumber: "5273044625"
+          registrationNumber: "524556447"
+      - match: "7705122392 (adres w jęz. rosyjskim: 105064, г. Москва, Пер. Малый Казённый, д. 3)"
+        props:
+          taxNumber: "7705122392"
+          address: "105064, г. Москва, Пер. Малый Казённый, д. 3"
       - match: ul. Udalcowa 2, Moskwa, Federacja Rosyjska
         props:
           address: ul. Udalcowa 2, Moskwa, Federacja Rosyjska
@@ -120,7 +125,9 @@ lookups:
       - match: "Plac Dąbrowskiego 1, 00-057 Warszawa "
         props:
           address: Plac Dąbrowskiego 1, 00-057 Warszawa
-      - match: "prowadzący działalność gospodarczą pod adresem: 00-844 Warszawa, ul. Grzybowska 87, REGON 147421934"
+      - match:
+          - "prowadzący działalność gospodarczą pod adresem: 00-844 Warszawa, ul. Grzybowska 87, REGON 147421934"
+          - "prowadzący działalność gospodarczą pod adresem: 00-844 Warszawa, ul. Grzybowska 87, "
         props:
           address: "00-844 Warszawa, ul. Grzybowska 87"
           registrationNumber: 147421934


### PR DESCRIPTION
Add REGON and colon variants to CHOPSKA so compound identifier strings like "KRS X, REGON Y, NIP Z" are split cleanly without one keyword swallowing another. Dirty values that still contain punctuation are resolved via the details lookup rather than emitted as-is.