### PR TITLE
Lower default HTTP timeout and pass it explicitly (incl. Zyte)

### DIFF
--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -82,6 +82,7 @@ HTTP requests for GET requests are automatically retried for connection and HTTP
 
 - `http`
     - `user_agent`: string, defaults to the value of the FTM_USER_AGENT setting. Set a custom value for the `User-Agent` header if needed.
+    - `timeout`: integer in seconds, default `60`. Connect and read timeout applied to both the context HTTP session and Zyte API requests. Increase it for sources that are slow to respond.
     - `backoff_factor`: float, default `1`. [Scales the exponential backoff](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.DEFAULT_ALLOWED_METHODS:~:text=with%20None.-,backoff_factor,-(float)%20%E2%80%93).
     - `max_retries`: integer in seconds, default `3`
     - `retry_methods`: List of strings, [default](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.DEFAULT_ALLOWED_METHODS) `['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT', 'TRACE']`

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -260,7 +260,7 @@ class Context:
             A response object.
         """
         self.log.debug(f"HTTP {method}", url=url)
-        timeout = (settings.HTTP_TIMEOUT, settings.HTTP_TIMEOUT)
+        timeout = (self.dataset.http.timeout, self.dataset.http.timeout)
 
         kwargs: Dict[str, Any] = {
             "headers": headers,

--- a/zavod/zavod/extract/zyte_api.py
+++ b/zavod/zavod/extract/zyte_api.py
@@ -127,10 +127,12 @@ def fetch_resource(
     out_path.parent.mkdir(parents=True, exist_ok=True)
     configure_session(context.http)
 
+    timeout = context.dataset.http.timeout
     api_response = context.http.post(
         ZYTE_API_URL,
         auth=(settings.ZYTE_API_KEY, ""),
         json=zyte_data,
+        timeout=(timeout, timeout),
     )
     api_response.raise_for_status()
 
@@ -270,10 +272,12 @@ def fetch(
     context.log.debug(f"Zyte API request: {zyte_request.url}", data=zyte_data)
     configure_session(context.http)
 
+    timeout = context.dataset.http.timeout
     api_response = context.http.post(
         ZYTE_API_URL,
         auth=(settings.ZYTE_API_KEY, ""),
         json=zyte_data,
+        timeout=(timeout, timeout),
     )
     api_response.raise_for_status()
 

--- a/zavod/zavod/meta/http.py
+++ b/zavod/zavod/meta/http.py
@@ -25,6 +25,9 @@ class HTTP(object):
                 "Both 'retry_statuses' and 'additional_retry_statuses' are set."
             )
 
+        # Connect and read timeout in seconds, adhered to by both the context
+        # HTTP session and Zyte API requests.
+        self.timeout: int = data.get("timeout", settings.HTTP_TIMEOUT)
         self.backoff_max: int = settings.HTTP_RETRY_BACKOFF_MAX
         self.retry_statuses: List[int] = list(statuses)
         retry_methods: List[str] = ensure_list(

--- a/zavod/zavod/runtime/http_.py
+++ b/zavod/zavod/runtime/http_.py
@@ -35,9 +35,12 @@ def make_session(http_conf: HTTP) -> Session:
     session.headers["User-Agent"] = http_conf.user_agent
     # Too many of our target sites have invalid SSL certificates:
     session.verify = False
+    # Default timeout only for callers that use the session directly. All the
+    # convenience methods (Context.fetch_*) and the Zyte extractor pass an
+    # explicit timeout, so this is just a safety net against an unbounded hang.
     session.request = partial(  # type: ignore
         session.request,
-        timeout=settings.HTTP_TIMEOUT,
+        timeout=http_conf.timeout,
     )
     retries = Retry(
         total=http_conf.total_retries,

--- a/zavod/zavod/settings.py
+++ b/zavod/zavod/settings.py
@@ -56,7 +56,10 @@ ARCHIVE_BACKFILL_STATEMENTS = as_bool(
 BACKFILL_RELEASE = env_str("ZAVOD_BACKFILL_RELEASE", "latest")
 
 # HTTP settings
-HTTP_TIMEOUT = 1200
+# Connect and read timeout in seconds, applied to both the context HTTP session
+# and Zyte API requests. Can be overridden per-dataset via the `http.timeout`
+# metadata option.
+HTTP_TIMEOUT = 60
 HTTP_RETRY_TOTAL = int(env.get("ZAVOD_HTTP_RETRY_TOTAL", 3))
 HTTP_RETRY_BACKOFF_FACTOR = float(env.get("ZAVOD_HTTP_RETRY_BACKOFF_FACTOR", 1.0))
 # urllib.util.Retry.DEFAULT_BACKOFF_MAX is 120


### PR DESCRIPTION
Fixes https://github.com/opensanctions/opensanctions/issues/4536.

The Zyte API POSTs never passed an explicit `timeout`, so they only relied on the default we set in `make_session` of 1200s / 20 min. So they weren't literally unbounded like the issue suggests, but 20 minutes is far too long for a per-request read, and it was easy for a stalled Zyte request to sit there for ages.

### On the "default" mechanism

To be precise, this isn't a real session-level timeout — `requests.Session` doesn't have one. What `make_session` does is monkeypatch the instance's `session.request` with a `functools.partial` that binds `timeout=` as a default kwarg:

```python
session.request = partial(session.request, timeout=http_conf.timeout)
```

Because that's an instance attribute, it shadows `Session.request`, and every convenience method (`session.get`, `session.post`, ...) ends up calling `self.request(...)`, so they all inherit that default unless they pass their own `timeout`. A call-time `timeout=` overrides the partial's bound default (partial keywords are overridden at call time). So `context.http.post(..., timeout=(60, 60))` really does win over the partial — I verified this end to end.

### Changes

- Drop the default `HTTP_TIMEOUT` from 1200s to 60s.
- Add an `http.timeout` dataset metadata option (defaults to `HTTP_TIMEOUT`).
- Pass it explicitly as the `(connect, read)` timeout in `Context.fetch_response` and both Zyte API POSTs. The `partial` default in `make_session` is now just a safety net for anything that pokes at the session directly.

I dropped the default to 60s but added the `http.timeout` setting precisely so that crawlers which genuinely need longer can quickly bump the timeout back up, rather than every crawler eating a 20-min ceiling. Not set on any dataset yet.


🤖 Generated with [Claude Code](https://claude.com/claude-code)