### PR TITLE
[docs] Note assert_all_accepted in names migration step 3

### DIFF
--- a/zavod/docs/extract/names.md
+++ b/zavod/docs/extract/names.md
@@ -182,7 +182,7 @@ entity.id = context.make_id(names_string, ...)
 h.apply_reviewed_name_string(context, entity, string=names_string)
 ```
 
-All sanctions crawlers should end with a call to `assert_all_accepted(context, raise_on_unaccepted=False)` (imported from `zavod.stateful.review`). This logs a warning with the count of any name reviews that are still unaccepted for the current dataset and version, rather than raising, so the crawler completes and emits output while flagging that reviews remain outstanding.
+All crawlers calling `h.review_names` or `h.apply_reviewed_names` should end with a call to `assert_all_accepted(context, raise_on_unaccepted=False)` (imported from `zavod.stateful.review`). This logs a warning with the count of any name reviews that are still unaccepted for the current dataset and version, rather than raising, so the crawler completes and emits output while flagging that reviews remain outstanding.
 
 After the deployment of step 3 has run, check the latest reviews and make sure new names were't auto-accepted between deploying step 1 and step 3.
 

--- a/zavod/docs/extract/names.md
+++ b/zavod/docs/extract/names.md
@@ -182,6 +182,8 @@ entity.id = context.make_id(names_string, ...)
 h.apply_reviewed_name_string(context, entity, string=names_string)
 ```
 
+All sanctions crawlers should end with a call to `assert_all_accepted(context, raise_on_unaccepted=False)` (imported from `zavod.stateful.review`). This logs a warning with the count of any name reviews that are still unaccepted for the current dataset and version, rather than raising, so the crawler completes and emits output while flagging that reviews remain outstanding.
+
 After the deployment of step 3 has run, check the latest reviews and make sure new names were't auto-accepted between deploying step 1 and step 3.
 
 **Non-sanctions crawler**:


### PR DESCRIPTION
Adds a paragraph to Step 3 of the name framework migration documentation (`zavod/docs/extract/names.md`) noting that all sanctions crawlers should end with `assert_all_accepted(context, raise_on_unaccepted=False)`.

The paragraph explains that this call logs a warning with the count of any name reviews still unaccepted for the current dataset and version (rather than raising), so the crawler completes and emits output while flagging that reviews remain outstanding.

Note: the requested `assert_all_accepted(raise=False)` maps to the actual parameter name `raise_on_unaccepted=False`, and the helper is imported from `zavod.stateful.review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)