### PR TITLE
Improved discoverability in wd_peps.yml

### DIFF
--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -366,6 +366,8 @@ lookups:
           - "Q62122498" # maire de Tournan-en-Brie
           - "Q62578836" # Permanent Representative of Hungary to the United Nations, New York
           - "Q63456757" # ambassador of Hungary to Azerbaijan
+          - "Q30056203" # ambassador to Qatar
+          - "Q30081888" # ambassador to Belarus
           - "Q854185" # Bezirksamtsleiter
           - "Q1006064" # Bundesgeschäftsführer
           - "Q1221110" # Dienstposten
@@ -439,6 +441,8 @@ lookups:
           - "Q60832272" # Grand voyer
           - "Q65238772" # intendant
           - "Q480319" # title of authority
+          - "Q7074545" # Oba of Lagos
+          - "Q3643105" # Rain Queen
           - "Q135842653" # directeur de cabinet du ministre des Outre-mer
           - "Q8349973" # insular council
           - "Q108466181" # judicial position
@@ -475,11 +479,9 @@ lookups:
           - "Q3149494" # printer to the King
           - "Q3290825" # churchwarden
           - "Q3504856" # substitute
-          - "Q3643105" # Rain Queen
           - "Q4048723" # SEO specialist
           - "Q4102597" # job vacancy
           - "Q5428874" # faculty member
-          - "Q7074545" # Oba of Lagos
           - "Q7140693" # partner
           - "Q7200276" # placeholder
           - "Q10438271" # office manager
@@ -496,8 +498,6 @@ lookups:
           - "Q23685787" # working student
           - "Q28689677" # honorary secretary
           - "Q29982545" # function in the Evangelical Church of Czech Brethren
-          - "Q30056203" # ambassador to Qatar
-          - "Q30081888" # ambassador to Belarus
           - "Q30582382" # excavation director
           - "Q30682903" # data protection officer
           - "Q51321989" # Professional engineer


### PR DESCRIPTION
Based on a PR I opened and closed previously but much more targeted in scope:

(1) Reclassified two ambassadors as PEPs in line with FATF definition. 

(2) The Oba of Lagos is a traditional monarch. Under section 29 of the regulations that apply in Nigeria, "members of royal families" are classed as PEPs: https://www.stanbicibtcbank.com/static_file/Nigeria/nigeriabank/Personal/Products/Ways%20To%20Bank/Self%20service%20banking/Agency%20Banking/AML%20CIRCULAR%20AND%20REGULATIONS%20MERGED%202022---.pdf 

(3) The Rain Queen is a traditional monarch of Balobedu a people of the Limpopo of South Africa. Under the rules set by the main stock exchange in South Africa, 'a member of a royal family or senior traditional leader' is a PEP. https://resource.capetown.gov.za/documentcentre/Documents/Financial%20documents/JSE_Register%20of_Domestic_Prominent_Influential_Persons.pdf