### PR TITLE
fix: harden us_finra_actions crawler against pagination/caching instability

### DIFF
--- a/datasets/us/finra_actions/crawler.py
+++ b/datasets/us/finra_actions/crawler.py
@@ -1,15 +1,15 @@
 """
 # Occasional issues:
 
-## Crawl completes but fewer than asserted entities are emitted.
+FINRA listing pages are newest-first and served through inconsistent caches.
+Intermediate pages can temporarily render the "No results found" empty state
+even though reruns later return rows; pagination can also drift if the listing
+changes while a crawl is in progress.
 
-Running the crawler locally the next day results in the expected number
-of entities being emitted.
-
-The crawl runs to the same number of pages (1231 in querystring) as usual.
-It's not clear whether entities are removed and then new entities added by
-the time we check the issue, or whether there's a bug. Keeping an eye on this
-for a bit longer (2024-07-31)
+The Zyte fetch validator requires a populated table and rejects the empty-state
+marker so these pages are retried and, if persistent, abort the crawl instead
+of emitting a partial run. The crawler also aborts if the advertised last page
+changes after pagination has been established.
 """
 
 from lxml.etree import _Element
@@ -18,6 +18,12 @@ from urllib.parse import urlparse, parse_qs
 
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
+
+
+RESULT_ROW_VALIDATOR = (
+    ".//table[not(ancestor-or-self::*//div"
+    "[contains(concat(' ', normalize-space(@class), ' '), ' view-empty ')])]//tr[td]"
+)
 
 
 def crawl_item(context: Context, row: Dict[str, _Element]) -> None:
@@ -90,22 +96,24 @@ def crawl(context: Context) -> None:
         context.log.info(f"Crawling page {page_num} of {max_page}")
         url = context.data_url + "?page=" + str(page_num)
         # Zyte because occasional cloudflare javascript challenge.
-        response = zyte_api.fetch_html(context, url, ".//table", absolute_links=True)
+        response = zyte_api.fetch_html(
+            context, url, RESULT_ROW_VALIDATOR, absolute_links=True
+        )
 
-        # Update max_page each iteration in case pagination changes.
+        # Check the page count each iteration in case pagination changes.
         new_max = get_max_page(response)
         if new_max is not None:
-            max_page = new_max
+            if max_page is None:
+                max_page = new_max
+            elif new_max != max_page:
+                raise RuntimeError(
+                    "FINRA pagination changed during crawl: "
+                    f"expected last page {max_page}, got {new_max} "
+                    f"on page {page_num}"
+                )
 
         table = response.find(".//table")
-        if table is None:
-            context.log.info("No table found. Skipping page.", page_num=page_num)
-            page_num += 1
-            continue
-        if response.find(".//div[@class='view-empty']") is not None:
-            context.log.info("No results found. Skipping page.", page_num=page_num)
-            page_num += 1
-            continue
+        assert table is not None, "Validated FINRA page did not contain a table"
 
         for row in h.parse_html_table(table):
             crawl_item(context, row)

--- a/datasets/us/finra_actions/crawler.py
+++ b/datasets/us/finra_actions/crawler.py
@@ -19,7 +19,6 @@ from urllib.parse import parse_qs, urljoin, urlparse
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
-
 RESULT_ROW_VALIDATOR = (
     ".//table[not(ancestor-or-self::*//div"
     "[contains(concat(' ', normalize-space(@class), ' '), ' view-empty ')])]//tr[td]"

--- a/datasets/us/finra_actions/crawler.py
+++ b/datasets/us/finra_actions/crawler.py
@@ -14,7 +14,7 @@ changes after pagination has been established.
 
 from lxml.etree import _Element
 from typing import Dict, Optional
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
@@ -43,6 +43,8 @@ def crawl_item(context: Context, row: Dict[str, _Element]) -> None:
     case_id_el = row.pop("case_id")
     case_id = h.element_text(case_id_el)
     source_url = case_id_el.get("href")
+    if source_url is not None:
+        source_url = urljoin(context.data_url, source_url)
     date = h.element_text(row.pop("action_date_sort_ascending"))
 
     for name in names:


### PR DESCRIPTION
## Summary

`us_finra_actions` no longer emits partial datasets when FINRA's listing pages misbehave. Intermittently-empty pages are retried through the existing Zyte fetch backoff, and the crawl aborts on pagination drift instead of publishing a shifted, incomplete run.

## Why this matters

Between runs the crawler was returning different entity sets with no corresponding change on FINRA's side. Issue #4632 traced two mechanisms: listing pages that intermittently render the "No results found" empty state because of inconsistent server-side caching, and newest-first pagination that shifts every record down a slot when a new action lands mid-crawl. @jbothma confirmed the flaky listing-page cache as the dominant cause. Entities like the Albert Gary Shilling records and "Adam A Pflum" dropped out of runs while still live on FINRA.

## Changes

- The Zyte unblock validator (`RESULT_ROW_VALIDATOR`, `datasets/us/finra_actions/crawler.py:21`) now requires a populated data row and rejects the `view-empty` marker, so empty-state pages fail validation and ride `zavod.extract.zyte_api.fetch_html`'s existing retry-with-backoff and cache-invalidation path. Persistent empties raise `UnblockFailedException` and abort the run. The old silent-skip branches in `crawl()` are removed, so a partial run cannot be emitted quietly.
- `crawl()` pins `max_page` on first observation and raises if `get_max_page()` later disagrees, aborting on mid-crawl pagination drift rather than continuing against a shifted listing. The previous good export stays published.
- `sourceUrl` hrefs are normalized with `urljoin` before emission so pages recovered by a validator-triggered retry still produce absolute URLs.

## Testing

`black --check`, `ruff check`, and a syntax check pass on the changed file. A live crawl was not run here since it needs Zyte API access; the empty-page path was traced against `fetch_html`'s retry and cache-invalidation behavior in `zavod/zavod/extract/zyte_api.py`.

This covers the retry-empty-pages and abort-on-drift items from the issue checklist. The stable-sort option and the FINRA-side cache fix remain open, so this mitigates rather than closes the flip-flopping.

Refs #4632
