### PR TITLE
Validate dataset index before publishing; abort validation on empty datasets

### DIFF
--- a/zavod/zavod/exporters/metadata.py
+++ b/zavod/zavod/exporters/metadata.py
@@ -1,6 +1,9 @@
+from datetime import datetime
 from enum import StrEnum
 import json
 from typing import Any, Dict, List
+
+from followthemoney.dataset.dataset import DatasetModel
 
 from zavod import settings
 from zavod.logs import get_logger
@@ -22,6 +25,29 @@ log = get_logger(__name__)
 class DatasetVersionResult(StrEnum):
     SUCCESS = "success"
     FAILURE = "failure"
+
+
+class DatasetIndexModel(DatasetModel):
+    """The dataset index (index.json) of a successful run, requiring the run
+    statistics that consumers of published datasets rely on (#4643)."""
+
+    version: str
+    updated_at: datetime
+    entity_count: int
+    target_count: int
+    thing_count: int
+    last_change: datetime
+
+
+def validate_index(dataset: Dataset) -> None:
+    """Check that the dataset index file is complete enough to be published.
+
+    Raises a pydantic ValidationError if required metadata is missing, e.g.
+    when statistics were never generated because no entities were emitted."""
+    index_path = dataset_resource_path(dataset.name, INDEX_FILE)
+    with open(index_path, "r") as fh:
+        data = json.load(fh)
+    DatasetIndexModel.model_validate(data)
 
 
 def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -16,6 +16,7 @@ from zavod.archive import DELTA_EXPORT_FILE, DELTA_INDEX_FILE
 from zavod.runtime.resources import DatasetResources
 from zavod.runtime.versions import get_latest
 from zavod.exporters import write_dataset_index
+from zavod.exporters.metadata import validate_index
 
 log = get_logger(__name__)
 
@@ -71,6 +72,7 @@ def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
     /datasets/{RELEASE}/{dataset}/ backward compatibility and
     /datasets/{LATEST}/{dataset}/ for discovery without the full catalog.
     """
+    validate_index(dataset)
 
     extra_artifacts = []
     all_published_files: List[str] = [

--- a/zavod/zavod/tests/test_cli.py
+++ b/zavod/zavod/tests/test_cli.py
@@ -41,6 +41,11 @@ def test_validate_dataset():
     runner = CliRunner()
     result = runner.invoke(cli, ["validate", "/dev/null"])
     assert result.exit_code != 0, result.output
+    # An uncrawled dataset has no entities, which fails validation:
+    result = runner.invoke(cli, ["validate", DATASET_1_YML.as_posix()])
+    assert result.exit_code != 0, result.output
+    result = runner.invoke(cli, ["crawl", DATASET_1_YML.as_posix()])
+    assert result.exit_code == 0, result.output
     result = runner.invoke(cli, ["validate", DATASET_1_YML.as_posix()])
     assert result.exit_code == 0, result.output
     shutil.rmtree(settings.DATA_PATH)

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -1,12 +1,15 @@
 import json
 from typing import Optional
 from followthemoney.dataset import VersionHistory
+from pydantic import ValidationError
+from pytest import raises
 from structlog.testing import capture_logs
 from logging import Logger
 
 from zavod import settings
 from zavod.meta import Dataset
 from zavod.archive import DELTA_EXPORT_FILE, get_dataset_artifact, clear_data_path
+from zavod.archive import dataset_resource_path
 from zavod.archive import iter_dataset_statements, iter_previous_statements
 from zavod.archive import STATISTICS_FILE, INDEX_FILE, STATEMENTS_FILE
 from zavod.archive import DATASETS, ARTIFACTS, VERSIONS_FILE
@@ -184,6 +187,37 @@ def test_publish_collection(testdataset1: Dataset, collection: Dataset):
         INDEX_FILE,
         CATALOG_FILE,
     } | STANDARD_EXPORTS  # fmt: skip
+
+
+def test_publish_incomplete_index(testdataset1: Dataset):
+    """Publishing is refused when the index is missing run statistics that
+    consumers of published datasets rely on, e.g. because no entities were
+    emitted (https://github.com/opensanctions/opensanctions/issues/4643)."""
+    linker = get_dataset_linker(testdataset1)
+    crawl_dataset(testdataset1)
+    store = get_store(testdataset1, linker)
+    store.sync()
+    view = store.view(testdataset1)
+    export_dataset(testdataset1, view)
+
+    index_path = dataset_resource_path(testdataset1.name, INDEX_FILE)
+    with open(index_path, "r") as fh:
+        index = json.load(fh)
+    for key in ("entity_count", "target_count", "thing_count", "last_change"):
+        del index[key]
+    with open(index_path, "w") as fh:
+        json.dump(index, fh)
+
+    with raises(ValidationError) as exc_info:
+        publish_dataset(testdataset1, republish_to_latest=True)
+    errors = {error["loc"][0] for error in exc_info.value.errors()}
+    assert errors == {"entity_count", "target_count", "thing_count", "last_change"}
+
+    # Nothing was archived or published:
+    published_path = settings.ARCHIVE_PATH / DATASETS
+    assert not (published_path / settings.RELEASE / testdataset1.name).exists()
+    assert not (published_path / "latest" / testdataset1.name).exists()
+    assert _read_history(testdataset1.name) is None
 
 
 def test_archive_failure(testdataset1: Dataset):

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -145,12 +145,12 @@ def test_no_assertions_error() -> None:
     assert ("error", "Dataset has no assertions.") in logs
 
 
-def test_no_entities_warning() -> None:
+def test_no_entities_abort() -> None:
     ds = Dataset(BASE_DATASET_CONFIG)
 
     validator, logs = run_validator(EmptyValidator, ds)
-    assert "No entities validated" in str(logs)
-    assert validator.abort is False
+    assert ("error", "No entities validated.") in logs
+    assert validator.abort is True
 
     emit_entity(ds, "Person", {"name": ["Vladimir Putin"]})
     validator, logs = run_validator(EmptyValidator, ds)

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -48,7 +48,7 @@ class SelfReferenceValidator(BaseValidator):
 
 
 class EmptyValidator(BaseValidator):
-    """Warn if no entities are validated."""
+    """Abort if no entities are validated."""
 
     def __init__(self, context: Context, view: View):
         super().__init__(context, view)
@@ -59,7 +59,8 @@ class EmptyValidator(BaseValidator):
 
     def finish(self) -> None:
         if self.is_empty:
-            self.context.log.warning("No entities validated.")
+            self.context.log.error("No entities validated.")
+            self.abort = True
 
 
 VALIDATORS: List[Type[BaseValidator]] = [


### PR DESCRIPTION
## What

Closes #4643.

Zavod currently publishes an invalid `index.json` when run statistics are missing or incomplete: a crawl that emits zero entities produces an index without `last_change`, and a never-succeeded dataset archives a failure index without any entity counts. Downstream catalog consumers that require these fields then fail to parse the dataset metadata.

Implementing the two points proposed in the issue:

1. **Prevent publishing when no entities were emitted** — `EmptyValidator` now logs an error and aborts the run instead of warning, so empty datasets fail validation and never reach the publish stage.
2. **Validate the metadata before publishing** — `publish_dataset()` now validates the local `index.json` against a new `DatasetIndexModel` (subclass of followthemoney's `DatasetModel` that makes `version`, `updated_at`, `entity_count`, `target_count`, `thing_count` and `last_change` required) before anything is uploaded. This also catches the zero-entity case on the direct `zavod export` + `zavod publish` path, which skips validators.

## Verification

- Reproduced first with a minimal zero-entity dataset: the exported `index.json` lacks `last_change` (success path); the failure path additionally lacks all three counts.
- After the change, `zavod run` on that dataset exits 1 at validation ("No entities validated."), and `zavod export` + `zavod publish` exits 1 with a `ValidationError` on `last_change`; nothing is archived or published.
- `pytest zavod/tests/`: 233 passed. `mypy --strict --exclude zavod/tests zavod/`: clean.
- Sanity check against production: `index.json` of `default`, `sanctions`, `peps`, `crime`, `securities`, `us_ofac_sdn`, `jp_meti_ru` and `ext_gb_coh_psc` (from `data.opensanctions.org/datasets/latest/`) all validate OK against the new model, so valid datasets are not rejected.

## Notes

- `test_cli.py::test_validate_dataset` used to run `zavod validate` on an uncrawled (hence empty) dataset and expect exit 0; it now crawls first and asserts the empty case fails, documenting the new behaviour.
- The archive-failure path (`write_dataset_index(FAILURE)`) still emits indexes without counts for never-succeeded datasets; per the comments around the failure semantics (#2483) that seemed out of scope here, but happy to extend if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)