### PR TITLE
[eu_journal_sanctions] Clarify scope and FSF hand-off in metadata

### DIFF
--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -29,19 +29,26 @@ tags:
   - sector.maritime
 url: https://docs.google.com/spreadsheets/d/1rauQMdCYTjTwmSzqfUvur1SfkCGYwfRn6_e5_oX39EY/edit?gid=0#gid=0
 summary: >-
-  Supplemental list of people, companies, and organizations sanctioned
-  for involvement in Russia's invasion of Ukraine.
+  Entities designated under EU sanctions programs in the Official Journal
+  but not yet included in the EU's consolidated sanctions list.
 description: |
   The European Union publishes a [consolidated sanctions list](/datasets/eu_fsf/)
   as a primary data source for sanctioned entities. However, sanctions are first
   published in the Official Journal of the EU (OJEU) and take immediate effect
-  when published.
+  when published. The transposition of new designations into the consolidated
+  file has often involved a significant delay (over 20 days in one case), meaning
+  that relying on the consolidated list alone would create significant legal risk.
 
-  The transposition of those new sanctions into the consolidated file has often
-  involved a significant delay (over 20 days in one case). That means that relying
-  on the the consolidated list along would lead to significant legal risk. This
-  dataset exists as a bridging mechanism to provide immediate access to the
-  latest sanctions data, based on manual analysis of the Official Journal.
+  This dataset exists as a bridging mechanism: when new designations are published
+  in the Official Journal under any EU sanctions program, we transcribe them here
+  based on manual analysis of the published legal acts. Once a designation has been incorporated
+  into the consolidated list, it is retired from this dataset so that the official
+  data becomes the authoritative source for it, including any eventual de-listing.
+
+  This dataset is therefore intentionally not a standalone view of EU sanctions:
+  comprehensive coverage is the combination of this dataset with the
+  [consolidated list](/datasets/eu_fsf/). The [EU Sanctions collection](/datasets/eu_sanctions/)
+  includes both, alongside the national sanctions lists of EU member states.
 data:
   url: https://docs.google.com/spreadsheets/d/e/2PACX-1vQZckYoLdt6O3awOs8piaaWCtFlaKtCNpBWcb36bqakVid31-a-JqmHBri0vch2ggB9R-7yq3jiCarN/pub?gid=0&single=true&output=csv
   format: CSV


### PR DESCRIPTION
The dataset summary still described `eu_journal_sanctions` as a Russia-specific supplemental list — a leftover from its origin in late 2023. The dataset has long since covered new designations under all EU sanctions programs (Hamas, Iran, Belarus, etc.), and a customer just asked whether the summary was an error.

This updates the summary and expands the description to explain the actual mechanism:

- new OJEU designations under any EU program are transcribed here as a bridge,
- entries are retired once they are transposed into the consolidated FSF, so the official source governs (including eventual de-listings),
- comprehensive EU coverage is therefore the combination of this dataset with `eu_fsf`, or the `eu_sanctions` collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)