### PR TITLE
Don't backfill statistics into the failure index

### DIFF
--- a/zavod/zavod/exporters/metadata.py
+++ b/zavod/zavod/exporters/metadata.py
@@ -87,6 +87,11 @@ def write_dataset_index(
             publish an index carrying entity counts from a previous run.
             (On successful exports the statistics exporter always runs, so a
             fresh local copy exists and no backfill happens either way.)
+
+            TODO: This flag should become obsolete once artifact backfills
+            reference an explicit version (last_successful, or the specific
+            version being exported/validated); see
+            https://github.com/opensanctions/operations/issues/2675
     """
     catalog = get_catalog()
     version = get_latest(dataset.name, backfill=True)

--- a/zavod/zavod/exporters/metadata.py
+++ b/zavod/zavod/exporters/metadata.py
@@ -24,8 +24,17 @@ class DatasetVersionResult(StrEnum):
     FAILURE = "failure"
 
 
-def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
-    """Build the barebones metadata block for a dataset, without artifact URLs."""
+def get_base_dataset_metadata(
+    dataset: Dataset, backfill_statistics: bool = True
+) -> Dict[str, Any]:
+    """Build the barebones metadata block for a dataset, without artifact URLs.
+
+    Args:
+        dataset: The dataset to generate metadata for.
+        backfill_statistics: Whether to fetch statistics.json from the archive
+            when no local copy exists. See `write_dataset_index` for the
+            reasoning behind this option.
+    """
     meta: Dict[str, Any] = {
         "issue_levels": {},
         "issue_count": 0,
@@ -35,15 +44,9 @@ def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
     # This reads the file produced by the statistics exporter which
     # contains entity counts for the dataset, aggregated by various
     # criteria:
-    # TODO: In the case of a failed run, this will currently backfill the stats from the last
-    #  previous run. That doesn't really make sense, because the resources of the index will
-    #  be empty - so what are these counts referring to? (Answer: the last successful run, and then
-    #  publish_failure will just publish that one over and over again).
-    #  But we currently show these numbers on our website, and we currently don't have well-defined
-    #  semantics how our website (or our customers) would figure out what the last successful run was.
-    #  For a brief discussion of our currently broken failure semantics,
-    #  see https://github.com/opensanctions/opensanctions/pull/2483
-    statistics_path = get_dataset_artifact(dataset.name, STATISTICS_FILE)
+    statistics_path = get_dataset_artifact(
+        dataset.name, STATISTICS_FILE, backfill=backfill_statistics
+    )
     if statistics_path.is_file():
         with open(statistics_path, "r") as fh:
             stats: Dict[str, Any] = json.load(fh)
@@ -67,8 +70,24 @@ def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
     return meta
 
 
-def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
-    """Export dataset metadata to index.json."""
+def write_dataset_index(
+    dataset: Dataset,
+    result: DatasetVersionResult,
+    backfill_statistics: bool = True,
+) -> None:
+    """Export dataset metadata to index.json.
+
+    Args:
+        dataset: The dataset to write the index for.
+        result: Whether the run being indexed succeeded or failed.
+        backfill_statistics: Whether to fetch statistics.json from the archive
+            when no local copy exists. This is so that catalog writers that
+            have not had a local crawl can backfill stats, but a failed
+            `zavod run` does not: a run that produced no data should not
+            publish an index carrying entity counts from a previous run.
+            (On successful exports the statistics exporter always runs, so a
+            fresh local copy exists and no backfill happens either way.)
+    """
     catalog = get_catalog()
     version = get_latest(dataset.name, backfill=True)
     if version is None:
@@ -80,7 +99,7 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
         version=version.id,
         is_collection=dataset.is_collection,
     )
-    meta = get_base_dataset_metadata(dataset)
+    meta = get_base_dataset_metadata(dataset, backfill_statistics=backfill_statistics)
     meta.update(dataset.to_opensanctions_dict(catalog))
 
     # Remove redundant dataset hierarchy metadata

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -123,10 +123,8 @@ def archive_failure(dataset: Dataset) -> None:
     # Clear out interim artifacts so they cannot pollute the metadata we're
     # generating.
     dataset_resource_path(dataset.name, STATEMENTS_FILE).unlink(missing_ok=True)
-    # TODO: The statistics file gets pulled in by write_dataset_index,
-    #  so they get published as part of the artifacts anyway.
-    #  For a brief discussion of our currently broken failure semantics,
-    #  see https://github.com/opensanctions/opensanctions/pull/2483
+    # The statistics file may have been written by a partially-completed export,
+    # so its counts wouldn't describe anything a consumer can download.
     dataset_resource_path(dataset.name, STATISTICS_FILE).unlink(missing_ok=True)
     dataset_resource_path(dataset.name, INDEX_FILE).unlink(missing_ok=True)
     dataset_resource_path(dataset.name, CATALOG_FILE).unlink(missing_ok=True)
@@ -134,7 +132,11 @@ def archive_failure(dataset: Dataset) -> None:
     dataset_resource_path(dataset.name, DELTA_EXPORT_FILE).unlink(missing_ok=True)
     dataset_resource_path(dataset.name, DELTA_INDEX_FILE).unlink(missing_ok=True)
 
-    write_dataset_index(dataset, DatasetVersionResult.FAILURE)
+    # Don't backfill statistics from the archive: this run produced no data, so
+    # the failure index should not carry entity counts from a previous run.
+    write_dataset_index(
+        dataset, DatasetVersionResult.FAILURE, backfill_statistics=False
+    )
     path = dataset_resource_path(dataset.name, INDEX_FILE)
     if not path.is_file():
         log.error("Metadata file not found: %s" % path, dataset=dataset.name)

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -134,6 +134,10 @@ def archive_failure(dataset: Dataset) -> None:
 
     # Don't backfill statistics from the archive: this run produced no data, so
     # the failure index should not carry entity counts from a previous run.
+    # TODO: Once artifact backfills reference an explicit version
+    # (https://github.com/opensanctions/operations/issues/2675), this flag can
+    # go away: a failure publish simply wouldn't reference any version to
+    # backfill from.
     write_dataset_index(
         dataset, DatasetVersionResult.FAILURE, backfill_statistics=False
     )

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -1,6 +1,8 @@
 import json
 from typing import Optional
-from followthemoney.dataset import VersionHistory
+
+import pytest
+from followthemoney.dataset import Version, VersionHistory
 from structlog.testing import capture_logs
 
 from zavod import settings
@@ -211,6 +213,7 @@ def test_archive_failure(testdataset1: Dataset):
     assert not artifact_path.joinpath(RESOURCES_FILE).exists()
     assert not artifact_path.joinpath(HASH_FILE).exists()
     assert not artifact_path.joinpath(DELTA_INDEX_FILE).exists()
+    assert not artifact_path.joinpath(STATISTICS_FILE).exists()
 
     # We don't want failed runs to end up in /datasets
     assert not latest_path.joinpath(INDEX_FILE).exists()
@@ -218,3 +221,51 @@ def test_archive_failure(testdataset1: Dataset):
     assert not latest_path.joinpath(ISSUES_FILE).exists()
     assert len(list(latest_path.glob("*"))) == 0
     assert len(list(release_path.glob("*"))) == 0
+
+
+def test_archive_failure_no_stale_statistics(
+    testdataset1: Dataset, monkeypatch: pytest.MonkeyPatch
+):
+    """A failed run following a successful one must not resurrect the previous
+    run's statistics from the archive in its failure index."""
+    linker = get_dataset_linker(testdataset1)
+    crawl_dataset(testdataset1)
+    store = get_store(testdataset1, linker)
+    store.sync()
+    export_dataset(testdataset1, store.view(testdataset1))
+    publish_dataset(testdataset1, republish_to_latest=True)
+    successful_version = settings.RUN_VERSION
+
+    # Fail a subsequent run under a fresh version, on a clean data path as in
+    # a production `zavod run`:
+    clear_data_path(testdataset1.name)
+    monkeypatch.setattr(settings, "RUN_VERSION", Version.new())
+    assert testdataset1.data is not None
+    testdataset1.data.format = "FAIL"
+    with pytest.raises(RunFailedException):
+        crawl_dataset(testdataset1)
+    archive_failure(testdataset1)
+
+    history = _read_history(testdataset1.name)
+    assert history is not None
+    assert history.latest is not None
+    assert history.latest.id == settings.RUN_VERSION.id
+    artifact_path = (
+        settings.ARCHIVE_PATH / ARTIFACTS / testdataset1.name / history.latest.id
+    )
+    # The failed version must not have statistics archived under it...
+    assert not artifact_path.joinpath(STATISTICS_FILE).exists()
+    # ...and its index must not carry counts from the previous successful run:
+    index = json.loads(artifact_path.joinpath(INDEX_FILE).read_text())
+    assert index["result"] == "failure"
+    assert "entity_count" not in index
+    assert "thing_count" not in index
+    assert "target_count" not in index
+
+    # The previous successful version's statistics remain untouched:
+    successful_path = (
+        settings.ARCHIVE_PATH / ARTIFACTS / testdataset1.name / successful_version.id
+    )
+    assert successful_path.joinpath(STATISTICS_FILE).exists()
+    successful_index = json.loads(successful_path.joinpath(INDEX_FILE).read_text())
+    assert successful_index["entity_count"] > 0


### PR DESCRIPTION
When a run fails, `archive_failure` deletes the local `statistics.json`, but `write_dataset_index` then quietly backfills it from the archive — so the failure index carries entity counts from the last successful run, and the stale stats file gets re-archived under the failed version. This is one of the two layers behind https://github.com/opensanctions/opensanctions/issues/4782.

`write_dataset_index` now takes a `backfill_statistics` argument. It defaults to True so catalog writers that never ran a local crawl keep working; `archive_failure` passes False, so a failure index carries no counts and failed versions get no `statistics.json` archived under them.

`zavod export` keeps working as before — the statistics exporter always runs during export, so a fresh local file exists on the success path and the backfill never fired there anyway.

The website now uses the last *successful* run to display stats and resources, so nothing needs the failure index to impersonate old numbers anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)