### PR TITLE
[ch_parlament] Map council names to English position names with Wikidata QIDs

### DIFF
--- a/datasets/ch/parlament/crawler.py
+++ b/datasets/ch/parlament/crawler.py
@@ -93,12 +93,22 @@ def crawl_councillor(context: Context, councillor_id: int) -> None:
         assert isinstance(body, dict)
         name = body.get("name")
         assert name is not None
+        # The API returns the chamber name in French regardless of lang; map it to
+        # the standard English position name and its Wikidata QID.
+        if name == "Conseil national":
+            position_name = "Member of the Swiss National Council"
+            wikidata_id = "Q18510612"
+        elif name == "Conseil des Etats":
+            position_name = "Member of the Swiss Council of States"
+            wikidata_id = "Q18510613"
+        else:
+            raise ValueError(f"Unexpected council name: {name!r}")
         position = h.make_position(
             context,
-            name=name,
+            name=position_name,
             country="ch",
             topics=["gov.legislative", "gov.national"],
-            # lang="eng",
+            wikidata_id=wikidata_id,
         )
         categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:


### PR DESCRIPTION
The Parliament API returns the chamber name (`council.name`) in French regardless of the `lang=en` request parameter, yielding "Conseil national" and "Conseil des Etats". Previously we passed this raw French string straight into `make_position`, which meant positions were named in French rather than the standard English term, and they carried no `wikidata_id`, so the position entity IDs were derived from the (French) name string instead of being anchored to a stable QID.

Replace this with an explicit if/elif mapping each known chamber to its standard English position name and its Wikidata QID:
- "Conseil national" → "Member of the Swiss National Council" (Q18510612)
- "Conseil des Etats" → "Member of the Swiss Council of States" (Q18510613)

Anything else raises a `ValueError` so the crawler fails loudly if the API ever introduces a new chamber name or changes the language of this field. Passing distinct QIDs also guarantees the two chambers stay separate Position entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
