### PR TITLE
Ship issues-agent prompts as a workflow artifact

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -36,8 +36,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          MATRIX=$(python -m contrib.maintenance.issues_agent)
+          MATRIX=$(python -m contrib.maintenance.issues_agent --prompts-dir task-prompts)
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+      # The prompts travel as an artifact, not inside the matrix output: they
+      # embed diagnostic reports full of arbitrary source data, and GitHub
+      # silently drops a job output when it spots anything resembling a secret
+      # in it ("Skip output 'matrix' since it may contain secret"), which
+      # breaks the fromJson() strategy expression downstream.
+      - name: Upload task prompts
+        uses: actions/upload-artifact@v7
+        with:
+          name: task-prompts
+          path: task-prompts/
 
   run-tasks:
     needs: generate-matrix
@@ -59,6 +70,20 @@ jobs:
       max-parallel: 4
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download task prompts
+        uses: actions/download-artifact@v8
+        with:
+          name: task-prompts
+          path: task-prompts
+
+      - name: Load task prompt
+        run: |
+          {
+            echo 'TASK_PROMPT<<TASK_PROMPT_EOF'
+            cat "task-prompts/${{ matrix.task.dataset }}.md"
+            echo 'TASK_PROMPT_EOF'
+          } >> "$GITHUB_ENV"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -113,7 +138,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: ${{ matrix.task.prompt }}
+          prompt: ${{ env.TASK_PROMPT }}
           claude_args: "--model ${{ matrix.task.model }} --max-turns ${{ matrix.task.max_turns }} --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,Skill,mcp__github__create_pull_request\""
           show_full_output: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ apicache-py3
 
 # Emacs
 *~
+task-prompts/

--- a/contrib/maintenance/issues_agent.py
+++ b/contrib/maintenance/issues_agent.py
@@ -4,11 +4,19 @@ Invoked by .github/workflows/issues-agent.yml as:
 
     python -m contrib.maintenance.issues_agent
 
-Emits the matrix JSON on stdout; everything human-readable goes to stderr.
+Emits the matrix JSON on stdout and writes each task's prompt to
+<prompts-dir>/<dataset>.md; everything human-readable goes to stderr. The
+prompts travel to the run-tasks job as a workflow artifact rather than inside
+the matrix: they embed diagnostic reports full of arbitrary source data, and
+GitHub silently drops a job output when it spots anything resembling a secret
+in it ("Skip output 'matrix' since it may contain secret"), which breaks the
+fromJson() strategy expression downstream.
+
 This module holds only agent policy — model/turn selection, branch naming and
 PR dedup. The shared mechanics live in the sibling modules of this package.
 """
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -55,7 +63,7 @@ def log(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def index_jobs() -> None:
+def index_jobs(prompts_dir: Path) -> None:
     outage_datasets = get_outage_datasets()
     open_autofix_branches = get_open_autofix_branches()
     tasks: list[Any] = []
@@ -149,9 +157,10 @@ def index_jobs() -> None:
             if n > 0
         ]
         title = f"[{name}]: {', '.join(counts)}"
+        (prompts_dir / f"{name}.md").write_text(prompt)
         tasks.append(
             {
-                "prompt": prompt,
+                "dataset": name,
                 "name": title,
                 "branch": branch,
                 "model": model,
@@ -164,4 +173,15 @@ def index_jobs() -> None:
 
 
 if __name__ == "__main__":
-    index_jobs()
+    parser = argparse.ArgumentParser(
+        description="Generate the issues-agent task matrix and prompt files."
+    )
+    parser.add_argument(
+        "--prompts-dir",
+        type=Path,
+        default=Path("task-prompts"),
+        help="directory to write one <dataset>.md prompt file per task into",
+    )
+    args = parser.parse_args()
+    args.prompts_dir.mkdir(parents=True, exist_ok=True)
+    index_jobs(args.prompts_dir)


### PR DESCRIPTION
## What

Fixes the issues-agent workflow failure after #4840: `Error when evaluating 'strategy' ... Error from function 'fromJson': empty input`, caused by the annotation above it — **"Skip output 'matrix' since it may contain secret."** GitHub scans job outputs for anything resembling a registered secret and silently drops the whole output on a match. The matrix had grown to ~360kB of agent prompts embedding diagnostic reports full of arbitrary source data (issue payloads, URLs, response snippets), so a match was a matter of time; scrubbing content would be whack-a-mole.

Structural fix:

- `issues_agent` writes each prompt to `task-prompts/<dataset>.md` (new `--prompts-dir` option) and emits a metadata-only matrix (`dataset`, `name`, `branch`, `model`, `max_turns`, `needs_zavod`) — ~5kB instead of ~360kB.
- `generate-matrix` uploads the prompt directory as an artifact; each `run-tasks` job downloads it and loads its dataset's prompt into `$GITHUB_ENV` for `claude-code-action`.
- `task-prompts/` gitignored for local runs.

## Verification

- Live run: 25 tasks, matrix JSON 4.6kB, 25 prompt files written; matrix entries carry no prompt text.
- `mypy --strict`, ruff, yamllint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)