### PR TITLE
Migrate sk/bg/me PEP crawlers to make_position(translate_name=True)

### DIFF
--- a/datasets/bg/jud_declarations/crawler.py
+++ b/datasets/bg/jud_declarations/crawler.py
@@ -8,15 +8,8 @@ from typing import Dict, Generator, List, Optional
 
 from zavod import Context, helpers as h
 from zavod.stateful.positions import categorise, OccupancyStatus
-from zavod.shed.trans import (
-    apply_translit_full_name,
-    make_position_translation_prompt,
-    ENGLISH,
-)
 
 
-TRANSLIT_OUTPUT = [ENGLISH]
-POSITION_PROMPT = prompt = make_position_translation_prompt("bul")
 # e.g. (name_html, name_pdf)
 # {
 #     ("Георги Иванов Иванов", "ВАНЯ СТОЯНОВА ЛАКОВСКА"),
@@ -178,9 +171,7 @@ def crawl_row(context: Context, row: Dict[str, HtmlElement], index_url: str) -> 
         name=position_name,
         lang="bul",
         country="BG",
-    )
-    apply_translit_full_name(
-        context, position, "bul", position_name, TRANSLIT_OUTPUT, POSITION_PROMPT
+        translate_name=True,
     )
 
     categorisation = categorise(context, position, default_is_pep=True)

--- a/datasets/me/acp_peps/crawler.py
+++ b/datasets/me/acp_peps/crawler.py
@@ -5,18 +5,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from zipfile import BadZipFile, ZipFile
 
-from zavod.shed.trans import (
-    ENGLISH,
-    apply_translit_full_name,
-    make_position_translation_prompt,
-)
 from zavod.stateful.positions import OccupancyStatus, categorise
 
 from zavod import Context, Entity
 from zavod import helpers as h
-
-TRANSLIT_OUTPUT = [ENGLISH]
-POSITION_PROMPT = prompt = make_position_translation_prompt("cnr")
 
 
 def fetch_latest_filing(
@@ -158,9 +150,8 @@ def emit_affiliated_position(
         context,
         position_name,
         country="me",
-    )
-    apply_translit_full_name(
-        context, position, "cnr", position_name, TRANSLIT_OUTPUT, POSITION_PROMPT
+        lang="cnr",
+        translate_name=True,
     )
 
     categorisation = categorise(context, position, default_is_pep=True)

--- a/datasets/sk/public_officials/crawler.py
+++ b/datasets/sk/public_officials/crawler.py
@@ -3,18 +3,10 @@ from lxml import etree
 from lxml.etree import _Element as Element
 from typing import Any, Dict, List
 
-from zavod.shed.trans import (
-    apply_translit_full_name,
-    make_position_translation_prompt,
-    ENGLISH,
-)
 from zavod.stateful.positions import OccupancyStatus, categorise
 
 from zavod import Context
 from zavod import helpers as h
-
-TRANSLIT_OUTPUT = [ENGLISH]
-POSITION_PROMPT = prompt = make_position_translation_prompt("slk")
 
 
 def parse_details(context: Context, link_el: Element) -> None:
@@ -98,12 +90,9 @@ def crawl_person(
             pos,
             lang="slk",
             country="SK",
+            translate_name=True,
         )
         person.add("position", pos)
-
-        apply_translit_full_name(
-            context, position, "slk", pos, TRANSLIT_OUTPUT, POSITION_PROMPT
-        )
 
         categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:


### PR DESCRIPTION
Follow-up to https://github.com/opensanctions/opensanctions/pull/4697 and part of https://github.com/opensanctions/opensanctions/issues/2874.

Now that `make_position(..., translate_name=True)` exists, these three crawlers can drop the old `make_position` + `apply_translit_full_name(POSITION_PROMPT)` dance and just pass the flag:

- `sk/public_officials` (`slk`)
- `bg/jud_declarations` (`bul`)
- `me/acp_peps` (`cnr`) — also adds the previously-missing `lang="cnr"` on the `make_position` call

The prompt and model are identical to what these crawlers used before (both route through `make_position_translation_prompt` + the default model, English-only output), so the translation itself doesn't change.

What *does* change is the shape: instead of two parallel `name` values (original + English), the position now carries a single English `name` with the original kept as `original_value` and the model as `origin` — i.e. the cleaner cz_pep_declarations behavior. So expect the position names to shift on the next crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)