### PR TITLE
Re-write QIDs during wd_ prod runs in the resolver

### DIFF
--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -83,12 +83,9 @@ def crawl_position(state: CrawlState, person: Entity, claim: Claim) -> None:
     if position is None or position.id is None:
         state.ignore_positions.add(item.id)
         return
-    if item.id != claim.qid:
-        state.context.log.warning(
-            "Redirected position QID",
-            original=claim.qid,
-            redirected=item.id,
-        )
+    if item.id != claim.qid and claim.qid is not None:
+        state.context.resolver.rename_node(claim.qid, item.id)
+        state.context.flush()
 
     occupancy = wikidata_occupancy(state.context, person, position, claim)
     if occupancy is not None:

--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -228,11 +228,8 @@ def crawl(context: Context) -> None:
             if pos_item is None:
                 continue
             if pos_item.id != wd_position.qid:
-                context.log.warning(
-                    "Redirected position QID",
-                    original=wd_position.qid,
-                    redirected=pos_item.id,
-                )
+                context.resolver.rename_node(wd_position.qid, pos_item.id)
+                context.flush()
 
             position = wikidata_position(context, client, pos_item)
             if position is None:


### PR DESCRIPTION
I am not certain this would get us style points. It basically moves the re-write we to in `contrib/rewrite_qids.py` into the crawler, and will get rid of the Wikidata moved QID warnings. Downside: resolver is being written from a crawler. 