### PR TITLE
Fix issues-agent prompt heredoc delimiter

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -82,6 +82,9 @@ jobs:
           {
             echo 'TASK_PROMPT<<TASK_PROMPT_EOF'
             cat "task-prompts/${{ matrix.task.dataset }}.md"
+            # The prompt file has no trailing newline (Jinja strips it), so
+            # force one — the closing delimiter must sit on its own line.
+            echo ''
             echo 'TASK_PROMPT_EOF'
           } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
All 25 tasks of [run 29085126785](https://github.com/opensanctions/opensanctions/actions/runs/29085126785) failed at "Load task prompt" with `Invalid value. Matching delimiter not found 'TASK_PROMPT_EOF'`. Jinja strips the template's trailing newline (`keep_trailing_newline=False` default), so the prompt files written by `issues_agent` don't end with `\n` — `cat` left the closing heredoc delimiter concatenated onto the prompt's last line, and the `$GITHUB_ENV` file-command parser never found it.

Fix: emit a newline before the delimiter in the "Load task prompt" step, so it always sits on its own line regardless of file content. Verified by reproducing the heredoc locally with a newline-less file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)