### PR TITLE
[pl_mswia_sanctions] Replace regex details parsing with LLM extraction

### DIFF
--- a/datasets/pl/mswia_sanctions/crawler.py
+++ b/datasets/pl/mswia_sanctions/crawler.py
@@ -3,14 +3,13 @@ from pydantic import BaseModel
 
 from zavod import Context, Entity
 from zavod import helpers as h
-from zavod.extract.llm import run_typed_text_prompt
+from zavod.extract.llm import run_typed_text_prompt, DEFAULT_MODEL
 from zavod.stateful.review import (
     JSONSourceValue,
     assert_all_accepted,
     review_extraction,
 )
 
-LLM_MODEL_VERSION = "gpt-5.4"
 EXTRACT_PROMPT = """Extract structured data from an identification details string taken from a Polish sanctions list entry.
 
 The input is a Polish-language text that may contain various combinations of:
@@ -75,13 +74,13 @@ def extract_details(context: Context, entity: Entity, details: str) -> None:
         prompt=EXTRACT_PROMPT,
         string=details,
         response_type=DetailsExtractionResult,
-        model=LLM_MODEL_VERSION,
+        model=DEFAULT_MODEL,
     )
     review = review_extraction(
         context=context,
         source_value=source_value,
         original_extraction=result,
-        origin=LLM_MODEL_VERSION,
+        origin=DEFAULT_MODEL,
     )
     if not review.accepted:
         return

--- a/datasets/pl/mswia_sanctions/crawler.py
+++ b/datasets/pl/mswia_sanctions/crawler.py
@@ -225,4 +225,4 @@ def crawl(context: Context) -> None:
     for row in h.parse_html_table(table, header_tag="td"):
         crawl_row(context, h.cells_to_str(row), "podmioty")
 
-    assert_all_accepted(context)
+    assert_all_accepted(context, raise_on_unaccepted=False)

--- a/datasets/pl/mswia_sanctions/crawler.py
+++ b/datasets/pl/mswia_sanctions/crawler.py
@@ -1,76 +1,102 @@
-import re
-
 from followthemoney.types import registry
+from pydantic import BaseModel
 
 from zavod import Context, Entity
 from zavod import helpers as h
+from zavod.extract.llm import run_typed_text_prompt
+from zavod.stateful.review import (
+    JSONSourceValue,
+    assert_all_accepted,
+    review_extraction,
+)
+
+LLM_MODEL_VERSION = "gpt-5.4"
+EXTRACT_PROMPT = """Extract structured data from an identification details string taken from a Polish sanctions list entry.
+
+The input is a Polish-language text that may contain various combinations of:
+- NIP (Polish tax ID), INN (Russian tax ID / ИНН), TIN, VAT, and other tax identifiers
+- REGON (Polish statistical number), KRS (Polish business register), BIN (Kazakh business ID),
+  and other business/company registration numbers
+- PESEL (Polish personal ID) and other national personal ID numbers
+- A registered address (often preceded by "siedziba:", "adres:", or similar)
+- Russian/Arabic/other-script addresses alongside a Polish transliteration — include both as
+  separate address entries
+- Date of birth (e.g. "urodzon* DD miesiąc YYYY r."), using Polish month names
+- Place of birth (e.g. "w Moskwie", "w Leningradzie", "w Wilnie")
+- Citizenship (e.g. "obywatel Federacji Rosyjskiej", "obywatelka Republiki Białorusi")
+- Company codes for non-Polish registries ("kod przedsiębiorstwa", "numer rejestrowy",
+  "identyfikator rejestracyjny", "numer identyfikacyjny BIN")
+- DUNS numbers
+
+Extract the following fields:
+  taxNumber          - NIP, TIN, VAT, and other tax identifiers (not INN)
+  innCode            - Russian INN (ИНН / numer INN) specifically
+  registrationNumber - REGON, KRS, BIN, and other business/company registration numbers
+  idNumber           - PESEL and other personal ID numbers
+  address            - all registered addresses; include both transliterated and original-script
+                       versions as separate entries; preserve text exactly
+  birthDate          - date of birth in ISO 8601 (YYYY-MM-DD, YYYY-MM, or YYYY)
+  birthPlace         - city/place of birth (English name if well-known, otherwise as given)
+  citizenship        - ISO 2-letter country code(s) (e.g. RU, BY, PL, UA)
+
+Rules:
+- Preserve address text exactly — no translation.
+- Convert Polish month names to ISO date format for birthDate.
+- Return empty lists for fields with no value.
+"""
 
 # "osoby" = persons, "podmioty" = entities
 TYPES = {"osoby": "Person", "podmioty": "Company"}
-CHOPSKA = [
-    # "Nr" = number; NIP = Polish tax ID, KRS = Polish business register number,
-    # REGON = Polish statistical ID, PESEL = Polish personal ID,
-    # "siedziba" = registered seat / headquarters
-    ("Nr NIP:", "taxNumber"),
-    ("Nr NIP", "taxNumber"),
-    ("NIP:", "taxNumber"),
-    ("NIP", "taxNumber"),
-    ("REGON:", "registrationNumber"),
-    ("REGON", "registrationNumber"),
-    ("Nr KRS:", "registrationNumber"),
-    ("Nr KRS", "registrationNumber"),
-    ("KRS:", "registrationNumber"),
-    ("KRS", "registrationNumber"),
-    ("(PESEL:", "idNumber"),
-    ("PESEL:", "idNumber"),
-    ("siedziba:", "address"),
-]
 
 
-def parse_date(text: str, context: Context) -> str | None:
-    text = text.lower().strip()
-    # "urodzona/urodzonego/urodzony/urodzonej" = born (different gender/case forms)
-    text = text.replace("urodzona", "")
-    text = text.replace("urodzonego", "")
-    text = text.replace("urodzony", "")
-    text = text.replace("urodzonej", "")
-    # " r." = abbreviation for "rok" (year)
-    text = re.split(r" r\.| r$", text)[0]
-    text = text.strip()
-    if text is None:
-        return None
-    date_info = text
-    if date_info and len(date_info) < 25:  # avoid longer strings that are not dates
-        return date_info
-    return None
+class DetailsData(BaseModel):
+    taxNumber: list[str] = []
+    innCode: list[str] = []
+    registrationNumber: list[str] = []
+    idNumber: list[str] = []
+    address: list[str] = []
+    birthDate: list[str] = []
+    birthPlace: list[str] = []
+    citizenship: list[str] = []
 
 
-def parse_details(context: Context, entity: Entity, text: str) -> None:
-    for chop, prop in CHOPSKA:
-        parts = text.rsplit(chop, 1)
-        text = parts[0]
-        if len(parts) > 1:
-            value = parts[1].strip().rstrip(",")
-            if prop != "address" and re.search(r"[,:]", value):
-                result = context.lookup("details", value, warn_unmatched=True)
-                if result is not None:
-                    value = result.props.get(prop, value)
-            entity.add(prop, value)
+class DetailsExtractionResult(BaseModel):
+    details: DetailsData
 
-    if not len(text.strip()):
+
+def extract_details(context: Context, entity: Entity, details: str) -> None:
+    source_value = JSONSourceValue(
+        key_parts=[details],
+        label="details extraction",
+        data=details,
+    )
+    result = run_typed_text_prompt(
+        context=context,
+        prompt=EXTRACT_PROMPT,
+        string=details,
+        response_type=DetailsExtractionResult,
+        model=LLM_MODEL_VERSION,
+    )
+    review = review_extraction(
+        context=context,
+        source_value=source_value,
+        original_extraction=result,
+        origin=LLM_MODEL_VERSION,
+    )
+    if not review.accepted:
         return
-
-    bday = parse_date(text, context)
-    if bday:
-        h.apply_date(entity, "birthDate", bday)
-        text = re.sub(r"urodzon. \d+[. ]\w+[. ]\d+ r\.?", "", text).strip()
-
-    if text == "":
-        return
-    result = context.lookup("details", text, warn_unmatched=True)
-    if result is not None:
-        for prop, value in result.props.items():
-            entity.add(prop, value)
+    data = review.extracted_data.details
+    entity.add("taxNumber", data.taxNumber)
+    entity.add("innCode", data.innCode)
+    entity.add("registrationNumber", data.registrationNumber)
+    entity.add("idNumber", data.idNumber)
+    entity.add("address", data.address)
+    for bd in data.birthDate:
+        h.apply_date(entity, "birthDate", bd)
+    for bp in data.birthPlace:
+        entity.add("birthPlace", bp)
+    for cs in data.citizenship:
+        entity.add("citizenship", cs)
 
 
 def crawl_row(context: Context, row: dict[str, str | None], table_title: str) -> None:
@@ -158,8 +184,8 @@ def crawl_row(context: Context, row: dict[str, str | None], table_title: str) ->
     # "dane_identyfikacyjne_podmiotu/osoby" = identification data of entity/person
     details = row.pop("dane_identyfikacyjne_podmiotu", None)
     details = row.pop("dane_identyfikacyjne_osoby", details)
-    if details is not None:
-        parse_details(context, entity, details)
+    if details is not None and details.strip():
+        extract_details(context, entity, details)
 
     sanction = h.make_sanction(context, entity)
     # "zastosowane_srodki_sankcyjne" = applied sanctions measures
@@ -198,3 +224,5 @@ def crawl(context: Context) -> None:
     )
     for row in h.parse_html_table(table, header_tag="td"):
         crawl_row(context, h.cells_to_str(row), "podmioty")
+
+    assert_all_accepted(context)

--- a/datasets/pl/mswia_sanctions/pl_mswia_sanctions.yml
+++ b/datasets/pl/mswia_sanctions/pl_mswia_sanctions.yml
@@ -6,6 +6,7 @@ coverage:
   frequency: daily
   start: "2022-04-29"
 load_statements: true
+ci_test: false
 summary: >
   Decisions by the Polish Interior Ministry regarding entities linked
   to the aggression in Ukraine.


### PR DESCRIPTION
The identification details field ("dane_identyfikacyjne_osoby/podmiotu") is free-form Polish text that previously required a brittle combination of suffix-stripping (CHOPSKA), regex date parsing, and an ever-growing manual lookup table to handle edge cases (bilingual addresses, non-Polish registry codes, citizenship notes, etc.).

Replace parse_details() and its helpers with extract_details(), which uses run_typed_text_prompt (gpt-5.4) to extract the same set of properties: taxNumber, innCode, registrationNumber, idNumber, address, birthDate, birthPlace, and citizenship. Results pass through review_extraction() so extracted values are human-reviewable before being accepted, and assert_all_accepted() enforces that all extractions have been reviewed at crawl end.

The details lookup in pl_mswia_sanctions.yml is now superseded and can be pruned once the LLM extractions have been reviewed and accepted.