### PR TITLE
[ru_dossier_center_poi] Fix Cyrillic mojibake and unstable IDs

### DIFF
--- a/datasets/ru/dossier_center_poi/crawler.py
+++ b/datasets/ru/dossier_center_poi/crawler.py
@@ -33,7 +33,7 @@ def paginate_crawl(
 def crawl_persons_list(
     context: Context, url: str, accomplices: bool = False
 ) -> str | None:
-    doc = context.fetch_html(url, cache_days=1, absolute_links=True)
+    doc = context.fetch_html(url, cache_days=1, absolute_links=True, encoding="utf-8")
 
     for anchor_url in h.xpath_strings(doc, '//div[@class="b-archive-item"]//a/@href'):
         crawl_person(context, anchor_url, accomplices)
@@ -45,7 +45,7 @@ def crawl_persons_list(
 
 
 def crawl_person(context: Context, url: str, accomplice: bool = False) -> None:
-    doc = context.fetch_html(url, cache_days=1)
+    doc = context.fetch_html(url, cache_days=1, encoding="utf-8")
 
     person_name = get_element_text(
         doc, '//div[@class="b-pr-section__field bottom-gap p-compact"]//p[1]'
@@ -94,7 +94,7 @@ def crawl_person(context: Context, url: str, accomplice: bool = False) -> None:
     )
 
     person = context.make("Person")
-    person.id = context.make_slug(person_name)
+    person.id = context.make_id(url)
     person.add("name", person_name, lang="rus")
     person.add("name", latinised)
     person.add("sourceUrl", url)

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -393,6 +393,7 @@ class Context:
         method: str = "GET",
         data: Optional[_Body] = None,
         absolute_links: bool = False,
+        encoding: Optional[str] = None,
     ) -> Element:
         """Execute an HTTP request using the contexts' session and return
         an HTML DOM object based on the response. If a `cache_days` argument
@@ -408,6 +409,10 @@ class Context:
             data: The data to be sent in the request body.
             absolute_links: Whether to convert relative links to absolute links.
                 Doesn't take redirects into account.
+            encoding: Override the response character encoding. Use this when a
+                source omits or misstates its HTTP charset, since the decoded
+                text is handed to the parser before the document's own charset
+                declaration can be consulted.
         Returns:
             An lxml-based DOM of the web page that has been returned.
         """
@@ -419,6 +424,7 @@ class Context:
             cache_days=cache_days,
             method=method,
             data=data,
+            encoding=encoding,
         )
         try:
             if text is None or len(text) == 0:


### PR DESCRIPTION
## Problem

The Dossier Center crawler was emitting entities with garbage IDs (e.g. `ru-dc-poi-dd2d3dmd1-2d-d1-dd-dond3-4nd3-4d2d-...` — actually Yevgeny Prigozhin) and mojibaked Cyrillic in every text field.

Root cause: `peps.dossier.center` serves pages as `Content-Type: text/html` with **no charset**. The `requests` library then defaults `response.encoding` to `ISO-8859-1` (RFC 2616), so `fetch_text` decodes the UTF-8 Cyrillic bytes as Latin-1. Since the already-decoded string is handed to `lxml`, the page's `<meta charset="UTF-8">` is never consulted, and the mojibake is locked in. `make_slug(person_name)` then turned the mangled name into an unstable garbage ID.

## Fix

- Expose an `encoding` parameter on `Context.fetch_html`, forwarding to the existing `fetch_text(encoding=...)` override.
- Crawler fetches with `encoding="utf-8"`.
- Key person IDs on `make_id(url)` instead of `make_slug(person_name)` — the source URL is a clean, stable, opaque key (no PII).

## Verification

Ran the full crawler: 102 entities, no warnings. Prigozhin's name is now `Евгений Викторович Пригожин`, his ID is `ru-dc-poi-4fc1439c31f2e3a5e6287c3a4da32c2d9ab5e946`, and there are **zero** mojibake markers in the output.

Note: this re-keys all 102 entities (IDs change from the old name-derived slugs to URL hashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)