### PR TITLE
fix entity ID to use name + slug

### DIFF
--- a/datasets/pg/parliament/crawler.py
+++ b/datasets/pg/parliament/crawler.py
@@ -124,7 +124,7 @@ def crawl_member(
         return
 
     person = context.make("Person")
-    person.id = context.make_slug(slug)
+    person.id = context.make_id(raw_name, slug)
 
     h.apply_reviewed_name_string(
         context, person, string=raw_name, llm_cleaning=True, lang="eng"


### PR DESCRIPTION
Entity ID was using inccorrectly just the slug (jurisdiction label). Updated to use the name and slug using `match_id`. This should close https://github.com/opensanctions/crawler-planning/issues/671