### PR TITLE
Use dataset language for position translation

### DIFF
--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -54,12 +54,13 @@ def make_position(
         number_of_seats: The number of seats that can hold the position.
         wikidata_id: The Wikidata QID of the position.
         source_url: The URL of the source the position was found in.
-        lang: The language of the position details.
-        translate_name: If True and `lang` is a non-English language, the
-            position name is translated to English via an LLM and stored as the
-            `name` (with the original kept as the value's original_value). The
-            entity id is always derived from the untranslated `name`, so it stays
-            stable and independent of the (LLM-produced) translation.
+        lang: Override the dataset language when the position details are in a
+            non-default language.
+        translate_name: If True and the resolved source language is non-English,
+            the position name is translated to English via an LLM and stored as
+            the `name` (with the original kept as the value's original_value).
+            The entity id is always derived from the untranslated `name`, so it
+            stays stable and independent of the (LLM-produced) translation.
 
     Returns:
         A new entity of type `Position`."""
@@ -81,16 +82,18 @@ def make_position(
     else:
         position.id = context.make_id(*parts, hash_prefix=id_hash_prefix)
 
+    source_lang = lang or context.lang
+
     # Optionally translate the name to English. The id above is keyed on the
     # untranslated name, so it stays stable regardless of the LLM output.
-    if translate_name and lang is not None and lang != "eng":
+    if translate_name and source_lang is not None and source_lang != "eng":
         # Local import to break the cycle: zavod.shed.trans imports the helpers
         # package, which imports this module. TODO: move the translation core to
         # a helpers-free zavod.helpers.translate in a followup so this can become
         # a top-level import.
         from zavod.shed.trans import translate_position_name
 
-        result = translate_position_name(context, LangText(text=name, lang=lang))
+        result = translate_position_name(context, LangText(text=name, lang=source_lang))
         translated = result.get_english()
         if translated is not None:
             position.add(

--- a/zavod/zavod/tests/helpers/test_positions.py
+++ b/zavod/zavod/tests/helpers/test_positions.py
@@ -94,6 +94,68 @@ def test_make_position_translate_name(testdataset1: Dataset):
     context.close()
 
 
+def test_make_position_translate_name_uses_dataset_language():
+    dataset = Dataset(
+        {
+            "name": "cz_positions",
+            "title": "Czech Positions",
+            "prefix": "czp",
+            "data": {
+                "url": "https://example.com/",
+                "format": "HTML",
+                "lang": "ces",
+            },
+        }
+    )
+    context = Context(dataset)
+    with patch(
+        "zavod.shed.trans.translate_position_name",
+        return_value=TranslationResult(
+            texts=[LangText(text="Member of Parliament", lang="eng")],
+            cache_key="cache-key",
+            origin="test-model",
+        ),
+    ) as mock_translate:
+        position = make_position(
+            context,
+            name="Poslanec",
+            country="cz",
+            translate_name=True,
+        )
+
+    mock_translate.assert_called_once_with(
+        context, LangText(text="Poslanec", lang="ces")
+    )
+    assert position.get("name") == ["Member of Parliament"]
+    context.close()
+
+
+def test_make_position_dataset_language_is_not_statement_override():
+    dataset = Dataset(
+        {
+            "name": "gb_positions",
+            "title": "UK Positions",
+            "prefix": "gbp",
+            "data": {
+                "url": "https://example.com/",
+                "format": "HTML",
+                "lang": "eng",
+            },
+        }
+    )
+    context = Context(dataset)
+    position = make_position(
+        context,
+        name="Speaker",
+        country="gb",
+        translate_name=True,
+    )
+
+    name_statement = next(s for s in position.statements if s.prop == "name")
+    assert name_statement.lang is None
+    context.close()
+
+
 def test_make_position_translate_fallback(testdataset1: Dataset):
     """When translation yields no English text, the original name is kept."""
     context = Context(testdataset1)


### PR DESCRIPTION
Updates h.make_position(..., translate_name=True) to fall back to the dataset default language from context.lang when no explicit lang override is provided. The helper uses a local source_lang for translation decisions so dataset defaults do not become explicit per-statement language overrides. Tests: /Users/pudo/.python/wrangle/bin/python -m pytest zavod/zavod/tests/helpers/test_positions.py; ruff check zavod/zavod/helpers/positions.py zavod/zavod/tests/helpers/test_positions.py.