### PR TITLE
[jp_mof_sanctions] Don't auto-accept irregular names in step 1

### DIFF
--- a/datasets/jp/mof_sanctions/crawler.py
+++ b/datasets/jp/mof_sanctions/crawler.py
@@ -205,9 +205,12 @@ def emit_row(
         original=original,
         suggested=suggested,
         is_irregular=is_irregular,
-        # weak_alias and nickname fields often contain notes/descriptions rather
-        # than actual names, so require human review when they are present.
-        default_accepted=not (raw_weak_alias or raw_nickname),
+        # Only auto-accept clean names. Names still flagged as irregular (e.g. ones that
+        # contain brackets, colons or an _x000D_ carriage-return artifact) are held back
+        # for human review instead of being locked in as accepted. The weak_alias and
+        # nickname fields often hold notes/descriptions rather than names, so they are
+        # held back too.
+        default_accepted=not is_irregular and not (raw_weak_alias or raw_nickname),
     )
     entity.add_cast("Person", "position", row.pop("position", []), lang="eng")
 

--- a/datasets/jp/mof_sanctions/jp_mof_sanctions.yml
+++ b/datasets/jp/mof_sanctions/jp_mof_sanctions.yml
@@ -83,6 +83,22 @@ assertions:
       Organization: 300
       CryptoWallet: 70
 
+names:
+  schema_rules:
+    # Names still containing these are not clean enough to auto-accept in step 1;
+    # flag them as irregular so they are held back for human review.
+    LegalEntity:
+      # "/" is already rejected by the baseline.
+      reject_chars: "()（）:：;；"
+      reject_strings:
+        - "_x000D_"
+    Person:
+      # The half-width brackets, colon and semicolon are already rejected by the
+      # Person baseline; add the full-width variants common in the Japanese source.
+      reject_chars: "（）：；"
+      reject_strings:
+        - "_x000D_"
+
 lookups:
   schema:
     options:


### PR DESCRIPTION
## Problem

In the step-1 name migration, `default_accepted` was decided independently of regularity, so a suggested name that `check_names_regularity` flagged as irregular (e.g. still containing `(`, `:`, `;` or an Excel `_x000D_` carriage-return artifact) was auto-accepted anyway — locking a dirty name in as reviewed without a human ever seeing it.

## Change

- **crawler.py**: gate auto-accept on regularity — `default_accepted=not is_irregular and not (raw_weak_alias or raw_nickname)`. Output is still unchanged in step 1 (it's driven by the crawler's own `entity.add(...)` calls); only the review's accepted state changes. Irregular names now get a review created but left **unaccepted** for a reviewer.
- **jp_mof_sanctions.yml**: add `names.schema_rules` so the regularity check actually catches these — reject brackets, colons and semicolons (half- and full-width) for `LegalEntity`/`Organization`, add the full-width variants for `Person` (half-width already in its baseline), and flag `_x000D_` as a reject string on both.

## Notes

- This is **forward-looking only**: re-running the crawler will not un-accept reviews that were already auto-accepted (an accepted review stays accepted unless the extraction/source changes or the crawler version bumps). Retroactively un-accepting the existing dirty reviews needs a separate maintenance step (planned: scope by the regularity check).
- `_x000D_` is a mangled carriage return, so it may also be present in the original string; flagging routes it to review, but stripping it at cell-read time could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)