### PR TITLE
[sg_gov_dir] Lower assertions - they've removed less senior positions

### DIFF
--- a/datasets/sg/gov_dir/sg_gov_dir.yml
+++ b/datasets/sg/gov_dir/sg_gov_dir.yml
@@ -39,10 +39,10 @@ data:
 assertions:
   min:
     schema_entities:
-      Person: 15_000
+      Person: 7_000
   max:
     schema_entities:
-      Person: 40_000
+      Person: 10_000
 
 lookups:
   type.email:


### PR DESCRIPTION
Notice on the website:
From 1 July 2026, SGDI will only list contact details of senior personnel to reduce the risk of Government Official Impersonation Scams (GOIS).