### PR TITLE
[ext_tokyo_mou_psc] Bump max schema_entities assertions

### DIFF
--- a/datasets/_externals/ext_tokyo_mou_psc.yml
+++ b/datasets/_externals/ext_tokyo_mou_psc.yml
@@ -76,5 +76,5 @@ assertions:
       Company: 50
   max:
     schema_entities:
-      Vessel: 500
-      Company: 150
+      Vessel: 4000
+      Company: 300


### PR DESCRIPTION
The `ext_tokyo_mou_psc` enricher started failing its `max` schema_entities assertions:

```
Assertion schema_entities failed for Vessel: 2773 is not <= threshold 500
Assertion schema_entities failed for Company: 186 is not <= threshold 150
```

This is a side effect of expanding the topics considered for enrichment to include the shadow fleet topic (`mare.shadow` etc.), which pulls in a lot more matched entities. So the counts growing is expected, not a regression — just bumping the thresholds with some headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)