### PR TITLE
Exclude HTML files from trailing-whitespace pre-commit hook

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: check-yaml
       - id: trailing-whitespace
+        exclude: '\.html?$'
       - id: check-merge-conflict
   - repo: local
     hooks:


### PR DESCRIPTION
Otherwise we're formatting html files intended for change comparison to upstream versions to adhere to our own formatting.