### PR TITLE
Use modification date to invalidate modified wd items in cache

### DIFF
--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -9,6 +9,7 @@ from nomenklatura.wikidata import Claim, WikidataClient
 from zavod.shed.wikidata.human import wikidata_basic_human
 from nomenklatura.wikidata.value import clean_wikidata_name
 from zavod.shed.wikidata.position import (
+    days_since_modified,
     position_holders,
     wikidata_occupancy,
     wikidata_position,
@@ -60,6 +61,9 @@ class CrawlState(object):
         self._emitted_positions: Set[str] = set()
         exc = [str(x) for x in context.dataset.config.get("exclusion_checks", [])]
         self.exclusion_checks: Set[str] = set(exc)
+        # schema:dateModified timestamps keyed by person QID, populated during discovery.
+        # Used by crawl_person to pass an appropriate cache_days to fetch_item.
+        self.person_modified_at: Dict[str, str] = {}
 
     def emit_position(self, position: Entity) -> None:
         if position.id is None:
@@ -113,7 +117,10 @@ def crawl_position(state: CrawlState, person: Entity, claim: Claim) -> None:
 
 
 def crawl_person(state: CrawlState, qid: str, recurse: bool = True) -> Optional[Entity]:
-    item = state.client.fetch_item(qid)
+    cache_days = days_since_modified(state.person_modified_at.get(qid))
+    item = state.client.fetch_item(
+        qid, cache_days=cache_days, randomize=cache_days is None
+    )
     if item is None:
         return None
     if item.id != qid:
@@ -199,7 +206,8 @@ def crawl_category(state: CrawlState, category_crawl_spec: Dict[str, Any]) -> No
 
 
 def crawl_position_holder(state: CrawlState, position_qid: str) -> Set[str]:
-    persons: Set[str] = set([])
+    persons: Set[str] = set()
+
     if position_qid in state.ignore_positions:
         return persons
     item = state.client.fetch_item(position_qid)
@@ -211,7 +219,12 @@ def crawl_position_holder(state: CrawlState, position_qid: str) -> Set[str]:
         state.ignore_positions.add(position_qid)
         return persons
 
-    persons = position_holders(state.client, item)
+    # find person QIDs such that person --( P39 position held )--> position_qid
+    holders = position_holders(state.client, item)
+    state.person_modified_at.update(holders)
+    persons.update(holders.keys())
+
+    # find person QIDs such that position_qid --( P1308 officeholder )--> person
     for claim in item.claims:
         if claim.property == "P1308":  # officeholder
             if claim.qid is not None:
@@ -251,9 +264,10 @@ def crawl_declarator(state: CrawlState) -> None:
     # Import all profiles which have a Declarator ID, a reference to a Russian PEP
     # site containing profiles of all elected officials in Russia.
     query = """
-    SELECT ?person WHERE {
+    SELECT ?person ?modifiedAt WHERE {
         ?person wdt:P1883 ?value .
-        ?person wdt:P31 wd:Q5
+        ?person wdt:P31 wd:Q5 .
+        ?person schema:dateModified ?modifiedAt .
     }
     """
     response = state.client.query(query)
@@ -262,6 +276,9 @@ def crawl_declarator(state: CrawlState) -> None:
         person_qid = result.plain("person")
         if person_qid is None:
             continue
+        modified_at = result.plain("modifiedAt")
+        if modified_at is not None:
+            state.person_modified_at[person_qid] = modified_at
         state.persons[person_qid] = FoundRecord(from_declarator=True)
         if person_qid not in state.person_topics:
             state.person_topics[person_qid] = set()

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -5,11 +5,12 @@ from io import StringIO
 from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urlencode
 
+from rigour.time import iso_datetime
+
 from nomenklatura.wikidata import Claim, WikidataClient
 from zavod.shed.wikidata.human import wikidata_basic_human
 from nomenklatura.wikidata.value import clean_wikidata_name
 from zavod.shed.wikidata.position import (
-    days_since_modified,
     position_holders,
     wikidata_occupancy,
     wikidata_position,
@@ -115,10 +116,8 @@ def crawl_position(state: CrawlState, person: Entity, claim: Claim) -> None:
 
 
 def crawl_person(state: CrawlState, qid: str, recurse: bool = True) -> Optional[Entity]:
-    cache_days = days_since_modified(state.person_modified_at.get(qid))
-    item = state.client.fetch_item(
-        qid, cache_days=cache_days, randomize=cache_days is None
-    )
+    modified_at = iso_datetime(state.person_modified_at.get(qid))
+    item = state.client.fetch_item(qid, modified_at=modified_at)
     if item is None:
         return None
     if item.id != qid:

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -61,8 +61,6 @@ class CrawlState(object):
         self._emitted_positions: Set[str] = set()
         exc = [str(x) for x in context.dataset.config.get("exclusion_checks", [])]
         self.exclusion_checks: Set[str] = set(exc)
-        # schema:dateModified timestamps keyed by person QID, populated during discovery.
-        # Used by crawl_person to pass an appropriate cache_days to fetch_item.
         self.person_modified_at: Dict[str, str] = {}
 
     def emit_position(self, position: Entity) -> None:

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -1,15 +1,16 @@
 import csv
 from collections import defaultdict
 from dataclasses import dataclass, field
+from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urlencode
 
+from nomenklatura.wikidata import Claim, WikidataClient
+from nomenklatura.wikidata.value import clean_wikidata_name
 from rigour.time import iso_datetime
 
-from nomenklatura.wikidata import Claim, WikidataClient
 from zavod.shed.wikidata.human import wikidata_basic_human
-from nomenklatura.wikidata.value import clean_wikidata_name
 from zavod.shed.wikidata.position import (
     position_holders,
     wikidata_occupancy,
@@ -62,7 +63,7 @@ class CrawlState(object):
         self._emitted_positions: Set[str] = set()
         exc = [str(x) for x in context.dataset.config.get("exclusion_checks", [])]
         self.exclusion_checks: Set[str] = set(exc)
-        self.person_modified_at: Dict[str, str] = {}
+        self.person_modified_at: Dict[str, datetime] = {}
 
     def emit_position(self, position: Entity) -> None:
         if position.id is None:
@@ -116,7 +117,7 @@ def crawl_position(state: CrawlState, person: Entity, claim: Claim) -> None:
 
 
 def crawl_person(state: CrawlState, qid: str, recurse: bool = True) -> Optional[Entity]:
-    modified_at = iso_datetime(state.person_modified_at.get(qid))
+    modified_at = state.person_modified_at.get(qid)
     item = state.client.fetch_item(qid, modified_at=modified_at)
     if item is None:
         return None
@@ -203,7 +204,7 @@ def crawl_category(state: CrawlState, category_crawl_spec: Dict[str, Any]) -> No
 
 
 def crawl_position_holder(state: CrawlState, position_qid: str) -> Set[str]:
-    persons: Set[str] = set()
+    persons: Set[str] = set([])
 
     if position_qid in state.ignore_positions:
         return persons
@@ -218,8 +219,10 @@ def crawl_position_holder(state: CrawlState, position_qid: str) -> Set[str]:
 
     # find person QIDs such that person --( P39 position held )--> position_qid
     holders = position_holders(state.client, item)
-    state.person_modified_at.update(holders)
     persons.update(holders.keys())
+    for person_qid, modified_at in holders.items():
+        if modified_at is not None:
+            state.person_modified_at[person_qid] = modified_at
 
     # find person QIDs such that position_qid --( P1308 officeholder )--> person
     for claim in item.claims:
@@ -275,7 +278,9 @@ def crawl_declarator(state: CrawlState) -> None:
             continue
         modified_at = result.plain("modifiedAt")
         if modified_at is not None:
-            state.person_modified_at[person_qid] = modified_at
+            modified_datetime = iso_datetime(modified_at)
+            if modified_datetime is not None:
+                state.person_modified_at[person_qid] = modified_datetime
         state.persons[person_qid] = FoundRecord(from_declarator=True)
         if person_qid not in state.person_topics:
             state.person_topics[person_qid] = set()

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -270,7 +270,7 @@ def crawl_declarator(state: CrawlState) -> None:
         ?person schema:dateModified ?modifiedAt .
     }
     """
-    response = state.client.query(query)
+    response = state.client.query(query, state.client.CACHE_SHORT)
     state.log.info("Found %d declarator profiles" % len(response.results))
     for result in response.results:
         person_qid = result.plain("person")

--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -8,7 +8,7 @@ from zavod import Context
 from zavod.entity import Entity
 from zavod.shed.wikidata.human import wikidata_basic_human
 from zavod.shed.wikidata.position import wikidata_occupancy, wikidata_position
-from zavod.shed.wikidata.position import position_holders
+from zavod.shed.wikidata.position import days_since_modified, position_holders
 
 
 class Country(NamedTuple):
@@ -38,10 +38,15 @@ def crawl_holder(
     client: WikidataClient,
     position: Entity,
     person_qid: str,
+    modified_at: Optional[str] = None,
 ) -> Optional[Entity]:
     if not is_qid(person_qid):
         return None
-    item = client.fetch_item(person_qid)
+    item = client.fetch_item(
+        person_qid,
+        cache_days=days_since_modified(modified_at),
+        randomize=modified_at is None,
+    )
     if item is None:
         return None
     if item.id != person_qid:
@@ -214,7 +219,6 @@ def crawl(context: Context) -> None:
     cache_days = context.dataset.config.get("cache_days", 14)
     client = WikidataClient(context.cache, context.http, cache_days=cache_days)
     position_classes = query_position_classes(context, client)
-
     for country in all_countries():
         context.log.info(f"Crawling country: {country.qid} ({country.label})")
 
@@ -241,8 +245,10 @@ def crawl(context: Context) -> None:
             context.log.info("Position [%s]: %s" % (position.id, position.caption))
 
             has_holders = False
-            for person in position_holders(client, pos_item):
-                holder = crawl_holder(context, client, position, person)
+            for person_qid, modified_at in position_holders(client, pos_item).items():
+                holder = crawl_holder(
+                    context, client, position, person_qid, modified_at
+                )
                 if holder is not None:
                     has_holders = True
 

--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -1,8 +1,9 @@
 from collections import defaultdict
 from typing import Optional, List, Generator, NamedTuple, Set
+from datetime import datetime
+
 from rigour.ids.wikidata import is_qid
 from rigour.territories import get_territories, get_territory_by_qid
-from rigour.time import iso_datetime
 from nomenklatura.wikidata import WikidataClient, SparqlBinding
 
 from zavod import Context
@@ -39,14 +40,11 @@ def crawl_holder(
     client: WikidataClient,
     position: Entity,
     person_qid: str,
-    modified_at: Optional[str] = None,
+    modified_at: Optional[datetime] = None,
 ) -> Optional[Entity]:
     if not is_qid(person_qid):
         return None
-    item = client.fetch_item(
-        person_qid,
-        modified_at=iso_datetime(modified_at),
-    )
+    item = client.fetch_item(person_qid, modified_at=modified_at)
     if item is None:
         return None
     if item.id != person_qid:

--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -2,13 +2,14 @@ from collections import defaultdict
 from typing import Optional, List, Generator, NamedTuple, Set
 from rigour.ids.wikidata import is_qid
 from rigour.territories import get_territories, get_territory_by_qid
+from rigour.time import iso_datetime
 from nomenklatura.wikidata import WikidataClient, SparqlBinding
 
 from zavod import Context
 from zavod.entity import Entity
 from zavod.shed.wikidata.human import wikidata_basic_human
 from zavod.shed.wikidata.position import wikidata_occupancy, wikidata_position
-from zavod.shed.wikidata.position import days_since_modified, position_holders
+from zavod.shed.wikidata.position import position_holders
 
 
 class Country(NamedTuple):
@@ -44,8 +45,7 @@ def crawl_holder(
         return None
     item = client.fetch_item(
         person_qid,
-        cache_days=days_since_modified(modified_at),
-        randomize=modified_at is None,
+        modified_at=iso_datetime(modified_at),
     )
     if item is None:
         return None

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 requires-python = ">= 3.12"
 dependencies = [
     "followthemoney == 4.9.2",
-    "nomenklatura == 4.11.2",
+    "nomenklatura == 4.11.3",
     "plyvel == 1.5.1", # Also update macOS install docs
     "rigour == 2.1.2",
     "datapatch >= 1.2.4, < 1.3",

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, Optional, Set
 
 from followthemoney import registry
@@ -6,6 +6,7 @@ from nomenklatura.wikidata import Item, WikidataClient, Claim
 from nomenklatura.wikidata.lang import MULTI_LANG
 from nomenklatura.wikidata.value import clean_wikidata_name
 from rigour.territories import get_territory_by_qid
+from rigour.time import iso_datetime
 
 from zavod import Context, Entity
 from zavod import helpers as h
@@ -238,20 +239,9 @@ def wikidata_position(
     return position
 
 
-def days_since_modified(modified_at: Optional[str]) -> Optional[int]:
-    """Return the number of whole days since a Wikidata schema:dateModified timestamp.
-
-    Returns None when no timestamp is provided.
-    """
-    if modified_at is None:
-        return None
-
-    modified = datetime.strptime(modified_at, "%Y-%m-%dT%H:%M:%SZ")
-    modified = modified.replace(tzinfo=timezone.utc)
-    return max(0, (datetime.now(timezone.utc) - modified).days)
-
-
-def position_holders(client: WikidataClient, item: Item) -> Dict[str, str]:
+def position_holders(
+    client: WikidataClient, item: Item
+) -> Dict[str, Optional[datetime]]:
     """Find persons who have held the position defined by `item`. This performs
     the inverted lookup on property P39 (position held). Independently, the crawler
     should check property P1308 (officeholder) on the position item itself.
@@ -265,14 +255,13 @@ def position_holders(client: WikidataClient, item: Item) -> Dict[str, str]:
         ?person schema:dateModified ?modifiedAt .
     }}
     """
-    holders: Dict[str, str] = {}
+    holders: Dict[str, Optional[datetime]] = {}
     response = client.query(query, client.CACHE_SHORT)
     for result in response.results:
         person_qid = result.plain("person")
         modified_at = result.plain("modifiedAt")
         if person_qid is not None:
-            assert modified_at is not None, (person_qid, item.id)
-            holders[person_qid] = modified_at
+            holders[person_qid] = iso_datetime(modified_at)
 
     return holders
 

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -268,7 +268,7 @@ def position_holders(client: WikidataClient, item: Item) -> Dict[str, str]:
     }}
     """
     holders: Dict[str, str] = {}
-    response = client.query(query)
+    response = client.query(query, client.CACHE_SHORT)
     for result in response.results:
         person_qid = result.plain("person")
         modified_at = result.plain("modifiedAt")

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timezone
 from typing import Dict, Optional, Set
-from logging import getLogger
 
 from followthemoney import registry
 from nomenklatura.wikidata import Item, WikidataClient, Claim
@@ -16,7 +15,6 @@ from zavod.util import LangText
 from zavod.stateful.positions import categorise
 from zavod.shed.wikidata.country import is_historical_country, item_countries
 
-log = getLogger(__name__)
 
 POSITION_BASICS: Set[str] = {
     "Q4164871",  # position

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -1,4 +1,6 @@
+from datetime import datetime, timezone
 from typing import Dict, Optional, Set
+from logging import getLogger
 
 from followthemoney import registry
 from nomenklatura.wikidata import Item, WikidataClient, Claim
@@ -13,6 +15,8 @@ from zavod.shed.trans import translate_position_name
 from zavod.util import LangText
 from zavod.stateful.positions import categorise
 from zavod.shed.wikidata.country import is_historical_country, item_countries
+
+log = getLogger(__name__)
 
 POSITION_BASICS: Set[str] = {
     "Q4164871",  # position
@@ -236,25 +240,43 @@ def wikidata_position(
     return position
 
 
-def position_holders(client: WikidataClient, item: Item) -> Set[str]:
+def days_since_modified(modified_at: Optional[str]) -> Optional[int]:
+    """Return the number of whole days since a Wikidata schema:dateModified timestamp.
+
+    Returns None when no timestamp is provided.
+    """
+    if modified_at is None:
+        return None
+
+    modified = datetime.strptime(modified_at, "%Y-%m-%dT%H:%M:%SZ")
+    modified = modified.replace(tzinfo=timezone.utc)
+    return max(0, (datetime.now(timezone.utc) - modified).days)
+
+
+def position_holders(client: WikidataClient, item: Item) -> Dict[str, str]:
     """Find persons who have held the position defined by `item`. This performs
     the inverted lookup on property P39 (position held). Independently, the crawler
     should check property P1308 (officeholder) on the position item itself.
+
+    Returns a dict mapping person QID → schema:dateModified timestamp (ISO 8601).
     """
     query = f"""
-    SELECT ?person WHERE {{
+    SELECT ?person ?modifiedAt WHERE {{
         ?person wdt:P39 wd:{item.id} .
-        ?person wdt:P31 wd:Q5
+        ?person wdt:P31 wd:Q5 .
+        ?person schema:dateModified ?modifiedAt .
     }}
     """
-    persons: Set[str] = set()
+    holders: Dict[str, str] = {}
     response = client.query(query)
     for result in response.results:
         person_qid = result.plain("person")
+        modified_at = result.plain("modifiedAt")
         if person_qid is not None:
-            persons.add(person_qid)
+            assert modified_at is not None, (person_qid, item.id)
+            holders[person_qid] = modified_at
 
-    return persons
+    return holders
 
 
 def wikidata_occupancy(


### PR DESCRIPTION
Part of https://github.com/opensanctions/opensanctions/issues/3488

Depends on https://github.com/opensanctions/nomenklatura/pull/332

Queries for the modification date of position holder items in sparql queries, then passes the modification date to the cache to use that as the cache cut-off and invalidate items cached before that date.

This has the effect that something that if a person was modified more recently than when we last fetched them, we invalidate the cache for their wikidata item and refetch.