### PR TITLE
[cu_inventario_legislatura] Use English position name with Wikidata QID

### DIFF
--- a/datasets/cu/inventario_legislatura/crawler.py
+++ b/datasets/cu/inventario_legislatura/crawler.py
@@ -29,15 +29,12 @@ IGNORE_COLUMNS = [
 
 
 def crawl(context: Context) -> None:
-    pos = "X Legislatura de la Asamblea Nacional del Poder Popular (ANPP)"
-    inception_date = "2023"
-    dissolution_date = "2028"
+    term_start = "2023"
     position = h.make_position(
         context,
-        pos,
+        "Member of the National Assembly of People's Power",
         country="cu",
-        inception_date=inception_date,
-        dissolution_date=dissolution_date,
+        wikidata_id="Q21272829",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)
@@ -62,6 +59,9 @@ def crawl(context: Context) -> None:
         entity.add("education", data.pop("nivel_escolar"))
         entity.add("political", data.pop("ujc_pcc"))
         h.apply_date(entity, "birthDate", data.pop("fecha_de_nacimiento"))
+        # ANPP deputies must be Cuban citizens: Ley Electoral (Ley No. 127/2019)
+        # Art. 9.1 ("Tienen derecho a ser elegidos los ciudadanos cubanos...").
+        # https://www.gacetaoficial.gob.cu/es/ley-no-127-ley-electoral-de-13-de-julio-de-2019
         entity.add("citizenship", "cu")
         entity.add("topics", "role.pep")
 
@@ -69,7 +69,12 @@ def crawl(context: Context) -> None:
             context,
             entity,
             position,
-            start_date=inception_date,
+            start_date=term_start,
+            # Even though the term runs until the next election (expected by March
+            # 2028), the source is a one-time press release rather than a continuously
+            # updated register. It tells us nothing about whether a given person still
+            # holds the seat today, so we can't assert an end date or imply that the
+            # occupancy is current.
             end_date=None,
             no_end_implies_current=False,
             categorisation=categorisation,

--- a/datasets/cu/inventario_legislatura/cu_inventario_legislatura.yml
+++ b/datasets/cu/inventario_legislatura/cu_inventario_legislatura.yml
@@ -1,6 +1,14 @@
 title: Cuba Members of the Parliament
 entry_point: crawler.py
 prefix: cuinv
+manual_check:
+  last_checked: "2026-06-30"
+  # ~1 week after the next ANPP election, expected by March 2028 (deputies elected
+  # 26 Mar 2023, 11 Mar 2018 — consistently late March). Targets ~2028-04-02.
+  interval: 642
+  message: >-
+    Check whether the next Cuban National Assembly (ANPP) election has happened — it
+    was expected by March 2028.
 coverage:
   frequency: monthly
   start: "2023-08-14"
@@ -40,6 +48,9 @@ assertions:
     schema_entities:
       Person: 420
       Position: 1
+    country_entities:
+      cu: 420
   max:
     schema_entities:
       Person: 550
+      Position: 1


### PR DESCRIPTION
Name the ANPP deputy position in English and key it on its Wikidata QID (Q21272829) instead of the term-bound Spanish string. The legislative term now lives on the occupancy rather than the position, which is the ongoing role. Add a `manual_check` targeting ~1 week after the next election (expected by March 2028), document the citizenship legal basis (Ley Electoral 127/2019 Art. 9.1), and tighten assertions with a `cu` country floor and a Position max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
