### PR TITLE
[zavod] Default property_fill_rate assertions for source datasets

### DIFF
--- a/zavod/zavod/meta/assertion.py
+++ b/zavod/zavod/meta/assertion.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Generator
@@ -60,6 +61,24 @@ class Assertion:
         return (
             f"<Assertion {self.metric.value} {self.comparison.value} {self.config!r}>"
         )
+
+
+def merge_assertions_config(
+    base: Dict[str, Any], override: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Deep-merge two assertion config dicts, with `override` winning at the leaf.
+
+    Nested dicts (comparison -> metric -> schema -> property) are merged
+    recursively; any non-dict value in `override` replaces the base value.
+    """
+    result = deepcopy(base)
+    for key, value in override.items():
+        existing = result.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            result[key] = merge_assertions_config(existing, value)
+        else:
+            result[key] = deepcopy(value)
+    return result
 
 
 def parse_assertions(config: Dict[str, Any]) -> Generator[Assertion, None, None]:

--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -44,6 +44,7 @@ DEFAULT_ASSERTIONS: Dict[str, Any] = {
     "min": {
         "property_fill_rate": {
             "Person": {"name": 0.95},
+            "LegalEntity": {"name": 0.95},
             "Organization": {"name": 0.95},
             "Company": {"name": 0.95},
         }

--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -13,7 +13,11 @@ from followthemoney.dataset.resource import DataResource
 from zavod import settings
 from zavod.archive import dataset_data_path
 from zavod.logs import get_logger
-from zavod.meta.assertion import Assertion, parse_assertions
+from zavod.meta.assertion import (
+    Assertion,
+    merge_assertions_config,
+    parse_assertions,
+)
 from zavod.meta.dates import DatesSpec
 from zavod.meta.http import HTTP
 from zavod.meta.model import DataModel, ZavodDatasetModel
@@ -25,6 +29,26 @@ if TYPE_CHECKING:
     from zavod.meta.catalog import ArchiveBackedCatalog
 
 log = get_logger(__name__)
+
+# Baseline assertions applied to every dataset. They can be overridden
+# per-dataset in the `assertions:` YAML block: because the merge happens at the
+# config-dict level (see `merge_assertions_config`), a dataset that sets e.g.
+# `min.property_fill_rate.Person.name` replaces the default threshold for that
+# exact schema/property while keeping the rest. Lower a threshold to 0 to
+# effectively disable a `min` default.
+#
+# `property_fill_rate` only applies to schemata the dataset actually emits: the
+# validator skips any schema with zero entities, so naming schemata a dataset
+# doesn't produce here is harmless.
+DEFAULT_ASSERTIONS: Dict[str, Any] = {
+    "min": {
+        "property_fill_rate": {
+            "Person": {"name": 0.95},
+            "Organization": {"name": 0.95},
+            "Company": {"name": 0.95},
+        }
+    }
+}
 
 
 class Dataset(FollowTheMoneyDataset):
@@ -51,9 +75,12 @@ class Dataset(FollowTheMoneyDataset):
         _type = "collection" if self.is_collection else "source"
         self._type: str = data.get("type", _type).lower().strip()
 
-        self.assertions: List[Assertion] = list(
-            parse_assertions(data.get("assertions", {}))
+        # The YAML block overrides defaults at the leaf level (see merge_assertions_config).
+        user_assertions_config = ensure_dict(data.get("assertions", {}))
+        assertions_config = merge_assertions_config(
+            DEFAULT_ASSERTIONS, user_assertions_config
         )
+        self.assertions: List[Assertion] = list(parse_assertions(assertions_config))
         """
         List of assertions which should be considered warnings if they fail.
 

--- a/zavod/zavod/tests/test_dataset.py
+++ b/zavod/zavod/tests/test_dataset.py
@@ -126,8 +126,9 @@ def test_validation(testdataset1: Dataset, testdataset3: Dataset):
     assert len(testdataset1.children) == 0
     assert len(testdataset1.datasets) == 1
     assert len(testdataset1.inputs) == 0
-    assert len(testdataset1.assertions) == 0
-    assert len(testdataset3.assertions) == 5
+    # Source datasets get the default assertions merged in (here: property_fill_rate).
+    assert len(testdataset1.assertions) == 1
+    assert len(testdataset3.assertions) == 6
     assert isinstance(testdataset3.assertions[0], Assertion)
 
 

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -177,6 +177,25 @@ def test_default_property_fill_rate_skips_absent_schema() -> None:
     assert validator.abort is True
 
 
+def test_default_property_fill_rate_company() -> None:
+    # Same as the Person case, for Company: this keeps the default assertion on
+    # Company covered so it isn't silently dropped.
+    ds = Dataset(BASE_DATASET_CONFIG)
+    emit_entity(ds, "Company", {"name": ["Acme Inc"]})
+    validator, _ = run_validator(StatisticsAssertionsValidator, ds)
+    assert validator.abort is False
+
+    # A Company present but without a name should fail the default.
+    ds2 = Dataset({**BASE_DATASET_CONFIG, "name": "test2"})
+    emit_entity(ds2, "Company", {"country": ["ru"]})
+    validator, logs = run_validator(StatisticsAssertionsValidator, ds2)
+    assert (
+        "error",
+        "Assertion property_fill_rate failed for Company.name: 0.0 is not >= threshold 0.95",
+    ) in logs
+    assert validator.abort is True
+
+
 def test_no_entities_warning() -> None:
     ds = Dataset(BASE_DATASET_CONFIG)
 

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -140,9 +140,41 @@ def test_countries_count_assertion(testdataset3) -> None:
 
 
 def test_no_assertions_error() -> None:
+    # The nudge is based on the YAML config, not the merged-in defaults: a source
+    # dataset with no explicit assertions still gets nudged.
     ds = Dataset({**BASE_DATASET_CONFIG, "assertions": {}})
+    assert ds.is_collection is False
     validator, logs = run_validator(StatisticsAssertionsValidator, ds)
     assert ("error", "Dataset has no assertions.") in logs
+
+
+def test_default_assertions_applied_to_sources() -> None:
+    # A source dataset with no explicit assertions still gets the baseline
+    # defaults merged in, so validation runs and doesn't spuriously abort.
+    ds = Dataset({**BASE_DATASET_CONFIG, "assertions": {}})
+    assert ds.is_collection is False
+    assert len(ds.assertions) > 0
+    validator, _ = run_validator(StatisticsAssertionsValidator, ds)
+    assert validator.abort is False
+
+
+def test_default_property_fill_rate_skips_absent_schema() -> None:
+    # The default Person/Organization/Company name fill-rate assertions must not
+    # fail a dataset that simply doesn't emit some of those schemata.
+    ds = Dataset(BASE_DATASET_CONFIG)
+    emit_entity(ds, "Person", {"name": ["Vladimir Putin"]})
+    validator, logs = run_validator(StatisticsAssertionsValidator, ds)
+    assert validator.abort is False
+
+    # A Person present but without a name should still fail the default.
+    ds2 = Dataset({**BASE_DATASET_CONFIG, "name": "test2"})
+    emit_entity(ds2, "Person", {"country": ["ru"]})
+    validator, logs = run_validator(StatisticsAssertionsValidator, ds2)
+    assert (
+        "error",
+        "Assertion property_fill_rate failed for Person.name: 0.0 is not >= threshold 0.95",
+    ) in logs
+    assert validator.abort is True
 
 
 def test_no_entities_warning() -> None:

--- a/zavod/zavod/validators/assertions.py
+++ b/zavod/zavod/validators/assertions.py
@@ -1,9 +1,10 @@
 from typing import Dict, Any
+from banal import ensure_dict
 
 from zavod.context import Context
 from zavod.entity import Entity
 from zavod.exporters.statistics import Statistics
-from zavod.meta.assertion import Assertion, Comparison, Metric
+from zavod.meta.assertion import Assertion, Comparison, Metric, parse_assertions
 from zavod.store import View
 from zavod.validators.common import BaseValidator
 
@@ -125,8 +126,17 @@ def check_assertion(
             (item["schema"], item["property"]): item["fill_rate"]
             for item in stats["things"]["entities_with_prop"]
         }
+        # Schemata the dataset actually emits, to tell "schema not emitted at all"
+        # (skip the assertion) apart from "schema present but property never
+        # filled" (fill rate 0.0, enforce). Without this a fill-rate assertion on
+        # a schema the dataset doesn't produce would spuriously fail as 0.0.
+        emitted_schemata = {
+            item["schema"] for item in stats["things"]["entities_with_prop"]
+        }
 
         for schema, properties in assertion.config.items():
+            if schema not in emitted_schemata:
+                continue
             for property, threshold in properties.items():
                 key = (schema, property)
                 fill_rate = stats_fill_rate_lookup.get(key, 0.0)
@@ -155,7 +165,14 @@ class StatisticsAssertionsValidator(BaseValidator):
         self.stats.observe(entity)
 
     def finish(self) -> None:
-        if len(self.context.dataset.assertions) == 0:
+        # Nudge maintainers based on what they configured in YAML, ignoring the
+        # baseline defaults that get merged into source datasets. Read the raw
+        # config rather than dataset.assertions, which already has the defaults
+        # merged in.
+        user_assertions_config = ensure_dict(
+            self.context.dataset._data.get("assertions", {})
+        )
+        if not list(parse_assertions(user_assertions_config)):
             self.context.log.error("Dataset has no assertions.")
 
         for assertion in self.context.dataset.assertions:


### PR DESCRIPTION
Adds baseline `property_fill_rate` assertions to every dataset so we get a name-coverage floor for free, and makes the metric's semantics play nicely with defaults across multiple schemata.

## What
- **Default assertions** (`meta/dataset.py`): `min.property_fill_rate` of `0.95` on `name` for `Person`, `Organization`, `Company`, applied to all datasets.
- **Overridable in YAML**: merged at the config-dict level via a new `merge_assertions_config` deep-merge (`meta/assertion.py`), so a dataset's `assertions:` block wins at the leaf. e.g. `min.property_fill_rate.Person.name: 0.8` replaces just that threshold; set it to `0` to disable a `min` default.
- **Semantics change** (`validators/assertions.py`): `PROPERTY_FILL_RATE` now skips any schema the dataset doesn't emit (zero entities). Without this, a default spanning three schemata would spuriously fail a Person-only dataset (the lookup defaults to `0.0`). A schema that *is* present but never fills the property still fails.
- **"No assertions" nudge** stays based on the maintainer's YAML config (read from `dataset._data`), not the merged-in defaults — so datasets without explicit assertions still get nudged to add real ones (e.g. entity counts).

## On collections
Defaults now apply to collections too. Note that collections aren't actually validated as part of `zavod run` today (`cli/etl.py` gates `validate_dataset` on `not is_collection`), so the defaults are inert for them in the normal pipeline and only fire under a manual `zavod validate <collection>`. But that gate is a practical performance decision, not a design stance — collections *should* conceptually be validatable — so I didn't want to bake "collections have no assertions" into the model as an axiom. Applying the defaults uniformly keeps the door open for whenever we do validate collections.

## Notes / open questions
- **These defaults are fatal.** `min` → `GTE` → aborts the export. A 95% name floor as a hard failure across all sources at once is a real policy change — happy to land it as `max` (warn-only) first if we'd rather ease it in.
- Fill rate is counted by *concrete* schema, so the `Organization` default only covers entities emitted literally as `Organization` (not `Company`/`PublicBody`/etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)