### PR TITLE
Issues 2026-07-02

### DIFF
--- a/datasets/hr/public_officials/crawler.py
+++ b/datasets/hr/public_officials/crawler.py
@@ -53,13 +53,27 @@ FIELDS = [
 ]
 
 
-def make_position_name(data: Dict[str, str]) -> Optional[str]:
+def build_position_name(data: Dict[str, str]) -> Optional[str]:
+    """Builds the full Croatian position name from the title and legal entity name.
+
+    When there's no title we fall back to the Croatian "Nepoznata dužnost" ("Unknown
+    position") so the whole name stays in one language and can be handed to
+    make_position for translation in a single pass. Returns None when there is neither
+    a title nor a legal entity.
+    """
     title = data.pop("position")
     legal_entity_name = data.pop("legal_entity")
     if title is None and legal_entity_name is None:
         return None
 
-    position_name = title or "Unknown position"
+    # Use the Croatian "Unknown position" placeholder so the whole name is one
+    # language and make_position can translate it (and key the ID off it) in a single
+    # pass. This does mean the placeholder ends up in the name's original_value even
+    # though it isn't literally from the source, but that's not catastrophic.
+    # The alternative is a whole dance: translate only the legal entity name, then
+    # prepend an English "Unknown position" ourselves, and set the name, lang and
+    # translation origin by hand rather than letting make_position do it.
+    position_name = title or "Nepoznata dužnost"
     if legal_entity_name:
         position_name = f"{position_name}, {legal_entity_name}"
     return position_name
@@ -68,8 +82,9 @@ def make_position_name(data: Dict[str, str]) -> Optional[str]:
 def make_affiliation_entities(
     context: Context,
     person: Entity,
+    *,
     position_name: Optional[str],
-    data: Dict[str, str],
+    position_data: Dict[str, str],
 ) -> List[Entity]:
     """Creates Position and Occupancy provided that the Occupancy meets OpenSanctions criteria.
     * A position's name include the title and optionally the name of the legal entity
@@ -80,11 +95,15 @@ def make_affiliation_entities(
     if position_name is None or position_name.strip() == "":
         return []
 
-    start_date = data.pop("position_start_date")
-    end_date = data.pop("position_end_date")
-    context.audit_data(data)
+    start_date = position_data.pop("position_start_date")
+    end_date = position_data.pop("position_end_date")
+    context.audit_data(position_data)
 
-    position = h.make_position(context, position_name, country="HR")
+    # The name is Croatian; make_position keys the ID on the untranslated name (so it
+    # stays stable) and stores the English translation for display.
+    position = h.make_position(
+        context, position_name, country="HR", lang="hrv", translate_name=True
+    )
 
     categorisation = categorise(context, position, default_is_pep=True)
     occupancy = h.make_occupancy(
@@ -103,12 +122,15 @@ def make_affiliation_entities(
 
 def make_person(
     context: Context,
+    *,
     first_name: str,
     last_name: str,
-    primary: Optional[str],
-    secondary: Optional[str],
+    primary_position_name: Optional[str],
+    secondary_position_name: Optional[str],
 ) -> Entity:
-    positions = sorted(p for p in [primary, secondary] if p is not None)
+    positions = sorted(
+        p for p in [primary_position_name, secondary_position_name] if p is not None
+    )
     position = positions[0] if positions else None
     person = context.make("Person")
     person.id = context.make_id(first_name, last_name, position)
@@ -136,29 +158,32 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
     position_entities = []
 
     primary_position_data = dict_keys_by_prefix(row, "primary_")
-    primary_position_name = make_position_name(primary_position_data)
+    primary_position_name = build_position_name(primary_position_data)
     secondary_data = dict_keys_by_prefix(row, "secondary_")
-    secondary_position_name = make_position_name(secondary_data)
+    secondary_position_name = build_position_name(secondary_data)
 
     person = make_person(
         context,
-        row.pop("first_name"),
-        row.pop("last_name"),
-        primary_position_name,
-        secondary_position_name,
+        first_name=row.pop("first_name"),
+        last_name=row.pop("last_name"),
+        primary_position_name=primary_position_name,
+        secondary_position_name=secondary_position_name,
     )
 
     position_entities.extend(
         make_affiliation_entities(
             context,
             person,
-            primary_position_name,
-            primary_position_data,
+            position_name=primary_position_name,
+            position_data=primary_position_data,
         )
     )
     position_entities.extend(
         make_affiliation_entities(
-            context, person, secondary_position_name, secondary_data
+            context,
+            person,
+            position_name=secondary_position_name,
+            position_data=secondary_data,
         )
     )
 

--- a/datasets/hr/public_officials/crawler.py
+++ b/datasets/hr/public_officials/crawler.py
@@ -78,7 +78,6 @@ def make_affiliation_entities(
     * A position with a legal entity but no title is titled 'Unknown position'
     * All positions (and Occupancies, Persons) are assumed to be Croatian
     * Positions with start and/or end date but no position name or legal entity name are discarded
-    * Positions not categorised as PEP are discarded
     """
     if position_name is None or position_name.strip() == "":
         return []
@@ -90,8 +89,6 @@ def make_affiliation_entities(
     position = h.make_position(context, position_name, country="HR")
 
     categorisation = categorise(context, position, default_is_pep=default_is_pep)
-    if not categorisation.is_pep:
-        return []
     occupancy = h.make_occupancy(
         context,
         person,

--- a/datasets/hr/public_officials/crawler.py
+++ b/datasets/hr/public_officials/crawler.py
@@ -68,10 +68,8 @@ def make_position_name(data: Dict[str, str]) -> Optional[str]:
 def make_affiliation_entities(
     context: Context,
     person: Entity,
-    *,
     position_name: Optional[str],
-    default_is_pep: bool,
-    position_data: Dict[str, str],
+    data: Dict[str, str],
 ) -> List[Entity]:
     """Creates Position and Occupancy provided that the Occupancy meets OpenSanctions criteria.
     * A position's name include the title and optionally the name of the legal entity
@@ -82,13 +80,13 @@ def make_affiliation_entities(
     if position_name is None or position_name.strip() == "":
         return []
 
-    start_date = position_data.pop("position_start_date")
-    end_date = position_data.pop("position_end_date")
-    context.audit_data(position_data)
+    start_date = data.pop("position_start_date")
+    end_date = data.pop("position_end_date")
+    context.audit_data(data)
 
     position = h.make_position(context, position_name, country="HR")
 
-    categorisation = categorise(context, position, default_is_pep=default_is_pep)
+    categorisation = categorise(context, position, default_is_pep=True)
     occupancy = h.make_occupancy(
         context,
         person,
@@ -105,15 +103,12 @@ def make_affiliation_entities(
 
 def make_person(
     context: Context,
-    *,
     first_name: str,
     last_name: str,
-    primary_position_name: Optional[str],
-    secondary_position_name: Optional[str],
+    primary: Optional[str],
+    secondary: Optional[str],
 ) -> Entity:
-    positions = sorted(
-        p for p in [primary_position_name, secondary_position_name] if p is not None
-    )
+    positions = sorted(p for p in [primary, secondary] if p is not None)
     position = positions[0] if positions else None
     person = context.make("Person")
     person.id = context.make_id(first_name, last_name, position)
@@ -141,38 +136,29 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
     position_entities = []
 
     primary_position_data = dict_keys_by_prefix(row, "primary_")
-    primary_has_title = primary_position_data.get("position") is not None
     primary_position_name = make_position_name(primary_position_data)
-    secondary_position_data = dict_keys_by_prefix(row, "secondary_")
-    secondary_has_title = secondary_position_data.get("position") is not None
-    secondary_position_name = make_position_name(secondary_position_data)
+    secondary_data = dict_keys_by_prefix(row, "secondary_")
+    secondary_position_name = make_position_name(secondary_data)
 
     person = make_person(
         context,
-        first_name=row.pop("first_name"),
-        last_name=row.pop("last_name"),
-        primary_position_name=primary_position_name,
-        secondary_position_name=secondary_position_name,
+        row.pop("first_name"),
+        row.pop("last_name"),
+        primary_position_name,
+        secondary_position_name,
     )
 
     position_entities.extend(
         make_affiliation_entities(
             context,
             person,
-            position_name=primary_position_name,
-            # "Unknown position" (no title) -> default to non-PEP
-            default_is_pep=primary_has_title,
-            position_data=primary_position_data,
+            primary_position_name,
+            primary_position_data,
         )
     )
     position_entities.extend(
         make_affiliation_entities(
-            context,
-            person,
-            position_name=secondary_position_name,
-            # "Unknown position" (no title) -> default to non-PEP
-            default_is_pep=secondary_has_title,
-            position_data=secondary_position_data,
+            context, person, secondary_position_name, secondary_data
         )
     )
 

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -686,14 +686,21 @@ PERSON_SECTIONS = [
 
 
 def crawl(context: Context) -> None:
+    # Commit the cache after each section so the transaction doesn't have to run as long
+    # as this long-running crawler.
     crawl_shadow_fleet(context)
+    context.flush()
     crawl_vessels(context)
+    context.flush()
     crawl_tools(context)
+    context.flush()
 
     for path, program_key, topic in ENTITY_SECTIONS:
         for url in crawl_listing(context, path):
             crawl_entity_page(context, url, program_key=program_key, topic=topic)
+        context.flush()
 
     for path, program_key, topic in PERSON_SECTIONS:
         for url in crawl_listing(context, path):
             crawl_person_page(context, url, program_key=program_key, topic=topic)
+        context.flush()


### PR DESCRIPTION
- **Revert "[hr_public_officials] Skip non-PEP positions before make_occupancy"**
  This reverts commit 86c1951de2918cddba1aaf212053eceead28b550.
  

- **Revert "[hr_public_officials] Don't default 'Unknown position' to PEP"**
  This reverts commit d9703930d16038029bf1c79d9b006d04d80e255c.
  

- **[hr_public_officials] Translate position names to English**
  Build the position name entirely in Croatian — including the "Nepoznata
  dužnost" ("Unknown position") placeholder when there's no title — and hand
  it to make_position with lang="hrv" and translate_name=True. make_position
  keys the entity ID on the untranslated name (so IDs stay stable) and stores
  the English translation for display.
  
  Also make make_person and make_affiliation_entities keyword-only for their
  position/name args.
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  

- **[ua_war_sanctions] Flush cache between sections to bound transaction size**
  Commit the cache after each crawl section so the long-running crawler's
  transaction doesn't grow large enough to weigh down the database.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  