### PR TITLE
Write an empty statements file for crawls that emit nothing

### DIFF
--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -173,6 +173,13 @@ class Context:
         """Flush the context to ensure all data is written to disk."""
         if self._db is not None:
             self._db.checkpoint()
+        # The statement writer is only opened on the first emit, so a crawl
+        # that emitted nothing would leave no statements file behind - and
+        # downstream stages would silently fall back to streaming a previous
+        # version's statements from the archive, republishing old data as a
+        # new successful run. Record the empty output explicitly instead.
+        if not self.dry_run and self._writer is None:
+            self._writer_path.touch()
 
     def close(self) -> None:
         """Flush and tear down the context."""

--- a/zavod/zavod/tests/fixtures/testdataset1/testentrypoint1.py
+++ b/zavod/zavod/tests/fixtures/testdataset1/testentrypoint1.py
@@ -65,6 +65,10 @@ def crawl(context: Context):
         # Used by tests to trigger a runner failure.
         raise RuntimeError("Pipeline is broken")
 
+    if context.dataset.data is not None and context.dataset.data.format == "EMPTY":
+        # Used by tests to simulate a crawl that completes without emitting anything.
+        return
+
     context.export_resource(data_path, CSV, title=context.SOURCE_TITLE)
     with open(data_path, "r") as fh:
         for row in csv.DictReader(fh):

--- a/zavod/zavod/tests/test_context.py
+++ b/zavod/zavod/tests/test_context.py
@@ -346,6 +346,25 @@ def test_crawl_dataset_wrapper(testdataset1: Dataset):
         crawl_dataset(testdataset1)
 
 
+def test_crawl_dataset_empty(testdataset1: Dataset):
+    """A crawl that completes without emitting anything still writes an
+    (empty) statements file, so that downstream stages read this run's output
+    instead of falling back to a previous version from the archive."""
+    path = dataset_resource_path(testdataset1.name, STATEMENTS_FILE)
+    assert testdataset1.data is not None
+    testdataset1.data.format = "EMPTY"
+
+    stats = crawl_dataset(testdataset1, dry_run=True)
+    assert stats.statements == 0
+    assert not path.exists()
+
+    stats = crawl_dataset(testdataset1)
+    assert stats.statements == 0
+    assert path.is_file()
+    assert path.stat().st_size == 0
+    assert len(list(iter_dataset_statements(testdataset1))) == 0
+
+
 def test_dataset_sink(testdataset1: Dataset):
     context = Context(testdataset1)
     assert context._writer_path.is_relative_to(settings.DATA_PATH)

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -1,11 +1,14 @@
 import json
 from typing import Optional
-from followthemoney.dataset import VersionHistory
+
+import pytest
+from followthemoney.dataset import Version, VersionHistory
 from structlog.testing import capture_logs
 
 from zavod import settings
 from zavod.meta import Dataset
 from zavod.archive import DELTA_EXPORT_FILE, get_dataset_artifact, clear_data_path
+from zavod.archive import dataset_resource_path
 from zavod.archive import iter_dataset_statements, iter_previous_statements
 from zavod.archive import STATISTICS_FILE, INDEX_FILE, STATEMENTS_FILE
 from zavod.archive import DATASETS, ARTIFACTS, VERSIONS_FILE
@@ -175,6 +178,41 @@ def test_publish_collection(testdataset1: Dataset, collection: Dataset):
     assert not release_path.joinpath(ISSUES_LOG).exists()
     assert not release_path.joinpath(VERSIONS_FILE).exists()
     assert not release_path.joinpath(HASH_FILE).exists()
+
+
+def test_empty_crawl_does_not_resurrect_archived_statements(
+    testdataset1: Dataset, monkeypatch: pytest.MonkeyPatch
+):
+    """A crawl that completes without emitting anything must yield an empty
+    store view, not fall back to streaming the previous successful version's
+    statements from the archive."""
+    linker = get_dataset_linker(testdataset1)
+    crawl_dataset(testdataset1)
+    store = get_store(testdataset1, linker)
+    store.sync()
+    export_dataset(testdataset1, store.view(testdataset1))
+    publish_dataset(testdataset1, republish_to_latest=True)
+    store.close()
+
+    # Run an empty crawl under a fresh version on a clean data path, as in a
+    # production `zavod run`:
+    clear_data_path(testdataset1.name)
+    monkeypatch.setattr(settings, "RUN_VERSION", Version.new())
+    assert testdataset1.data is not None
+    testdataset1.data.format = "EMPTY"
+    stats = crawl_dataset(testdataset1)
+    assert stats.statements == 0
+
+    # The archive holds the previous version's statements, but the empty local
+    # statements file from this run takes precedence:
+    assert dataset_resource_path(testdataset1.name, STATEMENTS_FILE).is_file()
+    assert len(list(iter_dataset_statements(testdataset1))) == 0
+
+    store = get_store(testdataset1, linker)
+    store.sync(clear=True)
+    view = store.view(testdataset1, external=False)
+    assert len(list(view.entities())) == 0
+    store.close()
 
 
 def test_archive_failure(testdataset1: Dataset):


### PR DESCRIPTION
The statement writer only opens on the first emit, so a crawler that completes without emitting anything leaves no local `statements.pack`. `store.sync` then silently streams the *previous* version's statements from the archive: validation passes on the old data and export republishes it as a fresh successful version. This is how `ext_ror` kept republishing its December data for half a year (https://github.com/opensanctions/opensanctions/issues/4782).

`Context.flush()` now touches an empty statements file if nothing was emitted. This happens at the end of the crawl rather than in `begin()`, so the file keeps meaning "complete output of a finished crawl" — `begin()` is also used by the export/validate contexts, where an empty statements.pack would be actively harmful. An empty crawl now yields an empty store view, and min entity count assertions abort the run.

Caveats: `--keep-data` still sees the previous run's local statements, and datasets without min-count assertions will now publish honestly-empty data instead of resurrecting old data. The archive fallback itself stays — collection exports legitimately depend on it.

Both new tests fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)