### PR TITLE
[br_pep] Translate position names

### DIFF
--- a/datasets/br/pep/crawler.py
+++ b/datasets/br/pep/crawler.py
@@ -44,7 +44,9 @@ def create_entity(raw_entity: Dict[str, Any], context: Context) -> None:
     person.add("citizenship", "br")
 
     position_name = f"{raw_entity['Descrição_Função']}, {raw_entity['Nome_Órgão']}"
-    position = h.make_position(context, position_name, country="br")
+    position = h.make_position(
+        context, position_name, country="br", lang="por", translate_name=True
+    )
     categorisation = categorise(context, position, default_is_pep=True)
 
     if not categorisation.is_pep:


### PR DESCRIPTION
Turns on English translation of position names for `br_pep` via `translate_name=True`.

Split into its own PR because of its size — it's the only one whose delta is over 10k on its own, so it gets released separately.

Refs https://github.com/opensanctions/opensanctions/issues/2874 (doesn't close it, just chips away).

Only Position `name`s change; position IDs are keyed on the untranslated name, so they stay stable and occupancies/persons aren't re-emitted. Expected delta:

| dataset | positions (≈ delta) |
|---|--:|
| br_pep | 13,516 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
