### PR TITLE
Version-prefix local working state for artifacts

### DIFF
--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -24,7 +24,7 @@ import shutil
 from pathlib import Path
 from functools import lru_cache
 from typing import TYPE_CHECKING
-from typing import Optional, Generator, TextIO, Set
+from typing import Optional, Generator, TextIO, Set, Tuple
 from rigour.mime.types import JSON
 from followthemoney import Statement
 from followthemoney.statement.serialize import read_pack_statements_decoded
@@ -89,8 +89,9 @@ def dataset_data_path(dataset_name: str) -> Path:
 
 
 def dataset_state_path(dataset_name: str) -> Path:
-    """The state directory is outside the main data directory and is used for temporary
-    processing artifacts (like the materialised graph, and the timestamp index)."""
+    """The state directory is outside the versioned data directories and is used for
+    temporary processing artifacts (like the materialised graph, and the timestamp
+    index)."""
     path = dataset_data_path(dataset_name) / "_state"
     path.mkdir(parents=True, exist_ok=True)
     return path.resolve()
@@ -101,22 +102,57 @@ def clear_data_path(dataset_name: str) -> None:
     shutil.rmtree(dataset_data_path(dataset_name), ignore_errors=True)
 
 
-def dataset_resource_path(dataset_name: str, resource: str) -> Path:
-    dataset_path = dataset_data_path(dataset_name)
-    return dataset_path.joinpath(resource)
+def dataset_version_path(dataset_name: str, version: Version) -> Path:
+    """The local working directory for one run (version) of the dataset. This mirrors
+    the layout of /artifacts/{dataset}/{version}/ in the archive."""
+    path = dataset_data_path(dataset_name) / version.id
+    path.mkdir(parents=True, exist_ok=True)
+    return path.resolve()
+
+
+def dataset_resource_path(dataset_name: str, version: Version, resource: str) -> Path:
+    return dataset_version_path(dataset_name, version).joinpath(resource)
+
+
+def latest_local_version(
+    dataset_name: str, with_resource: Optional[str] = None
+) -> Optional[Version]:
+    """The newest run version present in the local data directory, if any.
+
+    Args:
+        dataset_name: The dataset to look for.
+        with_resource: If given, only consider versions which have this file locally.
+    """
+    versions = []
+    for child in dataset_data_path(dataset_name).iterdir():
+        if not child.is_dir():
+            continue
+        try:
+            version = Version.from_string(child.name)
+        except ValueError:
+            continue
+        if with_resource is not None and not child.joinpath(with_resource).is_file():
+            continue
+        versions.append(version)
+    if not len(versions):
+        return None
+    return max(versions, key=lambda v: v.id)
 
 
 def get_dataset_artifact(
     dataset_name: str,
+    version: Version,
     resource: str,
     backfill: bool = True,
-    version: Optional[str] = None,
 ) -> Path:
-    path = dataset_resource_path(dataset_name, resource)
+    """Get the local path of an artifact of the given run (version) of the dataset,
+    backfilling it from exactly that version in the archive if it's not present
+    locally."""
+    path = dataset_resource_path(dataset_name, version, resource)
     if path.exists():
         return path
     if backfill:
-        object = get_artifact_object(dataset_name, resource, version)
+        object = get_artifact_object(dataset_name, resource, version.id)
         if object is not None:
             log.info(
                 "Backfilling dataset artifact...",
@@ -128,9 +164,6 @@ def get_dataset_artifact(
     return path
 
 
-# TODO(Leon Handreke): This function has some overlap with versions.get_history.
-# The right thing to do might be to have two functions, one to get the "root" version file
-# at artifacts/{dataset_name}/versions.json, and one to get the version file for a specific version.
 @lru_cache(maxsize=1000)
 def get_versions_data(
     dataset_name: str, version: Optional[str] = None
@@ -163,33 +196,53 @@ def iter_dataset_versions(dataset_name: str) -> Generator[Version, None, None]:
 
 
 def get_artifact_object(
-    dataset_name: str, resource: str, version: Optional[str] = None
+    dataset_name: str, resource: str, version: str
 ) -> Optional[ArchiveObject]:
+    """Get an artifact of exactly the given version of the dataset from the archive."""
     backend = get_archive_backend()
-    if version is not None:
-        name = f"{ARTIFACTS}/{dataset_name}/{version}/{resource}"
-        object = backend.get_object(name)
-        if object.exists():
-            return object
-    else:
-        for v in iter_dataset_versions(dataset_name):
-            name = f"{ARTIFACTS}/{dataset_name}/{v.id}/{resource}"
-            object = backend.get_object(name)
-            if object.exists():
-                return object
-
-    # FIXME: legacy fallback option of using the latest release
-    # REMOVE THIS AFTER MIGRATION
-    name = f"{DATASETS}/{LATEST}/{dataset_name}/{resource}"
+    name = f"{ARTIFACTS}/{dataset_name}/{version}/{resource}"
     object = backend.get_object(name)
     if object.exists():
         return object
     return None
 
 
-def publish_version_history(dataset_name: str) -> None:
-    """Publish the history of versions for a given dataset to the artifact directory."""
-    path = dataset_resource_path(dataset_name, VERSIONS_FILE)
+def find_archive_artifact(
+    dataset_name: str, resource: str
+) -> Tuple[Optional[Version], Optional[ArchiveObject]]:
+    """Find the newest version of the dataset in the archive that has the given
+    artifact. Use this only when there is no specific version to operate on, e.g.
+    when building a catalog of the latest published state of all datasets.
+
+    Returns:
+        A tuple of the version and the artifact object. The version is `None` if the
+        artifact was only found via the legacy unversioned archive layout.
+    """
+    for v in iter_dataset_versions(dataset_name):
+        object = get_artifact_object(dataset_name, resource, v.id)
+        if object is not None:
+            return v, object
+
+    # FIXME: legacy fallback option of using the latest release
+    # REMOVE THIS AFTER MIGRATION
+    backend = get_archive_backend()
+    name = f"{DATASETS}/{LATEST}/{dataset_name}/{resource}"
+    object = backend.get_object(name)
+    if object.exists():
+        log.warning(
+            "Artifact only found in legacy unversioned archive location",
+            dataset=dataset_name,
+            resource=resource,
+            object=name,
+        )
+        return None, object
+    return None, None
+
+
+def publish_version_history(dataset_name: str, version: Version) -> None:
+    """Publish the given run's version history file to the dataset's stable version
+    history location in the archive."""
+    path = dataset_resource_path(dataset_name, version, VERSIONS_FILE)
     if not path.exists():
         raise RuntimeError(f"Version history not found: {dataset_name}")
 
@@ -209,7 +262,7 @@ def archive_artifact(
     mime_type: Optional[str] = None,
 ) -> None:
     """Publish a file in the given versions artifact directory of the dataset."""
-    assert path.relative_to(dataset_data_path(dataset_name))
+    assert path.relative_to(dataset_version_path(dataset_name, version))
     name = f"{ARTIFACTS}/{dataset_name}/{version.id}/{resource}"
     backend = get_archive_backend()
     object = backend.get_object(name)
@@ -252,32 +305,62 @@ def _read_fh_statements(fh: TextIO, external: bool) -> StatementGen:
         yield stmt
 
 
-def iter_dataset_statements(dataset: "Dataset", external: bool = True) -> StatementGen:
-    """Create a generator that yields all statements in the given dataset."""
+def iter_dataset_statements(
+    dataset: "Dataset", external: bool = True, version: Optional[Version] = None
+) -> StatementGen:
+    """Create a generator that yields all statements in the given dataset.
+
+    Args:
+        dataset: The dataset to read statements for.
+        external: Include statements that are enrichment candidates.
+        version: The version of the dataset being operated on. For collections, this
+            applies to the collection itself, while the versions of its leaves are
+            resolved independently (latest local run, then newest archived version).
+    """
     for scope in dataset.leaves:
-        yield from _iter_scope_statements(scope, external=external)
+        scope_version = version if scope.name == dataset.name else None
+        yield from _iter_scope_statements(
+            scope, external=external, version=scope_version
+        )
 
 
-def iter_local_statements(dataset: "Dataset", external: bool = True) -> StatementGen:
-    """Create a generator that yields all statements in the given dataset."""
+def iter_local_statements(
+    dataset: "Dataset", version: Version, external: bool = True
+) -> StatementGen:
+    """Create a generator that yields all statements of the given run (version) of
+    the dataset from the local working directory."""
     assert not dataset.is_collection
-    path = dataset_resource_path(dataset.name, STATEMENTS_FILE)
+    path = dataset_resource_path(dataset.name, version, STATEMENTS_FILE)
     if settings.ARCHIVE_BACKFILL_STATEMENTS:
-        get_dataset_artifact(dataset.name, STATEMENTS_FILE)
+        get_dataset_artifact(dataset.name, version, STATEMENTS_FILE)
     if not path.exists():
         raise FileNotFoundError(f"Statements not found: {dataset.name}")
+    log.info(
+        "Reading local statements...",
+        current=dataset.name,
+        version=version.id,
+    )
     with open(path, "r") as fh:
         yield from _read_fh_statements(fh, external)
 
 
-def _iter_scope_statements(dataset: "Dataset", external: bool = True) -> StatementGen:
-    try:
-        yield from iter_local_statements(dataset, external=external)
-        return
-    except FileNotFoundError:
-        pass
+def _iter_scope_statements(
+    dataset: "Dataset", external: bool = True, version: Optional[Version] = None
+) -> StatementGen:
+    if version is None:
+        # No explicit version to operate on: prefer the latest local run, fall back
+        # to the newest version available in the archive.
+        version = latest_local_version(dataset.name, with_resource=STATEMENTS_FILE)
+    if version is not None:
+        try:
+            yield from iter_local_statements(dataset, version, external=external)
+            return
+        except FileNotFoundError:
+            pass
+        object = get_artifact_object(dataset.name, STATEMENTS_FILE, version.id)
+    else:
+        _, object = find_archive_artifact(dataset.name, STATEMENTS_FILE)
 
-    object = get_artifact_object(dataset.name, STATEMENTS_FILE)
     if object is not None:
         log.info(
             "Streaming statements...",
@@ -290,17 +373,17 @@ def _iter_scope_statements(dataset: "Dataset", external: bool = True) -> Stateme
     log.error(f"Cannot load statements for: {dataset.name}")
 
 
-def iter_previous_statements(
-    dataset: "Dataset", external: bool = True, version: Optional[str] = None
-) -> StatementGen:
-    """Load the statements from the previous release of the dataset by streaming them
-    from the data archive."""
+def iter_previous_statements(dataset: "Dataset", external: bool = True) -> StatementGen:
+    """Load the statements from the newest archived run of the dataset by streaming
+    them from the data archive. This is used to compare the current run against the
+    state of the previous one."""
     for scope in dataset.leaves:
-        object = get_artifact_object(dataset.name, STATEMENTS_FILE, version)
+        version, object = find_archive_artifact(scope.name, STATEMENTS_FILE)
         if object is not None:
             log.info(
                 "Streaming backfilled statements...",
                 current=scope.name,
+                version=None if version is None else version.id,
                 object=object.name,
             )
             with object.open() as fh:

--- a/zavod/zavod/cli/etl.py
+++ b/zavod/zavod/cli/etl.py
@@ -2,19 +2,37 @@ import sys
 from pathlib import Path
 
 import click
+from followthemoney.dataset import Version
 
 from zavod import settings
-from zavod.archive import clear_data_path
+from zavod.archive import clear_data_path, latest_local_version
 from zavod.cli import cli, DatasetInPath, _load_dataset, log
 from zavod.crawl import crawl_dataset
 from zavod.exc import RunFailedException
 from zavod.exporters import export_dataset
 from zavod.integration import get_dataset_linker
+from zavod.meta import Dataset
 from zavod.publish import publish_dataset, archive_failure
 from zavod.runtime.versions import make_version, set_last_successful_version
 from zavod.store import get_store
 from zavod.tools.load_db import load_dataset_to_db
 from zavod.validators import validate_dataset
+
+
+def _get_latest_local_version(dataset: Dataset) -> Version:
+    """The latest local run of the dataset, used when no version is given
+    explicitly."""
+    version = latest_local_version(dataset.name)
+    if version is None:
+        raise click.ClickException(
+            f"No local run found for dataset: {dataset.name}. Run a crawl first."
+        )
+    log.info(
+        "Operating on the latest local version",
+        dataset=dataset.name,
+        version=version.id,
+    )
+    return version
 
 
 @cli.command("crawl", help="Crawl a specific dataset")
@@ -40,11 +58,12 @@ def validate(dataset_path: Path, rebuild_store: bool = True) -> None:
     if dataset.model.disabled:
         log.info("Dataset is disabled, skipping: %s" % dataset.name)
         sys.exit(0)
+    version = _get_latest_local_version(dataset)
     linker = get_dataset_linker(dataset)
-    store = get_store(dataset, linker)
+    store = get_store(dataset, linker, version=version)
     try:
         store.sync(clear=rebuild_store)
-        validate_dataset(dataset, store.view(dataset, external=False))
+        validate_dataset(dataset, store.view(dataset, external=False), version)
     except Exception:
         log.exception("Validation failed for %r" % dataset_path)
         store.close()
@@ -59,11 +78,12 @@ def export(dataset_path: Path, rebuild_store: bool = True) -> None:
     if dataset.model.disabled:
         log.info("Dataset is disabled, skipping: %s" % dataset.name)
         sys.exit(0)
+    version = _get_latest_local_version(dataset)
     linker = get_dataset_linker(dataset)
-    store = get_store(dataset, linker)
+    store = get_store(dataset, linker, version=version)
     try:
         store.sync(clear=rebuild_store)
-        export_dataset(dataset, store.view(dataset, external=False))
+        export_dataset(dataset, store.view(dataset, external=False), version)
     except Exception:
         log.exception("Failed to export: %s" % dataset_path)
         sys.exit(1)
@@ -74,9 +94,9 @@ def export(dataset_path: Path, rebuild_store: bool = True) -> None:
 @click.option("-l", "--latest", is_flag=True, default=False)
 def publish(dataset_path: Path, latest: bool = False) -> None:
     dataset = _load_dataset(dataset_path)
-    make_version(dataset, settings.RUN_VERSION, append_new_version_to_history=False)
+    version = _get_latest_local_version(dataset)
     try:
-        publish_dataset(dataset, republish_to_latest=latest)
+        publish_dataset(dataset, version, republish_to_latest=latest)
     except Exception:
         log.exception("Failed to publish: %s" % dataset_path)
         sys.exit(1)
@@ -101,49 +121,53 @@ def run(
     if clear_data:
         clear_data_path(dataset.name)
 
+    # The whole run operates on a single new version, minted here.
+    version = settings.RUN_VERSION
+
     if dataset.model.disabled:
         log.info("Dataset is disabled, skipping: %s" % dataset.name)
-        archive_failure(dataset)
+        make_version(dataset, version)
+        archive_failure(dataset, version)
         sys.exit(0)
     # crawl if it's a dataset, just create a new version if it's a collection
     if dataset.model.entry_point is not None and not dataset.is_collection:
         try:
-            crawl_dataset(dataset, dry_run=False)
+            crawl_dataset(dataset, dry_run=False, version=version)
         except RunFailedException:
-            archive_failure(dataset)
+            archive_failure(dataset, version)
             sys.exit(1)
     else:
-        # crawl_dataset -> Context.begin does this in the case above
-        make_version(dataset, settings.RUN_VERSION, append_new_version_to_history=True)
+        # crawl_dataset does this in the case above
+        make_version(dataset, version)
 
     linker = get_dataset_linker(dataset)
-    store = get_store(dataset, linker)
+    store = get_store(dataset, linker, version=version)
     # Validate
     try:
         store.sync(clear=True)
         view = store.view(dataset, external=False)
         if not dataset.is_collection:
-            validate_dataset(dataset, view)
+            validate_dataset(dataset, view, version)
     except Exception:
         log.exception("Validation failed for %r" % dataset.name)
-        archive_failure(dataset)
+        archive_failure(dataset, version)
         store.close()
         sys.exit(1)
 
     # Export
     try:
-        export_dataset(dataset, view)
+        export_dataset(dataset, view, version)
         # Set the version as successful in the version file, which will be archived by publish_dataset.
-        set_last_successful_version(dataset, settings.RUN_VERSION)
+        set_last_successful_version(dataset, version)
     except Exception:
         log.exception("Failed to export: %s" % dataset_path)
-        archive_failure(dataset)
+        archive_failure(dataset, version)
         store.close()
         sys.exit(1)
 
     # Publish
     try:
-        publish_dataset(dataset, republish_to_latest=latest)
+        publish_dataset(dataset, version, republish_to_latest=latest)
 
         if not dataset.is_collection and dataset.model.load_statements:
             log.info("Loading dataset into database...", dataset=dataset.name)

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -1,4 +1,5 @@
 import orjson
+import shutil
 import contextvars
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Union, cast
@@ -18,6 +19,7 @@ from structlog.contextvars import bind_contextvars, reset_contextvars
 
 from zavod import settings
 from zavod.archive import STATEMENTS_FILE, dataset_data_path, dataset_resource_path
+from zavod.archive import dataset_version_path
 from zavod.audit import inspect
 from zavod.entity import Entity
 from zavod.integration.dedupe import get_resolver
@@ -35,7 +37,6 @@ from zavod.runtime.issues import DatasetIssues
 from zavod.runtime.resources import DatasetResources
 from zavod.runtime.stats import ContextStats
 from zavod.runtime.timestamps import TimeStampIndex
-from zavod.runtime.versions import get_latest, make_version
 from zavod.util import Element, join_slug, prefixed_hash_id
 
 
@@ -50,12 +51,15 @@ class Context:
 
     SOURCE_TITLE = "Source data"
 
-    def __init__(self, dataset: Dataset, dry_run: bool = False):
+    def __init__(self, dataset: Dataset, version: Version, dry_run: bool = False):
         self.dataset = dataset
+        self.version = version
+        """The version of the dataset this context is operating on."""
+        self.version_time_iso = version.dt.isoformat(sep="T", timespec="seconds")
         self.dry_run = dry_run
         self.stats = ContextStats()
-        self.issues = DatasetIssues(dataset)
-        self.resources = DatasetResources(dataset)
+        self.issues = DatasetIssues(dataset, version)
+        self.resources = DatasetResources(dataset, version)
         self.log = get_logger(dataset.name)
         self.http = make_session(dataset.http)
         self._db: Optional[Session] = None
@@ -65,7 +69,9 @@ class Context:
         self._structlog_contextvars_tokens: Optional[
             Mapping[str, contextvars.Token[Any]]
         ] = None
-        self._writer_path = dataset_resource_path(dataset.name, STATEMENTS_FILE)
+        self._writer_path = dataset_resource_path(
+            dataset.name, version, STATEMENTS_FILE
+        )
         self._writer: Optional[PackStatementWriter] = None
 
         self.lang: Optional[str] = None
@@ -108,11 +114,6 @@ class Context:
         return self._resolver
 
     @property
-    def version(self) -> Version:
-        """The current version of the dataset."""
-        return get_latest(self.dataset.name, backfill=False) or settings.RUN_VERSION
-
-    @property
     def timestamps(self) -> TimeStampIndex:
         """An index of the first_seen time of every statement previous emitted by
         the dataset. This is used to determine if a statement is new or not."""
@@ -131,14 +132,12 @@ class Context:
         """Prepare the context for running the exporter.
 
         Args:
-            clear: Remove the existing resources and issues from the dataset.
+            clear: Remove the existing resources and issues of this version of
+                the dataset.
         """
         self._structlog_contextvars_tokens = bind_contextvars(
             dataset=self.dataset.name,
             context=self,
-        )
-        make_version(
-            self.dataset, settings.RUN_VERSION, append_new_version_to_history=clear
         )
         if clear and not self.dry_run:
             self.resources.clear()
@@ -189,19 +188,34 @@ class Context:
             self.issues.export()
 
     def get_resource_path(self, name: PathLike) -> Path:
-        """Get the path to a file in the dataset data folder.
+        """Get the path to a working file in the dataset data folder, e.g. a fetched
+        source file. Use `export_resource` to register a file as a resource of this
+        run of the dataset.
 
         Args:
             name: The name of the file, relative to the dataset data folder.
 
         Returns:
             The full path to the file."""
-        return dataset_resource_path(self.dataset.name, str(name))
+        return dataset_data_path(self.dataset.name).joinpath(str(name))
+
+    def get_artifact_path(self, name: PathLike) -> Path:
+        """Get the path to a file in the working directory of the version of the
+        dataset this context is operating on.
+
+        Args:
+            name: The name of the file, relative to the version directory.
+
+        Returns:
+            The full path to the file."""
+        return dataset_resource_path(self.dataset.name, self.version, str(name))
 
     def export_resource(
         self, path: Path, mime_type: Optional[str] = None, title: Optional[str] = None
     ) -> DataResource:
-        """Register a file as a data resource exported by the dataset.
+        """Register a file as a data resource exported by this run of the dataset.
+        Files outside the working directory of this version (e.g. fetched source
+        files) are copied into it.
 
         Args:
             path: The file path of the exported resource
@@ -211,8 +225,22 @@ class Context:
         Returns:
             The generated resource object which has been saved.
         """
+        version_path = dataset_version_path(self.dataset.name, self.version)
+        data_path = dataset_data_path(self.dataset.name)
+        if path.is_relative_to(version_path):
+            name = path.relative_to(version_path).as_posix()
+        elif path.is_relative_to(data_path):
+            name = path.relative_to(data_path).as_posix()
+        else:
+            raise ValueError(f"Resource path is outside the data folder: {path}")
+
+        artifact_path = dataset_resource_path(self.dataset.name, self.version, name)
+        if path != artifact_path:
+            artifact_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(path, artifact_path)
+
         resource = self.dataset.resource_from_path(
-            path, mime_type=mime_type, title=title
+            artifact_path, name=name, mime_type=mime_type, title=title
         )
         if not self.dry_run:
             self.resources.save(resource)
@@ -645,10 +673,10 @@ class Context:
             )
             if stmt.id is None:
                 raise ValueError("Statement has no ID: %r", stmt)
-            stmt.first_seen = stamps.get(stmt.id, settings.RUN_TIME_ISO)
-            if stmt.first_seen == settings.RUN_TIME_ISO:
+            stmt.first_seen = stamps.get(stmt.id, self.version_time_iso)
+            if stmt.first_seen == self.version_time_iso:
                 self.stats.changed += 1
-            stmt.last_seen = settings.RUN_TIME_ISO
+            stmt.last_seen = self.version_time_iso
             if not self.dry_run:
                 if self._writer is None:
                     fh = self._writer_path.open("w", encoding=ENCODING)

--- a/zavod/zavod/crawl.py
+++ b/zavod/zavod/crawl.py
@@ -1,5 +1,7 @@
+from typing import Optional
 from requests.exceptions import RequestException
 from datapatch import LookupException
+from followthemoney.dataset import Version
 
 from zavod import settings
 from zavod.meta import Dataset
@@ -8,6 +10,7 @@ from zavod.exc import RunFailedException
 from zavod.archive import dataset_data_path
 from zavod.runtime.stats import ContextStats
 from zavod.runtime.loader import load_entry_point
+from zavod.runtime.versions import make_version
 from zavod.runner.enrich import enrich
 from zavod.reset import reset_caches
 
@@ -16,13 +19,21 @@ from zavod.reset import reset_caches
 assert enrich is not None
 
 
-def crawl_dataset(dataset: Dataset, dry_run: bool = False) -> ContextStats:
+def crawl_dataset(
+    dataset: Dataset, dry_run: bool = False, version: Optional[Version] = None
+) -> ContextStats:
     """Load the dataset entry point, configure a context, and then execute the entry
-    point; finally disband the context."""
-    context = Context(dataset, dry_run=dry_run)
+    point; finally disband the context.
+
+    A crawl is the start of a new run of the dataset, so this mints a new version
+    unless one is passed in."""
+    if version is None:
+        version = settings.RUN_VERSION
+    context = Context(dataset, version, dry_run=dry_run)
     if dataset.model.disabled:
         context.log.info("Source is disabled", source=dataset.name)
         return context.stats
+    make_version(dataset, version)
 
     try:
         context.begin(clear=True)

--- a/zavod/zavod/exporters/__init__.py
+++ b/zavod/zavod/exporters/__init__.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Type, Set
+from followthemoney.dataset import Version
 
 from zavod.exporters.consolidate import consolidate_entity
 from zavod.logs import get_logger
@@ -86,9 +87,10 @@ def export_data(context: Context, view: View) -> None:
         exporter.finish(view)
 
 
-def export_dataset(dataset: Dataset, view: View) -> None:
-    """Dump the contents of the dataset to the output directory."""
-    context = Context(dataset)
+def export_dataset(dataset: Dataset, view: View, version: Version) -> None:
+    """Dump the contents of the given run (version) of the dataset to its working
+    directory."""
+    context = Context(dataset, version)
     try:
         context.begin(clear=False)
         export_data(context, view)
@@ -96,7 +98,7 @@ def export_dataset(dataset: Dataset, view: View) -> None:
         context.close()
 
     # Export metadata and issues (after the context is closed & flushed)
-    write_delta_index(dataset)
-    write_dataset_index(dataset, DatasetVersionResult.SUCCESS)
-    write_catalog(dataset)
+    write_delta_index(dataset, version)
+    write_dataset_index(dataset, version, DatasetVersionResult.SUCCESS)
+    write_catalog(dataset, version)
     log.info("Exported dataset: %s" % dataset.name)

--- a/zavod/zavod/exporters/common.py
+++ b/zavod/zavod/exporters/common.py
@@ -18,7 +18,7 @@ class Exporter(object):
         self.context = context
         self.dataset = context.dataset
         self.resource_name = f"{self.FILE_NAME}"
-        self.path = context.get_resource_path(self.resource_name)
+        self.path = context.get_artifact_path(self.resource_name)
 
     def setup(self) -> None:
         pass

--- a/zavod/zavod/exporters/delta.py
+++ b/zavod/zavod/exporters/delta.py
@@ -14,7 +14,7 @@ class DeltaExporter(Exporter):
 
     def setup(self) -> None:
         super().setup()
-        self.delta = HashDelta(self.dataset)
+        self.delta = HashDelta(self.dataset, self.context.version)
         self.delta.backfill()
         self.counts = {
             "ADD": 0,

--- a/zavod/zavod/exporters/metadata.py
+++ b/zavod/zavod/exporters/metadata.py
@@ -1,6 +1,8 @@
 from enum import StrEnum
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+from followthemoney.dataset import Version
 
 from zavod import settings
 from zavod.logs import get_logger
@@ -9,11 +11,11 @@ from zavod.archive import INDEX_FILE, STATISTICS_FILE, ISSUES_FILE
 from zavod.archive import CATALOG_FILE, DELTA_INDEX_FILE, DELTA_EXPORT_FILE
 from zavod.archive import UNLISTED_RESOURCES
 from zavod.archive import get_dataset_artifact, get_artifact_object
+from zavod.archive import find_archive_artifact, latest_local_version
 from zavod.archive import iter_dataset_versions, dataset_resource_path
 from zavod.runtime.urls import make_artifact_url
 from zavod.runtime.resources import DatasetResources
 from zavod.runtime.issues import DatasetIssues
-from zavod.runtime.versions import get_latest
 from zavod.util import write_json
 
 log = get_logger(__name__)
@@ -24,26 +26,31 @@ class DatasetVersionResult(StrEnum):
     FAILURE = "failure"
 
 
-def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
-    """Build the barebones metadata block for a dataset, without artifact URLs."""
+def get_base_dataset_metadata(
+    dataset: Dataset, version: Optional[Version]
+) -> Dict[str, Any]:
+    """Build the barebones metadata block for a dataset, without artifact URLs.
+
+    Args:
+        dataset: The dataset to generate metadata for.
+        version: The run of the dataset to describe. Statistics and resources are
+            read from exactly this version, so e.g. a failed run (which produced
+            no statistics) never picks up entity counts from a previous run.
+            `None` if the dataset has never run.
+    """
     meta: Dict[str, Any] = {
         "issue_levels": {},
         "issue_count": 0,
         "updated_at": settings.RUN_TIME_ISO,
+        "resources": [],
     }
+    if version is None:
+        return meta
 
     # This reads the file produced by the statistics exporter which
     # contains entity counts for the dataset, aggregated by various
     # criteria:
-    # TODO: In the case of a failed run, this will currently backfill the stats from the last
-    #  previous run. That doesn't really make sense, because the resources of the index will
-    #  be empty - so what are these counts referring to? (Answer: the last successful run, and then
-    #  publish_failure will just publish that one over and over again).
-    #  But we currently show these numbers on our website, and we currently don't have well-defined
-    #  semantics how our website (or our customers) would figure out what the last successful run was.
-    #  For a brief discussion of our currently broken failure semantics,
-    #  see https://github.com/opensanctions/opensanctions/pull/2483
-    statistics_path = get_dataset_artifact(dataset.name, STATISTICS_FILE)
+    statistics_path = get_dataset_artifact(dataset.name, version, STATISTICS_FILE)
     if statistics_path.is_file():
         with open(statistics_path, "r") as fh:
             stats: Dict[str, Any] = json.load(fh)
@@ -57,7 +64,7 @@ def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
                 meta["last_change"] = last_change
 
     res_datas: List[Dict[str, Any]] = []
-    for res in DatasetResources(dataset).all():
+    for res in DatasetResources(dataset, version).all():
         if res.name in UNLISTED_RESOURCES:
             continue
         res_data = res.model_dump(mode="json", exclude_none=True)
@@ -67,20 +74,20 @@ def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
     return meta
 
 
-def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
-    """Export dataset metadata to index.json."""
+def write_dataset_index(
+    dataset: Dataset, version: Version, result: DatasetVersionResult
+) -> None:
+    """Export dataset metadata to index.json for the given run (version) of the
+    dataset."""
     catalog = get_catalog()
-    version = get_latest(dataset.name, backfill=True)
-    if version is None:
-        raise ValueError(f"No version found for dataset: {dataset.name}")
-    index_path = dataset_resource_path(dataset.name, INDEX_FILE)
+    index_path = dataset_resource_path(dataset.name, version, INDEX_FILE)
     log.info(
         "Writing dataset index",
         path=index_path,
         version=version.id,
         is_collection=dataset.is_collection,
     )
-    meta = get_base_dataset_metadata(dataset)
+    meta = get_base_dataset_metadata(dataset, version)
     meta.update(dataset.to_opensanctions_dict(catalog))
 
     # Remove redundant dataset hierarchy metadata
@@ -96,7 +103,7 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
         res_data["url"] = make_artifact_url(dataset.name, version.id, res_data["path"])
 
     if not dataset.is_collection:
-        issues = DatasetIssues(dataset)
+        issues = DatasetIssues(dataset, version)
         meta["issue_levels"] = issues.by_level()
         meta["issue_count"] = sum(meta["issue_levels"].values())
     meta["last_export"] = settings.RUN_TIME_ISO
@@ -108,7 +115,7 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
         dataset.name, version.id, STATISTICS_FILE
     )
 
-    delta_index_path = dataset_resource_path(dataset.name, DELTA_INDEX_FILE)
+    delta_index_path = dataset_resource_path(dataset.name, version, DELTA_INDEX_FILE)
     if delta_index_path.is_file():
         # Only generated for successful exports:
         meta["delta_url"] = make_artifact_url(
@@ -117,13 +124,11 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
     else:
         # If the delta index is not available, try to find the newest delta index
         # generate the URL from that:
-        for version in iter_dataset_versions(dataset.name):
-            object = get_artifact_object(
-                dataset.name, DELTA_EXPORT_FILE, version=version.id
-            )
+        for v in iter_dataset_versions(dataset.name):
+            object = get_artifact_object(dataset.name, DELTA_EXPORT_FILE, v.id)
             if object is not None:
                 meta["delta_url"] = make_artifact_url(
-                    dataset.name, version.id, DELTA_INDEX_FILE
+                    dataset.name, v.id, DELTA_INDEX_FILE
                 )
                 break
 
@@ -134,21 +139,34 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
 def get_catalog_dataset(dataset: Dataset) -> Dict[str, Any]:
     """Get a metadata description of a single dataset for the catalog.
 
-    Uses run information from the latest published index file, but patches it with the latest metadata from
-    the dataset object to allow us to quickly patch the catalog without waiting for another export.
+    Uses run information from the latest run available (a local run if present,
+    otherwise the newest published index file in the archive), but patches it with
+    the latest metadata from the dataset object to allow us to quickly patch the
+    catalog without waiting for another export.
     """
-    # Get a barebones metadata object, only relevant before the first export
-    meta = get_base_dataset_metadata(dataset)
+    index_data: Optional[Dict[str, Any]] = None
+    version = latest_local_version(dataset.name, with_resource=INDEX_FILE)
+    if version is None:
+        version, legacy_object = find_archive_artifact(dataset.name, INDEX_FILE)
+        if version is None and legacy_object is not None:
+            # FIXME: legacy fallback, remove after migration.
+            with legacy_object.open() as fh:
+                index_data = json.load(fh)
+    if version is not None:
+        path = get_dataset_artifact(dataset.name, version, INDEX_FILE)
+        if path.is_file():
+            with open(path, "r") as fh:
+                index_data = json.load(fh)
 
-    # Use the latest published index file, if available.
-    path = get_dataset_artifact(dataset.name, INDEX_FILE)
-    if path.is_file():
-        with open(path, "r") as fh:
-            meta.update(json.load(fh))
+    # Get a barebones metadata object, only relevant before the first export
+    meta = get_base_dataset_metadata(dataset, version)
+
+    if index_data is not None:
+        meta.update(index_data)
     else:
         log.warn(
             "No index file found, dataset likely hasn't run yet",
-            path=path.as_posix(),
+            dataset=dataset.name,
             report_issue=False,
         )
 
@@ -167,7 +185,10 @@ def get_catalog_datasets(scope: Dataset) -> List[Dict[str, Any]]:
 
 
 def write_delta_index(
-    dataset: Dataset, max_versions: int = 100, include_latest: bool = True
+    dataset: Dataset,
+    version: Version,
+    max_versions: int = 100,
+    include_latest: bool = True,
 ) -> None:
     """Export list of delta data versions for the dataset with their URLs
     associated."""
@@ -175,25 +196,20 @@ def write_delta_index(
 
     # This hasn't been uploaded yet, but will become available at the same
     # time as the index file:
-    latest = get_latest(dataset.name, backfill=False)
-    if latest is not None and include_latest:
-        data_path = dataset_resource_path(dataset.name, DELTA_EXPORT_FILE)
+    if include_latest:
+        data_path = dataset_resource_path(dataset.name, version, DELTA_EXPORT_FILE)
         if data_path.is_file() and data_path.stat().st_size > 0:
-            versions[latest.id] = make_artifact_url(
-                dataset.name, latest.id, DELTA_EXPORT_FILE
-            )
-
-    # Get the most recent versions of the dataset:
-    for version in iter_dataset_versions(dataset.name):
-        if version.id in versions:
-            continue
-        object = get_artifact_object(
-            dataset.name, DELTA_EXPORT_FILE, version=version.id
-        )
-        if object is not None and object.size() > 0:
             versions[version.id] = make_artifact_url(
                 dataset.name, version.id, DELTA_EXPORT_FILE
             )
+
+    # Get the most recent versions of the dataset:
+    for v in iter_dataset_versions(dataset.name):
+        if v.id in versions:
+            continue
+        object = get_artifact_object(dataset.name, DELTA_EXPORT_FILE, v.id)
+        if object is not None and object.size() > 0:
+            versions[v.id] = make_artifact_url(dataset.name, v.id, DELTA_EXPORT_FILE)
         if len(versions) >= max_versions:
             break
 
@@ -213,7 +229,7 @@ def write_delta_index(
     if len(versions) == 0:
         log.info(f"No delta versions found: {dataset.name}")
         return
-    index_path = dataset_resource_path(dataset.name, DELTA_INDEX_FILE)
+    index_path = dataset_resource_path(dataset.name, version, DELTA_INDEX_FILE)
     log.info("Writing delta versions index...", path=index_path.as_posix())
     with open(index_path, "wb") as fh:
         data = {
@@ -224,12 +240,12 @@ def write_delta_index(
         write_json(data, fh)
 
 
-def write_catalog(scope: Dataset) -> None:
+def write_catalog(scope: Dataset, version: Version) -> None:
     """Export a Nomenklatura-style data catalog file to represent all the datasets
     within this scope."""
     if not scope.is_collection:
         return
-    catalog_path = dataset_resource_path(scope.name, CATALOG_FILE)
+    catalog_path = dataset_resource_path(scope.name, version, CATALOG_FILE)
     log.info("Writing collection as catalog...", path=catalog_path.as_posix())
     with open(catalog_path, "wb") as fh:
         data = {

--- a/zavod/zavod/extract/names/dspy/compare.py
+++ b/zavod/zavod/extract/names/dspy/compare.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from followthemoney import Model
 
+from zavod import settings
 from zavod.context import Context
 from zavod.extract.names.clean import Names, SourceNames, clean_names
 from zavod.extract.names.dspy.clean import load_optimised_module
@@ -20,7 +21,7 @@ def compare_single_entity(examples_path: Path, output_path: Path) -> None:
     _train_set, _val_set, test_set = load_data(examples_path)
 
     fake_dataset: Dataset = Dataset({"name": "fake"})
-    context = Context(fake_dataset)
+    context = Context(fake_dataset, settings.RUN_VERSION)
 
     results = []
 

--- a/zavod/zavod/meta/catalog.py
+++ b/zavod/zavod/meta/catalog.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from followthemoney.dataset import DataCatalog
 
 from zavod.meta.dataset import Dataset
-from zavod.archive import get_dataset_artifact, INDEX_FILE
+from zavod.archive import find_archive_artifact, get_dataset_artifact
+from zavod.archive import latest_local_version, INDEX_FILE
 
 
 class ArchiveBackedCatalog(DataCatalog[Dataset]):
@@ -27,7 +28,14 @@ class ArchiveBackedCatalog(DataCatalog[Dataset]):
         dataset = super().get(name)
         if dataset is not None:
             return dataset
-        path = get_dataset_artifact(name, INDEX_FILE)
+        # The dataset is not defined locally, so use the metadata of the newest run
+        # available: a local one if present, otherwise from the archive.
+        version = latest_local_version(name, with_resource=INDEX_FILE)
+        if version is None:
+            version, _ = find_archive_artifact(name, INDEX_FILE)
+        if version is None:
+            return None
+        path = get_dataset_artifact(name, version, INDEX_FILE)
         if path.exists():
             return self.load_yaml(path)
         return None

--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -11,7 +11,6 @@ from followthemoney.dataset.coverage import DataCoverage
 from followthemoney.dataset.resource import DataResource
 
 from zavod import settings
-from zavod.archive import dataset_data_path
 from zavod.logs import get_logger
 from zavod.meta.assertion import Assertion, parse_assertions
 from zavod.meta.dates import DatesSpec
@@ -102,16 +101,23 @@ class Dataset(FollowTheMoneyDataset):
     def resource_from_path(
         self,
         path: Path,
+        name: str,
         mime_type: Optional[str] = None,
         title: Optional[str] = None,
     ) -> "DataResource":
-        """Create a resource description object from a local file path."""
+        """Create a resource description object from a local file path.
+
+        Args:
+            path: The local file to describe.
+            name: The name of the resource, i.e. its path relative to the root of
+                the run it belongs to.
+            mime_type: MIME type of the resource, will be guessed otherwise.
+            title: A human-readable description.
+        """
         if not path.exists():
             raise ValueError("File does not exist: %s" % path)
         if mime_type is None:
             mime_type, _ = mimetypes.guess_type(path.as_posix(), strict=False)
-        dataset_path_ = dataset_data_path(self.name)
-        name = path.relative_to(dataset_path_).as_posix()
 
         digest = sha1()
         size = 0

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from rigour.mime.types import JSON
+from followthemoney.dataset import Version
 
 from zavod.archive.backend import get_archive_backend
 from zavod.exporters.metadata import DatasetVersionResult
@@ -8,19 +9,20 @@ from zavod.meta import Dataset
 from zavod.logs import get_logger
 from zavod.archive import DATASETS, LATEST, UNLISTED_RESOURCES, dataset_resource_path
 from zavod.archive import publish_version_history, archive_artifact
-from zavod.archive import publish_artifact
+from zavod.archive import publish_artifact, get_dataset_artifact
 from zavod.archive import INDEX_FILE, CATALOG_FILE
 from zavod.archive import STATEMENTS_FILE, RESOURCES_FILE, STATISTICS_FILE
 from zavod.archive import VERSIONS_FILE, EXTRA_ARTIFACTS
 from zavod.archive import DELTA_EXPORT_FILE, DELTA_INDEX_FILE
 from zavod.runtime.resources import DatasetResources
-from zavod.runtime.versions import get_latest
 from zavod.exporters import write_dataset_index
 
 log = get_logger(__name__)
 
 
-def _archive_artifacts(dataset: Dataset, extra_artifacts: list[str] = []) -> None:
+def _archive_artifacts(
+    dataset: Dataset, version: Version, extra_artifacts: list[str] = []
+) -> None:
     """
     Upload every file we persist about a run to /artifacts/{dataset}/{version}/.
 
@@ -30,12 +32,8 @@ def _archive_artifacts(dataset: Dataset, extra_artifacts: list[str] = []) -> Non
     """
     extra_artifacts = list(extra_artifacts) + EXTRA_ARTIFACTS
 
-    version = get_latest(dataset.name, backfill=False)
-    if version is None:
-        raise ValueError(f"No working version found for dataset: {dataset.name}")
-
-    for resource in DatasetResources(dataset).all():
-        path = dataset_resource_path(dataset.name, resource.name)
+    for resource in DatasetResources(dataset, version).all():
+        path = dataset_resource_path(dataset.name, version, resource.name)
         if not path.is_file():
             log.error("Resource not found: %s" % path, dataset=dataset.name)
             continue
@@ -48,7 +46,7 @@ def _archive_artifacts(dataset: Dataset, extra_artifacts: list[str] = []) -> Non
         )
 
     for artifact in extra_artifacts:
-        path = dataset_resource_path(dataset.name, artifact)
+        path = dataset_resource_path(dataset.name, version, artifact)
         if not path.is_file():
             continue
         archive_artifact(
@@ -59,11 +57,13 @@ def _archive_artifacts(dataset: Dataset, extra_artifacts: list[str] = []) -> Non
             mime_type=JSON if artifact.endswith(".json") else None,
         )
 
-    publish_version_history(dataset.name)
+    publish_version_history(dataset.name, version)
 
 
-def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
-    """Publish a dataset.
+def publish_dataset(
+    dataset: Dataset, version: Version, republish_to_latest: bool = True
+) -> None:
+    """Publish the given run (version) of a dataset.
 
     Every file we persist about this run is uploaded to /artifacts/{dataset}/{version}/
 
@@ -71,11 +71,18 @@ def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
     /datasets/{RELEASE}/{dataset}/ backward compatibility and
     /datasets/{LATEST}/{dataset}/ for discovery without the full catalog.
     """
+    # Make sure the version history file of this run is available locally, e.g.
+    # when publishing a version that was crawled on another machine.
+    versions_path = get_dataset_artifact(dataset.name, version, VERSIONS_FILE)
+    if not versions_path.is_file():
+        raise ValueError(
+            f"No version history found for {dataset.name} at version {version.id}"
+        )
 
     extra_artifacts = []
     all_published_files: List[str] = [
         r.name
-        for r in DatasetResources(dataset).all()
+        for r in DatasetResources(dataset, version).all()
         if r.name not in UNLISTED_RESOURCES
     ]
     all_published_files.append(INDEX_FILE)
@@ -84,10 +91,7 @@ def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
         extra_artifacts.append(CATALOG_FILE)
         all_published_files.append(CATALOG_FILE)
 
-    _archive_artifacts(dataset, extra_artifacts)
-
-    version = get_latest(dataset.name, backfill=False)
-    assert version is not None
+    _archive_artifacts(dataset, version, extra_artifacts)
 
     if republish_to_latest:
         _warn_about_stale_latest_files(dataset, set(all_published_files))
@@ -113,8 +117,9 @@ def _warn_about_stale_latest_files(dataset: Dataset, published_files: set[str]) 
             )
 
 
-def archive_failure(dataset: Dataset) -> None:
-    """Upload failure information about a dataset to the archive."""
+def archive_failure(dataset: Dataset, version: Version) -> None:
+    """Upload failure information about the given run (version) of a dataset to
+    the archive."""
     # For collections, we used to refuse to archive_failure because we were worried about a failed
     # `default/index.json` ending up at `/datasets/latest/default/index.json` with empty resources.
     # That's no longer a concern: we stopped publishing failed `index.json` to `/datasets` in
@@ -125,23 +130,29 @@ def archive_failure(dataset: Dataset) -> None:
     # which is exactly what we want for surfacing the `issues.log`.
     # Clear out interim artifacts so they cannot pollute the metadata we're
     # generating.
-    dataset_resource_path(dataset.name, STATEMENTS_FILE).unlink(missing_ok=True)
-    # TODO: The statistics file gets pulled in by write_dataset_index,
-    #  so they get published as part of the artifacts anyway.
-    #  For a brief discussion of our currently broken failure semantics,
-    #  see https://github.com/opensanctions/opensanctions/pull/2483
-    dataset_resource_path(dataset.name, STATISTICS_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, INDEX_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, CATALOG_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, RESOURCES_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, DELTA_EXPORT_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, DELTA_INDEX_FILE).unlink(missing_ok=True)
+    dataset_resource_path(dataset.name, version, STATEMENTS_FILE).unlink(
+        missing_ok=True
+    )
+    # The statistics file may have been written by a partially-completed export, so
+    # its counts wouldn't describe anything a consumer can download. Because the
+    # index is generated from exactly this version, clearing it also guarantees the
+    # failure index carries no entity counts from a previous run.
+    dataset_resource_path(dataset.name, version, STATISTICS_FILE).unlink(
+        missing_ok=True
+    )
+    dataset_resource_path(dataset.name, version, INDEX_FILE).unlink(missing_ok=True)
+    dataset_resource_path(dataset.name, version, CATALOG_FILE).unlink(missing_ok=True)
+    dataset_resource_path(dataset.name, version, RESOURCES_FILE).unlink(missing_ok=True)
+    dataset_resource_path(dataset.name, version, DELTA_EXPORT_FILE).unlink(
+        missing_ok=True
+    )
+    dataset_resource_path(dataset.name, version, DELTA_INDEX_FILE).unlink(
+        missing_ok=True
+    )
 
-    write_dataset_index(dataset, DatasetVersionResult.FAILURE)
-    path = dataset_resource_path(dataset.name, INDEX_FILE)
+    write_dataset_index(dataset, version, DatasetVersionResult.FAILURE)
+    path = dataset_resource_path(dataset.name, version, INDEX_FILE)
     if not path.is_file():
         log.error("Metadata file not found: %s" % path, dataset=dataset.name)
         return
-    _archive_artifacts(dataset)
-    dataset_resource_path(dataset.name, RESOURCES_FILE).unlink(missing_ok=True)
-    dataset_resource_path(dataset.name, VERSIONS_FILE).unlink(missing_ok=True)
+    _archive_artifacts(dataset, version)

--- a/zavod/zavod/runtime/delta.py
+++ b/zavod/zavod/runtime/delta.py
@@ -9,17 +9,16 @@ from zavod.meta import Dataset
 from zavod.entity import Entity
 from zavod.archive import dataset_resource_path, dataset_state_path
 from zavod.archive import iter_dataset_versions, get_artifact_object, HASH_FILE
-from zavod.runtime.versions import get_latest
 
 log = get_logger(__name__)
 
 
 class HashDelta(object):
-    def __init__(self, dataset: Dataset):
+    def __init__(self, dataset: Dataset, version: Version):
         self.dataset = dataset
-        self.curr = get_latest(dataset.name, backfill=False)
+        self.curr: Version = version
         self.prev: Optional[Version] = None
-        self.curr_path = dataset_resource_path(dataset.name, HASH_FILE)
+        self.curr_path = dataset_resource_path(dataset.name, version, HASH_FILE)
         self.fh = self.curr_path.open("w")
         self.db_path = dataset_state_path(dataset.name) / "hashes"
         shutil.rmtree(self.db_path, ignore_errors=True)
@@ -44,7 +43,7 @@ class HashDelta(object):
         log.info("No previous hash data found.")
 
     def feed(self, entity: Entity) -> None:
-        if entity.id is None or self.curr is None:
+        if entity.id is None:
             return
         digest = sha1()
         digest.update(entity.id.encode("utf-8"))
@@ -83,7 +82,7 @@ class HashDelta(object):
                     if entity_id is not None:
                         yield entity_id, prev_hash, curr_hash
                     entity_id, prev_hash, curr_hash = new_id, None, None
-                if self.curr is not None and version_id == self.curr.id:
+                if version_id == self.curr.id:
                     curr_hash = hash
                 else:
                     prev_hash = hash

--- a/zavod/zavod/runtime/issues.py
+++ b/zavod/zavod/runtime/issues.py
@@ -4,9 +4,10 @@ from rigour.time import utc_now, datetime_iso
 from banal import is_mapping, hash_data
 from datetime import datetime
 from typing import Any, Dict, Generator, Optional, TypedDict, BinaryIO, cast
+from followthemoney.dataset import Version
 
 from zavod.meta import Dataset
-from zavod.archive import dataset_resource_path, get_dataset_artifact
+from zavod.archive import dataset_resource_path
 from zavod.archive import ISSUES_LOG, ISSUES_FILE
 
 
@@ -23,15 +24,17 @@ class Issue(TypedDict):
 
 
 class DatasetIssues(object):
-    """A log of issues that occurred during the running and export of a dataset."""
+    """A log of issues that occurred during the running and export of a given run
+    (version) of a dataset."""
 
-    def __init__(self, dataset: Dataset) -> None:
+    def __init__(self, dataset: Dataset, version: Version) -> None:
         self.dataset = dataset
+        self.version = version
         self.fh: Optional[BinaryIO] = None
 
     def write(self, event: Dict[str, Any]) -> None:
         if self.fh is None:
-            path = dataset_resource_path(self.dataset.name, ISSUES_LOG)
+            path = dataset_resource_path(self.dataset.name, self.version, ISSUES_LOG)
             self.fh = open(path, "ab")
 
         data = dict(event)  # copy so we can pop without side effects
@@ -62,10 +65,10 @@ class DatasetIssues(object):
     def clear(self) -> None:
         """Clear (delete) the issues log file."""
         self.close()
-        log_path = dataset_resource_path(self.dataset.name, ISSUES_LOG)
+        log_path = dataset_resource_path(self.dataset.name, self.version, ISSUES_LOG)
         with open(log_path, "w") as fh:
             fh.flush()
-        file_path = dataset_resource_path(self.dataset.name, ISSUES_FILE)
+        file_path = dataset_resource_path(self.dataset.name, self.version, ISSUES_FILE)
         file_path.unlink(missing_ok=True)
 
     def close(self) -> None:
@@ -77,10 +80,9 @@ class DatasetIssues(object):
     def all(self) -> Generator[Issue, None, None]:
         """Iterate over all issues in the log."""
         self.close()
-        # Don't backfill the issues log, otherwise we'll get issues from a previous run for collections.
-        # For data sources (that run crawl), that's not the case because they run clear() at the beginning
-        # of the crawl stage.
-        path = get_dataset_artifact(self.dataset.name, ISSUES_LOG, backfill=False)
+        # Don't backfill the issues log from the archive: issues describe what happened
+        # during this run on this machine, not what a previous stage archived.
+        path = dataset_resource_path(self.dataset.name, self.version, ISSUES_LOG)
         if not path.is_file():
             return
         with open(path, "rb") as fh:
@@ -99,7 +101,7 @@ class DatasetIssues(object):
     def export(self, path: Optional[Path] = None) -> None:
         """Export the issues log to a consolidated file."""
         if path is None:
-            path = dataset_resource_path(self.dataset.name, ISSUES_FILE)
+            path = dataset_resource_path(self.dataset.name, self.version, ISSUES_FILE)
         with open(path, "wb") as fh:
             issues = list(self.all())
             fh.write(orjson.dumps({"issues": issues}))

--- a/zavod/zavod/runtime/resources.py
+++ b/zavod/zavod/runtime/resources.py
@@ -1,6 +1,6 @@
 import json
 from typing import Dict, Any, List
-from followthemoney.dataset import DataResource
+from followthemoney.dataset import DataResource, Version
 
 from zavod.meta import Dataset
 from zavod.archive import dataset_resource_path
@@ -8,12 +8,12 @@ from zavod.archive import RESOURCES_FILE
 
 
 class DatasetResources(object):
-    """Store information about the resources in the dataset that have been emitted
-    from the context during runtime."""
+    """Store information about the resources in the given run (version) of the
+    dataset that have been emitted from the context during runtime."""
 
-    def __init__(self, dataset: Dataset) -> None:
+    def __init__(self, dataset: Dataset, version: Version) -> None:
         self.dataset = dataset
-        self.path = dataset_resource_path(dataset.name, RESOURCES_FILE)
+        self.path = dataset_resource_path(dataset.name, version, RESOURCES_FILE)
 
     def _store_resources(self, resources: List[DataResource]) -> None:
         with open(self.path, "w") as fh:
@@ -37,8 +37,6 @@ class DatasetResources(object):
     def all(self) -> List[DataResource]:
         resources: List[DataResource] = []
         data: Dict[str, Any] = {}
-        # if not self.path.exists():
-        #     self.path = get_dataset_artifact(self.dataset.name, RESOURCES_FILE)
         if self.path.exists():
             with open(self.path, "r") as fh:
                 data = json.load(fh)

--- a/zavod/zavod/runtime/versions.py
+++ b/zavod/zavod/runtime/versions.py
@@ -1,28 +1,19 @@
-from pathlib import Path
-from typing import Optional
 from followthemoney.dataset import Version, VersionHistory
 
 from zavod.meta import Dataset
 from zavod.archive import dataset_resource_path, get_versions_data
-from zavod.archive import get_dataset_artifact
 from zavod.archive import VERSIONS_FILE
 
 
-def _versions_path(dataset_name: str) -> Path:
-    return dataset_resource_path(dataset_name, VERSIONS_FILE)
+def make_version(dataset: Dataset, version: Version) -> None:
+    """Record a new run version of the dataset by writing the version history file
+    (the history known to the archive, plus this version) into the local working
+    directory of that version.
 
-
-def make_version(
-    dataset: Dataset, version: Version, append_new_version_to_history: bool = False
-) -> None:
-    """Add a new version to the dataset history.
-
-    Args:
-        append_new_version_to_history: If True, a new version will be appended to the existing version history.
-            If False, a new version will only be created if no versions exist yet.
-    """
-    path = _versions_path(dataset.name)
-    if path.exists() and not append_new_version_to_history:
+    Only the start of a new run (a crawl, or the start of a collection run) should
+    do this - all other stages operate on a version that already exists."""
+    path = dataset_resource_path(dataset.name, version, VERSIONS_FILE)
+    if path.exists():
         return
     # get_versions_data always reads from the archive, never from the local file system.
     data = get_versions_data(dataset.name)
@@ -35,8 +26,8 @@ def make_version(
 
 
 def set_last_successful_version(dataset: Dataset, version: Version) -> None:
-    """Set the last successful version in the dataset history."""
-    path = _versions_path(dataset.name)
+    """Set the last successful version in the given run's version history file."""
+    path = dataset_resource_path(dataset.name, version, VERSIONS_FILE)
     if not path.exists():
         raise RuntimeError(
             f"Version history file does not exist for dataset {dataset.name}"
@@ -50,18 +41,3 @@ def set_last_successful_version(dataset: Dataset, version: Version) -> None:
     history.last_successful = version
     with open(path, "w") as fh:
         fh.write(history.to_json())
-
-
-def get_history(dataset_name: str, backfill: bool = True) -> VersionHistory:
-    """Get the version history for a dataset."""
-    path = get_dataset_artifact(dataset_name, VERSIONS_FILE, backfill=backfill)
-    if not path.exists():
-        return VersionHistory([])
-    with open(path, "r") as fh:
-        return VersionHistory.from_json(fh.read())
-
-
-def get_latest(dataset_name: str, backfill: bool = True) -> Optional[Version]:
-    """Get the latest version for a dataset."""
-    history = get_history(dataset_name, backfill=backfill)
-    return history.latest

--- a/zavod/zavod/store.py
+++ b/zavod/zavod/store.py
@@ -3,6 +3,7 @@ import plyvel  # type: ignore
 from typing import List, Optional
 from followthemoney.exc import InvalidData
 from followthemoney import Statement
+from followthemoney.dataset import Version
 from nomenklatura.resolver import Linker
 from nomenklatura.store.level import LevelDBStore, LevelDBView
 
@@ -16,8 +17,10 @@ log = get_logger(__name__)
 View = LevelDBView[Dataset, Entity]
 
 
-def get_store(dataset: Dataset, linker: Linker[Entity]) -> "Store":
-    store = Store(dataset, linker)
+def get_store(
+    dataset: Dataset, linker: Linker[Entity], version: Optional[Version] = None
+) -> "Store":
+    store = Store(dataset, linker, version=version)
     return store
 
 
@@ -26,10 +29,14 @@ class Store(LevelDBStore[Dataset, Entity]):
         self,
         dataset: Dataset,
         linker: Linker[Entity],
+        version: Optional[Version] = None,
     ):
         path = dataset_state_path(dataset.name) / "store"
         super().__init__(dataset, linker, path)
         self.entity_class = Entity
+        self.version = version
+        """The version of the dataset being operated on, if an explicit one is
+        known. Collection leaves resolve their versions independently."""
 
     def view(self, scope: Dataset, external: bool = False) -> View:
         return LevelDBView(self, scope, external=external)
@@ -56,7 +63,9 @@ class Store(LevelDBStore[Dataset, Entity]):
         log.info("Building local LevelDB aggregator...", scope=self.dataset.name)
         idx = 0
         with self.writer() as writer:
-            stmts = iter_dataset_statements(self.dataset, external=True)
+            stmts = iter_dataset_statements(
+                self.dataset, external=True, version=self.version
+            )
             for idx, stmt in enumerate(stmts):
                 if idx > 0 and idx % 50_000 == 0:
                     log.info(

--- a/zavod/zavod/tests/conftest.py
+++ b/zavod/zavod/tests/conftest.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 from tempfile import mkdtemp
 import logging
+from followthemoney.dataset import Version
 from sqlalchemy import MetaData
 from nomenklatura import Resolver
 from nomenklatura.db import close_db, make_session, Session
@@ -119,8 +120,15 @@ def testdataset_dedupe() -> Dataset:
 
 
 @pytest.fixture(scope="function")
+def version() -> Version:
+    """The version minted for the current process, i.e. the one a crawl in a test
+    will produce and operate on."""
+    return settings.RUN_VERSION
+
+
+@pytest.fixture(scope="function")
 def vcontext(testdataset1) -> Generator[Context, None, None]:
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     yield context
     context.close()
 

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -265,7 +265,7 @@ def test_enrich_topic_gated(testdataset1: Dataset, testdataset_enrich_subject: D
     # --- Round 2: give oswell-spencer a risk topic in the subject store ---
     # Simulate what the graph analyzer would do after the first enricher run:
     # tag an adjacent (currently external) entity with a topic and emit external.
-    subject_ctx = Context(testdataset_enrich_subject)
+    subject_ctx = Context(testdataset_enrich_subject, settings.RUN_VERSION)
     subject_ctx.emit(Entity.from_data(testdataset_enrich_subject, UMBRELLA_CORP))
     oswell_patch = Entity.from_data(
         testdataset_enrich_subject,

--- a/zavod/zavod/tests/exporters/test_delta.py
+++ b/zavod/zavod/tests/exporters/test_delta.py
@@ -57,7 +57,8 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
         return resolver.apply(Entity.from_data(testdataset1, data))
 
     version = Version.new("aaa")
-    make_version(testdataset1, version, append_new_version_to_history=True)
+    make_version(testdataset1, version)
+    version_path = dataset_path / version.id
     store.clear()
     writer = store.writer()
     writer.add_entity(e(ENTITY_B))
@@ -67,10 +68,10 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     writer.flush()
     view = store.view(testdataset1)
     assert len(list(view.entities())) == 4
-    export_dataset(testdataset1, view)
+    export_dataset(testdataset1, view, version)
 
-    assert dataset_path.joinpath(DELTA_EXPORT_FILE).exists()
-    with open(dataset_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
+    assert version_path.joinpath(DELTA_EXPORT_FILE).exists()
+    with open(version_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
         objects = [json.loads(line) for line in fh.readlines()]
         assert len(objects) == 4, objects
         for data in objects:
@@ -78,13 +79,14 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
 
     expected_versions = [str(version)]
     _assert_delta_index_matches_expected(
-        dataset_path / DELTA_INDEX_FILE, expected_versions
+        version_path / DELTA_INDEX_FILE, expected_versions
     )
 
-    _archive_artifacts(testdataset1)
+    _archive_artifacts(testdataset1, version)
 
     version2 = Version.new("bbb")
-    make_version(testdataset1, version2, append_new_version_to_history=True)
+    make_version(testdataset1, version2)
+    version2_path = dataset_path / version2.id
     store.clear()
     writer = store.writer()
     writer.add_entity(e(ENTITY_A))
@@ -95,9 +97,9 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     writer.add_entity(e(ENTITY_CX))
     writer.flush()
 
-    export_dataset(testdataset1, view)
-    assert dataset_path.joinpath(DELTA_EXPORT_FILE).exists()
-    with open(dataset_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
+    export_dataset(testdataset1, view, version2)
+    assert version2_path.joinpath(DELTA_EXPORT_FILE).exists()
+    with open(version2_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
         objects = [json.loads(line) for line in fh.readlines()]
         assert len(objects) == 3, [o["entity"]["id"] for o in objects]
         for data in objects:
@@ -109,13 +111,14 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
                 assert data["op"] == "DEL"
     expected_versions.append(str(version2))
     _assert_delta_index_matches_expected(
-        dataset_path / DELTA_INDEX_FILE, expected_versions
+        version2_path / DELTA_INDEX_FILE, expected_versions
     )
 
     # Round 3: check that the delta exporter can handle resolver changes
-    _archive_artifacts(testdataset1)
+    _archive_artifacts(testdataset1, version2)
     version3 = Version.new("ccc")
-    make_version(testdataset1, version3, append_new_version_to_history=True)
+    make_version(testdataset1, version3)
+    version3_path = dataset_path / version3.id
     canon_id = resolver.decide("EC", "ECX", Judgement.POSITIVE)
     store.clear()
     writer = store.writer()
@@ -126,13 +129,11 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     writer.add_entity(e(changed))
     writer.add_entity(e(ENTITY_CX))
     writer.flush()
-    # writer.release()
-    # assert len(store.get_history(testdataset1.name)) == 3
     view = store.view(testdataset1)
 
-    export_dataset(testdataset1, view)
-    assert dataset_path.joinpath(DELTA_EXPORT_FILE).exists()
-    with open(dataset_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
+    export_dataset(testdataset1, view, version3)
+    assert version3_path.joinpath(DELTA_EXPORT_FILE).exists()
+    with open(version3_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
         objects = [json.loads(line) for line in fh.readlines()]
         assert len(objects) == 3, [o["entity"]["id"] for o in objects]
         for data in objects:
@@ -148,5 +149,5 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
                 assert data["op"] == "DEL"
     expected_versions.append(str(version3))
     _assert_delta_index_matches_expected(
-        dataset_path / DELTA_INDEX_FILE, expected_versions
+        version3_path / DELTA_INDEX_FILE, expected_versions
     )

--- a/zavod/zavod/tests/exporters/test_exporters.py
+++ b/zavod/zavod/tests/exporters/test_exporters.py
@@ -14,7 +14,7 @@ from zavod.entity import Entity
 from zavod.integration.dedupe import get_dataset_linker
 from zavod.store import get_store
 from zavod.exporters import export_dataset
-from zavod.archive import clear_data_path, DATASETS
+from zavod.archive import clear_data_path, dataset_version_path
 from zavod.exporters.ftm import FtMExporter
 from zavod.exporters.names import NamesExporter
 from zavod.exporters.simplecsv import SimpleCSVExporter
@@ -42,7 +42,7 @@ def emit_entity(
     id_: Optional[str] = None,
     properties: dict[str, list[str]] = {},
 ) -> Entity:
-    context = Context(ds)
+    context = Context(ds, settings.RUN_VERSION)
     context.begin()
 
     entity = Entity.from_data(
@@ -56,20 +56,21 @@ def emit_entity(
 
 
 def export(dataset: Dataset) -> None:
+    version = settings.RUN_VERSION
     linker = get_dataset_linker(dataset)
-    store = get_store(dataset, linker)
+    store = get_store(dataset, linker, version=version)
     store.sync(clear=True)
     view = store.view(dataset)
-    export_dataset(dataset, view)
+    export_dataset(dataset, view, version)
 
 
 def read_exported_entities(dataset: Dataset) -> list[ValueEntity]:
-    dataset_path = settings.DATA_PATH / DATASETS / dataset.name
+    dataset_path = dataset_version_path(dataset.name, settings.RUN_VERSION)
     return list(path_entities(dataset_path / "entities.ftm.json", ValueEntity))
 
 
 def test_export(testdataset1: Dataset):
-    dataset_path = settings.DATA_PATH / DATASETS / testdataset1.name
+    dataset_path = dataset_version_path(testdataset1.name, settings.RUN_VERSION)
     clear_data_path(testdataset1.name)
 
     crawl_dataset(testdataset1)
@@ -123,7 +124,7 @@ def test_export(testdataset1: Dataset):
 
 def test_minimal_export_config(testdataset2: Dataset):
     """Test export when dataset.exporters is empty list"""
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset2.name
+    dataset_path = dataset_version_path(testdataset2.name, settings.RUN_VERSION)
     clear_data_path(testdataset2.name)
 
     crawl_dataset(testdataset2)
@@ -148,7 +149,7 @@ def test_minimal_export_config(testdataset2: Dataset):
 
 def test_custom_export_config(testdataset2_export: Dataset):
     """Test export when dataset.exporters has custom exports listed"""
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset2_export.name
+    dataset_path = dataset_version_path(testdataset2_export.name, settings.RUN_VERSION)
     clear_data_path(testdataset2_export.name)
 
     crawl_dataset(testdataset2_export)
@@ -248,7 +249,7 @@ def test_ftm_referents(testdataset1: Dataset, resolver: Resolver[Entity]):
 
 
 def test_names(testdataset1: Dataset):
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    dataset_path = dataset_version_path(testdataset1.name, settings.RUN_VERSION)
     clear_data_path(testdataset1.name)
 
     crawl_dataset(testdataset1)
@@ -265,7 +266,7 @@ def test_names(testdataset1: Dataset):
 
 
 def test_targets_simple(testdataset1: Dataset):
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    dataset_path = dataset_version_path(testdataset1.name, settings.RUN_VERSION)
     clear_data_path(testdataset1.name)
 
     crawl_dataset(testdataset1)
@@ -318,7 +319,7 @@ def test_targets_simple(testdataset1: Dataset):
 
 
 def test_statements(testdataset1: Dataset):
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    dataset_path = dataset_version_path(testdataset1.name, settings.RUN_VERSION)
     clear_data_path(testdataset1.name)
 
     crawl_dataset(testdataset1)
@@ -355,7 +356,7 @@ def test_statements_preserves_consolidated_removals() -> None:
 
     export(collection)
 
-    dataset_path = settings.DATA_PATH / DATASETS / collection.name
+    dataset_path = dataset_version_path(collection.name, settings.RUN_VERSION)
 
     # Statements export must contain both the original variants, even though
     # consolidation removes "JOHN DOE" as a case-duplicate of "John Doe".

--- a/zavod/zavod/tests/exporters/test_maritime.py
+++ b/zavod/zavod/tests/exporters/test_maritime.py
@@ -4,12 +4,12 @@ from zavod.tests.exporters.util import harnessed_export
 from zavod.meta import Dataset
 from zavod.exporters.maritime import MaritimeExporter
 from zavod import settings
-from zavod.archive import clear_data_path
+from zavod.archive import clear_data_path, dataset_version_path
 from zavod.crawl import crawl_dataset
 
 
 def test_maritime(testdataset_maritime: Dataset):
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset_maritime.name
+    dataset_path = dataset_version_path(testdataset_maritime.name, settings.RUN_VERSION)
     clear_data_path(testdataset_maritime.name)
 
     crawl_dataset(testdataset_maritime)

--- a/zavod/zavod/tests/exporters/test_metadata.py
+++ b/zavod/zavod/tests/exporters/test_metadata.py
@@ -13,12 +13,13 @@ from zavod.store import get_store
 def test_metadata_collection_export(
     testdataset1: Dataset, collection: Dataset, resolver: Resolver[Entity]
 ) -> None:
-    ds_path = settings.DATA_PATH / "datasets" / testdataset1.name
-    crawl_dataset(testdataset1)
-    store = get_store(testdataset1, resolver)
+    version = settings.RUN_VERSION
+    ds_path = settings.DATA_PATH / "datasets" / testdataset1.name / version.id
+    crawl_dataset(testdataset1, version=version)
+    store = get_store(testdataset1, resolver, version=version)
     store.sync()
     view = store.view(testdataset1)
-    export_dataset(testdataset1, view)
+    export_dataset(testdataset1, view, version)
     assert ds_path.is_dir()
     catalog_path = ds_path / "catalog.json"
     assert not catalog_path.is_file()
@@ -33,8 +34,8 @@ def test_metadata_collection_export(
         assert testdataset1.model.resolve is False
         assert index["resolve"] is False, index
 
-    collection_path = settings.DATA_PATH / "datasets" / collection.name
-    export_dataset(collection, view)
+    collection_path = settings.DATA_PATH / "datasets" / collection.name / version.id
+    export_dataset(collection, view, version)
     assert collection_path.is_dir()
 
     with open(collection_path / "index.json", "r") as fh:

--- a/zavod/zavod/tests/exporters/test_nested.py
+++ b/zavod/zavod/tests/exporters/test_nested.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from zavod import settings
 from zavod.meta import Dataset
-from zavod.archive import clear_data_path
+from zavod.archive import clear_data_path, dataset_version_path
 from zavod.exporters.nested import NestedTargetsJSONExporter
 from zavod.crawl import crawl_dataset
 from zavod.tests.exporters.util import harnessed_export
@@ -13,7 +13,7 @@ TIME_SECONDS_FMT = "%Y-%m-%dT%H:%M:%S"
 
 
 def test_nested_targets(testdataset1: Dataset):
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    dataset_path = dataset_version_path(testdataset1.name, settings.RUN_VERSION)
     clear_data_path(testdataset1.name)
 
     crawl_dataset(testdataset1)

--- a/zavod/zavod/tests/exporters/test_securities.py
+++ b/zavod/zavod/tests/exporters/test_securities.py
@@ -4,12 +4,12 @@ from zavod.tests.exporters.util import harnessed_export
 from zavod.meta import Dataset
 from zavod.exporters.securities import SecuritiesExporter
 from zavod import settings
-from zavod.archive import clear_data_path
+from zavod.archive import clear_data_path, dataset_version_path
 from zavod.crawl import crawl_dataset
 
 
 def test_securities(testdataset2_export: Dataset):
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset2_export.name
+    dataset_path = dataset_version_path(testdataset2_export.name, settings.RUN_VERSION)
     clear_data_path(testdataset2_export.name)
 
     crawl_dataset(testdataset2_export)

--- a/zavod/zavod/tests/exporters/test_senzing.py
+++ b/zavod/zavod/tests/exporters/test_senzing.py
@@ -2,7 +2,7 @@ from json import loads
 
 from zavod import settings
 from zavod.meta import Dataset
-from zavod.archive import clear_data_path
+from zavod.archive import clear_data_path, dataset_version_path
 from zavod.exporters.senzing import SenzingExporter
 from zavod.crawl import crawl_dataset
 from zavod.tests.exporters.util import harnessed_export
@@ -11,7 +11,7 @@ from zavod.tests.exporters.util import harnessed_export
 def test_senzing(testdataset1: Dataset):
     """Tests whether the senzing output contain the expected entities, with expected
     keys and value formats."""
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    dataset_path = dataset_version_path(testdataset1.name, settings.RUN_VERSION)
     clear_data_path(testdataset1.name)
 
     crawl_dataset(testdataset1)

--- a/zavod/zavod/tests/exporters/test_statistics.py
+++ b/zavod/zavod/tests/exporters/test_statistics.py
@@ -1,7 +1,7 @@
 from json import load
 
 from zavod import settings, Context
-from zavod.archive import clear_data_path
+from zavod.archive import clear_data_path, dataset_version_path
 from zavod.exporters.statistics import StatisticsExporter
 from zavod.meta import Dataset
 from zavod.crawl import crawl_dataset
@@ -9,7 +9,7 @@ from zavod.tests.exporters.util import harnessed_export
 
 
 def test_statistics(testdataset1: Dataset):
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    dataset_path = dataset_version_path(testdataset1.name, settings.RUN_VERSION)
     clear_data_path(testdataset1.name)
 
     crawl_dataset(testdataset1)
@@ -54,7 +54,7 @@ def test_statistics(testdataset1: Dataset):
 
 
 def test_sanction_programs(testdataset1):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     company = context.make("Company")
     company.id = "company-evil"
@@ -70,7 +70,7 @@ def test_sanction_programs(testdataset1):
     context.close()
     harnessed_export(StatisticsExporter, testdataset1)
 
-    dataset_path = settings.DATA_PATH / "datasets" / testdataset1.name
+    dataset_path = dataset_version_path(testdataset1.name, settings.RUN_VERSION)
     with open(dataset_path / "statistics.json") as statistics_file:
         statistics = load(statistics_file)
 

--- a/zavod/zavod/tests/exporters/util.py
+++ b/zavod/zavod/tests/exporters/util.py
@@ -1,3 +1,4 @@
+from zavod import settings
 from zavod.context import Context
 from zavod.exporters.consolidate import consolidate_entity
 from zavod.store import get_store
@@ -6,11 +7,12 @@ from zavod.integration import get_dataset_linker
 
 
 def harnessed_export(exporter_class, dataset, linker=None) -> None:
-    context = Context(dataset)
+    version = settings.RUN_VERSION
+    context = Context(dataset, version)
     context.begin(clear=False)
     if linker is None:
         linker = get_dataset_linker(dataset)
-    store = get_store(dataset, linker)
+    store = get_store(dataset, linker, version=version)
     store.sync()
     view = store.view(dataset)
 

--- a/zavod/zavod/tests/extract/test_zyte_api.py
+++ b/zavod/zavod/tests/extract/test_zyte_api.py
@@ -2,6 +2,7 @@ import pytest
 import requests_mock
 from base64 import b64encode
 
+from zavod import settings
 from zavod.context import Context
 from zavod.meta.dataset import Dataset
 from zavod.extract.zyte_api import (
@@ -14,7 +15,7 @@ from zavod.extract.zyte_api import (
 
 
 def test_browser_html(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -52,7 +53,7 @@ def test_browser_html(testdataset1: Dataset):
 
 
 def test_fetch_html_http_response_body(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -85,7 +86,7 @@ def test_fetch_html_http_response_body(testdataset1: Dataset):
 
 
 def test_fetch_html_detects_missing_charset(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     # Legacy pages declare their encoding only in a <meta> tag, not the HTTP
     # Content-Type header. Byte 0xf0 ('š' in windows-1257) is invalid UTF-8, so
@@ -115,7 +116,7 @@ def test_fetch_html_detects_missing_charset(testdataset1: Dataset):
 
 
 def test_unblock_failed(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -130,7 +131,7 @@ def test_unblock_failed(testdataset1: Dataset):
 
 
 def test_caching(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -154,7 +155,7 @@ def test_caching(testdataset1: Dataset):
 
 
 def test_fetch_resource(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     url = "https://test.com/download.csv"
 
     with requests_mock.Mocker() as m:
@@ -210,7 +211,7 @@ def test_fetch_resource(testdataset1: Dataset):
 
 
 def test_fetch_text(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -237,7 +238,7 @@ def test_fetch_text(testdataset1: Dataset):
 
 
 def test_fetch_json(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -267,7 +268,7 @@ def test_fetch_json(testdataset1: Dataset):
 
 
 def test_fetch_json_expect_json(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.post(

--- a/zavod/zavod/tests/helpers/test_positions.py
+++ b/zavod/zavod/tests/helpers/test_positions.py
@@ -10,7 +10,7 @@ from zavod.helpers.positions import make_position, make_occupancy, earliest_term
 
 
 def test_make_position(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     name = "Minister of finance"
     de = make_position(context, name=name, country="de")
     de_with_date = make_position(
@@ -25,7 +25,7 @@ def test_make_position(testdataset1: Dataset):
 
 
 def test_make_position_full(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     org = context.make("Organization")
     org.id = "myorg"
     one_with_everything = make_position(
@@ -66,7 +66,7 @@ def test_make_position_translate_name(testdataset1: Dataset):
     """With translate_name, a non-English name is translated to English
     and stored as the name (original kept as original_value), while the id stays
     keyed on the untranslated name so it's stable regardless of the LLM output."""
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     with patch(
         "zavod.shed.trans.translate_position_name",
         return_value=TranslationResult(
@@ -107,7 +107,7 @@ def test_make_position_translate_name_uses_dataset_language():
             },
         }
     )
-    context = Context(dataset)
+    context = Context(dataset, settings.RUN_VERSION)
     with patch(
         "zavod.shed.trans.translate_position_name",
         return_value=TranslationResult(
@@ -143,7 +143,7 @@ def test_make_position_dataset_language_is_not_statement_override():
             },
         }
     )
-    context = Context(dataset)
+    context = Context(dataset, settings.RUN_VERSION)
     position = make_position(
         context,
         name="Speaker",
@@ -158,7 +158,7 @@ def test_make_position_dataset_language_is_not_statement_override():
 
 def test_make_position_translate_fallback(testdataset1: Dataset):
     """When translation yields no English text, the original name is kept."""
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     with patch(
         "zavod.shed.trans.translate_position_name",
         return_value=TranslationResult(texts=[], cache_key=None, origin="test-model"),
@@ -176,7 +176,7 @@ def test_make_position_translate_fallback(testdataset1: Dataset):
 
 def test_make_position_translate_skipped_for_english(testdataset1: Dataset):
     """Translation is skipped when the language is already English or unset."""
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     with patch("zavod.shed.trans.translate_position_name") as mock_translate:
         eng = make_position(
             context,
@@ -195,7 +195,7 @@ def test_make_position_translate_skipped_for_english(testdataset1: Dataset):
 
 
 def test_make_occupancy(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     pos = make_position(context, name="A position", country="ls")
     person = context.make("Person")
     person.id = "thabo"
@@ -230,7 +230,7 @@ def test_occupancy_not_same_start_end_id(testdataset1: Dataset):
     same end but no start, don't end up with the same ID. This occurs in the wild
     when a source has an unknown start date, ends a term, then starts the next
     term."""
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     pos = make_position(context, name="A position", country="ls")
     person = context.make("Person")
     person.id = "thabo"
@@ -262,7 +262,7 @@ def test_occupancy_dataset_coverage():
             "prefix": "dataset1",
         },
     )
-    context1 = Context(dataset1)
+    context1 = Context(dataset1, settings.RUN_VERSION)
     pos = make_position(context1, name="A position", country="ls")
     person = context1.make("Person")
     person.id = "thabo"
@@ -287,7 +287,7 @@ def test_occupancy_dataset_coverage():
             "prefix": "dataset2",
         },
     )
-    context2 = Context(dataset2)
+    context2 = Context(dataset2, settings.RUN_VERSION)
     pos2 = make_position(context2, name="A position", country="ls")
     person2 = context2.make("Person")
     person2.id = "thabo"

--- a/zavod/zavod/tests/helpers/test_securities.py
+++ b/zavod/zavod/tests/helpers/test_securities.py
@@ -1,10 +1,11 @@
+from zavod import settings
 from zavod.context import Context
 from zavod.meta import Dataset
 from zavod.helpers.securities import make_security
 
 
 def test_make_security(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     entity = make_security(context, "XS1234567890")
     assert entity.id == "isin-XS1234567890"
     assert entity.schema.name == "Security"

--- a/zavod/zavod/tests/runtime/test_issues.py
+++ b/zavod/zavod/tests/runtime/test_issues.py
@@ -1,14 +1,17 @@
 import json
 from rigour.time import iso_datetime
 import logging
+from zavod import settings
 from zavod.archive import ISSUES_FILE, dataset_resource_path
 from zavod.context import Context
 from zavod.meta import Dataset
 
 
 def test_issue_logger(testdataset1: Dataset, logger: logging.Logger):
-    issues_path = dataset_resource_path(testdataset1.name, ISSUES_FILE)
-    context = Context(testdataset1)
+    issues_path = dataset_resource_path(
+        testdataset1.name, settings.RUN_VERSION, ISSUES_FILE
+    )
+    context = Context(testdataset1, settings.RUN_VERSION)
     context.begin(clear=True)
     assert not issues_path.exists()
     entity = context.make("Person")
@@ -45,7 +48,7 @@ def test_issue_logger(testdataset1: Dataset, logger: logging.Logger):
             assert issue["level"] in ("warning", "error")
             assert issue["dataset"] == testdataset1.name
 
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     context.begin(clear=True)
     assert len(list(context.issues.all())) == 0
     context.close()

--- a/zavod/zavod/tests/runtime/test_resources.py
+++ b/zavod/zavod/tests/runtime/test_resources.py
@@ -1,6 +1,7 @@
 import pytest
 import shutil
 
+from zavod import settings
 from zavod.archive import dataset_resource_path
 from zavod.meta import Dataset
 from zavod.runtime.resources import DatasetResources
@@ -11,17 +12,18 @@ CSV_PATH = DATASET_1_YML.parent / "dataset.csv"
 
 
 def test_resources(testdataset1: Dataset):
-    resources = DatasetResources(testdataset1)
+    version = settings.RUN_VERSION
+    resources = DatasetResources(testdataset1, version)
     resources.clear()
     assert len(resources.all()) == 0
 
     with pytest.raises(ValueError):
-        testdataset1.resource_from_path(CSV_PATH)
+        testdataset1.resource_from_path(CSV_PATH.parent / "nonexistent.csv", "x.csv")
 
-    resource_path = dataset_resource_path(testdataset1.name, "dataset.csv")
+    resource_path = dataset_resource_path(testdataset1.name, version, "dataset.csv")
     shutil.copyfile(CSV_PATH, resource_path)
 
-    resource = testdataset1.resource_from_path(resource_path)
+    resource = testdataset1.resource_from_path(resource_path, "dataset.csv")
     assert resource.name == "dataset.csv"
     assert resource.size is not None
     assert resource.size > 0
@@ -35,7 +37,7 @@ def test_resources(testdataset1: Dataset):
     resources.save(resource)
     assert len(resources.all()) == 1
 
-    resources2 = DatasetResources(testdataset1)
+    resources2 = DatasetResources(testdataset1, version)
     assert len(resources2.all()) == 1
     assert resources2.all()[0].name == "dataset.csv"
 

--- a/zavod/zavod/tests/runtime/test_timestamps.py
+++ b/zavod/zavod/tests/runtime/test_timestamps.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from shutil import copyfile
 from rigour.time import utc_now
+from followthemoney.dataset import Version
 
 from zavod import settings
 from zavod.meta import Dataset
@@ -34,20 +35,31 @@ def test_timestamps(testdataset1: Dataset):
     assert "TimeStampIndex" in repr(index), repr(index)
 
 
-def test_backfill(testdataset1: Dataset):
+def test_backfill(testdataset1: Dataset, monkeypatch):
     prev_time = settings.RUN_TIME_ISO
     crawl_dataset(testdataset1)
 
     archive_path = settings.ARCHIVE_PATH / "datasets/latest" / testdataset1.name
     archive_path.mkdir(parents=True, exist_ok=True)
     copyfile(
-        settings.DATA_PATH / "datasets" / testdataset1.name / "statements.pack",
+        settings.DATA_PATH
+        / "datasets"
+        / testdataset1.name
+        / settings.RUN_VERSION.id
+        / "statements.pack",
         archive_path / "statements.pack",
     )
 
-    settings.RUN_TIME = settings.RUN_TIME + timedelta(days=1)
-    settings.RUN_TIME_ISO = settings.RUN_TIME.isoformat(sep="T", timespec="seconds")
-    settings.RUN_DATE = settings.RUN_TIME.date().isoformat()
+    # A new run a day later is a new version. monkeypatch restores the process
+    # globals afterwards, so bumping the run time doesn't leak into other tests.
+    later = settings.RUN_TIME + timedelta(days=1)
+    later_version = Version.from_string(later.strftime("%Y%m%d%H%M%S") + "-bbb")
+    monkeypatch.setattr(settings, "RUN_VERSION", later_version)
+    monkeypatch.setattr(settings, "RUN_TIME", later)
+    monkeypatch.setattr(
+        settings, "RUN_TIME_ISO", later.isoformat(sep="T", timespec="seconds")
+    )
+    monkeypatch.setattr(settings, "RUN_DATE", later.date().isoformat())
     second_time = settings.RUN_TIME_ISO
     crawl_dataset(testdataset1)
 

--- a/zavod/zavod/tests/stateful/test_positions.py
+++ b/zavod/zavod/tests/stateful/test_positions.py
@@ -15,7 +15,7 @@ from zavod.helpers.positions import make_position
 
 
 def test_occupancy_status(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     person = context.make("Person")
     person.id = "thabo"
 
@@ -164,7 +164,7 @@ def test_occupancy_status(testdataset1: Dataset):
 
 
 def test_categorise_flow(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     position = make_position(
         context, "A position", country="ls", subnational_area="Maseru"
     )
@@ -205,7 +205,7 @@ def test_categorise_flow(testdataset1: Dataset):
 def test_categorise_updates_changed_metadata(testdataset1: Dataset):
     """When caption/countries/subnationalArea on a position change, the
     existing row is updated in place rather than a new one being inserted."""
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     position = make_position(
         context, "Minister of Health", country="us", subnational_area="California"

--- a/zavod/zavod/tests/stateful/test_review.py
+++ b/zavod/zavod/tests/stateful/test_review.py
@@ -1,6 +1,7 @@
 from lxml import html
 from rigour.time import utc_now
 from pydantic import BaseModel
+from followthemoney.dataset import Version
 
 from zavod import settings
 from zavod.context import Context
@@ -38,7 +39,7 @@ def get_all_rows(conn, key):
 
 
 def test_new_key_saved_and_accepted_false(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     data = DummyModel(foo="bar")
     review = review_extraction(
         context,
@@ -63,8 +64,10 @@ def test_no_change_updates_last_seen_version(testdataset1, monkeypatch):
     #   postconditions:
     #     - no new row
     #     - last_seen_version updated
-    monkeypatch.setattr(settings, "RUN_VERSION", "20240101010101-aaa")
-    context1 = Context(testdataset1)
+    monkeypatch.setattr(
+        settings, "RUN_VERSION", Version.from_string("20240101010101-aaa")
+    )
+    context1 = Context(testdataset1, settings.RUN_VERSION)
     context1.begin(clear=True)
     context1_version = context1.version.id
     source_value = mock_source_value("key2")
@@ -79,8 +82,10 @@ def test_no_change_updates_last_seen_version(testdataset1, monkeypatch):
     key2 = review_key("key2")
     row = get_row(context1.db, key2)
     assert row and row["last_seen_version"] == context1_version
-    monkeypatch.setattr(settings, "RUN_VERSION", "20240101010102-aaa")
-    context2 = Context(testdataset1)
+    monkeypatch.setattr(
+        settings, "RUN_VERSION", Version.from_string("20240101010102-aaa")
+    )
+    context2 = Context(testdataset1, settings.RUN_VERSION)
     context2.begin(clear=True)
     context2_version = context2.version.id
     review2 = review_extraction(
@@ -115,7 +120,7 @@ def test_source_changed_resets_review(testdataset1: Dataset):
     #   Also testing that original default_accepted=True saves,
     #   but the resetting crawl can set it to False.
 
-    context1 = Context(testdataset1)
+    context1 = Context(testdataset1, settings.RUN_VERSION)
     source_value1 = TextSourceValue(
         key_parts="key3", label="test", url="http://s", text="bar"
     )
@@ -142,7 +147,7 @@ def test_source_changed_resets_review(testdataset1: Dataset):
         key_parts="key3", label="test", url="http://s", text="baz"
     )
     data2 = DummyModel(foo="baz")
-    context2 = Context(testdataset1)
+    context2 = Context(testdataset1, settings.RUN_VERSION)
     review = review_extraction(
         context2,
         crawler_version=1,
@@ -170,7 +175,7 @@ def test_unaccepted_updates_original_extraction(testdataset1: Dataset):
     #     - a new version of the review is created
     #     - original_extraction is the new data
     #     - extracted_data is is the new data
-    context1 = Context(testdataset1)
+    context1 = Context(testdataset1, settings.RUN_VERSION)
     data1 = DummyModel(foo="foo")
     review1 = review_extraction(
         context1,
@@ -187,7 +192,7 @@ def test_unaccepted_updates_original_extraction(testdataset1: Dataset):
     assert row1["original_extraction"]["foo"] == "foo"
     assert row1["extracted_data"]["foo"] == "foo"
 
-    context2 = Context(testdataset1)
+    context2 = Context(testdataset1, settings.RUN_VERSION)
     data2 = DummyModel(foo="bar")
     review_extraction(
         context2,
@@ -209,7 +214,7 @@ def test_unaccepted_updates_original_extraction(testdataset1: Dataset):
 
 
 def test_crawler_version_bump_resets_review(testdataset1: Dataset):
-    context1 = Context(testdataset1)
+    context1 = Context(testdataset1, settings.RUN_VERSION)
     review = review_extraction(
         context1,
         crawler_version=1,
@@ -232,7 +237,7 @@ def test_crawler_version_bump_resets_review(testdataset1: Dataset):
         foo: str
         baz: str  # baz is required in the new model -> backward incompatible
 
-    context2 = Context(testdataset1)
+    context2 = Context(testdataset1, settings.RUN_VERSION)
     review = review_extraction(
         context2,
         crawler_version=2,
@@ -327,7 +332,7 @@ def test_source_changed_updates_source_fields(testdataset1: Dataset):
     #   postconditions:
     #     - source_value, source_mime_type, source_label, source_url are all
     #       updated to reflect the new source
-    context1 = Context(testdataset1)
+    context1 = Context(testdataset1, settings.RUN_VERSION)
     source_value1 = TextSourceValue(
         key_parts="key8", label="label-old", url="http://s/old", text="old text"
     )
@@ -340,7 +345,7 @@ def test_source_changed_updates_source_fields(testdataset1: Dataset):
         default_accepted=True,
     )
 
-    context2 = Context(testdataset1)
+    context2 = Context(testdataset1, settings.RUN_VERSION)
     source_value2 = TextSourceValue(
         key_parts="key8", label="label-new", url="http://s/new", text="new text"
     )

--- a/zavod/zavod/tests/test_archive.py
+++ b/zavod/zavod/tests/test_archive.py
@@ -1,5 +1,7 @@
 import shutil
 
+from followthemoney.dataset import Version
+
 from zavod import settings
 from zavod.meta import Dataset
 from zavod.runtime.versions import make_version
@@ -13,7 +15,7 @@ def test_archive_then_publish(testdataset1: Dataset):
     name = "foo.json"
     version = settings.RUN_VERSION
     data_path = dataset_data_path(testdataset1.name)
-    local_path = dataset_resource_path(testdataset1.name, name)
+    local_path = dataset_resource_path(testdataset1.name, version, name)
     artifacts_root = settings.ARCHIVE_PATH / ARTIFACTS
     datasets_root = settings.ARCHIVE_PATH / DATASETS
 
@@ -57,22 +59,33 @@ def test_archive_then_publish(testdataset1: Dataset):
 
 def test_artifact_backfill(testdataset1: Dataset):
     name = "foo.json"
-    local_path = dataset_resource_path(testdataset1.name, name)
+    version = settings.RUN_VERSION
+    local_path = dataset_resource_path(testdataset1.name, version, name)
     assert not local_path.exists()
     with open(local_path, "w") as fh:
         fh.write("hello, world!\n")
 
     artifacts_path = settings.ARCHIVE_PATH / ARTIFACTS / testdataset1.name
-    archive_artifact(local_path, testdataset1.name, settings.RUN_VERSION, name)
+    archive_artifact(local_path, testdataset1.name, version, name)
     assert artifacts_path.is_dir()
     local_path.unlink()
-    local_path = get_dataset_artifact(testdataset1.name, name)
-    # Data is unpublished:
+    assert not local_path.exists()
+
+    # Backfilling references an exact version and does not depend on a published
+    # version history existing.
     versions_file = artifacts_path / VERSIONS_FILE
     assert not versions_file.exists()
-    assert not local_path.exists()
-    make_version(testdataset1, settings.RUN_VERSION)
-    publish_version_history(testdataset1.name)
+    backfilled = get_dataset_artifact(testdataset1.name, version, name)
+    assert backfilled.exists()
+    assert backfilled.read_text() == "hello, world!\n"
+
+    # A different version has no such artifact, so nothing is backfilled.
+    backfilled.unlink()
+    other_version = Version.new("zzz")
+    missing = get_dataset_artifact(testdataset1.name, other_version, name)
+    assert not missing.exists()
+
+    # Publishing the version history writes the dataset's root versions.json.
+    make_version(testdataset1, version)
+    publish_version_history(testdataset1.name, version)
     assert versions_file.exists()
-    local_path = get_dataset_artifact(testdataset1.name, name)
-    assert local_path.exists()

--- a/zavod/zavod/tests/test_cli.py
+++ b/zavod/zavod/tests/test_cli.py
@@ -32,6 +32,11 @@ def test_export_dataset():
     runner = CliRunner()
     result = runner.invoke(cli, ["export", "/dev/null"])
     assert result.exit_code != 0, result.output
+    # Export operates on the latest local run, so it errors without a crawl first.
+    result = runner.invoke(cli, ["export", DATASET_1_YML.as_posix()])
+    assert result.exit_code != 0, result.output
+    result = runner.invoke(cli, ["crawl", DATASET_1_YML.as_posix()])
+    assert result.exit_code == 0, result.output
     result = runner.invoke(cli, ["export", DATASET_1_YML.as_posix()])
     assert result.exit_code == 0, result.output
     shutil.rmtree(settings.DATA_PATH)
@@ -41,6 +46,11 @@ def test_validate_dataset():
     runner = CliRunner()
     result = runner.invoke(cli, ["validate", "/dev/null"])
     assert result.exit_code != 0, result.output
+    # Validation operates on the latest local run, so it errors without a crawl first.
+    result = runner.invoke(cli, ["validate", DATASET_1_YML.as_posix()])
+    assert result.exit_code != 0, result.output
+    result = runner.invoke(cli, ["crawl", DATASET_1_YML.as_posix()])
+    assert result.exit_code == 0, result.output
     result = runner.invoke(cli, ["validate", DATASET_1_YML.as_posix()])
     assert result.exit_code == 0, result.output
     shutil.rmtree(settings.DATA_PATH)
@@ -122,16 +132,25 @@ def test_run_update_last_successful_version(
 ):
     runner = CliRunner()
 
-    # testdataset3 has validation errors, so last_successful should NOT be set
+    # testdataset3 has validation errors, so last_successful should NOT be set.
+    # The crawl still minted the version, so the version history file exists.
     result = runner.invoke(cli, ["run", "--latest", DATASET_3_YML.as_posix()])
     assert result.exit_code != 0, result.output
-    versions_path = dataset_resource_path(testdataset3.name, VERSIONS_FILE)
-    assert not versions_path.exists(), "versions.json should not exist after failed run"
+    versions_path = dataset_resource_path(
+        testdataset3.name, settings.RUN_VERSION, VERSIONS_FILE
+    )
+    assert versions_path.exists(), "versions.json should exist after crawl"
+    history = VersionHistory.from_json(versions_path.read_text())
+    assert history.last_successful is None, (
+        "last_successful should not be set on failure"
+    )
 
     # testdataset1 succeeds, so last_successful should be set
     result = runner.invoke(cli, ["run", "--latest", DATASET_1_YML.as_posix()])
     assert result.exit_code == 0, result.output
-    versions_path = dataset_resource_path(testdataset1.name, VERSIONS_FILE)
+    versions_path = dataset_resource_path(
+        testdataset1.name, settings.RUN_VERSION, VERSIONS_FILE
+    )
     assert versions_path.exists(), "versions.json should exist after run"
     history = VersionHistory.from_json(versions_path.read_text())
     assert history.last_successful is not None

--- a/zavod/zavod/tests/test_context.py
+++ b/zavod/zavod/tests/test_context.py
@@ -22,7 +22,7 @@ from zavod.tests.conftest import XML_DOC
 
 
 def test_context_helpers(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     assert context.dataset == testdataset1
     assert "docs.google.com" in context.data_url
     assert testdataset1.name in repr(context)
@@ -75,7 +75,7 @@ def test_context_helpers(testdataset1: Dataset):
 
 
 def test_context_dry_run(testdataset1: Dataset):
-    context = Context(testdataset1, dry_run=True)
+    context = Context(testdataset1, settings.RUN_VERSION, dry_run=True)
     assert context.dataset == testdataset1
     context.begin(clear=True)
     assert context.dry_run
@@ -85,7 +85,7 @@ def test_context_dry_run(testdataset1: Dataset):
 
 
 def test_context_get_fetchers(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.get("/bla", text="Hello, World!")
@@ -151,7 +151,7 @@ def test_context_get_fetchers(testdataset1: Dataset):
 
 
 def test_context_fetch_text_encoding_cache(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     url = "https://test.com/encoding"
     body = "商务部".encode("utf-8")
 
@@ -175,7 +175,7 @@ def test_context_fetch_text_encoding_cache(testdataset1: Dataset):
 
 
 def test_context_post_fetchers(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with requests_mock.Mocker() as m:
         m.post("/bla", text="Hello, World!")
@@ -223,7 +223,7 @@ def test_context_post_fetchers(testdataset1: Dataset):
 
 
 def test_context_fetchers_exceptions(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
 
     with pytest.raises(ValueError, match="Unsupported HTTP method.+"):
         context.fetch_text("https://test.com/bla", cache_days=0, method="PLOP")
@@ -270,7 +270,7 @@ def test_context_fetchers_exceptions(testdataset1: Dataset):
 
 
 def test_context_clear_url(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     url = "https://test.com/bla"
 
     with requests_mock.Mocker() as m:
@@ -313,11 +313,13 @@ def test_context_clear_url(testdataset1: Dataset):
 
 
 def test_crawl_dataset(testdataset1: Dataset):
-    path = dataset_resource_path(testdataset1.name, STATEMENTS_FILE)
+    path = dataset_resource_path(
+        testdataset1.name, settings.RUN_VERSION, STATEMENTS_FILE
+    )
     if path.is_file():
         path.unlink()
     assert len(list(iter_dataset_statements(testdataset1))) == 0
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     context.begin(clear=True)
     assert len(context.resources.all()) == 0
     func = load_entry_point(testdataset1)
@@ -347,7 +349,7 @@ def test_crawl_dataset_wrapper(testdataset1: Dataset):
 
 
 def test_dataset_sink(testdataset1: Dataset):
-    context = Context(testdataset1)
+    context = Context(testdataset1, settings.RUN_VERSION)
     assert context._writer_path.is_relative_to(settings.DATA_PATH)
     entity = context.make("Person")
     entity.id = "foo"

--- a/zavod/zavod/tests/test_logs.py
+++ b/zavod/zavod/tests/test_logs.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import zavod
-from zavod import Context, Dataset
+from zavod import Context, Dataset, settings
 from zavod.archive import dataset_resource_path, ISSUES_FILE
 from zavod.logs import (
     RedactingProcessor,
@@ -98,8 +98,10 @@ def test_redacts_issue_logger(testdataset1: Dataset):
     logger = zavod.logs.configure_logging()
 
     try:
-        issues_path = dataset_resource_path(testdataset1.name, ISSUES_FILE)
-        context = Context(testdataset1)
+        issues_path = dataset_resource_path(
+            testdataset1.name, settings.RUN_VERSION, ISSUES_FILE
+        )
+        context = Context(testdataset1, settings.RUN_VERSION)
         context.begin(clear=True)
         assert not issues_path.exists()
 

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -17,6 +17,7 @@ from zavod.store import get_store
 from zavod.exporters import export_dataset
 from zavod.integration import get_dataset_linker
 from zavod.publish import publish_dataset, archive_failure
+from zavod.runtime.versions import make_version
 from zavod.exc import RunFailedException
 
 STANDARD_EXPORTS = {
@@ -55,14 +56,15 @@ def test_publish_dataset(testdataset1: Dataset):
     assert not latest_path.joinpath(INDEX_FILE).exists()
     history = _read_history(testdataset1.name)
     assert history is None
-    crawl_dataset(testdataset1)
-    store = get_store(testdataset1, linker)
+    version = settings.RUN_VERSION
+    crawl_dataset(testdataset1, version=version)
+    store = get_store(testdataset1, linker, version=version)
     store.sync()
     view = store.view(testdataset1)
-    export_dataset(testdataset1, view)
+    export_dataset(testdataset1, view, version)
 
     with capture_logs() as cap_logs:
-        publish_dataset(testdataset1, republish_to_latest=False)
+        publish_dataset(testdataset1, version, republish_to_latest=False)
     assert not filter_logs(cap_logs, ("warning", "error")), cap_logs
     history = _read_history(testdataset1.name)
     assert history is not None
@@ -97,7 +99,7 @@ def test_publish_dataset(testdataset1: Dataset):
     latest_artifacts = {str(p.name) for p in latest_path.glob("*")}
     assert latest_artifacts == set()
 
-    publish_dataset(testdataset1, republish_to_latest=True)
+    publish_dataset(testdataset1, version, republish_to_latest=True)
     assert latest_path.joinpath(INDEX_FILE).exists()
 
     artifact_index = artifact_path.joinpath(INDEX_FILE).read_bytes()
@@ -122,9 +124,9 @@ def test_publish_dataset(testdataset1: Dataset):
     clear_data_path(testdataset1.name)
     assert len(list(iter_dataset_statements(testdataset1))) > 5
     assert len(list(iter_previous_statements(testdataset1))) > 5
-    path = get_dataset_artifact(testdataset1.name, INDEX_FILE, backfill=False)
+    path = get_dataset_artifact(testdataset1.name, version, INDEX_FILE, backfill=False)
     assert not path.exists()
-    path = get_dataset_artifact(testdataset1.name, INDEX_FILE, backfill=True)
+    path = get_dataset_artifact(testdataset1.name, version, INDEX_FILE, backfill=True)
     assert path.exists()
 
 
@@ -137,15 +139,18 @@ def test_publish_collection(testdataset1: Dataset, collection: Dataset):
     release_path = published_path / settings.RELEASE / collection.name
     latest_path = published_path / "latest" / collection.name
 
-    crawl_dataset(testdataset1)
-    store = get_store(testdataset1, linker)
+    version = settings.RUN_VERSION
+    crawl_dataset(testdataset1, version=version)
+    store = get_store(testdataset1, linker, version=version)
     store.sync()
     view = store.view(testdataset1)
-    export_dataset(testdataset1, view)
+    export_dataset(testdataset1, view, version)
 
-    export_dataset(collection, view)
+    # A collection run mints its own version (leaves were crawled in their own runs).
+    make_version(collection, version)
+    export_dataset(collection, view, version)
     with capture_logs() as cap_logs:
-        publish_dataset(collection, republish_to_latest=True)
+        publish_dataset(collection, version, republish_to_latest=True)
     assert not filter_logs(cap_logs, ("warning", "error")), cap_logs
 
     history = _read_history(collection.name)
@@ -196,11 +201,12 @@ def test_archive_failure(testdataset1: Dataset):
     latest_path = published_path / "latest" / testdataset1.name
     assert testdataset1.data is not None
     testdataset1.data.format = "FAIL"
+    version = settings.RUN_VERSION
     try:
-        crawl_dataset(testdataset1)
+        crawl_dataset(testdataset1, version=version)
     except RunFailedException:
         with capture_logs() as cap_logs:
-            archive_failure(testdataset1)
+            archive_failure(testdataset1, version)
         assert not filter_logs(cap_logs, ("warning", "error")), cap_logs
     clear_data_path(testdataset1.name)
 
@@ -247,15 +253,17 @@ def test_archive_collection_failure(
     # Simulate something that logs results in an issue log during a collection run
     collection.model.exports.add("missing.exp")
 
-    crawl_dataset(testdataset1)
-    store = get_store(testdataset1, linker)
+    version = settings.RUN_VERSION
+    crawl_dataset(testdataset1, version=version)
+    store = get_store(testdataset1, linker, version=version)
     store.sync()
     view = store.view(testdataset1)
-    export_dataset(testdataset1, view)
+    export_dataset(testdataset1, view, version)
 
-    export_dataset(collection, view)
+    make_version(collection, version)
+    export_dataset(collection, view, version)
     # let's imagine there was an exception causing abort
-    archive_failure(collection)
+    archive_failure(collection, version)
 
     history = _read_history(collection.name)
     assert history is not None

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -3,7 +3,7 @@ import uuid
 
 from structlog.testing import capture_logs
 
-from zavod import Entity
+from zavod import Entity, settings
 from zavod.context import Context
 from zavod.crawl import crawl_dataset
 from zavod.integration import get_dataset_linker
@@ -25,7 +25,7 @@ BASE_DATASET_CONFIG = {
 
 
 def run_validator(clazz: Type[BaseValidator], dataset: Dataset):
-    context = Context(dataset)
+    context = Context(dataset, settings.RUN_VERSION)
     linker = get_dataset_linker(dataset)
     store = get_store(dataset, linker)
     # Pass clear so that if the test emits statements and re-validates, we pick that up.
@@ -46,7 +46,7 @@ def run_validator(clazz: Type[BaseValidator], dataset: Dataset):
 
 
 def emit_entity(ds: Dataset, schema: str, properties: dict[str, list[str]]) -> Entity:
-    context = Context(ds)
+    context = Context(ds, settings.RUN_VERSION)
     context.begin()
 
     entity = Entity.from_data(

--- a/zavod/zavod/tests/tools/test_export_catalog.py
+++ b/zavod/zavod/tests/tools/test_export_catalog.py
@@ -11,11 +11,12 @@ from zavod.exporters import export_dataset
 
 
 def export(dataset: Dataset) -> None:
+    version = settings.RUN_VERSION
     linker = get_dataset_linker(dataset)
-    store = get_store(dataset, linker)
+    store = get_store(dataset, linker, version=version)
     store.sync()
     view = store.view(dataset)
-    export_dataset(dataset, view)
+    export_dataset(dataset, view, version)
 
 
 def test_export_index(testdataset1: Dataset, testdataset2: Dataset):

--- a/zavod/zavod/tools/export_catalog.py
+++ b/zavod/zavod/tools/export_catalog.py
@@ -1,18 +1,28 @@
 import json
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from followthemoney import model, registry
+from followthemoney.dataset import Version
 
 from zavod import settings
 from zavod.util import write_json
 from zavod.meta import Dataset
 from zavod.runtime.urls import make_artifact_url, make_published_url
-from zavod.runtime.versions import get_latest
 from zavod.exporters.metadata import get_catalog_datasets
 from zavod.archive import datasets_path, get_dataset_artifact
+from zavod.archive import find_archive_artifact, latest_local_version
 from zavod.archive import INDEX_FILE, STATISTICS_FILE
 from zavod.logs import get_logger
 
 log = get_logger(__name__)
+
+
+def _latest_version(dataset_name: str, resource: str) -> Optional[Version]:
+    """Resolve the newest run of a dataset that has the given resource: a local run
+    if present, otherwise the newest one available in the archive."""
+    version = latest_local_version(dataset_name, with_resource=resource)
+    if version is None:
+        version, _ = find_archive_artifact(dataset_name, resource)
+    return version
 
 
 def get_opensanctions_catalog(scope: Dataset) -> Dict[str, Any]:
@@ -21,14 +31,18 @@ def get_opensanctions_catalog(scope: Dataset) -> Dict[str, Any]:
     datasets = get_catalog_datasets(scope)
 
     schemata = set()
-    statistics_path = get_dataset_artifact(scope.name, STATISTICS_FILE)
-    if statistics_path.is_file():
-        with open(statistics_path, "r") as fh:
-            stats: Dict[str, Any] = json.load(fh)
-            schemata.update(stats.get("schemata", []))
+    stats_version = _latest_version(scope.name, STATISTICS_FILE)
+    if stats_version is not None:
+        statistics_path = get_dataset_artifact(
+            scope.name, stats_version, STATISTICS_FILE
+        )
+        if statistics_path.is_file():
+            with open(statistics_path, "r") as fh:
+                stats: Dict[str, Any] = json.load(fh)
+                schemata.update(stats.get("schemata", []))
 
     log.info("Generating catalog", schemata=len(schemata), datasets=len(datasets))
-    default_version = get_latest("default", backfill=False)
+    default_version = _latest_version("default", "statements.csv")
     if default_version is not None:
         statements_url = make_artifact_url(
             "default", default_version.id, "statements.csv"

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -1,7 +1,8 @@
 from typing import List, Type
 from followthemoney import registry
+from followthemoney.dataset import Version
 
-from zavod.archive import dataset_data_path
+from zavod.archive import dataset_version_path
 from zavod.context import Context
 from zavod.exc import RunFailedException
 from zavod.meta.dataset import Dataset
@@ -70,18 +71,18 @@ VALIDATORS: List[Type[BaseValidator]] = [
 ]
 
 
-def validate_dataset(dataset: Dataset, view: View) -> None:
+def validate_dataset(dataset: Dataset, view: View, version: Version) -> None:
     """
     Run all validators on the given view.
 
     Returns True if publication should be aborted.
     """
-    context = Context(dataset)
+    context = Context(dataset, version)
     try:
         context.begin(clear=False)
         context.log.info(
             "Validating dataset",
-            path=dataset_data_path(dataset.name),
+            path=dataset_version_path(dataset.name, version),
         )
 
         validators = [validator(context, view) for validator in VALIDATORS]


### PR DESCRIPTION
Phase 1 of https://github.com/opensanctions/operations/issues/2675.

Getting an artifact always takes a version now, both in the archive (already true) and on local disk. That kills the implicit "closest thing available, locally or backfilled from the archive" resolution: each stage operates on a version that verifiably exists, and the logs show which one.

## What's in this PR (phase 1)

- Local run artifacts move from a flat `data/datasets/<name>/` to `data/datasets/<name>/<version>/`, mirroring `artifacts/<name>/<version>/` in the archive. New helpers: `dataset_version_path`, `latest_local_version`, `find_archive_artifact`.
- `Context` takes a required `Version`. Only a crawl (or the start of a collection run) mints one; validate/export/publish receive it and no longer invent versions.
- `get_dataset_artifact` requires an exact version. The "latest published" case is now explicit via `find_archive_artifact` / `latest_local_version`, used only where we actually want that (catalog building, `ArchiveBackedCatalog`). The `datasets/latest` legacy fallback is isolated there behind a `# REMOVE AFTER MIGRATION` warning.
- Statement `first_seen`/`last_seen` stamp from the run's `version.dt` rather than the process-global `RUN_TIME` (behaviour-identical today, correct once stages run in separate processes).
- `export_resource` copies working files (e.g. fetched sources) into the version dir; exporters write there directly via the new `context.get_artifact_path`.
- A failed run has no `statistics.json` at its version, so the failure index carries no stale entity counts — this removes the need for the `backfill_statistics` flag from the earlier `failure-index-no-stats-backfill` branch; that fix falls out for free here.

Tests are updated and green (`pytest zavod/tests/` 231 passed; `mypy --strict` clean apart from a pre-existing unrelated `http_.py` stub error). Behavioural changes reflected in the tests:

- `zavod export`/`validate` operate on the latest local run and error if there's been no crawl yet.
- A failed run still mints its version (so `versions.json` exists) but leaves `last_successful` unset.
- Backfilling references an exact version and no longer depends on a published version history.

## Not yet (follow-ups)

- Move fetched sources into `_state/` (they still land in the dataset root for now).
- `--version` CLI option (validate/export/publish currently default to the latest local version, which is the intended default) and the `--clear-data` → `--clear-state` rename.
- Coordinated `kombinat` change (it calls `get_dataset_artifact` / `get_catalog_datasets` directly) — **this must land before merge**, since the `get_dataset_artifact` signature changed. `zavod run`-based orchestration is unaffected.
- `zavod/docs` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)