### PR TITLE
[hr_public_officials] Don't default 'Unknown position' to PEP

### DIFF
--- a/datasets/hr/public_officials/crawler.py
+++ b/datasets/hr/public_officials/crawler.py
@@ -68,8 +68,10 @@ def make_position_name(data: Dict[str, str]) -> Optional[str]:
 def make_affiliation_entities(
     context: Context,
     person: Entity,
+    *,
     position_name: Optional[str],
-    data: Dict[str, str],
+    default_is_pep: bool,
+    position_data: Dict[str, str],
 ) -> List[Entity]:
     """Creates Position and Occupancy provided that the Occupancy meets OpenSanctions criteria.
     * A position's name include the title and optionally the name of the legal entity
@@ -80,13 +82,13 @@ def make_affiliation_entities(
     if position_name is None or position_name.strip() == "":
         return []
 
-    start_date = data.pop("position_start_date")
-    end_date = data.pop("position_end_date")
-    context.audit_data(data)
+    start_date = position_data.pop("position_start_date")
+    end_date = position_data.pop("position_end_date")
+    context.audit_data(position_data)
 
     position = h.make_position(context, position_name, country="HR")
 
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position, default_is_pep=default_is_pep)
     occupancy = h.make_occupancy(
         context,
         person,
@@ -103,12 +105,15 @@ def make_affiliation_entities(
 
 def make_person(
     context: Context,
+    *,
     first_name: str,
     last_name: str,
-    primary: Optional[str],
-    secondary: Optional[str],
+    primary_position_name: Optional[str],
+    secondary_position_name: Optional[str],
 ) -> Entity:
-    positions = sorted(p for p in [primary, secondary] if p is not None)
+    positions = sorted(
+        p for p in [primary_position_name, secondary_position_name] if p is not None
+    )
     position = positions[0] if positions else None
     person = context.make("Person")
     person.id = context.make_id(first_name, last_name, position)
@@ -136,29 +141,38 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
     position_entities = []
 
     primary_position_data = dict_keys_by_prefix(row, "primary_")
+    primary_has_title = primary_position_data.get("position") is not None
     primary_position_name = make_position_name(primary_position_data)
-    secondary_data = dict_keys_by_prefix(row, "secondary_")
-    secondary_position_name = make_position_name(secondary_data)
+    secondary_position_data = dict_keys_by_prefix(row, "secondary_")
+    secondary_has_title = secondary_position_data.get("position") is not None
+    secondary_position_name = make_position_name(secondary_position_data)
 
     person = make_person(
         context,
-        row.pop("first_name"),
-        row.pop("last_name"),
-        primary_position_name,
-        secondary_position_name,
+        first_name=row.pop("first_name"),
+        last_name=row.pop("last_name"),
+        primary_position_name=primary_position_name,
+        secondary_position_name=secondary_position_name,
     )
 
     position_entities.extend(
         make_affiliation_entities(
             context,
             person,
-            primary_position_name,
-            primary_position_data,
+            position_name=primary_position_name,
+            # "Unknown position" (no title) -> default to non-PEP
+            default_is_pep=primary_has_title,
+            position_data=primary_position_data,
         )
     )
     position_entities.extend(
         make_affiliation_entities(
-            context, person, secondary_position_name, secondary_data
+            context,
+            person,
+            position_name=secondary_position_name,
+            # "Unknown position" (no title) -> default to non-PEP
+            default_is_pep=secondary_has_title,
+            position_data=secondary_position_data,
         )
     )
 


### PR DESCRIPTION
Some rows in `hr_public_officials` have a legal entity but no role title, which we name `"Unknown position"`. Those can't tell us whether the holder is politically exposed, so `default_is_pep` is now derived from whether the source actually provided a title, instead of always defaulting to `True`.

Also did a bit of cleanup while I was in there: made the args after `context`/`person` keyword-only in `make_person`/`make_affiliation_entities`, and renamed a few things for clarity (`data` → `position_data`, `primary`/`secondary` → `primary_position_name`/`secondary_position_name`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)