### PR TITLE
[my_dewan_rakyat] Add Malaysia Dewan Rakyat PEP crawler

### DIFF
--- a/datasets/my/dewan_rakyat/crawler.py
+++ b/datasets/my/dewan_rakyat/crawler.py
@@ -1,0 +1,176 @@
+import re
+import urllib3
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import categorise
+
+# The parliament portal serves an incomplete TLS certificate chain, which makes
+# the default `requests` verification fail. Disabling verification is acceptable
+# here: the source is a public government site and there is no login or secret.
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def parse_detail(context: Context, url: str) -> dict[str, str]:
+    """Return the label -> value pairs of a member's `MAKLUMAT` info table."""
+    doc = context.fetch_html(url, cache_days=7)
+    data: dict[str, str] = {}
+    for row in h.xpath_elements(doc, ".//tr[td/strong]"):
+        cells = h.xpath_elements(row, "./td")
+        if len(cells) != 2:
+            continue
+        label = h.element_text(cells[0])
+        data[label] = h.element_text(cells[1])
+    return data
+
+
+def crawl_member(context: Context, member_id: str, url: str) -> None:
+    data = parse_detail(context, url)
+    name = data.pop("Nama", None)
+    if name is None:
+        context.log.warning("Member without a name", url=url)
+        return
+    jawatan = data.pop("Jawatan dalam Parlimen", "")
+    kabinet = data.pop("Jawatan dalam Kabinet", "")
+    party = data.pop("Parti", "")
+    constituency = data.pop("Parlimen", "")
+    email = data.pop("Email", "")
+
+    person = context.make("Person")
+    person.id = context.make_slug(member_id)
+    person.add("name", h.strip_name_titles(context, name))
+    person.add("sourceUrl", url)
+    # Membership of the House of Representatives requires Malaysian citizenship
+    # under Article 47 of the Federal Constitution of Malaysia (the Speaker and
+    # Secretary are likewise Malaysian office holders):
+    # https://lom.agc.gov.my/ (Laws of Malaysia — Federal Constitution)
+    person.add("citizenship", "my")
+    # "BEBAS" means the member is an independent, i.e. holds no party affiliation.
+    if party and party != "BEBAS":
+        person.add("political", party)
+    # Some members list several contact addresses in one field, separated by
+    # slashes or commas. The "-" placeholder is dropped via a type.email lookup.
+    person.add("email", h.multi_split(email, ["/", ",", ";"]))
+
+    # A member with a constituency (P-code) is an elected MP; the Speaker and the
+    # Secretary hold no constituency and are identified by their `Jawatan` role.
+    positions: list[Entity] = []
+    if constituency:
+        positions.append(
+            h.make_position(
+                context,
+                name="Member of the Dewan Rakyat",
+                country="my",
+                wikidata_id="Q21290861",
+                lang="eng",
+            )
+        )
+        if jawatan == "Timbalan Yang di-Pertua Dewan Rakyat":
+            positions.append(
+                h.make_position(
+                    context,
+                    name="Deputy Speaker of the Dewan Rakyat",
+                    country="my",
+                    wikidata_id="Q126361900",
+                    lang="eng",
+                )
+            )
+    elif jawatan == "Yang di-Pertua Dewan Rakyat":
+        positions.append(
+            h.make_position(
+                context,
+                name="Speaker of the Dewan Rakyat",
+                country="my",
+                wikidata_id="Q7574262",
+                lang="eng",
+            )
+        )
+    elif jawatan == "Setiausaha Dewan Rakyat":
+        positions.append(
+            h.make_position(
+                context,
+                name="Secretary of the Dewan Rakyat",
+                country="my",
+                lang="eng",
+            )
+        )
+    else:
+        context.log.warning(
+            "Member without constituency or known role",
+            url=url,
+            jawatan=jawatan,
+        )
+        return
+
+    # Many members also hold an executive (cabinet) office, e.g. "Menteri
+    # Ekonomi" (Minister of Economy) or "Timbalan Menteri Pertahanan" (Deputy
+    # Minister of Defence). The Malay title is translated to English; the
+    # position id stays keyed on the untranslated name. Normalise "&" to "dan"
+    # so the two spellings of a ministry collapse to one position.
+    if kabinet and kabinet != "-":
+        positions.append(
+            h.make_position(
+                context,
+                name=kabinet.replace("&", "dan"),
+                country="my",
+                lang="msa",
+                translate_name=True,
+            )
+        )
+
+    context.audit_data(
+        data,
+        ignore=[
+            "Tempat Duduk",
+            "Kawasan",
+            "Negeri",
+            "No. Telefon",
+            "No. Faks",
+            "Media Sosial",
+            "Alamat Surat-menyurat",
+        ],
+    )
+
+    emitted = False
+    for position in positions:
+        categorisation = categorise(context, position, default_is_pep=True)
+        if not categorisation.is_pep:
+            continue
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(position)
+        context.emit(occupancy)
+        emitted = True
+
+    if emitted:
+        context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    context.http.verify = False
+    doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
+    links = h.xpath_elements(
+        doc,
+        ".//ul[contains(@class,'member-of-parliament')]/li//a[contains(@href,'id=')]",
+    )
+    if len(links) < 180:
+        raise ValueError("Unexpectedly few members: %d" % len(links))
+
+    seen: set[str] = set()
+    for link in links:
+        href = link.get("href")
+        if href is None:
+            continue
+        match = re.search(r"[?&]id=(\d+)", href)
+        if match is None:
+            context.log.warning("Member link without id", href=href)
+            continue
+        member_id = match.group(1)
+        if member_id in seen:
+            continue
+        seen.add(member_id)
+        crawl_member(context, member_id, href)

--- a/datasets/my/dewan_rakyat/crawler.py
+++ b/datasets/my/dewan_rakyat/crawler.py
@@ -1,20 +1,53 @@
 import re
+from typing import Iterator
+
 import urllib3
 
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
-from zavod.stateful.positions import categorise
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.stateful.review import assert_all_accepted
 
 # The parliament portal serves an incomplete TLS certificate chain, which makes
 # the default `requests` verification fail. Disabling verification is acceptable
 # here: the source is a public government site and there is no login or secret.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+# Minimum roster size below which the roster page is assumed to be broken.
+DEWAN_RAKYAT_MIN = 180
+TOPICS = ["gov.legislative", "gov.national"]
+
+# The `Position in the Parliament` field is inconsistently localized: most values
+# arrive in Malay even under `lang=en`, but the House clerk arrives in English.
+OFFICER_POSITIONS: dict[str, tuple[str, list[str], str | None]] = {
+    "Yang di-Pertua Dewan Rakyat": (
+        "Speaker of the Dewan Rakyat",
+        TOPICS,
+        "Q7574262",
+    ),
+    "Timbalan Yang di-Pertua Dewan Rakyat": (
+        "Deputy Speaker of the Dewan Rakyat",
+        TOPICS,
+        "Q126361900",
+    ),
+    "Ketua Majlis": ("Leader of the Dewan Rakyat", TOPICS, None),
+    "Timbalan Ketua Majlis": ("Deputy Leader of the Dewan Rakyat", TOPICS, None),
+    "Secretary Of The House Of Representatives": (
+        "Secretary of the Dewan Rakyat",
+        ["gov.admin", "gov.national"],
+        None,
+    ),
+}
+
 
 def parse_detail(context: Context, url: str) -> dict[str, str]:
-    """Return the label -> value pairs of a member's `MAKLUMAT` info table."""
-    doc = context.fetch_html(url, cache_days=7)
+    """Return the label -> value pairs of a member's `MAKLUMAT` info table.
+
+    `lang=en` yields English field labels ("Name", "Position in the Parliament",
+    ...); the detail links on the roster page omit it, so it is requested here.
+    """
+    doc = context.fetch_html(url, params={"lang": "en"}, cache_days=7)
     data: dict[str, str] = {}
     for row in h.xpath_elements(doc, ".//tr[td/strong]"):
         cells = h.xpath_elements(row, "./td")
@@ -25,152 +58,205 @@ def parse_detail(context: Context, url: str) -> dict[str, str]:
     return data
 
 
-def crawl_member(context: Context, member_id: str, url: str) -> None:
-    data = parse_detail(context, url)
-    name = data.pop("Nama", None)
-    if name is None:
-        context.log.warning("Member without a name", url=url)
-        return
-    jawatan = data.pop("Jawatan dalam Parlimen", "")
-    kabinet = data.pop("Jawatan dalam Kabinet", "")
-    party = data.pop("Parti", "")
-    constituency = data.pop("Parlimen", "")
-    email = data.pop("Email", "")
+def constituency_name(data: dict[str, str]) -> str | None:
+    """Build a human-readable constituency from a representative's detail table."""
+    parts = [data.get("Area"), data.get("State")]
+    labels = [p for p in parts if p and p != "-"]
+    if not labels:
+        return None
+    return ", ".join(labels)
 
+
+def make_member(context: Context, member_id: str, name: str, url: str) -> Entity:
+    """Build the Person for a representative (id, name, source, citizenship)."""
     person = context.make("Person")
     person.id = context.make_slug(member_id)
-    person.add("name", h.strip_name_titles(context, name))
+    h.apply_reviewed_name_string(
+        context, person, string=name, llm_cleaning=True, lang="msa"
+    )
+    person.add("name", name)
     person.add("sourceUrl", url)
     # Membership of the House of Representatives requires Malaysian citizenship
-    # under Article 47 of the Federal Constitution of Malaysia (the Speaker and
-    # Secretary are likewise Malaysian office holders):
+    # under Article 47 of the Federal Constitution of Malaysia (the presiding
+    # officers are likewise Malaysian office holders):
     # https://lom.agc.gov.my/ (Laws of Malaysia — Federal Constitution)
     person.add("citizenship", "my")
-    # "BEBAS" means the member is an independent, i.e. holds no party affiliation.
-    if party and party != "BEBAS":
-        person.add("political", party)
-    # Some members list several contact addresses in one field, separated by
-    # slashes or commas. The "-" placeholder is dropped via a type.email lookup.
-    person.add("email", h.multi_split(email, ["/", ",", ";"]))
+    return person
 
-    # A member with a constituency (P-code) is an elected MP; the Speaker and the
-    # Secretary hold no constituency and are identified by their `Jawatan` role.
-    positions: list[Entity] = []
-    if constituency:
-        positions.append(
-            h.make_position(
-                context,
-                name="Member of the Dewan Rakyat",
-                country="my",
-                wikidata_id="Q21290861",
-                lang="eng",
-            )
+
+def emit_occupancy(
+    context: Context,
+    person: Entity,
+    position: Entity,
+    categorisation: PositionCategorisation | None = None,
+    constituency: str | None = None,
+) -> None:
+    """Emit an occupancy of `position` held by `person`, if it qualifies as PEP.
+
+    `categorisation` is reused when the caller already categorised the position
+    (the shared Member seat, categorised once in `crawl`); otherwise the position
+    is categorised here. The position and person are emitted alongside each
+    qualifying occupancy, so a person is materialised only if they hold at least
+    one PEP position."""
+    if categorisation is None:
+        categorisation = categorise(context, position)
+    if not categorisation.is_pep:
+        return
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", constituency)
+    context.emit(position)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def emit_officer(context: Context, person: Entity, role: str | None) -> None:
+    """Emit the presiding-officer occupancy for a role label, if known.
+
+    Roles absent from `OFFICER_POSITIONS` (ordinary members and the cabinet titles
+    that pollute the role field) are ignored."""
+    spec = OFFICER_POSITIONS.get(role) if role is not None else None
+    if spec is None:
+        return
+    name, topics, wikidata_id = spec
+    position = h.make_position(
+        context,
+        name=name,
+        country="my",
+        topics=topics,
+        wikidata_id=wikidata_id,
+        lang="eng",
+    )
+    emit_occupancy(context, person, position)
+
+
+def emit_cabinet(context: Context, person: Entity, cabinet: str | None) -> None:
+    """Emit an executive (cabinet) office held alongside a seat, if any.
+
+    Cabinet titles are Malay, so they are translated to English; the position id
+    stays keyed on the untranslated name. "&" is normalised to "dan" so the two
+    spellings of a ministry collapse to one position."""
+    if not cabinet or cabinet == "-":
+        return
+    position = h.make_position(
+        context,
+        name=cabinet.replace("&", "dan"),
+        country="my",
+        lang="msa",
+        translate_name=True,
+    )
+    emit_occupancy(context, person, position)
+
+
+def crawl_member(
+    context: Context,
+    member_id: str,
+    url: str,
+    member_position: Entity,
+    member_categorisation: PositionCategorisation,
+) -> None:
+    data = parse_detail(context, url)
+
+    name = data.pop("Name")
+    role = data.pop("Position in the Parliament", None)
+    cabinet = data.pop("Position in Cabinet", None)
+
+    # `Parliament` is the constituency code (e.g. "P075"); its presence marks an
+    # elected MP. The readable constituency name is built from `Area`/`State`.
+    constituency_code = data.pop("Parliament")
+    constituency = constituency_name(data)
+
+    person = make_member(context, member_id, name, url)
+    party = data.pop("Party", None)
+    if party != "BEBAS":  # BEBAS marks an independent, not a party affiliation
+        person.add("political", party)
+    person.add("email", h.multi_split(data.pop("Email", ""), ["/", ",", ";"]))
+
+    # A member with a constituency (P-code) is an elected MP holding the shared
+    # Member seat, with the constituency recorded on the occupancy. The presiding
+    # officers (Speaker, Secretary) hold no constituency and are identified by role.
+    if constituency_code:
+        emit_occupancy(
+            context,
+            person,
+            member_position,
+            categorisation=member_categorisation,
+            constituency=constituency,
         )
-        if jawatan == "Timbalan Yang di-Pertua Dewan Rakyat":
-            positions.append(
-                h.make_position(
-                    context,
-                    name="Deputy Speaker of the Dewan Rakyat",
-                    country="my",
-                    wikidata_id="Q126361900",
-                    lang="eng",
-                )
-            )
-    elif jawatan == "Yang di-Pertua Dewan Rakyat":
-        positions.append(
-            h.make_position(
-                context,
-                name="Speaker of the Dewan Rakyat",
-                country="my",
-                wikidata_id="Q7574262",
-                lang="eng",
-            )
-        )
-    elif jawatan == "Setiausaha Dewan Rakyat":
-        positions.append(
-            h.make_position(
-                context,
-                name="Secretary of the Dewan Rakyat",
-                country="my",
-                lang="eng",
-            )
-        )
+        # A sitting MP may additionally be the Deputy Speaker.
+        emit_officer(context, person, role)
+    elif role in OFFICER_POSITIONS:
+        # The Speaker and the Secretary (House clerk) hold no constituency.
+        emit_officer(context, person, role)
     else:
         context.log.warning(
-            "Member without constituency or known role",
-            url=url,
-            jawatan=jawatan,
+            "Member without constituency or known role", url=url, role=role
         )
         return
 
-    # Many members also hold an executive (cabinet) office, e.g. "Menteri
-    # Ekonomi" (Minister of Economy) or "Timbalan Menteri Pertahanan" (Deputy
-    # Minister of Defence). The Malay title is translated to English; the
-    # position id stays keyed on the untranslated name. Normalise "&" to "dan"
-    # so the two spellings of a ministry collapse to one position.
-    if kabinet and kabinet != "-":
-        positions.append(
-            h.make_position(
-                context,
-                name=kabinet.replace("&", "dan"),
-                country="my",
-                lang="msa",
-                translate_name=True,
-            )
-        )
+    emit_cabinet(context, person, cabinet)
 
     context.audit_data(
         data,
         ignore=[
-            "Tempat Duduk",
-            "Kawasan",
-            "Negeri",
-            "No. Telefon",
-            "No. Faks",
-            "Media Sosial",
-            "Alamat Surat-menyurat",
+            "Seat Number",
+            "Phone Number",
+            "Fax No.",
+            "Social Media",
+            "Mailing Address",
+            "Area",
+            "State",
         ],
     )
 
-    emitted = False
-    for position in positions:
-        categorisation = categorise(context, position, default_is_pep=True)
-        if not categorisation.is_pep:
-            continue
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        context.emit(position)
-        context.emit(occupancy)
-        emitted = True
 
-    if emitted:
-        context.emit(person)
+def iter_member_links(
+    context: Context, roster_url: str, minimum: int
+) -> Iterator[tuple[str, str]]:
+    """Yield (member_id, profile_url) for each member listed on the chamber roster."""
+    doc = context.fetch_html(roster_url, absolute_links=True, cache_days=1)
+    links = h.xpath_strings(
+        doc,
+        ".//ul[contains(@class,'member-of-parliament')]/li//a[contains(@href,'id=')]/@href",
+    )
+    if len(links) < minimum:
+        raise ValueError(
+            "Unexpectedly few members at %s: %d" % (roster_url, len(links))
+        )
+    for link in links:
+        match = re.search(r"[?&]id=(\d+)", link)
+        if match is None:
+            raise ValueError("Member link without id: %s" % link)
+        yield match.group(1), link
 
 
 def crawl(context: Context) -> None:
     context.http.verify = False
-    doc = context.fetch_html(context.data_url, absolute_links=True, cache_days=1)
-    links = h.xpath_elements(
-        doc,
-        ".//ul[contains(@class,'member-of-parliament')]/li//a[contains(@href,'id=')]",
-    )
-    if len(links) < 180:
-        raise ValueError("Unexpectedly few members: %d" % len(links))
 
-    seen: set[str] = set()
-    for link in links:
-        href = link.get("href")
-        if href is None:
-            continue
-        match = re.search(r"[?&]id=(\d+)", href)
-        if match is None:
-            context.log.warning("Member link without id", href=href)
-            continue
-        member_id = match.group(1)
-        if member_id in seen:
-            continue
-        seen.add(member_id)
-        crawl_member(context, member_id, href)
+    # The single Member seat is held by all ordinary members, so it is built and
+    # categorised once here and passed down; the exceptional roles (presiding
+    # officers, cabinet offices) are categorised as encountered.
+    member_position = h.make_position(
+        context,
+        name="Member of the Dewan Rakyat",
+        country="my",
+        topics=TOPICS,
+        wikidata_id="Q21290861",
+        lang="eng",
+    )
+    member_categorisation = categorise(context, member_position)
+    if member_categorisation.is_pep:
+        context.emit(member_position)
+
+    for member_id, url in iter_member_links(
+        context, context.data_url, DEWAN_RAKYAT_MIN
+    ):
+        crawl_member(context, member_id, url, member_position, member_categorisation)
+
+    assert_all_accepted(context, raise_on_unaccepted=False)

--- a/datasets/my/dewan_rakyat/my_dewan_rakyat.yml
+++ b/datasets/my/dewan_rakyat/my_dewan_rakyat.yml
@@ -1,0 +1,90 @@
+title: "Malaysia Dewan Rakyat"
+entry_point: crawler.py
+prefix: my-dr
+coverage:
+  frequency: weekly
+  start: 2026-07-02
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the House of Representatives, the lower house of the Parliament of Malaysia
+description: |
+  Members of parliament of the Malaysian House of Representatives (Dewan Rakyat),
+  scraped from the official parliament portal. The roster is maintained by the
+  Parliament of Malaysia and updated as seats change through by-elections.
+
+  In addition to the elected members, the dataset includes the Speaker
+  (Yang di-Pertua) and the Secretary (Setiausaha) of the house.
+url: https://www.parlimen.gov.my/ahli-dewan.html?uweb=dr
+publisher:
+  name: Parliament of Malaysia
+  description: >
+    The Parliament of Malaysia is the national legislature, comprising the
+    Dewan Rakyat (House of Representatives) and the Dewan Negara (Senate).
+  url: https://www.parlimen.gov.my/
+  country: my
+  official: true
+data:
+  url: https://www.parlimen.gov.my/ahli-dewan.html?uweb=dr
+  format: HTML
+  lang: msa
+
+tags:
+  - list.pep
+
+# The most common honorifics and courtesy titles prepended to Malaysian names,
+# stripped from the head of the name by h.strip_name_titles. Hereditary name
+# particles that are NOT titles (Wan, Syed, Sharifah, Nik, Tengku, Raja, ...)
+# are left untouched. The trailing space enforces a word boundary.
+names:
+  prefixes_strip:
+    - "Yang Amat Berhormat "
+    - "Yang Berhormat "
+    - "Datuk Seri Panglima "
+    - "Datuk Seri Utama "
+    - "Dato' Seri Utama "
+    - "Dato' Seri Panglima "
+    - "Datuk Seri "
+    - "Dato' Seri "
+    - "Dato Seri "
+    - "Dato' Sri "
+    - "Tan Sri "
+    - "Puan Sri "
+    - "YAB "
+    - "YB "
+    - "Datuk "
+    - "Dato' "
+    - "Dato "
+    - "Datin "
+    - "Tuan "
+    - "Puan "
+    - "Encik "
+    - "Cik "
+    - "Haji "
+    - "Hajah "
+    - "Dr. "
+    - "Prof. "
+    - "Ir. "
+    - "Ts. "
+
+lookups:
+  type.email:
+    options:
+      # Placeholder used by the source when no address is on file.
+      - match: "-"
+        value: null
+      # Source typo with an empty subdomain; the correct address is unknown.
+      - match: "adamadli@.gov.my"
+        value: null
+
+assertions:
+  min:
+    schema_entities:
+      Person: 180
+      Position: 40
+    country_entities:
+      my: 180
+  max:
+    schema_entities:
+      Person: 400
+      Position: 90

--- a/datasets/my/dewan_rakyat/my_dewan_rakyat.yml
+++ b/datasets/my/dewan_rakyat/my_dewan_rakyat.yml
@@ -1,4 +1,4 @@
-title: "Malaysia Dewan Rakyat"
+title: "Malaysia Members of Dewan Rakyat"
 entry_point: crawler.py
 prefix: my-dr
 coverage:
@@ -9,7 +9,7 @@ ci_test: false
 summary: >-
   Members of the House of Representatives, the lower house of the Parliament of Malaysia
 description: |
-  Members of the Dewan Rakyat, the House of Representatives, which is the lower
+  Members of the Dewan Rakyat, the House of Representatives, the lower
   house of the Parliament of Malaysia. Its members are elected from single-member
   federal constituencies. Each member, including the chamber's presiding officers,
   is recorded with their name, party affiliation, and the constituency they

--- a/datasets/my/dewan_rakyat/my_dewan_rakyat.yml
+++ b/datasets/my/dewan_rakyat/my_dewan_rakyat.yml
@@ -2,19 +2,21 @@ title: "Malaysia Dewan Rakyat"
 entry_point: crawler.py
 prefix: my-dr
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-07-02
 load_statements: true
 ci_test: false
 summary: >-
   Members of the House of Representatives, the lower house of the Parliament of Malaysia
 description: |
-  Members of parliament of the Malaysian House of Representatives (Dewan Rakyat),
-  scraped from the official parliament portal. The roster is maintained by the
-  Parliament of Malaysia and updated as seats change through by-elections.
+  Members of the Dewan Rakyat, the House of Representatives, which is the lower
+  house of the Parliament of Malaysia. Its members are elected from single-member
+  federal constituencies. Each member, including the chamber's presiding officers,
+  is recorded with their name, party affiliation, and the constituency they
+  represent.
 
-  In addition to the elected members, the dataset includes the Speaker
-  (Yang di-Pertua) and the Secretary (Setiausaha) of the house.
+  Members who also hold an executive office additionally carry their cabinet
+  position.
 url: https://www.parlimen.gov.my/ahli-dewan.html?uweb=dr
 publisher:
   name: Parliament of Malaysia
@@ -25,47 +27,38 @@ publisher:
   country: my
   official: true
 data:
-  url: https://www.parlimen.gov.my/ahli-dewan.html?uweb=dr
+  url: https://www.parlimen.gov.my/ahli-dewan.html?uweb=dr&lang=en
   format: HTML
-  lang: msa
+  lang: eng
 
 tags:
   - list.pep
 
-# The most common honorifics and courtesy titles prepended to Malaysian names,
-# stripped from the head of the name by h.strip_name_titles. Hereditary name
-# particles that are NOT titles (Wan, Syed, Sharifah, Nik, Tengku, Raja, ...)
-# are left untouched. The trailing space enforces a word boundary.
+# The most common honorifics and courtesy titles prepended to Malaysian names.
+# Hereditary name particles that are NOT titles (Wan, Syed, Sharifah, Nik,
+# Tengku, Raja, ...) are left untouched.
 names:
-  prefixes_strip:
-    - "Yang Amat Berhormat "
-    - "Yang Berhormat "
-    - "Datuk Seri Panglima "
-    - "Datuk Seri Utama "
-    - "Dato' Seri Utama "
-    - "Dato' Seri Panglima "
-    - "Datuk Seri "
-    - "Dato' Seri "
-    - "Dato Seri "
-    - "Dato' Sri "
-    - "Tan Sri "
-    - "Puan Sri "
-    - "YAB "
-    - "YB "
-    - "Datuk "
-    - "Dato' "
-    - "Dato "
-    - "Datin "
-    - "Tuan "
-    - "Puan "
-    - "Encik "
-    - "Cik "
-    - "Haji "
-    - "Hajah "
-    - "Dr. "
-    - "Prof. "
-    - "Ir. "
-    - "Ts. "
+  schema_rules:
+    Person:
+      reject_strings:
+        - "Berhormat "
+        - "Seri"
+        - "Sri"
+        - "YAB"
+        - "YB"
+        - "Datuk "
+        - "Dato"
+        - "Datin"
+        - "Tuan"
+        - "Puan"
+        - "Encik"
+        - "Cik"
+        - "Haji"
+        - "Hajah"
+        - "Dr."
+        - "Prof."
+        - "Ir."
+        - "Ts."
 
 lookups:
   type.email:


### PR DESCRIPTION
Adds a PEP crawler for the **Dewan Rakyat** (House of Representatives), the lower house of the Parliament of Malaysia. Closes opensanctions/crawler-planning#714.

## Source
Official parliament portal (`parlimen.gov.my`, `uweb=dr`). All 222 members are enumerated from the roster page; each member's detail page is then fetched for their role, party and contact info.

## What it emits
- **222 Persons**, all `role.pep`, with `citizenship: my` (Article 47 of the Federal Constitution).
- **Positions**: Member of the Dewan Rakyat (`Q21290861`), Speaker (`Q7574262`), Deputy Speaker (`Q126361900`), Secretary of the house, plus **56 cabinet/ministerial positions** translated from Malay via `make_position(translate_name=True)`. Ministers hold both their Member seat and their cabinet office.
- 60 Positions / 280 Occupancies total.

## Notes for review
- **TLS**: the site serves an incomplete certificate chain, so the crawler sets `context.http.verify = False` (public government source, no secrets). This is why `ci_test: false`.
- **Names**: the most common Malaysian honorifics are stripped; hereditary name particles (Wan, Syed, Tengku…) are preserved. A handful of rarer *state* honorifics (Datuk Amar, Dato' Indera, Dato Sri) are intentionally left in place.
- **Cabinet titles** are translated per-string, so a Minister vs Deputy Minister of the same ministry can differ slightly in English wording — reconcilable in the position-review UI.
- Emails are captured to `Person:email`, splitting multi-address fields; the `-` placeholder and one source typo are dropped via a `type.email` lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)