### PR TITLE
Issues 2026-07-03

### DIFF
--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -89,7 +89,7 @@ def page_settings(page: Page) -> tuple[Page, dict[str, Any]]:
 
 
 def crawl_pdf_url(context: Context) -> str:
-    pdf_link_xpath = "//*[text()='NV Exclusion List ']"
+    pdf_link_xpath = "//a[normalize-space()='NV Exclusion List']"
     doc = zyte_api.fetch_html(
         context, context.data_url, pdf_link_xpath, geolocation="US", absolute_links=True
     )

--- a/datasets/us/sec/harmed_investors/crawler.py
+++ b/datasets/us/sec/harmed_investors/crawler.py
@@ -1,13 +1,9 @@
 from zavod import Context, helpers as h
 from zavod.util import Element
 
-HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-    "Accept-Encoding": "gzip, deflate, br",
-    "Sec-Fetch-Dest": "document",
-    "Sec-Fetch-Mode": "navigate",
-}
+# SEC's Fair Access policy blocks browser-mimicking user agents and requires
+# a declared UA with contact info. See https://www.sec.gov/developer
+HEADERS = {"User-Agent": "OpenSanctions tech@opensanctions.org"}
 
 
 def crawl_item(item: Element, context: Context) -> None:


### PR DESCRIPTION
- **[us_sec_harmed_investors] Use declared user-agent**
  SEC's Fair Access policy blocks browser-mimicking user agents, so use the
  same declared UA (with contact info) as us_sec_litigation.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  

- **[us_nv_med_exclusions] Fix PDF link unblock validator**
  The site trimmed the trailing space from the "NV Exclusion List" link
  text, so the exact-match XPath stopped matching and fetch_html kept
  raising UnblockFailedException even though the page was fetched fine.
  Use normalize-space() to be robust to whitespace changes.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  