### PR TITLE
[ext_ror] Lower min Organization assertion to 30

### DIFF
--- a/datasets/_externals/ext_ror.yml
+++ b/datasets/_externals/ext_ror.yml
@@ -93,7 +93,7 @@ config:
 assertions:
   min:
     schema_entities:
-      Organization: 210
+      Organization: 30
   max:
     schema_entities:
       Organization: 500


### PR DESCRIPTION
Lowers the minimum Organization entity assertion for the ROR enricher from 210 to 30 orgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)