### PR TITLE
Translate position names for several PEP datasets

### DIFF
--- a/datasets/cl/info_probidad/crawler.py
+++ b/datasets/cl/info_probidad/crawler.py
@@ -70,7 +70,11 @@ def crawl_row(context: Context, declaration_id: int) -> None:
     service_entity = entity.pop("Servicio_Entidad")
     position_institution = service_entity.pop("nombre")
     position = h.make_position(
-        context, f"{position_name}, {position_institution}", country="cl", lang="spa"
+        context,
+        f"{position_name}, {position_institution}",
+        country="cl",
+        lang="spa",
+        translate_name=True,
     )
 
     # 'cargos' can be marked as PEPs for all institutions in cl_info_probidad.yml

--- a/datasets/es/parliament/crawler.py
+++ b/datasets/es/parliament/crawler.py
@@ -37,6 +37,7 @@ def emit_pep_entities(
     political_group: Optional[str] = None,
     is_pep: bool,
     wikidata_id: Optional[str] = None,
+    translate_name: bool = False,
 ) -> bool:
     person.add("position", position_name)
     position = h.make_position(
@@ -46,6 +47,7 @@ def emit_pep_entities(
         lang=lang,
         topics=["gov.legislative", "gov.national"],
         wikidata_id=wikidata_id,
+        translate_name=translate_name,
     )
     categorisation = categorise(context, position, default_is_pep=is_pep)
     occupancy = h.make_occupancy(
@@ -196,6 +198,7 @@ def crawl_senator(context: Context, senator_url: str) -> bool:
                 start_date=cargo.findtext("cargoAltaFec"),
                 end_date=cargo.findtext("cargoBajaFec"),
                 is_pep=True,
+                translate_name=True,
             )
 
         if legislatura.findtext("legislaturaActual") == "SI":

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -83,8 +83,10 @@ def crawl(context: Context) -> None:
     position = h.make_position(
         context,
         "Member of the European Parliament",
+        wikidata_id="Q27169",
         country="eu",
         topics=["gov.igo", "gov.legislative"],
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)

--- a/datasets/mk/officials/crawler.py
+++ b/datasets/mk/officials/crawler.py
@@ -47,6 +47,7 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
         position_names[0],
         country="mk",
         lang="mkd",
+        translate_name=True,
     )
     position.add("name", position_names[1:])
 

--- a/datasets/no/brreg/crawler.py
+++ b/datasets/no/brreg/crawler.py
@@ -197,6 +197,8 @@ def crawl_soe_peps(
                 topics=["gov.soe"],
                 country=["no"],
                 organization=entity,
+                lang="nob",
+                translate_name=True,
             )
             categorisation = categorise(context, position, default_is_pep=True)
 

--- a/datasets/pt/parliament/crawler.py
+++ b/datasets/pt/parliament/crawler.py
@@ -95,6 +95,8 @@ def crawl_parliament(context: Context, parl_name: str, url: str) -> None:
                 name=f"{leadership_role['carDes']}, Assembleia da República",
                 topics=["gov.national", "gov.legislative"],
                 country=["pt"],
+                lang="por",
+                translate_name=True,
             )
             categorisation_leadership = categorise(
                 context, position_leadership, default_is_pep=None

--- a/datasets/se/riksdag/crawler.py
+++ b/datasets/se/riksdag/crawler.py
@@ -77,6 +77,7 @@ def position_for_mandate(context: Context, role: dict[str, Any]) -> Optional[Ent
         return h.make_position(
             context,
             name="Member of the European Parliament",
+            wikidata_id="Q27169",
             country="eu",
             topics=["gov.igo", "gov.legislative"],
             lang="eng",

--- a/datasets/se/riksdag/crawler.py
+++ b/datasets/se/riksdag/crawler.py
@@ -83,8 +83,7 @@ def position_for_mandate(context: Context, role: dict[str, Any]) -> Optional[Ent
         )
     if typ == "Departement":
         # Ministers are listed with their Swedish title (e.g. "Statsråd",
-        # "Finansminister", "Statsminister"). We keep it verbatim rather than
-        # translating the dozens of portfolio variants into English.
+        # "Finansminister", "Statsminister").
         if not roll:
             context.log.warning("Cabinet mandate without a title", role=role)
             return None
@@ -94,6 +93,7 @@ def position_for_mandate(context: Context, role: dict[str, Any]) -> Optional[Ent
             country="se",
             topics=["gov.national", "gov.executive"],
             lang="swe",
+            translate_name=True,
         )
     if typ in SKIP_MANDATE_TYPES:
         return None

--- a/datasets/uy/pep/crawler.py
+++ b/datasets/uy/pep/crawler.py
@@ -36,7 +36,11 @@ def parse_sheet_row(context: Context, row: Dict[str, str]) -> None:
     person.add("country", "uy")
 
     position = h.make_position(
-        context, f"{role}, {organization_name}", country="uy", lang="spa"
+        context,
+        f"{role}, {organization_name}",
+        country="uy",
+        lang="spa",
+        translate_name=True,
     )
 
     categorisation = categorise(context, position)


### PR DESCRIPTION
Enables English translation of position names across a batch of PEP datasets, and adds the Wikidata ID for "Member of the European Parliament" (Q27169) to `eu_meps` and `se_riksdag`.

Refs https://github.com/opensanctions/opensanctions/issues/2874.

These are the smaller datasets bundled into one PR — br_pep and co_funcion_publica got their own PRs since their deltas are large (br_pep is over 10k on its own); the rest together still come in well under 10k. Only Position `name`s change — IDs are keyed on the untranslated name, so they stay stable and occupancies/persons aren't re-emitted. For a few of these we only translate a subset of positions (se_riksdag: cabinet posts; es_parliament: senator roles; pt_parliament: leadership; eu_meps: just the QID), so those are upper bounds. Expected delta:

| dataset | positions (≈ delta) |
|---|--:|
| mk_officials | 2,351 |
| no_brreg | 1,947 |
| cl_info_probidad | 928 |
| uy_pep | 799 |
| es_parliament | 668 |
| se_riksdag | 39 |
| pt_parliament | 5 |
| eu_meps | 1 |
| **total** | **~6,738** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
