### PR TITLE
Document archive layout and how to investigate past dataset runs

### DIFF
--- a/.claude/docs/archive-investigation.md
+++ b/.claude/docs/archive-investigation.md
@@ -1,0 +1,103 @@
+# Investigating Dataset Runs via the Data Archive
+
+How to investigate past versions of a dataset using the data.opensanctions.org
+archive — why an entity count changed, when an entity appeared or disappeared,
+whether runs failed, and what a past run actually produced.
+
+First read the module docstring of `zavod/zavod/archive/__init__.py` — it
+contains the full, authoritative documentation of the archive layout: the
+`/artifacts/` and `/datasets/` prefixes, the root `versions.json` file and its
+`last_successful` field, how version walking works, and the `result` field
+marking a run as success or failure. Everything below assumes that layout.
+Version IDs are opaque strings; their one guaranteed property is that they
+sort chronologically.
+
+## Accessing files
+
+Prefer `gsutil` against the production bucket — unlike HTTPS it can list
+directories, which is often the fastest way to see what a run produced:
+
+```
+gsutil ls gs://data.opensanctions.org/artifacts/{dataset}/
+gsutil ls gs://data.opensanctions.org/artifacts/{dataset}/{version}/
+gsutil cat gs://data.opensanctions.org/artifacts/{dataset}/{version}/index.json
+```
+
+Only fall back to HTTPS (same paths on `https://data.opensanctions.org`, no
+auth needed) if gsutil fails, e.g. for lack of credentials.
+
+## Walking versions
+
+`zavod.archive.iter_dataset_versions()` requires a configured archive backend
+(GCS credentials or a local mirror), so for read-only investigation use plain
+HTTPS with the `followthemoney` version model instead (verified to work
+standalone in the workspace venv):
+
+```python
+from typing import Iterator
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+from followthemoney.dataset import Version, VersionHistory
+
+ARCHIVE = "https://data.opensanctions.org"
+
+
+def iter_versions(dataset: str) -> Iterator[Version]:
+    """Yield a dataset's versions newest-first, hopping through the
+    versions.json snapshots in the version artifact directories."""
+    url = f"{ARCHIVE}/artifacts/{dataset}/versions.json"
+    seen: set[str] = set()
+    while True:
+        try:
+            history = VersionHistory.from_json(urlopen(url).read().decode())
+        except HTTPError:
+            return
+        new = [v for v in history.items[::-1] if v.id not in seen]
+        if not new:
+            return  # genesis reached
+        yield from new
+        seen.update(v.id for v in new)
+        url = f"{ARCHIVE}/artifacts/{dataset}/{history.items[0].id}/versions.json"
+```
+
+Each yielded `Version` has `.id` and `.dt` (a `datetime`), so you can stop
+walking once you're past the time window you care about.
+
+## What to look at, cheap to detailed
+
+1. `index.json` of past versions — `entity_count`, `target_count`, and
+   `result` (`"success"`/`"failure"`). Fetch it for a range of versions to
+   locate *when* a count changed or runs started failing.
+2. `statistics.json` — more detail on *where* a change happened: entity
+   counts by schema and by country, target counts, `last_change`.
+3. `issues.json` — warnings/errors emitted during that run; usually the
+   fastest way to diagnose a `"failure"` version.
+4. `entities.delta.json` — *what* actually changed, entity by entity. Larger,
+   but definitive. `delta.json` in the same directory indexes recent versions
+   that have delta files.
+
+Example `entities.delta.json` lines (line-based JSON; `ADD`/`MOD` carry the
+full entity, `DEL` only the ID):
+
+```json
+{"op": "ADD", "entity": {"id": "NK-EXTo6dyj9d94bQbSMGLmS3", "caption": "Fly Baghdad", "schema": "LegalEntity", "datasets": ["us_ofac_sdn"], "properties": {"name": ["Fly Baghdad"], "topics": ["sanction"]}, "target": true}}
+{"op": "DEL", "entity": {"id": "ofac-1ea2aa5bcbe8a0ee96f1335a86573d2c23674f95"}}
+```
+
+Archive files are often large (deltas and `statistics.json` especially) —
+don't `curl` them into context. Write a small Python script that streams and
+aggregates, e.g.:
+
+```python
+import json
+from collections import Counter
+from urllib.request import urlopen
+
+url = f"{ARCHIVE}/artifacts/us_ofac_sdn/{version_id}/entities.delta.json"
+ops: Counter[tuple[str, str]] = Counter()
+for line in urlopen(url):
+    row = json.loads(line)
+    ops[(row["op"], row["entity"].get("schema", "?"))] += 1
+print(ops.most_common(20))
+```

--- a/.claude/docs/archive-investigation.md
+++ b/.claude/docs/archive-investigation.md
@@ -4,6 +4,13 @@ How to investigate past versions of a dataset using the data.opensanctions.org
 archive — why an entity count changed, when an entity appeared or disappeared,
 whether runs failed, and what a past run actually produced.
 
+**This requires Google Cloud credentials.** Pass `--use-gcs` to the commands
+below by default: the public site refuses some objects that do exist (old runs
+of since-removed datasets answer 403, not 404), and directory listings are only
+possible against the bucket. Without credentials you can still read any archive
+path you know the name of over plain HTTPS, but deep history will come back
+`unreadable`.
+
 First read the module docstring of `zavod/zavod/archive/__init__.py` — it
 contains the full, authoritative documentation of the archive layout: the
 `/artifacts/` and `/datasets/` prefixes, the root `versions.json` file and its
@@ -15,7 +22,7 @@ chronologically.
 ## Walking the run history
 
 ```bash
-python -m contrib.maintenance.versions <dataset_name> -n 30
+python -m contrib.maintenance.versions <dataset_name> -n 30 --use-gcs
 ```
 
 Prints one row per archived run, newest first: version ID, export timestamp,
@@ -25,10 +32,6 @@ run's `statistics.json`, so blank for failed runs), and `--start <version>` to
 resume the walk further back than the last row printed — the tool hops the
 per-run `versions.json` snapshots, so history goes back to the dataset's first
 run.
-
-Old runs of datasets that have since been removed answer 403 over HTTPS. Pass
-`--use-gcs` to read the bucket directly instead; this needs Google Cloud
-credentials, so only reach for it when a row comes back `unreadable`.
 
 ## Listing what a run produced
 

--- a/.claude/docs/archive-investigation.md
+++ b/.claude/docs/archive-investigation.md
@@ -9,70 +9,52 @@ contains the full, authoritative documentation of the archive layout: the
 `/artifacts/` and `/datasets/` prefixes, the root `versions.json` file and its
 `last_successful` field, how version walking works, and the `result` field
 marking a run as success or failure. Everything below assumes that layout.
-Version IDs are opaque strings; their one guaranteed property is that they
-sort chronologically.
+Version IDs are opaque strings; their one guaranteed property is that they sort
+chronologically.
 
-## Accessing files
+## Walking the run history
 
-Prefer `gsutil` against the production bucket — unlike HTTPS it can list
-directories, which is often the fastest way to see what a run produced:
-
-```
-gsutil ls gs://data.opensanctions.org/artifacts/{dataset}/
-gsutil ls gs://data.opensanctions.org/artifacts/{dataset}/{version}/
-gsutil cat gs://data.opensanctions.org/artifacts/{dataset}/{version}/index.json
+```bash
+python -m contrib.maintenance.versions <dataset_name> -n 30
 ```
 
-Only fall back to HTTPS (same paths on `https://data.opensanctions.org`, no
-auth needed) if gsutil fails, e.g. for lack of credentials.
+Prints one row per archived run, newest first: version ID, export timestamp,
+success/failure, entity and target counts, and the run's `index.json` URL. Add
+`--schema Person --schema Company` for per-schema entity counts (read from each
+run's `statistics.json`, so blank for failed runs), and `--start <version>` to
+resume the walk further back than the last row printed — the tool hops the
+per-run `versions.json` snapshots, so history goes back to the dataset's first
+run.
 
-## Walking versions
+Old runs of datasets that have since been removed answer 403 over HTTPS. Pass
+`--use-gcs` to read the bucket directly instead; this needs Google Cloud
+credentials, so only reach for it when a row comes back `unreadable`.
 
-`zavod.archive.iter_dataset_versions()` requires a configured archive backend
-(GCS credentials or a local mirror), so for read-only investigation use plain
-HTTPS with the `followthemoney` version model instead (verified to work
-standalone in the workspace venv):
+## Listing what a run produced
 
-```python
-from typing import Iterator
-from urllib.error import HTTPError
-from urllib.request import urlopen
+HTTPS can't list directories, so use `gcloud storage` (not `gsutil` — it's
+deprecated) against the production bucket:
 
-from followthemoney.dataset import Version, VersionHistory
-
-ARCHIVE = "https://data.opensanctions.org"
-
-
-def iter_versions(dataset: str) -> Iterator[Version]:
-    """Yield a dataset's versions newest-first, hopping through the
-    versions.json snapshots in the version artifact directories."""
-    url = f"{ARCHIVE}/artifacts/{dataset}/versions.json"
-    seen: set[str] = set()
-    while True:
-        try:
-            history = VersionHistory.from_json(urlopen(url).read().decode())
-        except HTTPError:
-            return
-        new = [v for v in history.items[::-1] if v.id not in seen]
-        if not new:
-            return  # genesis reached
-        yield from new
-        seen.update(v.id for v in new)
-        url = f"{ARCHIVE}/artifacts/{dataset}/{history.items[0].id}/versions.json"
+```bash
+gcloud storage ls gs://data.opensanctions.org/artifacts/{dataset}/{version}/
+gcloud storage cat gs://data.opensanctions.org/artifacts/{dataset}/{version}/index.json
 ```
 
-Each yielded `Version` has `.id` and `.dt` (a `datetime`), so you can stop
-walking once you're past the time window you care about.
+Every archive path is also readable over plain HTTPS without auth, at
+`https://data.opensanctions.org/<same path>` — use that when you know the file
+name and don't have credentials.
 
-## What to look at, cheap to detailed
+## Digging into a single run, cheap to detailed
 
-1. `index.json` of past versions — `entity_count`, `target_count`, and
-   `result` (`"success"`/`"failure"`). Fetch it for a range of versions to
-   locate *when* a count changed or runs started failing.
-2. `statistics.json` — more detail on *where* a change happened: entity
-   counts by schema and by country, target counts, `last_change`.
-3. `issues.json` — warnings/errors emitted during that run; usually the
-   fastest way to diagnose a `"failure"` version.
+1. `index.json` — `entity_count`, `target_count`, `result`. The version table
+   above is just this file across many runs; read it directly for the rest of
+   the run metadata (resources, `last_change`, `entry_point`).
+2. `statistics.json` — where a change happened: entity counts by schema and by
+   country, target counts, sanctions programs.
+3. `issues.json` / `issues.log` — warnings and errors from that run; usually
+   the fastest way to diagnose a `"failure"` version. For the latest run,
+   `python -m contrib.maintenance.aggregate_issues <dataset_name>` groups them
+   by message pattern.
 4. `entities.delta.json` — *what* actually changed, entity by entity. Larger,
    but definitive. `delta.json` in the same directory indexes recent versions
    that have delta files.
@@ -85,8 +67,8 @@ full entity, `DEL` only the ID):
 {"op": "DEL", "entity": {"id": "ofac-1ea2aa5bcbe8a0ee96f1335a86573d2c23674f95"}}
 ```
 
-Archive files are often large (deltas and `statistics.json` especially) —
-don't `curl` them into context. Write a small Python script that streams and
+Archive files are often large (deltas and `statistics.json` especially) — don't
+`curl` them into context. Write a small Python script that streams and
 aggregates, e.g.:
 
 ```python
@@ -94,7 +76,7 @@ import json
 from collections import Counter
 from urllib.request import urlopen
 
-url = f"{ARCHIVE}/artifacts/us_ofac_sdn/{version_id}/entities.delta.json"
+url = f"https://data.opensanctions.org/artifacts/us_ofac_sdn/{version_id}/entities.delta.json"
 ops: Counter[tuple[str, str]] = Counter()
 for line in urlopen(url):
     row = json.loads(line)

--- a/.claude/skills/debug-crawler/SKILL.md
+++ b/.claude/skills/debug-crawler/SKILL.md
@@ -24,6 +24,17 @@ Read the crawler's `.yml` and `crawler.py` from the paths the report resolves. N
 the **row data** on each issue — for source-value issues the keys are slugified
 column names, values are cell contents.
 
+The report only covers the latest run and the last successful one. For an overview of
+what the crawler produced over time — when counts moved, since when runs have been
+failing, when a schema appeared — walk the archived history:
+
+```bash
+python -m contrib.maintenance.versions <dataset_name> -n 30
+```
+
+`.claude/docs/archive-investigation.md` covers digging into individual past runs from
+there.
+
 ## Step 2: Inspect the current source data
 
 The source has likely changed. Use `OPENSANCTIONS_ZYTE_API_KEY` (already set in the

--- a/.claude/skills/debug-crawler/SKILL.md
+++ b/.claude/skills/debug-crawler/SKILL.md
@@ -24,19 +24,6 @@ Read the crawler's `.yml` and `crawler.py` from the paths the report resolves. N
 the **row data** on each issue — for source-value issues the keys are slugified
 column names, values are cell contents.
 
-The report only covers the latest run and the last successful one. For an overview of
-what the crawler produced over time — when counts moved, since when runs have been
-failing, when a schema appeared — walk the archived history:
-
-```bash
-python -m contrib.maintenance.versions <dataset_name> -n 30
-```
-
-`.claude/docs/archive-investigation.md` covers digging into individual past runs from
-there. Only follow it in an interactive session with a human, who likely has the Google
-Cloud credentials it needs — in unattended runs stick to the command above, which works
-over plain HTTPS.
-
 ## Step 2: Inspect the current source data
 
 The source has likely changed. Use `OPENSANCTIONS_ZYTE_API_KEY` (already set in the
@@ -71,6 +58,24 @@ otherwise) and set `ci_test: false` on the dataset.
 ## Step 3: Diagnose
 
 Compare what the source actually contains against what the crawler expects.
+
+### If the question is "since when?"
+
+Only when the diagnosis actually turns on how the dataset changed over time — counts
+drifted outside the `assertions:` bounds, or you need to know since when runs have been
+failing to line it up against a source or crawler change. Don't walk the history as a
+matter of course; the diagnostic report already covers the latest run and the last
+successful one, which is what most failures need.
+
+```bash
+python -m contrib.maintenance.versions <dataset_name> -n 30
+```
+
+One row per archived run, newest first, with entity and target counts; add
+`--schema Person` (repeatable) to see where a count moved. `.claude/docs/archive-investigation.md`
+goes further, into individual past runs and deltas — follow it only in an interactive
+session with a human, who likely has the Google Cloud credentials it needs. The command
+above works over plain HTTPS.
 
 ### Common failures
 

--- a/.claude/skills/debug-crawler/SKILL.md
+++ b/.claude/skills/debug-crawler/SKILL.md
@@ -33,7 +33,9 @@ python -m contrib.maintenance.versions <dataset_name> -n 30
 ```
 
 `.claude/docs/archive-investigation.md` covers digging into individual past runs from
-there.
+there. Only follow it in an interactive session with a human, who likely has the Google
+Cloud credentials it needs — in unattended runs stick to the command above, which works
+over plain HTTPS.
 
 ## Step 2: Inspect the current source data
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Use search (grep/glob/find) to find the most relevant starting document. Once yo
 * Standardising a dataset's metadata: use the `/dataset-metadata` skill
 * General crawler patterns (helpers, lookups, FTM schemata, qsv analysis): `.claude/docs/crawler-guide.md`
 * Filing a dataset issue or marking a source outage — only when a human asks for it in an interactive session, never in an automated run: `.claude/docs/issue-filing.md`
+* Investigating past versions of dataset runs on the https://data.opensanctions.org archive (entity counts over time, when an entity disappeared, failed runs): `.claude/docs/archive-investigation.md`
 
 ## Coding hints
 

--- a/contrib/maintenance/__init__.py
+++ b/contrib/maintenance/__init__.py
@@ -3,6 +3,7 @@
 Modules in this package are invoked from the repository root, e.g.:
 
     python -m contrib.maintenance.diagnose <dataset_name>
+    python -m contrib.maintenance.versions <dataset_name>
     python -m contrib.maintenance.issues_agent
 
 They deliberately avoid importing zavod so they start fast and run with just

--- a/contrib/maintenance/archive.py
+++ b/contrib/maintenance/archive.py
@@ -18,11 +18,17 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
 from itertools import islice
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any, Generator
 
 from . import session
 
+if TYPE_CHECKING:
+    from google.cloud.storage import Bucket  # type: ignore
+
 ARCHIVE_SITE = "https://data.opensanctions.org"
+# The GCS bucket the site serves: same object paths, but readable with
+# credentials rather than publicly. See enable_gcs.
+ARCHIVE_BUCKET = "data.opensanctions.org"
 # The scopes we maintain are published as separate catalogs with disjoint
 # dataset sets: default (sanctions/PEPs) and KYB (corporate registries).
 CATALOG_URLS = [
@@ -90,6 +96,39 @@ class VersionsInfo:
         return list(self.items)
 
 
+_bucket: "Bucket | None" = None
+
+
+def enable_gcs() -> None:
+    """Read JSON artifacts straight from the GCS bucket instead of over HTTPS.
+
+    The public site refuses some objects that do exist — old runs of datasets
+    that have since been removed answer 403, not 404 — which makes deep history
+    unreadable over HTTPS. Reading the bucket needs `google-cloud-storage`
+    (a zavod dependency, so already in the workspace venv) and credentials,
+    which the standalone contexts this package targets don't have; hence opt-in,
+    and hence the lazy import.
+
+    Call before the first fetch: fetch_json memoizes per URL, not per backend.
+    """
+    global _bucket
+    from google.cloud.storage import Client
+
+    _bucket = Client().bucket(ARCHIVE_BUCKET)
+
+
+def _fetch_gcs_json(url: str) -> Any | None:
+    """Read one archive URL's object from the bucket; None when it doesn't exist."""
+    from google.cloud.exceptions import NotFound
+
+    assert _bucket is not None
+    blob = _bucket.blob(url.removeprefix(f"{ARCHIVE_SITE}/"))
+    try:
+        return json.loads(blob.download_as_bytes())
+    except NotFound:
+        return None
+
+
 @lru_cache(maxsize=1024)
 def fetch_json(url: str) -> Any | None:
     """GET and parse a JSON document, memoized per URL for the process lifetime.
@@ -106,6 +145,8 @@ def fetch_json(url: str) -> Any | None:
     unparseable payloads raise, and are not cached, so a retry gets a fresh
     attempt.
     """
+    if _bucket is not None:
+        return _fetch_gcs_json(url)
     response = session.get(url)
     if response.status_code == 404:
         return None

--- a/contrib/maintenance/archive.py
+++ b/contrib/maintenance/archive.py
@@ -4,6 +4,9 @@ Archive semantics this module encodes:
 
 * `artifacts/{name}/versions.json` holds `{"items": [...], "last_successful"}`;
   `items[-1]` is the most recent run, successful or not.
+* The item window is bounded, but every run archives its own `versions.json`
+  snapshot, so older history is reachable by hopping snapshots — see
+  `iter_versions`.
 * Version IDs are `YYYYMMDDHHMMSS-xxx` — parseable run timestamps.
 * Failed runs still archive `index.json`, `issues.json` and `issues.log`, but
   `statistics.json`, `statements.pack`, `resources.json` and `delta.json` are
@@ -119,6 +122,38 @@ def get_versions(dataset_name: str) -> VersionsInfo | None:
         items=list(data.get("items", [])),
         last_successful=data.get("last_successful"),
     )
+
+
+def iter_versions(
+    dataset_name: str, start: str | None = None
+) -> Generator[str, None, None]:
+    """Yield a dataset's version IDs newest first, walking the whole history.
+
+    The root versions.json only lists a bounded window of recent runs. Each run
+    archives a snapshot of that window as it stood at the time, so the walk
+    continues at the snapshot of the oldest version seen so far and stops once
+    a window adds nothing new (genesis reached, or the snapshot is missing).
+
+    `start` resumes the walk at an archived version instead of the newest run,
+    reading that version's own snapshot — so consecutive walks can page through
+    a long history. Yields nothing if the dataset or the start version has no
+    versions.json.
+    """
+    url = f"{ARCHIVE_SITE}/artifacts/{dataset_name}/versions.json"
+    if start is not None:
+        url = artifact_url(dataset_name, start, "versions.json")
+    seen: set[str] = set()
+    while True:
+        data = fetch_json(url)
+        if data is None:
+            return
+        items = list(data.get("items", []))
+        fresh = [item for item in reversed(items) if item not in seen]
+        if not fresh:
+            return
+        yield from fresh
+        seen.update(fresh)
+        url = artifact_url(dataset_name, items[0], "versions.json")
 
 
 def head_artifact(

--- a/contrib/maintenance/versions.py
+++ b/contrib/maintenance/versions.py
@@ -9,14 +9,16 @@ a schema first appeared. Each row links its `index.json`, the entry point for
 digging into a single run.
 
 The archived version history comes in bounded windows, so `--start` resumes the
-walk at a version a previous invocation printed.
+walk at a version a previous invocation printed. Runs the public site answers
+403 for — typically old runs of since-removed datasets — are readable with
+`--use-gcs`, if you have Google Cloud credentials.
 """
 
 import argparse
 import sys
 from typing import Any
 
-from .archive import artifact_url, fetch_artifact, iter_versions
+from .archive import artifact_url, enable_gcs, fetch_artifact, iter_versions
 
 DEFAULT_COUNT = 20
 
@@ -135,7 +137,15 @@ def main() -> None:
         help="add a column with this schema's entity count, read from each run's "
         "statistics.json (repeatable, e.g. --schema Person --schema Company)",
     )
+    parser.add_argument(
+        "--use-gcs",
+        action="store_true",
+        help="read the archive bucket directly instead of the public site; needs "
+        "Google Cloud credentials, but reaches runs the site answers 403 for",
+    )
     args = parser.parse_args()
+    if args.use_gcs:
+        enable_gcs()
     try:
         table = build_table(
             args.name, count=args.count, start=args.start, schemata=args.schema

--- a/contrib/maintenance/versions.py
+++ b/contrib/maintenance/versions.py
@@ -1,0 +1,150 @@
+"""Print a table of a dataset's recent archived runs, newest first.
+
+    python -m contrib.maintenance.versions <dataset_name> [-n 20]
+
+The diagnose report covers the latest run and the last successful one; this is
+the history companion: it walks back over past runs so you can see how the
+dataset behaved over time — when entity counts moved, how often runs fail, when
+a schema first appeared. Each row links its `index.json`, the entry point for
+digging into a single run.
+
+The archived version history comes in bounded windows, so `--start` resumes the
+walk at a version a previous invocation printed.
+"""
+
+import argparse
+import sys
+from typing import Any
+
+from .archive import artifact_url, fetch_artifact, iter_versions
+
+DEFAULT_COUNT = 20
+
+
+def _fmt_export(index: dict[str, Any]) -> str:
+    """The run's export timestamp, minute precision."""
+    stamp = index.get("last_export")
+    if not isinstance(stamp, str):
+        return "?"
+    return stamp.replace("T", " ")[:16]
+
+
+def _fmt_count(value: Any) -> str:
+    return str(value) if isinstance(value, int) else "-"
+
+
+def _schema_counts(name: str, version_id: str) -> dict[str, int]:
+    """Thing counts by schema from a run's statistics.json.
+
+    Empty for failed runs — they never export statistics. Only *thing* schemata
+    are counted there, so intervals like Sanction have no count.
+    """
+    stats = fetch_artifact(name, version_id, "statistics.json")
+    if stats is None:
+        return {}
+    return {item["name"]: item["count"] for item in stats["things"]["schemata"]}
+
+
+def build_table(
+    name: str,
+    count: int = DEFAULT_COUNT,
+    start: str | None = None,
+    schemata: list[str] | None = None,
+) -> str:
+    """Render the run history of one dataset as a markdown table."""
+    schemata = schemata or []
+    versions: list[str] = []
+    for version_id in iter_versions(name, start=start):
+        versions.append(version_id)
+        if len(versions) >= count:
+            break
+    if not versions:
+        where = f" at or before {start}" if start is not None else ""
+        raise RuntimeError(f"No archived runs found for {name}{where}.")
+
+    columns = ["version", "exported_at", "result", "entities", "targets"]
+    columns += schemata + ["index.json"]
+    lines = [
+        f"# {len(versions)} archived runs of {name}, newest first",
+        "",
+        "| " + " | ".join(columns) + " |",
+        "|" + "---|" * len(columns),
+    ]
+    for version_id in versions:
+        try:
+            index = fetch_artifact(name, version_id, "index.json")
+        except Exception as exc:
+            index = None
+            note = f"unreadable: {exc}"
+        else:
+            note = "absent"
+        if index is None:
+            # A version listed in a window whose index is gone or unreadable —
+            # old runs of removed datasets do that. The row still records that
+            # the run happened.
+            cells = [version_id] + ["-"] * (len(columns) - 2) + [note]
+            lines.append("| " + " | ".join(cells) + " |")
+            continue
+        cells = [
+            version_id,
+            _fmt_export(index),
+            str(index.get("result", "?")),
+            _fmt_count(index.get("entity_count")),
+            _fmt_count(index.get("target_count")),
+        ]
+        if schemata:
+            try:
+                counts = _schema_counts(name, version_id)
+            except Exception:
+                # One unreadable statistics.json blanks its schema cells rather
+                # than aborting the whole table.
+                counts = {}
+            cells += [_fmt_count(counts.get(schema)) for schema in schemata]
+        cells.append(artifact_url(name, version_id, "index.json"))
+        lines.append("| " + " | ".join(cells) + " |")
+
+    lines.append("")
+    lines.append(
+        f"To walk further back: `--start {versions[-1]}` (or an older version "
+        "ID, if you know one)."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Print a table of a dataset's recent archived runs."
+    )
+    parser.add_argument("name", help="dataset name, e.g. us_ofac_sdn")
+    parser.add_argument(
+        "-n",
+        "--count",
+        type=int,
+        default=DEFAULT_COUNT,
+        help=f"how many runs to walk back over (default {DEFAULT_COUNT})",
+    )
+    parser.add_argument(
+        "--start",
+        metavar="VERSION",
+        help="begin the walk at this archived version instead of the newest run",
+    )
+    parser.add_argument(
+        "--schema",
+        action="append",
+        metavar="SCHEMA",
+        help="add a column with this schema's entity count, read from each run's "
+        "statistics.json (repeatable, e.g. --schema Person --schema Company)",
+    )
+    args = parser.parse_args()
+    try:
+        table = build_table(
+            args.name, count=args.count, start=args.start, schemata=args.schema
+        )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+    print(table, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -1,19 +1,58 @@
 """
 The archive is the place where we store the outputs of zavod runs
-beyond beyond their local scratch space.
-
-`/artifacts/{dataset}/{version}/` is the canonical, immutable location for all
-outputs of a given run, and is what we point to in the metadata.
-
-`/datasets/{date_stamp}/{dataset}/` is where the metadata and listed resources
-can be found for the latest successful run on a given day.
-
-`/datasets/latest/{dataset}/` is where the the metadata and listed resources can
-be found for the latest successful run.
+beyond their local scratch space.
 
 See archive backends for operating on the archive - in OpenSanctions production
-this is the Google Cloud Storage bucket data.opensanctions.org.
-A local filesystem path can be used in development and testing.
+this is the Google Cloud Storage bucket served at
+https://data.opensanctions.org. A local filesystem path can be used in
+development and testing.
+
+Layout
+------
+
+`/artifacts/{dataset}/{version}/` is the canonical, immutable location for all
+outputs of a given run, and is what we point to in the metadata. It holds both
+the listed resources (e.g. `entities.ftm.json`) and run artifacts such as
+`index.json`, `statistics.json`, `issues.json`, `statements.pack`,
+`entities.delta.json`, `delta.json` and a `versions.json` snapshot.
+
+`/artifacts/{dataset}/versions.json` is the root version file: a window of the
+most recent version IDs of the dataset (oldest first, up to
+`VersionHistory.LENGTH`) plus the ID of the last successful run, e.g.
+`{"items": ["20260629141001-mek", ...], "last_successful": "20260707123218-hai"}`.
+It is updated on every run, including failed ones.
+
+`/datasets/{date_stamp}/{dataset}/` is where the metadata and listed resources
+can be found for the latest successful run on a given day (server-side copies
+of the `/artifacts/` objects).
+
+`/datasets/latest/{dataset}/` is the same for the latest successful run
+overall. `/datasets/latest/{dataset}/index.json` is the stable URL for the
+latest metadata of a dataset.
+
+Walking versions
+----------------
+
+Version IDs (see `followthemoney.dataset.versions.Version`) are opaque
+strings, but they sort chronologically. The root
+version file only holds a bounded window, but every run's artifact directory
+contains a `versions.json` snapshot whose window ends at that version. To walk
+the full history: read the root version file, iterate its items newest-first,
+then fetch `/artifacts/{dataset}/{oldest_item}/versions.json` and repeat until
+the window no longer extends further back. This is implemented in
+`iter_dataset_versions()`.
+
+Success and failure
+-------------------
+
+Each run's `index.json` has a `result` field, either "success" or "failure".
+Failed runs are archived to `/artifacts/` too (with issues, but without data
+resources), but never published to `/datasets/` - so `/datasets/latest/` always
+reflects the last successful run. `last_successful` in the root `versions.json`
+keeps pointing at the newest version whose run succeeded.
+
+Terminology
+-----------
 
 When storing in /artifacts we use the verb "archive".
 When storing in /datasets we use the verb "publish".

--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -40,7 +40,13 @@ contains a `versions.json` snapshot whose window ends at that version. To walk
 the full history: read the root version file, iterate its items newest-first,
 then fetch `/artifacts/{dataset}/{oldest_item}/versions.json` and repeat until
 the window no longer extends further back. This is implemented in
-`iter_dataset_versions()`.
+`iter_dataset_versions()`, which needs a configured archive backend.
+
+To inspect the run history of a production dataset without one, use the
+maintenance tool, which walks the same snapshots over plain HTTPS and
+tabulates each run's `index.json`:
+
+    python -m contrib.maintenance.versions <dataset_name>
 
 Success and failure
 -------------------


### PR DESCRIPTION
This is a take on https://github.com/opensanctions/operations/issues/2674 — when something unclear has gone wrong with a dataset, Claude should be able to go dig through past runs on the archive without having the file layout explained to it (or reading half of zavod) every time.

Two pieces:

- The `zavod.archive` module docstring is now a proper layout reference: `/artifacts/` vs `/datasets/`, the root `versions.json` (window of version IDs + `last_successful`), how to walk versions past the window, and the `result` field / failure semantics. Living in the module means it's in context whenever the archive code gets edited.
- A new `.claude/docs/archive-investigation.md` with the investigation procedure: gsutil first (it can list directories, HTTPS can't), a standalone version-walking snippet using `followthemoney.dataset.VersionHistory` (verified against the live archive — `zavod.archive.iter_dataset_versions` needs a configured backend, so it's no good for read-only poking), the index.json → statistics.json → deltas escalation, and a "stream large files instead of dumping them into context" example. Referenced from the root CLAUDE.md next to the crawler guide.

The investigation doc points at the docstring for the layout instead of duplicating it, and version IDs are treated as opaque throughout — the only documented property is that they sort chronologically.

The issue asks "Is this a claude skill, or better docs, or both?" — I went back and forth on that, and actually built two of the options before landing here:

a) a nested `zavod/archive/CLAUDE.md` — rejected because nested CLAUDE.md files auto-load when *editing* files in that directory, which is exactly backwards: you're rarely hacking on the archive module while investigating a dataset, and when you *are* investigating, nothing pulls it into context.
b) a reference doc in `.claude/docs/` like the crawler guide — what I went with.
c) human-readable docs in `zavod/docs` (I had a version that rendered the module docstring via mkdocstrings) — rejected because the audience is wrong: gsutil invocations and "don't dump large files into your context" tips are agent-directed, not something for the human zavod docs. The layout reference itself stays human-readable in the docstring anyway.
d) a skill (`/investigate-dataset-archive`, which this branch briefly was) — rejected because a skill is centered around one defined task, and investigating a dataset issue takes many forms; a reference doc that gets pulled in whenever the archive comes up fits better than a single scripted procedure.

Let me know if you disagree!

🤖 Generated with [Claude Code](https://claude.com/claude-code)