### PR TITLE
[py_congreso] Lower Person min assertion to 480

### DIFF
--- a/datasets/py/congreso/py_congreso.yml
+++ b/datasets/py/congreso/py_congreso.yml
@@ -46,7 +46,7 @@ lookups:
 assertions:
   min:
     schema_entities:
-      Person: 550
+      Person: 480
       Position: 2
     country_entities:
       py: 100


### PR DESCRIPTION
## What

Lower the `Person` min assertion in `py_congreso` from **550** to **480**.

CI was failing with:

```
py_congreso: Assertion schema_entities failed for Person: 511 is not >= threshold 550
```

## Analysis

The 550 floor was set in https://github.com/opensanctions/opensanctions/commit/7b48b3394f7d695144c87b976babadc349741b01 (alongside the rewrite that started emitting historical members), but it was set against the **raw** number of entities the crawler emits, while the assertion actually measures the **post-resolution export**.

The source assigns a **fresh `idParlamentario` per term/seat**, not a stable per-person ID. So a legislator who served multiple terms is emitted as a separate `Person` for each term, and the production resolver merges them back into one real person.

Concretely, for the current source data:

| Stage | Person count |
|---|---|
| Raw entities emitted (unique `idParlamentario` past the cutoff) | 693 |
| After resolver dedup (what `statistics.json` / assertions count) | 507 |
| CI reported | 511 |

The resolver collapses **186** source IDs into **134** real people. A few examples (most-merged first):

- Silvio Adalberto Ovelar Benítez — 5 IDs (`py-cgso-10, -100061, -100657, -101339, -268`)
- Lilian Graciela Samaniego González — 5 IDs
- Juan Carlos Wasmosy Monti (ex-president) — 4 IDs
- Blas Antonio Llano Ramos — 4 IDs

So 550 can never pass post-resolution; the real number is ~510. I set the floor to **480** to leave a bit of headroom. Max (1400) is untouched.

Note there's also a slow downward drift over time: `earliest_term_start` filters on `period_start` with 30y slack, but `make_occupancy` drops occupancies whose `period_end` is >20y ago (`EXTENDED_AFTER_OFFICE`, cutoff currently ~2006). The oldest cohort (1998–2003) is now dropped at the occupancy level, and that window keeps advancing each year until a new term lands — another reason not to hug the threshold too tightly.

## Follow-up (not in this PR)

The crawler keys persons on `idParlamentario`, which isn't stable across terms, so it leans entirely on the resolver to dedup ~27% of its output. If the source exposes a stable per-person identifier we could key on that and emit clean entities directly. Bigger change, the resolver handles it fine for now, so leaving it as a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)