### PR TITLE
Fable skill compact experiment

### DIFF
--- a/.claude/docs/crawler-guide.md
+++ b/.claude/docs/crawler-guide.md
@@ -89,7 +89,7 @@ def crawl(context: Context) -> None:
 
 `context.data_url` is from `data.url` in the YAML.
 
-**Fail loudly.** Crash or warn on unexpected data — never silently emit ambiguous output.
+**Strict interpretation.** Every source value within the crawler's scope is handled, explicitly ignored, or raises a signal — crash or warn on unexpected data, never silently emit ambiguous output. See `zavod/docs/best_practices/strict_interpretation.md`.
 
 ### Fetching data
 

--- a/.claude/skills/refactor-crawler/SKILL.md
+++ b/.claude/skills/refactor-crawler/SKILL.md
@@ -5,49 +5,37 @@ argument-hint: "[crawler.py path]"
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash
 ---
 
-# Crawler cleanup
+# Refactor crawler
 
-Refactor an existing crawler so it follows the OpenSanctions/zavod best practices. Typical
-input is a first-draft or AI-generated crawler that works but is verbose, brittle, or
-non-idiomatic. Target path: $ARGUMENTS
+Bring an existing crawler in line with current best practices. Typical input is a
+first-draft or AI-generated crawler that works but is verbose, brittle, or non-idiomatic.
+Target path: $ARGUMENTS
 
-**The authoritative rules live in `zavod/docs/best_practices/`. This skill is the
-_procedure_ for applying them plus before→after recipes.** When a rule is unclear or a
-case isn't covered here, read the linked doc — do not invent a convention.
+The rules live in `zavod/docs/best_practices/` — this skill is only the procedure for
+applying them. When a rule is unclear, read the doc; do not invent a convention.
 
-## Golden rule: refactor, don't rewrite behaviour
+## Golden rule: every output change must be deliberate
 
-The output data must not change unless a change is a genuine correctness fix. This is a
-**style and robustness** pass: restructure code, tighten selectors, move logic into
-helpers, add guards — but keep the set of entities and property values the crawler emits
-the same. If you believe a value is actually wrong, call it out to the user separately;
-don't silently alter what's emitted.
+Output may change when the refactor brings a methodological gain — e.g. moving to
+`h.apply_date` (warnings + `original_value`), `h.make_address` composition, a
+`type.address` lookup dropping placeholders, a tightened selector excluding junk. Name
+each such change in your summary and tie it to the method that caused it. Never silently
+alter emitted values. Leave name cleaning as it is: changing it means the sequenced,
+multi-PR migration to the review system in `zavod/docs/extract/names.md`, out of scope
+for a refactor pass.
 
-Sanctioned/legal names are especially sensitive: never introduce LLM-based or heuristic
-name "cleaning". See `zavod/docs/extract/names.md`.
+## Prime directive: strict interpretation
 
-## Second golden rule: make it brittle on the unexpected
+`zavod/docs/best_practices/strict_interpretation.md` — every source value within the
+crawler's scope is handled, explicitly ignored, or raises a signal. A refactored crawler
+must be **more** likely to fail loudly than the draft it replaces, never less: when you
+remove a branch, replace it with a guard, not with silence.
 
-Distrust all input. A refactored crawler should be **more** likely to fail loudly than the
-draft it replaces — never less. When the code meets something it doesn't understand at
-runtime — an unmapped category, a shape that doesn't match, a field that's suddenly empty,
-a count that's off — it must **warn, error, or crash rather than guess or silently drop
-data**. Emitting ambiguous or partial data is worse than failing, because the failure gets
-noticed and the bad data doesn't. (CLAUDE.md: "When a crawler encounters uncertainty in any
-of the data it is parsing, it should crash or produce an error instead of emitting
-ambiguous data.")
+## The docs
 
-A refactor that makes code shorter but swallows more edge cases is a regression. When you
-remove a branch, replace it with a guard, not with silence. Concrete moves are in
-[Pattern 17](#17-fail-loud-turn-silent-assumptions-into-guards); it also reinforces the
-loud-failure angle already in patterns 5, 6, 13, and 14.
-
-## Read first
-
-The best-practices docs, each governing one area below:
-
-- `best_practices/patterns.md` — crawler structure, naming, helpers, constants, logging, assertions, pagination
-- `best_practices/xpath_and_html.md` — typed HTML helpers, selector quality, failing loudly
+- `best_practices/strict_interpretation.md` — the prime directive: destructive parsing, `audit_data`, assertions, categorical coverage
+- `best_practices/patterns.md` — structure, naming, helpers, constants, logging, pagination, text hygiene
+- `best_practices/xpath_and_html.md` — typed HTML helpers, selector quality
 - `best_practices/entity_id.md` — `make_id` vs `make_slug`, which fields, `key=`
 - `best_practices/datapatch_lookups.md` — replacing inline conditionals with YAML lookups
 - `best_practices/dates_meta.md` — `apply_date` and dataset-level date formats
@@ -57,301 +45,37 @@ The best-practices docs, each governing one area below:
 - `best_practices/priorities.md` — which properties are worth the effort
 - `best_practices/merge_checklist.md` — the pre-merge review checklist
 
-Related skills: for pure type-annotation errors use `/typechecker-fixes`; this skill covers
-structure and idiom, and defers the mypy details to it.
+For pure type-annotation errors, defer to the `/typechecker-fixes` skill.
 
 ## Workflow
 
-1. **Read the crawler and its `.yml`.** Note the data source shape (HTML/CSV/XLSX/JSON/API),
-   existing `lookups:`, `dates:`, and `http:` sections.
-2. **Apply the patterns below**, most impactful first: structure → selectors/parsing →
-   IDs → dates/addresses → lookups → HTTP/caching → logging/assertions → style nits.
-3. **Verify** (see the section at the end): `mypy --strict`, `ruff`, and a `zavod crawl`
-   run with a clean `issues.log`.
-4. **Summarise** what changed and flag anything you deliberately left alone.
-
----
-
-## Patterns
-
-Each pattern cites the doc that owns it. Read that doc when a case here is ambiguous.
-
-### 1. Split into `crawl` + per-record functions — `patterns.md`
-
-The entrypoint `crawl(context)` fetches data, turns it into an iterable of dicts/rows, and
-loops — delegating each record to a `crawl_row` / `crawl_item` / `crawl_person` function
-that unpacks, cleans, builds entities, and emits. Name functions that lead to emitted
-entities `crawl_<thing>`; name pure extractors specifically (`parse_row`), never
-`process_data`.
-
-```python
-# Before: one 150-line crawl() with nested branching
-def crawl(context):
-    for row in rows:
-        if row["type"] == "vessel":
-            ... 40 lines ...
-        elif row["type"] == "person":
-            ... 40 lines ...
-
-# After
-def crawl_vessel(context: Context, row: dict[str, str]) -> None: ...
-def crawl_person(context: Context, row: dict[str, str]) -> None: ...
-
-def crawl(context: Context) -> None:
-    for row in fetch_rows(context):
-        crawl_row(context, row)
-```
-
-Prefer the parsing helpers that yield dicts over hand-rolled loops: `h.parse_html_table`,
-`h.parse_xlsx_sheet`, `h.parse_pdf_table`, `csv.DictReader`.
-
-### 2. Helpers at module level, not closures — `patterns.md`
-
-Move nested functions out to module level and pass what they need as arguments. `context`
-comes first.
-
-### 3. Return early to flatten nesting — `patterns.md`
-
-Invert `if A: <body>` into `if not A: return` so the main path is un-indented.
-
-```python
-name = row.pop("name")
-listing_date = row.pop("listing_date")
-if not (name and listing_date):
-    return
-entity = context.make("LegalEntity")
-entity.id = context.make_id(name, listing_date)
-```
-
-### 4. Inline single-use literals; earn every constant — `patterns.md`
-
-A `TOPICS = [...]`, `COLUMNS = [...]`, or header list referenced once reads better inlined
-at the call site. Declare a module constant only for: **precompiled regexes**, **genuine
-reuse** (2+ sites), or **an enumeration that is the data** (e.g. a `POSITIONS` mapping).
-
-```python
-# Keep as a constant — compiled once, correctness/perf:
-REGEX_DOB = re.compile(r"\b(\d{4})\b")
-# Inline instead of hoisting a one-off:
-person.add("topics", "sanction")
-```
-
-### 5. Capture all fields, then `audit_data` the remainder — `patterns.md`
-
-Read source records into a dict, `pop()` each field as you use it, and end each record with
-`context.audit_data(row, ignore=[...])` so newly-appearing fields raise a warning instead
-of being dropped silently.
-
-Descriptive fields with **no FTM equivalent** (hair colour, internal codes) go into the
-`ignore` list — do **not** pack them into `notes`/`description` as `f"Hair: {x}"` strings.
-
-```python
-context.audit_data(row, ignore=["hair_colour", "internal_ref"])
-```
-
-### 6. Typed, semantic, loud XPath — `xpath_and_html.md`
-
-Replace raw `.xpath()` (returns `Any`) with the typed helpers, and make selections fail
-loudly when they don't match.
-
-```python
-# Before
-rows = table.xpath("./tbody/tr")            # Any; empty selection = silent no-op
-title = doc.xpath(".//h1/text()")[0]
-
-# After
-rows = h.xpath_elements(table, "./tbody/tr", expect_exactly=12)
-title = h.element_text(h.xpath_element(doc, ".//h1"))
-```
-
-- One expected match → `h.xpath_element` (raises on 0 or many). Known count → `expect_exactly=`.
-  Open-ended but non-empty → `assert len(items) > 0, items`.
-- Selectors: specific but semantic. Prefer `.//div[@id="content"]//table` over positional
-  `div[3]`; prefer `contains(@class, 'abc')` over `@class='abc'` (watch for `abc-footer`).
-- `.findall()` is fine for trivial relative selectors; reach for `xpath_*` when you need
-  predicates/axes/`contains`.
-- Use `h.assert_dom_hash` (with `text_only=True`) to get warned when hand-parsed page
-  regions drift.
-
-### 7. Entity IDs: right fields, raw values, `make_id` by default — `entity_id.md`
-
-- Default to `context.make_id(...)`. Use `context.make_slug(...)` **only** for a single,
-  clean, authority-defined identifier — never for names/DOB/ID numbers, never multi-field.
-- Feed **raw source values**: no trimming, casing, parsing, or substitution (that would
-  mutate every previously-computed ID).
-- Pick the fewest stable, mandatory fields that disambiguate.
-- Don't set `.id` on entities from `h.make_sanction`/`h.make_address`/`h.make_position` —
-  they derive it. Pass `key=` when one entity has several of the same sub-entity.
-
-```python
-# Before
-entity.id = context.make_slug(name.lower().strip(), dob)   # PII + cleaned + multi-part
-# After
-entity.id = context.make_id(name, dob)                     # raw values, hashed
-```
-
-### 8. Dates via `apply_date` + dataset formats — `dates_meta.md`
-
-Replace manual `strptime`/`datetime` parsing with `h.apply_date` / `h.apply_dates`, and
-declare formats (and non-English months) in the `.yml` `dates:` section. This emits
-warnings on bad dates and preserves `original_value`.
-
-```python
-# Before
-entity.add("birthDate", datetime.strptime(v, "%d.%m.%Y").date().isoformat())
-# After  (yml: dates.formats: ['%d.%m.%Y'])
-h.apply_date(entity, "birthDate", v)
-```
-
-Never make a date more precise than the source (`datapatch_lookups.md`).
-
-### 9. Addresses via `make_address` + `copy_address` — `addresses.md`
-
-Pass structured parts to `h.make_address` and inline them with `h.copy_address`; don't
-pre-format the `full` string in the crawler. Don't emit standalone `Address` entities by
-default. For country-only data, `entity.add("country", value)` directly.
-
-```python
-address = h.make_address(context, street=row.pop("street"), city=row.pop("city"),
-                         postal_code=row.pop("zip"), country=row.pop("country"))
-h.copy_address(entity, address)
-```
-
-### 10. Lookups instead of inline conditionals — `datapatch_lookups.md`
-
-Move recurring value fixes/mappings into the YAML `lookups:` section: date typos, header
-translations, source-type → FTM schema, relationship → FTM relation, program names. `type.*`
-lookups apply automatically; named lookups are called via `context.lookup_value` /
-`context.lookup`.
-
-```python
-# Before
-schema = "Person" if t in ("individual", "person") else "Organization"
-# After (yml lookup type.entity), applied where you dispatch schema
-schema = context.lookup_value("type.entity", t)
-```
-
-### 11. HTTP through `context.fetch_*` — `http_operations.md`
-
-Use `context.fetch_text/html/json` (caching, retries, status checks) instead of raw
-`requests`. For bot-blocking set a browser-like `http.user_agent` in the `.yml`, then
-richer headers; for geo/network blocks or JS challenges route through `zavod.extract.zyte_api`
-(sets `ci_test: false`). Use `doc.make_links_absolute(url)` rather than `urljoin`.
-
-### 12. Caching: don't cache index or paginated pages — `caching.md`
-
-Index/listing pages: no cache (or ≤1 day) so new entities surface fast. Never cache
-paginated pages — added items shift entries between pages and cause disappear/reappear
-bugs. Detail pages of slow-moving sources may cache longer.
-
-### 13. Pagination that fails loudly, never spins — `patterns.md`
-
-Model the site's own controls (next-URL, max page number). Avoid `while True`; if
-unavoidable, add a page counter with an `assert pages < N`. Prefer a `KeyError` on
-structural change over silent under-collection.
-
-```python
-next_url: str | None = context.data_url
-while next_url:
-    data = context.fetch_json(next_url)
-    next_url = data["links"]["next"]   # KeyError on change; None ends the loop
-    for item in data["data"]:
-        crawl_row(context, item)
-```
-
-### 14. Logging levels & assertions — `patterns.md`
-
-- `warning` for things the team should act on (unmapped entity type, unexpected shape) —
-  these surface on the Issues page. Not for known-permanent 404s.
-- `info` for progress on large crawls; `debug` for dev detail.
-- Add assertions for invariants (a Person has a name, a required field is present) so
-  breakage fails at runtime rather than emitting ambiguous data.
-
-```python
-context.log.warning("Unhandled entity type", type=entity_type)
-assert position_name is not None, entity.id
-```
-
-### 15. Text hygiene & original language — `patterns.md`
-
-- Capture free text in its source language; pass a 3-letter code via `lang=` when known:
-  `sanction.add("reason", text, lang="rus")`. Don't translate arbitrary text.
-- Clean stray whitespace/space chars with `normality.squash_spaces` / `.replace("\xa0", " ")`,
-  not ad-hoc slicing.
-
-### 16. Imports & typing — `patterns.md` + `/typechecker-fixes`
-
-Order imports stdlib → third-party → `zavod` (`ruff check --fix --select I <file>`). Fully
-type the crawler; use builtin generics (`dict`, `list`) and `X | None`. For the mypy-strict
-details defer to the `/typechecker-fixes` skill.
-
-### 17. Fail loud: turn silent assumptions into guards — `patterns.md`, `xpath_and_html.md`
-
-This is the [second golden rule](#second-golden-rule-make-it-brittle-on-the-unexpected)
-applied line by line. As you refactor, hunt for places where the draft quietly guesses or
-drops data on the unexpected, and replace them with a warning, an error, or a crash. Pick
-the loudness by whether the crawler can meaningfully continue:
-
-- **Crash / raise** when continuing would emit ambiguous or wrong data, or when the
-  assumption is structural (the whole parse is invalid if it's false). An `assert` with a
-  message, a raised exception, or an unguarded `dict[key]`/`row.pop(key)` that `KeyError`s
-  on drift are all fine.
-- **`context.log.warning`** when one record is unmappable but the rest of the crawl is
-  still valid — e.g. a category not in your lookup. Warnings hit the Issues page and get
-  reviewed daily. Skip that record; don't emit a half-built entity.
-- **Never** `except: pass`, `.get(key, "")` to paper over a missing mandatory field, a
-  bare `else` that lumps unknown inputs into a default schema/branch, or an empty selection
-  that loops zero times and emits nothing.
-
-```python
-# Before: unknown types silently become organizations; empty match emits nothing
-schema = "Person" if kind == "person" else "Organization"
-for row in table.xpath(".//tr"):
-    ...
-
-# After: unknown input is surfaced, not guessed; empty selection can't pass unnoticed
-schema = context.lookup_value("type.entity", kind)
-if schema is None:
-    context.log.warning("Unmapped entity type", kind=kind)
-    return
-rows = h.xpath_elements(table, ".//tr")
-assert len(rows) > 0, "no rows matched — page structure changed?"
-```
-
-```python
-# Before: a bare except hides real breakage
-try:
-    dob = parse_the_date(raw)
-except Exception:
-    dob = None
-
-# After: let apply_date warn on unparseable input and keep the original_value
-h.apply_date(entity, "birthDate", raw)   # emits a warning on bad input, doesn't hide it
-```
-
-When you deliberately allow an unhandled value (a field with no FTM home, a known-benign
-category), make the allowance **explicit** — `context.audit_data(row, ignore=[...])`, a
-lookup option, or a commented guard — so a genuinely new value still trips the alarm.
-
----
+1. **Read the crawler and its `.yml`.** Note the data source shape (HTML/CSV/XLSX/JSON/API)
+   and the existing `lookups:`, `dates:`, and `http:` sections.
+2. **Capture a baseline**: run `zavod crawl` on the unmodified crawler and keep the
+   statement counts and a few sample entities to diff against later.
+3. **Read the docs for the areas the crawler touches** and apply them, most impactful
+   first: structure → selectors/parsing → IDs → dates/addresses → lookups → HTTP/caching →
+   logging/assertions → style nits.
+4. **Verify** (below).
+5. **Summarise**: which best-practice areas changed, every output change and its
+   methodological justification, and anything deliberately left alone.
 
 ## Verification
 
-Run from the repo root after refactoring:
+From the repo root:
 
 ```bash
-ruff check --fix --select I <crawler.py>          # import order
-cd zavod && mypy --strict <path/to/crawler.py>    # strict types (mypy-datasets hook enforces this)
-cd /Users/vestloporvats/projects/opensanctions && zavod crawl <path/to/dataset.yml>
+ruff check --fix --select I <path/to/crawler.py>   # import order
+cd zavod && mypy --strict <path/to/crawler.py>     # enforced by the mypy-datasets hook
+zavod crawl <path/to/dataset.yml>                  # from the repo root
 ```
 
 Then confirm:
 
-- `data/datasets/<name>/issues.log` is empty of new warnings/errors (transient network
-  errors excepted).
-- Entity/property output is unchanged vs. before the refactor (diff statement counts or
-  spot-check a few entities) — this pass must not alter emitted data.
+- New strict-interpretation guards are welcome — but when one fires on today's data, add
+  the missing lookup mapping rather than handing the warning off. The facility for many
+  warnings stays in the code; `issues.log` is clean (transient network errors excepted).
+- Diff the output against the baseline run (statement counts, spot-check entities) and
+  **account for every difference** — each must trace to a named methodological gain.
 - The crawler still satisfies its `assertions:` in the `.yml`.
-
-Finally walk the `merge_checklist.md` items relevant to what you touched, and tell the user
-which best-practice areas you changed and which you intentionally left as-is.
+- Walk the `merge_checklist.md` items relevant to what you touched.

--- a/zavod/docs/best_practices/entity_id.md
+++ b/zavod/docs/best_practices/entity_id.md
@@ -1,6 +1,6 @@
 # Entity ID generation
 
-An entity's ID controls which records merge into one entity within a dataset and across the catalog, and must stay stable after publication.
+An entity's ID controls which records merge into one entity within a dataset and across the catalog, and must stay stable after publication. A dataset is published once it is added to a collection in `datasets/_collections/` (see [releasing a dataset](release.md)); before that point, ID schemes can change freely.
 
 ## What an entity ID is for
 

--- a/zavod/docs/best_practices/patterns.md
+++ b/zavod/docs/best_practices/patterns.md
@@ -1,5 +1,7 @@
 # Common Patterns
 
+Several of the patterns below (detecting unhandled data, assertions, warnings) exist to serve one principle: [strict interpretation](strict_interpretation.md) — every source value within the crawler's scope is handled, explicitly ignored, or raises a signal.
+
 The following are some patterns that have proved useful:
 
 ## Common crawler code structure

--- a/zavod/docs/best_practices/strict_interpretation.md
+++ b/zavod/docs/best_practices/strict_interpretation.md
@@ -1,0 +1,83 @@
+# Strict interpretation
+
+A crawler that meets source data it does not understand must crash or warn, rather than silently absorb the change.
+
+OpenSanctions processes risk and compliance data. A new field appears in the source, a category of entity is renamed, a column heading changes: when a crawler quietly absorbs a shift it did not anticipate, the result can understate or overstate the risk associated with an entity, or fail to reproduce the information needed to identify it. It is always better for a crawler to generate maintenance work for the team than to silently ignore a change in the source data that it does not understand.
+
+The requirement: every source value within the crawler's scope is either handled, explicitly ignored, or raises a signal. How a crawler meets it is not dogma; the practices below are the proven mechanisms.
+
+## Two decisions: what is in scope, and how to enforce it
+
+### Scope follows the source's purpose
+
+- On **sanctions lists and watchlists**, the whole record is in scope by default. Records are compact, and any field can bear on the risk statement or on identifying the entity. A new field is a signal worth a warning.
+- On **content-rich sources** such as parliamentary websites, the source routinely publishes facts the crawler does not capture: committee memberships, recent speeches, constituency office hours. Scope is a deliberate decision, guided by the [data priorities](priorities.md). Strictness applies to the fields inside that scope. There is no obligation to account for facts the crawler never set out to capture, and no warning is owed when out-of-scope content changes.
+- **Always in scope**, on every source type: categorical fields that determine interpretation. See [complete coverage](#key-categorical-fields-need-complete-coverage) below.
+
+### Mechanism follows the data format
+
+- **Structured records** — JSON objects, XML elements, CSV and spreadsheet rows, and HTML tables via [`h.parse_html_table`][zavod.helpers.parse_html_table] — give you a bounded record to exhaust: parse destructively and audit the remainder.
+- **Free-form HTML** gives you no record to audit; "accounting for every value on the page" is meaningless there. Strictness lives in the selectors instead.
+
+The two axes often correlate: sanctions data tends to arrive structured, while PEP data is often crawled from HTML. Don't let that blur them. An HTML sanctions table parsed with `parse_html_table` still gets popped and audited row by row, and a content-rich JSON API still gets audited, with the out-of-scope fields listed in `ignore=`.
+
+## Pick the loudness by whether the crawl can continue
+
+- **Crash** when continuing would emit wrong or ambiguous data, or when the broken assumption is structural, meaning the whole parse is invalid if it's false. An unguarded `row.pop(key)`, an `assert` with a message, or `required: true` on a lookup are all fine ways to crash.
+- **Warn and skip the record** with `context.log.warning` when one record is unmappable but the rest of the crawl is still valid. Warnings surface on the [Issues](https://www.opensanctions.org/issues/) page, where a daily rotation fixes them; generating that work is the point.
+
+A skip is an alarm state, not an accepted outcome: dropping a record that the source publishes is itself a strict-interpretation failure. A warning lives for a day or a few, never permanently: whoever sees it resolves it by adding the missing mapping — the guard remains to catch the next unknown value.
+
+See [logging and crawler feedback](patterns.md#logging-and-crawler-feedback) for what belongs at warning vs. info level.
+
+## Structured records: pop, then audit the remainder
+
+Read each record into a `dict` and remove each field with `.pop()` as you map it. Use the one-argument form for mandatory fields: `row.pop("name")` raises a `KeyError` the day the source drops or renames the field, instead of adding `None` to the entity.
+
+Close each record with [`context.audit_data()`][zavod.context.Context.audit_data], which warns about fields still left in the `dict`. A field the source introduces tomorrow lands in the remainder and produces a warning instead of being dropped.
+
+Fields that are out of scope or have [no FollowTheMoney equivalent](patterns.md#fields-with-no-followthemoney-equivalent) go into the `ignore=[...]` list. That list is an explicit allowance and doubles as the documented scope decision; a genuinely new field still trips the alarm:
+
+```python
+context.audit_data(row, ignore=["hair_colour", "committee_memberships"])
+```
+
+## Free-form HTML: strictness lives in the selectors
+
+Extract the in-scope fields with selections that fail when the page no longer matches expectations, and leave the rest of the page alone:
+
+- [`h.xpath_element`][zavod.helpers.xpath_element] raises on zero or multiple matches; `expect_exactly=` pins a known count; open-ended selections get an `assert len(items) > 0, items`.
+- [`h.assert_dom_hash`][zavod.helpers.assert_dom_hash] warns when a hand-parsed page region drifts.
+
+See [XPath and HTML](xpath_and_html.md) for the full toolkit and selector-quality guidance.
+
+## Assert the invariants of a valid parse
+
+Assert what must be true for the parse to be valid, so breakage fails at the offending line rather than emitting ambiguous data downstream:
+
+```python
+assert position_name is not None, entity.id
+```
+
+See [data assertions](patterns.md#data-assertions). Dataset-level [assertions in the metadata](../metadata.md#data-assertions) are the outermost net: they catch a crawl that silently under-collects.
+
+## Key categorical fields need complete coverage
+
+When a source field determines interpretation — an entity or subject type, a name type, a relationship category — enumerate every known value in a [lookup](datapatch_lookups.md) and treat an unknown value as a signal. The rule holds on every source type, however narrow the scope otherwise is: never fall through to a default. A bare `else` that lumps unknown categories into `LegalEntity` is exactly the silent risk misstatement that strict interpretation exists to prevent.
+
+In increasing loudness:
+
+- `context.lookup_value(...)` with an explicit `None` check (or `warn_unmatched=True`) that warns and skips the record. `eu_fsf` maps `subject_type` this way: `person` → `Person`, `enterprise` → `Organization`, and anything else warns and skips.
+- `required: true` on the lookup, so a miss raises a `LookupException` and halts the crawl.
+
+`type.*` lookups are the exception: they clean individual property values. An unmatched value flows on to normal property validation.
+
+Column headings are categorical input too. Some non-English tabular crawlers map each native language column heading to a stable slug through a `columns` lookup, so the crawler code reads in English. When the source renames a column, the expected key goes missing and the destructive-parsing net catches it.
+
+## Anti-patterns
+
+- `except: pass`, or any broad `except` that swallows parse errors.
+- `.get(key, default)` on a mandatory field.
+- A bare `else` or fallback schema for unknown categorical values.
+- Looping over a possibly-empty selection with no count guard, so the crawler silently emits nothing.
+- Packing out-of-scope facts into `notes` or `description` strings to "handle" them. Out of scope means left alone, not smuggled into free text.

--- a/zavod/mkdocs.yml
+++ b/zavod/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - context.md
   - helpers.md
   - Best practices:
+      - best_practices/strict_interpretation.md
       - best_practices/caching.md
       - best_practices/patterns.md
       - best_practices/addresses.md


### PR DESCRIPTION
Stacked on #4788. Compacts the refactor-crawler skill and extracts its underlying principle into the docs:

- New `zavod/docs/best_practices/strict_interpretation.md`: every source value within the crawler's scope is handled, explicitly ignored, or raises a signal — with scope/mechanism decisions, loudness guidance, and anti-patterns. Added to the mkdocs nav and cross-linked from `patterns.md` and the crawler guide.
- `refactor-crawler` skill slimmed from 17 inline pattern recipes to procedure only, delegating rules to the best-practices docs. Output changes are now allowed when they trace to a named methodological gain (baseline diff required), instead of demanding byte-identical output.
- Warnings framed as work items for the daily issues rotation (fixed within days, never permanent) rather than as per-milestone zero counts.
- Name cleaning declared out of scope for a refactor pass — changing it means the multi-PR review-system migration in `zavod/docs/extract/names.md`.
- `entity_id.md` states when a dataset counts as published (added to a collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)