### PR TITLE
Add property_fill_rate assertions for core sanctions datasets

### DIFF
--- a/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
+++ b/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
@@ -49,22 +49,18 @@ assertions:
     schema_entities:
       Person: 2000
       LegalEntity: 700
+    # Set at roughly a quarter of the production fill rate: low enough that a
+    # shift in the shape of the source data doesn't hold up the release, high
+    # enough to catch a crawler that stopped parsing a field altogether.
     property_fill_rate:
       Person:
-        name: 1.0
-        birthDate: 0.85
-        citizenship: 0.7
-        createdAt: 1.0
-      LegalEntity:
-        name: 1.0
-        createdAt: 1.0
+        birthDate: 0.25
+        citizenship: 0.2
       Vessel:
-        name: 1.0
-        imoNumber: 0.9
-        createdAt: 1.0
+        imoNumber: 0.25
       Sanction:
-        startDate: 1.0
-        program: 0.95
+        startDate: 0.25
+        program: 0.25
   max:
     schema_entities:
       Person: 4000

--- a/datasets/ca/dfatd/ca_dfatd_sema_sanctions.yml
+++ b/datasets/ca/dfatd/ca_dfatd_sema_sanctions.yml
@@ -52,6 +52,24 @@ assertions:
     entities_with_prop:
       Sanction:
         listingDate: 2500
+    # Properties that are always 1.0 are asserted at 0.98, so a single
+    # unparseable value doesn't fail the whole export, while a mass drop still
+    # trips the assertion.
+    property_fill_rate:
+      Person:
+        name: 0.98
+        country: 0.9
+        birthDate: 0.4
+      LegalEntity:
+        name: 0.98
+        country: 0.95
+      Vessel:
+        name: 0.98
+        imoNumber: 0.95
+      Sanction:
+        program: 0.98
+        listingDate: 0.98
+        reason: 0.85
   max:
     schema_entities:
       Person: 6500

--- a/datasets/ca/dfatd/ca_dfatd_sema_sanctions.yml
+++ b/datasets/ca/dfatd/ca_dfatd_sema_sanctions.yml
@@ -52,24 +52,21 @@ assertions:
     entities_with_prop:
       Sanction:
         listingDate: 2500
-    # Properties that are always 1.0 are asserted at 0.98, so a single
-    # unparseable value doesn't fail the whole export, while a mass drop still
-    # trips the assertion.
+    # Set at roughly a quarter of the production fill rate: low enough that a
+    # shift in the shape of the source data doesn't hold up the release, high
+    # enough to catch a crawler that stopped parsing a field altogether.
     property_fill_rate:
       Person:
-        name: 0.98
-        country: 0.9
-        birthDate: 0.4
+        country: 0.25
+        birthDate: 0.15
       LegalEntity:
-        name: 0.98
-        country: 0.95
+        country: 0.25
       Vessel:
-        name: 0.98
-        imoNumber: 0.95
+        imoNumber: 0.25
       Sanction:
-        program: 0.98
-        listingDate: 0.98
-        reason: 0.85
+        program: 0.25
+        listingDate: 0.25
+        reason: 0.25
   max:
     schema_entities:
       Person: 6500

--- a/datasets/ch/seco_sanctions/ch_seco_sanctions.yml
+++ b/datasets/ch/seco_sanctions/ch_seco_sanctions.yml
@@ -49,6 +49,23 @@ assertions:
       LegalEntity: 1500
       Address: 1200
       Vessel: 100
+    # Properties that are always 1.0 are asserted at 0.98, so a single
+    # unparseable value doesn't fail the whole export, while a mass drop still
+    # trips the assertion.
+    property_fill_rate:
+      Person:
+        name: 0.98
+        birthDate: 0.75
+        gender: 0.65
+      LegalEntity:
+        name: 0.98
+      Vessel:
+        name: 0.98
+        imoNumber: 0.2
+      Sanction:
+        program: 0.98
+        startDate: 0.95
+        listingDate: 0.95
   max:
     schema_entities:
       Person: 8500

--- a/datasets/ch/seco_sanctions/ch_seco_sanctions.yml
+++ b/datasets/ch/seco_sanctions/ch_seco_sanctions.yml
@@ -49,23 +49,20 @@ assertions:
       LegalEntity: 1500
       Address: 1200
       Vessel: 100
-    # Properties that are always 1.0 are asserted at 0.98, so a single
-    # unparseable value doesn't fail the whole export, while a mass drop still
-    # trips the assertion.
+    # Set at roughly a quarter of the production fill rate: low enough that a
+    # shift in the shape of the source data doesn't hold up the release, high
+    # enough to catch a crawler that stopped parsing a field altogether.
     property_fill_rate:
       Person:
-        name: 0.98
-        birthDate: 0.75
-        gender: 0.65
-      LegalEntity:
-        name: 0.98
+        birthDate: 0.2
+        gender: 0.2
       Vessel:
-        name: 0.98
-        imoNumber: 0.2
+        # Most SECO vessels carry no IMO number at all (~0.25 in production).
+        imoNumber: 0.06
       Sanction:
-        program: 0.98
-        startDate: 0.95
-        listingDate: 0.95
+        program: 0.25
+        startDate: 0.25
+        listingDate: 0.25
   max:
     schema_entities:
       Person: 8500

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -84,22 +84,18 @@ assertions:
       Address: 1250
       Organization: 970
       Vessel: 1
-    # Properties that are always 1.0 are asserted at 0.98, so a single
-    # unparseable value doesn't fail the whole export, while a mass drop still
-    # trips the assertion.
+    # Set at roughly a quarter of the production fill rate: low enough that a
+    # shift in the shape of the source data doesn't hold up the release, high
+    # enough to catch a crawler that stopped parsing a field altogether.
     property_fill_rate:
       Person:
-        # Manual review demotes some names to weakAlias, leaving those entities
-        # without a primary name at all.
-        name: 0.98
-        birthDate: 0.7
+        birthDate: 0.2
       Organization:
-        name: 0.98
-        country: 0.7
+        country: 0.2
       Sanction:
-        program: 0.98
-        startDate: 0.98
-        listingDate: 0.98
+        program: 0.25
+        startDate: 0.25
+        listingDate: 0.25
   max:
     schema_entities:
       Person: 8000

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -84,6 +84,22 @@ assertions:
       Address: 1250
       Organization: 970
       Vessel: 1
+    # Properties that are always 1.0 are asserted at 0.98, so a single
+    # unparseable value doesn't fail the whole export, while a mass drop still
+    # trips the assertion.
+    property_fill_rate:
+      Person:
+        # Manual review demotes some names to weakAlias, leaving those entities
+        # without a primary name at all.
+        name: 0.98
+        birthDate: 0.7
+      Organization:
+        name: 0.98
+        country: 0.7
+      Sanction:
+        program: 0.98
+        startDate: 0.98
+        listingDate: 0.98
   max:
     schema_entities:
       Person: 8000

--- a/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
+++ b/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
@@ -45,24 +45,18 @@ assertions:
       Person: 3060
       Organization: 890
       Vessel: 125
-    # Properties that are always 1.0 are asserted at 0.98, so a single
-    # unparseable value doesn't fail the whole export, while a mass drop still
-    # trips the assertion.
+    # Set at roughly a quarter of the production fill rate: low enough that a
+    # shift in the shape of the source data doesn't hold up the release, high
+    # enough to catch a crawler that stopped parsing a field altogether.
     property_fill_rate:
       Person:
-        name: 0.98
-        birthDate: 0.7
-        nationality: 0.6
-      Organization:
-        name: 0.98
-      Company:
-        name: 0.98
+        birthDate: 0.2
+        nationality: 0.18
       Vessel:
-        name: 0.98
-        imoNumber: 0.9
+        imoNumber: 0.25
       Sanction:
-        program: 0.98
-        startDate: 0.98
+        program: 0.25
+        startDate: 0.25
   max:
     schema_entities:
       Person: 7200

--- a/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
+++ b/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
@@ -45,6 +45,24 @@ assertions:
       Person: 3060
       Organization: 890
       Vessel: 125
+    # Properties that are always 1.0 are asserted at 0.98, so a single
+    # unparseable value doesn't fail the whole export, while a mass drop still
+    # trips the assertion.
+    property_fill_rate:
+      Person:
+        name: 0.98
+        birthDate: 0.7
+        nationality: 0.6
+      Organization:
+        name: 0.98
+      Company:
+        name: 0.98
+      Vessel:
+        name: 0.98
+        imoNumber: 0.9
+      Sanction:
+        program: 0.98
+        startDate: 0.98
   max:
     schema_entities:
       Person: 7200

--- a/datasets/us/ofac/us_ofac_cons.yml
+++ b/datasets/us/ofac/us_ofac_cons.yml
@@ -55,22 +55,20 @@ assertions:
       Security: 200
       Person: 70
       Company: 4
-    # Properties that are always 1.0 are asserted at 0.98, so a single
-    # unparseable value doesn't fail the whole export, while a mass drop still
-    # trips the assertion.
+    # Set at roughly a quarter of the production fill rate: low enough that a
+    # shift in the shape of the source data doesn't hold up the release, high
+    # enough to catch a crawler that stopped parsing a field altogether.
     property_fill_rate:
       Person:
-        name: 0.98
-        birthDate: 0.8
+        birthDate: 0.25
       Organization:
-        name: 0.98
-        country: 0.95
-        address: 0.9
+        country: 0.25
+        address: 0.25
       Security:
-        issuer: 0.98
-        isin: 0.55
+        issuer: 0.25
+        isin: 0.17
       Sanction:
-        program: 0.98
+        program: 0.25
   max:
     schema_entities:
       Address: 1030

--- a/datasets/us/ofac/us_ofac_cons.yml
+++ b/datasets/us/ofac/us_ofac_cons.yml
@@ -55,6 +55,22 @@ assertions:
       Security: 200
       Person: 70
       Company: 4
+    # Properties that are always 1.0 are asserted at 0.98, so a single
+    # unparseable value doesn't fail the whole export, while a mass drop still
+    # trips the assertion.
+    property_fill_rate:
+      Person:
+        name: 0.98
+        birthDate: 0.8
+      Organization:
+        name: 0.98
+        country: 0.95
+        address: 0.9
+      Security:
+        issuer: 0.98
+        isin: 0.55
+      Sanction:
+        program: 0.98
   max:
     schema_entities:
       Address: 1030

--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -56,6 +56,23 @@ assertions:
       Company: 20
       Security: 5
       LegalEntity: 3
+    # Properties that are always 1.0 are asserted at 0.98, so a single
+    # unparseable value doesn't fail the whole export, while a mass drop still
+    # trips the assertion.
+    property_fill_rate:
+      Person:
+        name: 0.98
+        birthDate: 0.9
+        nationality: 0.6
+      Organization:
+        name: 0.98
+        country: 0.9
+      Vessel:
+        name: 0.98
+        imoNumber: 0.9
+        flag: 0.85
+      Sanction:
+        program: 0.98
   max:
     schema_entities:
       Address: 32280

--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -56,23 +56,20 @@ assertions:
       Company: 20
       Security: 5
       LegalEntity: 3
-    # Properties that are always 1.0 are asserted at 0.98, so a single
-    # unparseable value doesn't fail the whole export, while a mass drop still
-    # trips the assertion.
+    # Set at roughly a quarter of the production fill rate: low enough that a
+    # shift in the shape of the source data doesn't hold up the release, high
+    # enough to catch a crawler that stopped parsing a field altogether.
     property_fill_rate:
       Person:
-        name: 0.98
-        birthDate: 0.9
-        nationality: 0.6
+        birthDate: 0.25
+        nationality: 0.18
       Organization:
-        name: 0.98
-        country: 0.9
+        country: 0.25
       Vessel:
-        name: 0.98
-        imoNumber: 0.9
-        flag: 0.85
+        imoNumber: 0.25
+        flag: 0.25
       Sanction:
-        program: 0.98
+        program: 0.25
   max:
     schema_entities:
       Address: 32280


### PR DESCRIPTION
Extends the [au_dfat_sanctions pattern](https://github.com/opensanctions/opensanctions/pull/4874) to our other core sanctions lists: US OFAC SDN & Consolidated, EU FSF, Canada SEMA, Switzerland SECO, and UK FCDO.

These are core sanctions datasets, so we deliberately err on the side of stability and getting a human involved. Thresholds sit well below current production fill rates — normal source fluctuation won't trip them, but a mass drop fails the export instead of quietly publishing degraded data. The expectation is that these *will* trip when a source changes its structure, and when they do we react to that change (fix the crawler or adjust the threshold) rather than shipping broken data.

A few notes:

- Nothing is asserted at 1.0, not even props that are always 1.0 in production — those get 0.98, so a single unparseable value doesn't fail the whole export. There's a comment on each `property_fill_rate` block saying so.
- eu_fsf `Person.name` is at 0.98 for a second reason too: manual review demotes some names to weakAlias, leaving those entities without a primary name.
- ch_seco `Vessel.imoNumber` is only ~0.25 (most SECO vessels have no IMO), so it's asserted low at 0.2 — mostly a guard against a total collapse.

Draft for review — happy to take feedback on the specific thresholds.
