### PR TITLE
[au_dfat_sanctions] Add property_fill_rate assertions for core attributes

### DIFF
--- a/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
+++ b/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
@@ -49,6 +49,22 @@ assertions:
     schema_entities:
       Person: 2000
       LegalEntity: 700
+    property_fill_rate:
+      Person:
+        name: 1.0
+        birthDate: 0.85
+        citizenship: 0.7
+        createdAt: 1.0
+      LegalEntity:
+        name: 1.0
+        createdAt: 1.0
+      Vessel:
+        name: 1.0
+        imoNumber: 0.9
+        createdAt: 1.0
+      Sanction:
+        startDate: 1.0
+        program: 0.95
   max:
     schema_entities:
       Person: 4000


### PR DESCRIPTION
On 2026-07-10 the AU DFAT source published a botched export of the Consolidated List: the date columns lost their date formatting and came through as raw Excel serial integers (e.g. `46126`) instead of dates. Our date parsing drops those, so that one run lost `createdAt`, `startDate` and `birthDate` across the whole dataset. It emitted 26,295 `Rejected property value` warnings, but warnings don't fail a run, so the dateless data got published anyway. The source fixed it four hours later.

| Time (UTC) | Version ID | control_date | Effect |
|---|---|---|---|
| 2026-07-10 00:02 | `20260710000202-xex` | real dates | dates present (last good run) |
| 2026-07-10 02:02 | `20260710020201-mjz` | `int` serials (e.g. `46126`) | `createdAt`, `startDate`, `birthDate` dropped dataset-wide |
| 2026-07-10 06:02 | `20260710060201-lrz` | real dates | source fixed, dates restored |

Add `property_fill_rate` assertions on the core identifying attributes and the date properties. A `min` fill rate fails the export, so a repeat keeps the last good version live instead of quietly publishing degraded data. Thresholds sit below observed fill rates so normal source fluctuation doesn't trip them; the properties that are structurally always present (`name`, `createdAt`, `startDate`) are asserted at 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)