### PR TITLE
Count issues for collections in index.json

### DIFF
--- a/zavod/zavod/exporters/metadata.py
+++ b/zavod/zavod/exporters/metadata.py
@@ -95,10 +95,9 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
     for res_data in meta["resources"]:
         res_data["url"] = make_artifact_url(dataset.name, version.id, res_data["path"])
 
-    if not dataset.is_collection:
-        issues = DatasetIssues(dataset)
-        meta["issue_levels"] = issues.by_level()
-        meta["issue_count"] = sum(meta["issue_levels"].values())
+    issues = DatasetIssues(dataset)
+    meta["issue_levels"] = issues.by_level()
+    meta["issue_count"] = sum(meta["issue_levels"].values())
     meta["last_export"] = settings.RUN_TIME_ISO
     meta["result"] = result.value
     # NOTE: when adding a another URL here, make sure to update Delivery Service,

--- a/zavod/zavod/tests/exporters/test_metadata.py
+++ b/zavod/zavod/tests/exporters/test_metadata.py
@@ -1,11 +1,14 @@
 import json
+import logging
 
 from nomenklatura import Resolver
 
 from zavod import settings
+from zavod.context import Context
 from zavod.crawl import crawl_dataset
 from zavod.entity import Entity
 from zavod.exporters import export_dataset
+from zavod.exporters.metadata import DatasetVersionResult, write_dataset_index
 from zavod.meta import Dataset
 from zavod.store import get_store
 
@@ -55,3 +58,23 @@ def test_metadata_collection_export(
         assert ds["updated_at"] == settings.RUN_TIME_ISO
         if ds["name"] in (collection.name, testdataset1.name):
             assert len(ds["resources"]) > 2
+
+
+def test_metadata_collection_issue_count(
+    collection: Dataset, logger: logging.Logger
+) -> None:
+    """Issues logged against a collection (e.g. assemble errors surfaced when its
+    store is built during export) are counted in the collection's index.json."""
+    context = Context(collection)
+    context.begin(clear=True)
+    context.log.error("This is an assemble error")
+    context.log.warning("This is a warning")
+    context.close()
+
+    write_dataset_index(collection, DatasetVersionResult.SUCCESS)
+
+    index_path = settings.DATA_PATH / "datasets" / collection.name / "index.json"
+    with open(index_path, "r") as fh:
+        index = json.load(fh)
+    assert index["issue_count"] == 2, index
+    assert index["issue_levels"] == {"error": 1, "warning": 1}, index


### PR DESCRIPTION
Collections never surfaced export-stage issues on the site's issues page.

When a collection's store is built, nomenklatura assemble errors (and
similar) get logged against the collection during export and land in its
`issues.json` — which is written and published just like for crawled
datasets. But `write_dataset_index` gated `issue_count`/`issue_levels` on
`not dataset.is_collection`, leaving the count at 0. The site's issues page
filters on `issue_count > 0`, so these issues were invisible.

The gate is from https://github.com/opensanctions/opensanctions/commit/4403cb37d ("do not export issues for
collections"), back when `DatasetIssues.all()` backfilled from the archive
and would pull stale issues into collections (which don't `clear()` their
log during a crawl stage). `all()` now reads with `backfill=False`, so the
original hazard is gone and counting collection issues is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)