### PR TITLE
docs: position names via lang= and translate_name, not YAML lookups

### DIFF
--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -63,7 +63,7 @@ assertions:
 
 - Include `Position` counts in assertions when the crawler creates multiple position types.
 - `frequency` matches source update cadence (daily/weekly/monthly). PEP crawlers do not have to be monthly.
-- PEP crawlers may need a `position` lookup to translate non-English role labels into standard English names (see `examples.md`). Beyond that, lookups rarely go past `type.*`.
+- Lookups rarely go past `type.*` for PEP crawlers. (Non-English role labels are handled by `translate_name=True` in `make_position`, not lookups.)
 
 ## Step 3: Write the crawler module
 
@@ -88,7 +88,18 @@ capture".
 
 Build position names with `h.make_position`. Rules:
 
-- Name positions **in English**. Use the standard English term for the role; keep native-language terminology only for proper nouns of specific institutions (e.g. `Landtag of Mecklenburg-Vorpommern`). When the source labels roles in another language, declare a `position` lookup in the YAML to translate them before passing to `h.make_position`.
+- **Always pass `lang=`** (ISO 639-3, e.g. `lang="eng"`, `lang="fra"`) declaring the
+  language the position name is in. Two cases:
+    - **Crawler-supplied names** (the standard case — e.g. a parliament crawler where
+      the name is always `Member of the ... Parliament`): write the name in English
+      and pass `lang="eng"`. Use the standard English term for the role; keep
+      native-language terminology only for proper nouns of specific institutions
+      (e.g. `Landtag of Mecklenburg-Vorpommern`).
+    - **Source-supplied names** (role labels read from the data): pass them through
+      as-is with the source language as `lang=` and `translate_name=True` —
+      `make_position` translates the name to English via LLM and keys the entity ID
+      on the untranslated original, so the ID stays stable. Do not translate labels
+      via a `position` YAML lookup.
 - Include the role, the organisational body where relevant, and the geographic jurisdiction. For members of national parliaments, include `citizenship` (except UK Parliament).
 - Avoid: legislative term, an elected official's constituency, or the country for sub-national representatives.
 - `wikidata_id` becomes the position's entity ID, so never pass the same QID to multiple distinct positions — they'd collapse into one entity. Per-municipality/region positions usually omit `wikidata_id` (per-locality QIDs rarely exist on Wikidata) and rely on `subnational_area=...` to disambiguate; pass a QID only when each subnational position has its own unique Wikidata entry.

--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -63,7 +63,7 @@ assertions:
 
 - Include `Position` counts in assertions when the crawler creates multiple position types.
 - `frequency` matches source update cadence (daily/weekly/monthly). PEP crawlers do not have to be monthly.
-- Lookups rarely go past `type.*` for PEP crawlers. (Non-English role labels are handled by `translate_name=True` in `make_position`, not lookups.)
+- Lookups rarely go past `type.*` for PEP crawlers. (Non-English role labels are handled by `translate_name=True` in `make_position`; a `position` translation lookup is only worth it when the source has very few distinct labels.)
 
 ## Step 3: Write the crawler module
 
@@ -98,8 +98,10 @@ Build position names with `h.make_position`. Rules:
     - **Source-supplied names** (role labels read from the data): pass them through
       as-is with the source language as `lang=` and `translate_name=True` —
       `make_position` translates the name to English via LLM and keys the entity ID
-      on the untranslated original, so the ID stays stable. Do not translate labels
-      via a `position` YAML lookup.
+      on the untranslated original, so the ID stays stable. Only when the source has
+      very few distinct labels, a `position` YAML lookup translating them to English
+      (then `lang="eng"`) is fine instead — see the subnational variant in
+      `examples.md`.
 - Include the role, the organisational body where relevant, and the geographic jurisdiction. For members of national parliaments, include `citizenship` (except UK Parliament).
 - Avoid: legislative term, an elected official's constituency, or the country for sub-national representatives.
 - `wikidata_id` becomes the position's entity ID, so never pass the same QID to multiple distinct positions — they'd collapse into one entity. Per-municipality/region positions usually omit `wikidata_id` (per-locality QIDs rarely exist on Wikidata) and rely on `subnational_area=...` to disambiguate; pass a QID only when each subnational position has its own unique Wikidata entry.

--- a/.claude/skills/crawler-pep/examples.md
+++ b/.claude/skills/crawler-pep/examples.md
@@ -119,24 +119,38 @@ Key differences from Pattern A:
 Same `default_is_pep=None` shape as Pattern B, but used for sources where each record names
 a sub-national position (e.g. mayor of municipality X). Two extras:
 
-- Pass the source-language label with `lang=` and `translate_name=True`.
+- Translate the role label to English via a `position` lookup. This is only
+  applicable when the source has very few distinct position names (a handful of
+  role labels shared across all municipalities). Otherwise, pass the
+  source-language label with `lang=` and `translate_name=True` as in Pattern B.
 - Pass `subnational_area=...` and **omit `wikidata_id`** — a Wikidata ID would
   collapse every municipality into the same entity.
 
 ```python
+res = context.lookup("position", row.pop("MAN_LABEL"))
+assert res is not None, f"Unknown position: {row['MAN_LABEL']!r}"
 position = h.make_position(
     context,
-    # Compose the whole name in the source language; translate_name produces the
-    # English name in one pass and keys the ID on the untranslated original.
-    name=f"{row.pop('MAN_LABEL')} de {commune_label}",
+    name=f"{res.value} of {commune_label}",   # English name + locality
     country="lu",
     subnational_area=commune_label,           # NOT wikidata_id — per-locality
-    lang="fra",
-    translate_name=True,
+    lang="eng",                               # already English after the lookup
 )
 categorisation = categorise(context, position, default_is_pep=None)
 if not categorisation.is_pep:
     return
+```
+
+YAML side — declare the translation lookup:
+
+```yaml
+lookups:
+  position:
+    options:
+      - match: Bourgmestre
+        value: Mayor
+      - match: Échevin
+        value: Alderman
 ```
 
 ## Pattern C: Multi-position crawler with `default_is_pep=True`

--- a/.claude/skills/crawler-pep/examples.md
+++ b/.claude/skills/crawler-pep/examples.md
@@ -58,6 +58,7 @@ def crawl(context: Context) -> None:
         name="Member of Parliament",
         country="xx",
         wikidata_id="Q...",
+        lang="eng",  # crawler-supplied names are always English
     )
     categorisation = categorise(context, position, default_is_pep=True)
     # Gate even with default_is_pep=True: the position may have been un-flagged
@@ -78,8 +79,10 @@ PEP status is determined by the UI review workflow, not the crawler.
 
 ```python
 def crawl_member(context: Context, row: dict[str, Any]) -> None:
-    role = row.pop("role")
-    position = h.make_position(context, name=role, country="fr")
+    role = row.pop("role")  # source-supplied, in French
+    position = h.make_position(
+        context, name=role, country="fr", lang="fra", translate_name=True
+    )
     # default_is_pep=None: defers PEP determination to the UI
     categorisation = categorise(context, position, default_is_pep=None)
 
@@ -116,35 +119,24 @@ Key differences from Pattern A:
 Same `default_is_pep=None` shape as Pattern B, but used for sources where each record names
 a sub-national position (e.g. mayor of municipality X). Two extras:
 
-- Translate the role label to English via a `position` lookup.
+- Pass the source-language label with `lang=` and `translate_name=True`.
 - Pass `subnational_area=...` and **omit `wikidata_id`** — a Wikidata ID would
   collapse every municipality into the same entity.
 
 ```python
-res = context.lookup("position", row.pop("MAN_LABEL"))
-assert res is not None, f"Unknown position: {row['MAN_LABEL']!r}"
 position = h.make_position(
     context,
-    name=f"{res.value} of {commune_label}",   # English name + locality
+    # Compose the whole name in the source language; translate_name produces the
+    # English name in one pass and keys the ID on the untranslated original.
+    name=f"{row.pop('MAN_LABEL')} de {commune_label}",
     country="lu",
     subnational_area=commune_label,           # NOT wikidata_id — per-locality
     lang="fra",
+    translate_name=True,
 )
 categorisation = categorise(context, position, default_is_pep=None)
 if not categorisation.is_pep:
     return
-```
-
-YAML side — declare the translation lookup:
-
-```yaml
-lookups:
-  position:
-    options:
-      - match: Bourgmestre
-        value: Mayor
-      - match: Échevin
-        value: Alderman
 ```
 
 ## Pattern C: Multi-position crawler with `default_is_pep=True`
@@ -171,6 +163,7 @@ def crawl(context: Context) -> None:
             name=config["name"],
             country="ie",
             wikidata_id=config.get("wikidata_id"),
+            lang="eng",
         )
         categorisation = categorise(context, position, default_is_pep=True)
         context.emit(position)

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -84,7 +84,8 @@ Do
   pass. When the position name comes from the source in a non-English language,
   pass it unmodified with `translate_name=True` — the helper translates it to
   English and derives the entity ID from the untranslated name, keeping IDs
-  stable.
+  stable. When the source has only very few distinct labels, a `position` lookup
+  in the YAML translating them to English is an acceptable alternative.
 - include the role
 - include the organizational body where needed
 - include the specific geographic jurisdiction where relevant

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -75,12 +75,16 @@ The [Position](https://www.opensanctions.org/reference/#schema.Position) `name` 
 
 Do
 
-- write the position in English. Use the standard English term for the role
-  (e.g. `Mayor`, not `Bourgmestre`). Preserve native-language terminology only for
-  proper nouns of specific institutions where translation would obscure the
-  reference (e.g. `Landtag of Mecklenburg-Vorpommern`, not `State Parliament of …`).
-  When the source labels roles in another language, declare a `position` lookup
-  in the YAML to translate each label before passing it to `h.make_position`.
+- write the position in English when the crawler supplies the name itself. Use
+  the standard English term for the role (e.g. `Mayor`, not `Bourgmestre`).
+  Preserve native-language terminology only for proper nouns of specific
+  institutions where translation would obscure the reference
+  (e.g. `Landtag of Mecklenburg-Vorpommern`, not `State Parliament of …`).
+- always pass `lang=` to `h.make_position` declaring the language of the name you
+  pass. When the position name comes from the source in a non-English language,
+  pass it unmodified with `translate_name=True` — the helper translates it to
+  English and derives the entity ID from the untranslated name, keeping IDs
+  stable.
 - include the role
 - include the organizational body where needed
 - include the specific geographic jurisdiction where relevant


### PR DESCRIPTION
Updates the crawler-pep skill (and the conflicting bit in `zavod/docs/peps.md`) on how position names should be passed to `h.make_position`:

- Always pass `lang=` declaring the language of the position name.
- Crawler-supplied names (the standard "Member of the ... Parliament" case) are always written in English, so `lang="eng"`.
- Source-supplied names in a non-English language get passed through as-is with `translate_name=True`, instead of translating them via a `position` lookup in the YAML. The helper keys the entity ID on the untranslated name, so IDs stay stable.

Also updated the skill's examples to match (the subnational variant now mirrors what e.g. `datasets/hr/public_officials/crawler.py` actually does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)