### PR TITLE
[ro_cdep_deputies] Reject and refetch invalid member pages

### DIFF
--- a/datasets/ro/cdep_deputies/crawler.py
+++ b/datasets/ro/cdep_deputies/crawler.py
@@ -39,26 +39,54 @@ NAME_XPATH = ".//h1[@class='mp-profile-name2025']"
 ROSTER_URL = "https://www.cdep.ro/ords/pls/parlam/structura2015.de?leg=%s&idl=2"
 
 
+class InvalidMemberPage(Exception):
+    pass
+
+
 def fetch_html(
-    context: Context, url: str, absolute_links: bool = False, attempts: int = 6
+    context: Context,
+    url: str,
+    absolute_links: bool = False,
+    attempts: int = 6,
+    required_xpath: str | None = None,
 ) -> _Element:
-    """Fetch and parse an HTML page, retrying transient connection failures.
+    """Fetch and parse an HTML page, retrying transient bad responses.
 
     cdep.ro frequently resets connections mid-crawl; a plain `context.fetch_html`
     aborts the whole run on the first drop. This backs off and retries so the crawl
-    survives the flaky server, while still failing loudly once retries are exhausted.
+    survives the flaky server. When a marker XPath is supplied, bad cached or
+    interstitial pages are rejected and refetched before the member is skipped.
     """
     for attempt in range(1, attempts + 1):
         try:
-            return context.fetch_html(
+            doc = context.fetch_html(
                 url, absolute_links=absolute_links, cache_days=CACHE_DAYS
             )
+            if required_xpath is not None:
+                try:
+                    h.xpath_elements(doc, required_xpath, expect_exactly=1)
+                except ValueError as exc:
+                    context.clear_url(url)
+                    raise InvalidMemberPage(str(exc)) from exc
+            return doc
         except RequestException as exc:
             if attempt == attempts:
                 raise
             pause = 2**attempt
             context.log.info(
                 "Retrying after connection error",
+                url=url,
+                attempt=attempt,
+                pause=pause,
+                error=str(exc),
+            )
+            time.sleep(pause)
+        except InvalidMemberPage as exc:
+            if attempt == attempts:
+                raise
+            pause = 2**attempt
+            context.log.info(
+                "Retrying after invalid member page",
                 url=url,
                 attempt=attempt,
                 pause=pause,
@@ -93,12 +121,14 @@ def crawl_member(
     idm = match.group(1)
 
     try:
-        doc = fetch_html(context, url)
-    except RequestException:
+        doc = fetch_html(context, url, required_xpath=NAME_XPATH)
+    except (RequestException, InvalidMemberPage) as exc:
         # A single member page that stays unreachable after all retries shouldn't
         # abort a crawl of thousands of pages; drop it and let the `min` assertions
         # catch any wholesale shortfall.
-        context.log.warning("Skipping member after repeated fetch failures", url=url)
+        context.log.warning(
+            "Skipping member after repeated fetch failures", url=url, error=str(exc)
+        )
         return
 
     name = h.element_text(h.xpath_element(doc, NAME_XPATH))

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -389,11 +389,7 @@ class Context:
             try:
                 return orjson.loads(text)
             except Exception:
-                cache_url = build_url(url, params)
-                fingerprint = request_hash(
-                    cache_url, auth=auth, method=method, data=data
-                )
-                self.clear_url(fingerprint)
+                self.clear_url(url, params=params, auth=auth, method=method, data=data)
                 raise
 
     def fetch_html(
@@ -447,19 +443,29 @@ class Context:
                 cast(html.HtmlElement, doc).make_links_absolute(url, params)
             return doc
         except Exception as exc:
-            cache_url = build_url(url, params)
-            fingerprint = request_hash(cache_url, auth=auth, method=method, data=data)
-            self.clear_url(fingerprint)
+            self.clear_url(url, params=params, auth=auth, method=method, data=data)
             raise exc
 
-    def clear_url(self, fingerprint: str) -> None:
+    def clear_url(
+        self,
+        url: str,
+        params: ParamsType = None,
+        auth: _Auth = None,
+        method: str = "GET",
+        data: Optional[_Body] = None,
+        encoding: Optional[str] = None,
+    ) -> None:
+        """Evict a cached response so the next fetch re-hits the server.
+
+        Reach for this when a fetch succeeded at the HTTP level but returned a bad
+        body (an interstitial, truncated, or otherwise unusable page) that must not
+        be served from cache. Pass the same arguments you fetched the URL with, so
+        the matching cache entry is the one that gets removed.
         """
-        Remove a given URL from the cache using request fingerprint
-        Args:
-            fingerprint: The unique fingerprint of the request.
-        Returns:
-            None
-        """
+        cache_url = build_url(url, params)
+        fingerprint = request_hash(
+            cache_url, auth=auth, method=method, data=data, encoding=encoding
+        )
         self.cache.delete(fingerprint)
 
     def parse_resource_xml(self, name: PathLike) -> etree._ElementTree:

--- a/zavod/zavod/tests/test_context.py
+++ b/zavod/zavod/tests/test_context.py
@@ -5,6 +5,7 @@ import pytest
 import requests_mock
 import structlog
 from requests.adapters import HTTPAdapter
+from rigour.urls import build_url
 from followthemoney.statement import read_statements, PACK
 
 from zavod import settings
@@ -264,6 +265,49 @@ def test_context_fetchers_exceptions(testdataset1: Dataset):
 
     # Checking that cleanup function wiped the cache properly
     assert list(context.cache.all(None)) == []
+
+    context.close()
+
+
+def test_context_clear_url(testdataset1: Dataset):
+    context = Context(testdataset1)
+    url = "https://test.com/bla"
+
+    with requests_mock.Mocker() as m:
+        m.get("/bla", text="Hello, World!")
+        assert context.fetch_text(url, cache_days=14) == "Hello, World!"
+        # Second read is served from cache, so the server is only hit once.
+        assert context.fetch_text(url, cache_days=14) == "Hello, World!"
+        assert m.call_count == 1
+
+    # clear_url takes the URL (not a pre-hashed fingerprint) and evicts the entry.
+    assert context.cache.get(request_hash(url, method="GET"), max_age=14) is not None
+    context.clear_url(url)
+    assert context.cache.get(request_hash(url, method="GET"), max_age=14) is None
+
+    # With the entry gone, the next fetch re-hits the server.
+    with requests_mock.Mocker() as m:
+        m.get("/bla", text="Fresh, World!")
+        assert context.fetch_text(url, cache_days=14) == "Fresh, World!"
+        assert m.call_count == 1
+
+    # The fingerprint depends on the fetch args, so clearing with mismatched args
+    # leaves the cached entry in place.
+    with requests_mock.Mocker() as m:
+        m.get("/bla", text="Param, World!")
+        assert (
+            context.fetch_text(url, params={"q": "1"}, cache_days=14) == "Param, World!"
+        )
+    context.clear_url(url)  # no params: different fingerprint, no eviction
+    assert (
+        context.cache.get(request_hash(build_url(url, {"q": "1"}), method="GET"), 14)
+        is not None
+    )
+    context.clear_url(url, params={"q": "1"})
+    assert (
+        context.cache.get(request_hash(build_url(url, {"q": "1"}), method="GET"), 14)
+        is None
+    )
 
     context.close()
 


### PR DESCRIPTION
cdep.ro intermittently serves a member detail page without the profile heading (an interstitial or stale-cached body). Previously that surfaced as a `ValueError: Expected 1 elements, got 0 for xpath ".//h1[@class='mp-profile-name2025']"` and aborted the entire crawl on a single bad page.

## Changes

- **`[zavod]`** Rework `context.clear_url` to take a URL (plus the optional fetch args) instead of a pre-computed fingerprint, hashing internally to mirror the `fetch_*` signatures. Datasets no longer need to reach into `zavod.runtime.http_.request_hash`. The two internal callers (`fetch_json`/`fetch_html` error paths) are rewired onto it. Adds `test_context_clear_url`.
- **`[ro_cdep_deputies]`** `fetch_html` now validates a marker XPath on member pages; a page missing it gets its cache entry evicted and is refetched with backoff, and is only skipped (with a warning) once retries are exhausted — instead of crashing the run.

## Verification

- `pytest zavod/tests/test_context.py` → 10 passed
- `mypy --strict` clean on zavod (122 files) and on the crawler
- Crawler runs to completion: 1379 entities, empty issues.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)