### PR TITLE
Issues 2026-07-01

### DIFF
--- a/datasets/hr/public_officials/crawler.py
+++ b/datasets/hr/public_officials/crawler.py
@@ -78,6 +78,7 @@ def make_affiliation_entities(
     * A position with a legal entity but no title is titled 'Unknown position'
     * All positions (and Occupancies, Persons) are assumed to be Croatian
     * Positions with start and/or end date but no position name or legal entity name are discarded
+    * Positions not categorised as PEP are discarded
     """
     if position_name is None or position_name.strip() == "":
         return []
@@ -89,6 +90,8 @@ def make_affiliation_entities(
     position = h.make_position(context, position_name, country="HR")
 
     categorisation = categorise(context, position, default_is_pep=default_is_pep)
+    if not categorisation.is_pep:
+        return []
     occupancy = h.make_occupancy(
         context,
         person,

--- a/datasets/us/in/med_exclusions/us_in_med_exclusions.yml
+++ b/datasets/us/in/med_exclusions/us_in_med_exclusions.yml
@@ -53,9 +53,9 @@ publisher:
   url: https://www.in.gov/fssa/
   official: true
   country: "us"
-url: "https://www.in.gov/fssa/ompp/provider-information4/termination-of-provider-participation-in-medicaid-and-chip/"
+url: "https://www.in.gov/fssa/ompp/provider-information/termination-of-provider-participation-in-medicaid-and-chip"
 data:
-  url: https://www.in.gov/fssa/ompp/provider-information4/termination-of-provider-participation-in-medicaid-and-chip/
+  url: https://www.in.gov/fssa/ompp/provider-information/termination-of-provider-participation-in-medicaid-and-chip/
   format: HTML
   lang: eng
 


### PR DESCRIPTION
- **[hr_public_officials] Skip non-PEP positions before make_occupancy**
  Don't pass a position to make_occupancy once it's categorised as non-PEP,
  which now happens for 'Unknown position' rows.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  

- **[us_in_med_exclusions] update URL**
  