### PR TITLE
[ror] Fix name extraction for ROR schema v2

### DIFF
--- a/datasets/_global/ror/crawler.py
+++ b/datasets/_global/ror/crawler.py
@@ -24,7 +24,6 @@ def crawl_item(context: Context, item: Dict[str, Any]) -> None:
     entity = context.make("Organization")
     entity.id = context.make_slug(ror_uri.rsplit("/", 1)[-1])
     entity.add("sourceUrl", ror_uri)
-    entity.add("name", item.pop("name", None))
     for name in item.pop("names", []):
         lang = iso_639_alpha3(name.get("lang", ""))
         types = name.pop("types", [])
@@ -33,7 +32,7 @@ def crawl_item(context: Context, item: Dict[str, Any]) -> None:
             prop = "alias"
         if "acronym" in types:
             prop = "weakAlias"
-        entity.add(prop, name.get("name"), lang=lang)
+        entity.add(prop, name.get("value"), lang=lang)
 
     entity.add("sector", item.pop("types"))
 


### PR DESCRIPTION
`ror` has been emitting organizations without names since 2025-12-31. Here's the whole story.

### How the bug happened

- **2025-12-16** — ROR published schema **v2.0** and, for the first time, *dropped the v1 data file* from the Zenodo dump. Up to then every dump shipped both `<ver>-ror-data.json` (v1 schema) and `<ver>-ror-data_schema_v2.json` (v2 schema). Our crawler picks the file matching `*-data.json`, which had always resolved to the **v1** file — the one with a top-level `name`.
- **~2025-12-17 → 12-30** — with only v2 files left in the zip, the old crawler crashed on the new shape (`item.pop("name")` etc.), so the dataset just stopped updating and the last good version stayed live.
- **2025-12-31** — 8173b481530f0ea623952e75cd12285e38498157 adapted the crawler to v2. It correctly migrated locations, links, `external_ids`, domains and so on — but the names migration had a one-key bug: the new `names[]` loop read `name.get("name")`, whereas v2 keys the value as `name.get("value")`. It also kept a vestigial top-level `entity.add("name", item.pop("name", None))` that no longer matches anything in v2.
- Net effect: **every field migrated correctly except names**, which silently went to zero (`.get()` returns `None` for a missing key, so nothing crashed). This first v2 crawl also re-keyed/reshaped essentially every entity, producing a 238k-record delta (~120k MOD + a 59k ADD/59k DEL swap) — the name loss rode along inside that churn.
- Nothing caught it because the only assertions on `ror` check entity *counts*, which stayed healthy (100k–200k orgs) the whole time.

### The fix

One key: `name.get("name")` → `name.get("value")`, plus dropping the dead v1 top-level `name` line. That's the entire behavioral change.

### Now-fixed situation

Verified with a local crawl + export against the current v2.9 dump:
- Name fill rate **0.99971** (129,008 / 129,046 orgs named). The 38 without a `name` legitimately have only `alias`/`acronym`-typed names in the source.
- `names.txt` back to 258,991 lines (was 0 bytes in production).
- The local delta is **129,046 MOD records, 0 ADD/DEL** — every org modified purely to restore its name. So the first production delta after this ships will be a one-time ~129k MOD bulk update as names come back, which monitoring customers will consume as such.

### On prevention

This slipped through because the only assertions on `ror` check entity *counts*, which stayed healthy the whole time. I'll implement a more generic mechanism to guard against silent property drop-offs across datasets, rather than hand-rolling per-dataset fill-rate thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
