### PR TITLE
[us_finra_actions] Bust Varnish cache per crawl to avoid stale listings

### DIFF
--- a/datasets/us/finra_actions/crawler.py
+++ b/datasets/us/finra_actions/crawler.py
@@ -4,15 +4,22 @@
 FINRA listing pages are newest-first and served through inconsistent caches.
 Intermediate pages can temporarily render the "No results found" empty state
 even though reruns later return rows; pagination can also drift if the listing
-changes while a crawl is in progress.
+changes while a crawl is in progress. Stale Varnish entries can also return an
+older slice of the (shifting) list, so records skip or duplicate across pages.
 
-The Zyte fetch validator requires a populated table and rejects the empty-state
-marker so these pages are retried and, if persistent, abort the crawl instead
-of emitting a partial run. The crawler also aborts if the advertised last page
-changes after pagination has been established.
+Mitigations:
+
+- Every request carries a per-run `cache_bust` query parameter so Varnish
+  treats each page URL as unique and fetches fresh from origin.
+- The Zyte fetch validator requires a populated table and rejects the
+  empty-state marker so those pages are retried and, if persistent, abort the
+  crawl instead of emitting a partial run.
+- The crawler aborts if the advertised last page changes after pagination has
+  been established.
 """
 
 from lxml.etree import _Element
+from secrets import token_urlsafe
 from typing import Dict, Optional
 from urllib.parse import parse_qs, urljoin, urlparse
 
@@ -93,9 +100,12 @@ def crawl(context: Context) -> None:
     # when later pages still have data.
     page_num = 0
     max_page = None
+    # A single token for the whole crawl bypasses Varnish's stale per-page
+    # entries without varying between our own pages within one run.
+    cache_bust = token_urlsafe(8)
     while max_page is None or page_num <= max_page:
         context.log.info(f"Crawling page {page_num} of {max_page}")
-        url = context.data_url + "?page=" + str(page_num)
+        url = f"{context.data_url}?page={page_num}&cache_bust={cache_bust}"
         # Zyte because occasional cloudflare javascript challenge.
         response = zyte_api.fetch_html(
             context, url, RESULT_ROW_VALIDATOR, absolute_links=True


### PR DESCRIPTION
## Summary

Adds a per-run `cache_bust` query parameter to every FINRA listing page fetch so Varnish keys each request as fresh and returns the current origin state.

## Why

PR #4784 covered persistently-empty pages (retry) and page-count drift (abort) but did not stop the third failure mode called out in #4632: FINRA's Varnish serves stale copies of listing pages, so sequential paging skips or duplicates records when the list has shifted since Varnish last cached that URL. Post-fix runs still show ~500 ADD / ~500 DEL / ~150 MOD per weekly run (see [comment on #4632](https://github.com/opensanctions/opensanctions/issues/4632#issuecomment-4924049158)).

## Verification that this bypasses Varnish

Probed FINRA's response headers directly:

- Without `cache_bust`: `x-cache: HIT`, `age: 428s` — stale cached copy.
- With `cache_bust=<random>`: `x-cache: MISS`, `age: 0` — fresh origin fetch.

A back-to-back Zyte fetch of `page=10` with and without the parameter showed 15 rows in both cases and the same `last_page=1293`, but a different top row and different row ordering — the exact skip/shift signature the issue describes. The `cache_bust` value is preserved into FINRA's pagination links (`?cache_bust=…&page=1293`), so `get_max_page` still parses correctly.

Parameter name is intentionally readable so it's obvious in FINRA's access logs what we're doing and why.

## Follow-up

If the next few weekly runs still show ~500-record churn, the remaining checklist item is a stable sort (case ID / official date asc), which needs FINRA-side support.

Refs #4632

🤖 Generated with [Claude Code](https://claude.com/claude-code)
