### PR TITLE
Translate position names via LLM in more crawlers

### DIFF
--- a/datasets/at/meine_abgeordneten/crawler.py
+++ b/datasets/at/meine_abgeordneten/crawler.py
@@ -132,7 +132,9 @@ def crawl_mandate(
         )
         return None
 
-    position = h.make_position(context, position_name, country="at", lang="deu")
+    position = h.make_position(
+        context, position_name, country="at", lang="deu", translate_name=True
+    )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return None

--- a/datasets/fr/hatvp_declarations/crawler.py
+++ b/datasets/fr/hatvp_declarations/crawler.py
@@ -37,6 +37,8 @@ def crawl_row(context: Context, row: Dict[str, str | None]) -> None:
         context,
         name=role,
         country="fr",
+        lang="fra",
+        translate_name=True,
     )
 
     categorisation = categorise(context, position, default_is_pep=None)

--- a/datasets/ge/declarations/crawler.py
+++ b/datasets/ge/declarations/crawler.py
@@ -329,9 +329,7 @@ def crawl_declaration(context: Context, *, item: dict[str, Any]) -> None:
         position_name_kat,
         country="ge",
         lang="kat",
-    )
-    apply_translit_full_name(
-        context, position, "kat", position_name_kat, TRANSLIT_OUTPUT, POSITION_PROMPT
+        translate_name=True,
     )
     categorisation = categorise(context, position, default_is_pep=None)
     if not categorisation.is_pep:

--- a/datasets/lt/pep_declarations/crawler.py
+++ b/datasets/lt/pep_declarations/crawler.py
@@ -120,7 +120,9 @@ def parse_affiliations(
                 context,
                 name=main_duty,
                 topics=None,
-                country="LT",
+                country="lt",
+                lang="lit",
+                translate_name=True,
             )
             categorisation = categorise(
                 context,


### PR DESCRIPTION
Switch several crawlers over to `make_position(..., translate_name=True)` so source-language position names get translated to English via the LLM:

- `at_meine_abgeordneten` — German (`lang="deu"`)
- `fr_hatvp_declarations` — French (`lang="fra"`)
- `lt_pep_declarations` — Lithuanian (`lang="lit"`); also fixed the country code casing (`LT` → `lt`)
- `ge_declarations` — Georgian (`lang="kat"`); replaces the old `apply_translit_full_name(...)` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)