### PR TITLE
[ke_judiciary] Implement PR #4792 review feedback

### DIFF
--- a/datasets/ke/judiciary/crawler.py
+++ b/datasets/ke/judiciary/crawler.py
@@ -5,45 +5,42 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# Each superior court has its own listing page and its own position. The
-# category slug appears in the CSS classes of each judge card and is used as
-# a guard against cross-category widgets; min_count guards against silent
-# page-structure changes per court.
+# Judge cards live in the single team-member grid on each court's listing page.
+# Scoping card selection to that grid keeps stray team-member widgets elsewhere
+# on the page out, without hardcoding a per-court category slug.
+CARDS_XPATH = (
+    "//div[contains(@class, 'wpb-our-team-members')]"
+    "//div[contains(@class, 'wpb-team-default-item')]"
+)
+
+# One listing page (relative to the dataset URL) and one court-level position
+# per superior court.
 COURTS = [
     {
-        "url": "https://judiciary.go.ke/supreme-court-judges/",
-        "category": "supreme-court-judges",
+        "path": "supreme-court-judges/",
         "position": "Justice of the Supreme Court of Kenya",
-        "min_count": 5,
     },
     {
-        "url": "https://judiciary.go.ke/court-of-appeal-judges/",
-        "category": "court-of-appeal-judges",
+        "path": "court-of-appeal-judges/",
         "position": "Judge of the Court of Appeal of Kenya",
-        "min_count": 25,
     },
     {
-        "url": "https://judiciary.go.ke/high-court-judges/",
-        "category": "high-court-judges",
+        "path": "high-court-judges/",
         "position": "Judge of the High Court of Kenya",
-        "min_count": 70,
     },
     {
-        "url": "https://judiciary.go.ke/employment-and-labour-relations-court-judges/",
-        "category": "employment-and-labour-relations-court-judges",
+        "path": "employment-and-labour-relations-court-judges/",
         "position": "Judge of the Employment and Labour Relations Court of Kenya",
-        "min_count": 10,
     },
     {
-        "url": "https://judiciary.go.ke/environment-and-land-court-judges/",
-        "category": "environment-and-land-court-judges",
+        "path": "environment-and-land-court-judges/",
         "position": "Judge of the Environment and Land Court of Kenya",
-        "min_count": 35,
     },
 ]
 
-# Card designations marking a judicial leadership office. Holders receive an
-# additional Position/Occupancy on top of their court-level one.
+# Card position titles marking a judicial leadership office. Holders receive an
+# additional Position/Occupancy on top of their court-level one. Keys are the
+# lower-cased, whitespace-normalised title as it appears on the card.
 LEADERSHIP_POSITIONS = {
     "chief justice and president of the supreme court of kenya": (
         "Chief Justice of Kenya"
@@ -60,63 +57,35 @@ LEADERSHIP_POSITIONS = {
     ),
 }
 
-# Designations that carry no extra office. "President-Elect, Court of Appeal"
-# is deliberately here: the source marks the holder as elect, so they are
-# modelled as a serving Court of Appeal judge only, not as court president.
-PLAIN_DESIGNATIONS = {
-    "judge of the supreme court of kenya",
-    "judge, court of appeal",
-    "president-elect, court of appeal",
-    "judge, high court",
-    "judge of the elrc",
-    "judge, environment and land court",
-}
 
-# Kenyan honours and other post-nominals that follow a comma in the listed
-# name (e.g. "Hon. Justice Martha Koome, EGH"). Only known post-nominals are
-# stripped so that a data change upstream surfaces as a warning rather than
-# silently truncating a name.
-POST_NOMINALS = {
-    "EGH",
-    "MGH",
-    "CBS",
-    "EBS",
-    "OGW",
-    "HSC",
-    "SC",
-    "FCIArb",
-    "FCPS(K)",
-    "MBS",
-    "PhD",
-    "OLY",
-}
-POST_NOMINALS_NORMALIZED = {p.replace(".", "").casefold() for p in POST_NOMINALS}
+def make_pep_position(
+    context: Context, name: str
+) -> tuple[Entity, PositionCategorisation]:
+    position = h.make_position(
+        context,
+        name=name,
+        country="ke",
+        topics=["gov.national", "gov.judicial"],
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+    return position, categorisation
 
 
-def normalize_titles(raw: str) -> str:
-    """Fix formatting artifacts seen on the site.
+def parse_cards(doc: HtmlElement) -> list[tuple[str, str, str]]:
+    """Return (profile_url, name, position_title) per judge card.
 
-    - glued honorifics: "Hon.Lady Justice ..." -> "Hon. Lady Justice ..."
-    - hyphen broken by a line wrap: "Onga- rora" -> "Onga-rora" (the site's
-      own profile slugs write the unbroken form)
-    - spaced en-dash in double-barrelled surnames: "Lagat – Korir" ->
-      "Lagat-Korir"
+    Judges are rendered as WordPress team-member cards. Each card has one name
+    anchor in `h5.wpb-otm-name` and one `span.designation` role label.
     """
-    name = " ".join(raw.replace("Hon.", "Hon. ").split())
-    name = name.replace(" – ", "-").replace("–", "-")
-    if "- " in name:
-        name = name.replace("- ", "-")
-    return name
-
-
-def clean_post_nominals(context: Context, raw: str) -> str:
-    parts = [part.strip() for part in raw.split(",")]
-    name = parts[0]
-    for extra in parts[1:]:
-        if extra.replace(".", "").casefold() not in POST_NOMINALS_NORMALIZED:
-            context.log.warning("Unknown post-nominal, keeping in name", name=raw)
-            return raw
-    return name
+    results: list[tuple[str, str, str]] = []
+    for card in h.xpath_elements(doc, CARDS_XPATH):
+        url = h.xpath_string(card, ".//h5[@class='wpb-otm-name']/a/@href")
+        name = h.xpath_string(card, ".//h5[@class='wpb-otm-name']/a/text()")
+        position_title = h.xpath_string(card, ".//span[@class='designation']/text()")
+        results.append((url, name, position_title))
+    return results
 
 
 def crawl_judge(
@@ -125,15 +94,14 @@ def crawl_judge(
     raw_name: str,
     positions: list[tuple[Entity, PositionCategorisation]],
 ) -> None:
-    slug = profile_url.rstrip("/").split("/")[-1]
-
     person = context.make("Person")
-    person.id = context.make_id(slug)
-    raw_name = normalize_titles(raw_name)
-    no_honours = clean_post_nominals(context, raw_name)
-    clean_name = h.strip_name_titles(context, no_honours)
-    original_name = raw_name if clean_name != raw_name else None
-    person.add("name", clean_name, lang="eng", original_value=original_name)
+    person.id = context.make_id(profile_url.rstrip("/").split("/")[-1])
+    # Name cleaning (titles, honorifics, post-nominals) is handed to the review
+    # system with LLM cleaning, as this is a non-sanctions dataset. Names are
+    # flagged as needing cleaning by the `names` rules in the dataset YAML.
+    h.apply_reviewed_name_string(
+        context, person, string=raw_name, llm_cleaning=True, lang="eng"
+    )
     person.add("sourceUrl", profile_url)
     # Judges are State officers (Constitution of Kenya, art. 260); State
     # officers must be Kenyan citizens and may not hold dual citizenship
@@ -141,101 +109,32 @@ def crawl_judge(
     # https://www.constituteproject.org/constitution/Kenya_2010
     person.add("citizenship", "ke")
 
-    emitted = False
     for position, categorisation in positions:
         occupancy = h.make_occupancy(
             context, person, position, categorisation=categorisation
         )
-        if occupancy is None:
-            continue
-        context.emit(occupancy)
-        emitted = True
-    if emitted:
-        context.emit(person)
-
-
-def parse_cards(doc: HtmlElement, category: str) -> list[tuple[str, str, str | None]]:
-    """Return (profile_url, raw_name, designation) per judge card.
-
-    Judges are rendered as WordPress team-member cards. Each card carries the
-    court's category as a CSS class token, links to the judge's profile page
-    (the anchor around the name has text; the photo anchor has none), and
-    holds the role label in a `span.designation` element.
-    """
-    card_xpath = (
-        "//*[contains(concat(' ', normalize-space(@class), ' '), "
-        f"' wpb_team_member_category-{category} ')]"
-    )
-    results: list[tuple[str, str, str | None]] = []
-    seen: set[str] = set()
-    for card in h.xpath_elements(doc, card_xpath):
-        url, name = None, ""
-        for anchor in h.xpath_elements(card, ".//a[contains(@href, '/team_member/')]"):
-            text = " ".join(anchor.text_content().split())
-            href = anchor.get("href")
-            if href and len(text) > len(name):
-                url, name = href, text
-        if url is None or len(name) < 5:
-            continue
-        url = url.split("#", 1)[0].split("?", 1)[0]
-        if url in seen:
-            continue
-        seen.add(url)
-        spans = h.xpath_elements(card, ".//span[@class='designation']")
-        designation = h.element_text(spans[0]) if spans else None
-        results.append((url, name, designation))
-    return results
-
-
-def make_pep_position(
-    context: Context, name: str
-) -> tuple[Entity, PositionCategorisation] | None:
-    position = h.make_position(
-        context,
-        name=name,
-        country="ke",
-        topics=["gov.national", "gov.judicial"],
-        lang="eng",
-    )
-    categorisation = categorise(context, position, default_is_pep=True)
-    if not categorisation.is_pep:
-        return None
-    context.emit(position)
-    return position, categorisation
+        if occupancy is not None:
+            context.emit(occupancy)
+            context.emit(person)
 
 
 def crawl(context: Context) -> None:
+    # Leadership offices are held alongside a court seat; build them once.
     leadership: dict[str, tuple[Entity, PositionCategorisation]] = {}
+    for label, office in LEADERSHIP_POSITIONS.items():
+        leadership[label] = make_pep_position(context, office)
+
     for court in COURTS:
         court_position = make_pep_position(context, court["position"])
-        if court_position is None:
-            continue
-
-        doc = context.fetch_html(court["url"], cache_days=1, absolute_links=True)
-        cards = parse_cards(doc, court["category"])
-        if len(cards) < court["min_count"]:
-            context.log.warning(
-                "Unexpectedly few judges on page",
-                url=court["url"],
-                found=len(cards),
-                expected_at_least=court["min_count"],
-            )
-        for profile_url, raw_name, designation in cards:
+        doc = context.fetch_html(
+            context.data_url + court["path"], cache_days=1, absolute_links=True
+        )
+        cards = parse_cards(doc)
+        assert len(cards) > 0, f"No judges found for {court['path']}"
+        for profile_url, raw_name, position_title in cards:
             positions = [court_position]
-            label = " ".join((designation or "").split()).casefold()
-            if label in LEADERSHIP_POSITIONS:
-                office = LEADERSHIP_POSITIONS[label]
-                if office not in leadership:
-                    office_position = make_pep_position(context, office)
-                    if office_position is not None:
-                        leadership[office] = office_position
-                if office in leadership:
-                    positions.append(leadership[office])
-            elif label and label not in PLAIN_DESIGNATIONS:
-                context.log.warning(
-                    "Unknown designation, treating as plain judge",
-                    designation=designation,
-                    name=raw_name,
-                )
+            label = " ".join(position_title.split()).casefold()
+            if label in leadership:
+                positions.append(leadership[label])
             crawl_judge(context, profile_url, raw_name, positions)
         context.log.info("Crawled court", position=court["position"], judges=len(cards))

--- a/datasets/ke/judiciary/crawler.py
+++ b/datasets/ke/judiciary/crawler.py
@@ -4,6 +4,7 @@ from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.stateful.review import assert_all_accepted
 
 # Judge cards live in the single team-member grid on each court's listing page.
 # Scoping card selection to that grid keeps stray team-member widgets elsewhere
@@ -108,6 +109,7 @@ def crawl_judge(
     # (arts. 78(1), 78(2)).
     # https://www.constituteproject.org/constitution/Kenya_2010
     person.add("citizenship", "ke")
+    person.add("topics", "role.judge")
 
     for position, categorisation in positions:
         occupancy = h.make_occupancy(
@@ -138,3 +140,5 @@ def crawl(context: Context) -> None:
                 positions.append(leadership[label])
             crawl_judge(context, profile_url, raw_name, positions)
         context.log.info("Crawled court", position=court["position"], judges=len(cards))
+
+    assert_all_accepted(context, raise_on_unaccepted=False)

--- a/datasets/ke/judiciary/ke_judiciary.yml
+++ b/datasets/ke/judiciary/ke_judiciary.yml
@@ -5,31 +5,21 @@ coverage:
   frequency: monthly
   start: 2026-07-05
 load_statements: true
-ci_test: false # Live external government website, not available in CI
+ci_test: true
 summary: Current judges of the superior courts listed by the Judiciary of Kenya
 description: |
-  Serving judges of Kenya's superior courts, as listed on the official website
-  of the Judiciary of Kenya. The superior courts are established by Chapter 10
-  of the Constitution of Kenya (2010):
+  Judges of Kenya's five superior courts — the Supreme Court, the Court of
+  Appeal, the High Court, the Employment and Labour Relations Court, and the
+  Environment and Land Court — established under Chapter 10 of the Constitution
+  of Kenya (2010).
 
-  * the **Supreme Court** (Article 163) — the Chief Justice, Deputy Chief
-    Justice and five other judges;
-  * the **Court of Appeal** (Article 164);
-  * the **High Court** (Article 165);
-  * the **Employment and Labour Relations Court** and the **Environment and
-    Land Court**, courts with the status of the High Court established under
-    Article 162(2).
-
-  The crawler follows the five judge-listing pages linked under "Judges" in
-  the site navigation, one per court. Each sitting judge is recorded with
-  their name, court-level position, and a link to their profile page.
-  Judicial leadership offices exposed by the source (Chief Justice, Deputy
-  Chief Justice, Principal Judge of the High Court and of the Employment and
-  Labour Relations Court, Presiding Judge of the Environment and Land Court)
-  are modelled as additional positions held alongside the court seat. A
-  judge marked "President-Elect" of the Court of Appeal is recorded as a
-  judge of that court only. Judges of the superior courts exercise national
-  judicial authority and are treated as politically exposed persons.
+  Each judge is recorded with their name and their court-level judicial
+  position. Judges holding a leadership office (Chief Justice, Deputy Chief
+  Justice, Principal Judge of the High Court or of the Employment and Labour
+  Relations Court, or Presiding Judge of the Environment and Land Court) also
+  carry that office as an additional position. Judges of the superior courts
+  exercise national judicial authority and are treated as politically exposed
+  persons.
 url: https://judiciary.go.ke/
 publisher:
   name: The Judiciary of Kenya
@@ -41,7 +31,7 @@ publisher:
   country: ke
   official: true
 data:
-  url: https://judiciary.go.ke/supreme-court-judges/
+  url: https://judiciary.go.ke/
   format: HTML
   lang: eng
 
@@ -61,27 +51,13 @@ assertions:
       Position: 15
 
 names:
-  prefixes_strip:
-    - "Hon."
-    - "Hon"
-    - "Lady Justice"
-    - "lady Justice"
-    - "Mr. Justice"
-    - "Mrs. Justice"
-    - "Justice"
-    - "Lady"
-    - "lady"
-    - "Mr."
-    - "Mrs."
-    - "Ms."
-    - "Ms"
-    - "(Dr.)"
-    - "(Dr)."
-    - "(Dr)"
-    - "Dr."
-    - "Dr"
-    - "(Prof.)"
-    - "(Prof)"
-    - "Prof."
-    - "Prof"
-    - "(Rtd)"
+  schema_rules:
+    Person:
+      # Judge names on the source carry honorific titles (e.g. "Hon. Justice",
+      # "Hon. Lady Justice") and, in some cases, comma-separated post-nominals
+      # ("..., EGH"). These reject rules flag the names as needing cleaning so
+      # they are sent for LLM-assisted review rather than emitted as-is.
+      reject_strings:
+        - "Justice"
+        - "Judge"
+      reject_chars: ","


### PR DESCRIPTION
Implements the review feedback on #4792 for the `ke_judiciary` crawler:

- Hand name cleaning to the review system (`h.apply_reviewed_name_string`, `llm_cleaning=True`); flag names via `names.schema_rules`.
- Fetch pages relative to `context.data_url`; scope cards to the `wpb-our-team-members` grid (drop per-court category).
- Simplify `parse_cards` to `h.xpath_string`; rename `designation` → `position_title`.
- Drop `default_is_pep=True`, the redundant position/`emitted` checks, `min_count`, and the unknown-designation logic; assert ≥1 judge per court.
- Tighten the description; enable `ci_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)