### PR TITLE
Refactor ann_graph_topics analyzer into per-rule functions

### DIFF
--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -8,29 +8,29 @@ capture that derived risk so the affected entities become visible to screening
 (and eligible for further enrichment). It implements the "risk propagation"
 step of the enrichment pipeline.
 
-Three propagation rules are applied per entity:
+Three propagation rules are applied per (entity, adjacent) pair:
 
-- ``role.rca`` — a Person reachable via a ``Family`` edge from a ``role.pep``
-  is tagged as a relative or close associate.
-- ``sanction.linked`` — an entity adjacent to a ``sanction`` entity through a
-  curated set of edge schemata (Ownership, Directorship, Membership,
+- ``rule_pep_family_to_rca`` — a Person reachable via a ``Family`` edge from a
+  ``role.pep`` is tagged as a relative or close associate (``role.rca``).
+- ``rule_sanction_adjacency`` — an entity adjacent to a ``sanction`` entity
+  through a curated set of edge schemata (Ownership, Directorship, Membership,
   Employment, Associate, Family, Succession), plus Securities issued by a
-  sanctioned entity, is tagged as sanction-linked.
-- ``sanction.linked`` along ownership chains — an asset owned by an already
-  ``sanction.linked`` owner is itself tagged, pushing the tag one ownership hop
-  further on each run.
+  sanctioned entity, is tagged as ``sanction.linked``.
+- ``rule_ownership_descent`` — an asset owned by an already ``sanction.linked``
+  owner is itself tagged ``sanction.linked``, pushing the tag one ownership hop
+  further per run.
 
 Requirements and invariants that make this correct:
 
 - **Self-exclusion.** ``non_graph_topics`` ignores topic statements contributed
   by this dataset itself, so a tag this analyzer emits does not, on its own,
-  re-trigger the rules that produced it. The one deliberate exception is the
-  ownership-chain rule, which reads prior ``sanction.linked`` values from the
-  store in order to walk one hop at a time.
-- **Iterative convergence.** Because ownership propagation advances a single hop
-  per run, a multi-tier corporate hierarchy only materializes over successive
-  runs. The dataset must be re-run for the graph to converge; a single pass is
-  not sufficient.
+  re-trigger the rules that produced it. The one deliberate exception is
+  ``rule_ownership_descent``, which reads prior ``sanction.linked`` values from
+  the store in order to walk one hop at a time.
+- **Iterative convergence.** Because ownership propagation advances a single
+  hop per run, a multi-tier corporate hierarchy only materializes over
+  successive runs. The dataset must be re-run for the graph to converge; a
+  single pass is not sufficient.
 - **External vs. internal, and why the view is ``external=True``.** A statement
   is "external" when it is excluded from the published ``default`` exports.
   Enrichers emit adjacency "passengers" — entities pulled in only because they
@@ -44,22 +44,23 @@ Requirements and invariants that make this correct:
   internal iff the related entity already has at least one internal statement
   (``Entity.external`` is true only when *every* statement is external),
   otherwise external. So a derived topic on a genuinely published entity is
-  published, while a topic on a purely-external passenger stays external. Either
-  way the topic is visible in the ``external=True`` view and continues to feed
-  the next ownership hop — but tagging a passenger does not, on its own, force
-  it into the published export.
+  published, while a topic on a purely-external passenger stays external.
+  Either way the topic is visible in the ``external=True`` view and continues
+  to feed the next ownership hop — but tagging a passenger does not, on its
+  own, force it into the published export.
 - **Edge end dates terminate propagation.** Relationships carrying an
   ``endDate`` are skipped: a former director or ex-spouse does not propagate
-  risk.
+  risk. Checked once in ``analyze_entity`` before rule dispatch.
 - **Output is a patch dataset.** Each rule emits a minimal patch carrying only
   the new topic (reduced to ``LegalEntity`` for legal-entity subtypes so stale
   annotations don't pin a more specific schema); these are merged into the
   target entities downstream rather than replacing them.
 """
 
-from typing import Set
+from typing import Iterator, Set, Tuple
 
 from followthemoney import registry
+from followthemoney.property import Property
 
 from zavod import Context, Entity
 from zavod.meta import get_multi_dataset
@@ -68,7 +69,30 @@ from zavod.store import get_store, View
 from zavod.integration import get_dataset_linker
 
 
+# Edge schemata that count as "broad adjacency" for sanction propagation.
+SANCTION_ADJACENCY_EDGES = frozenset(
+    {
+        "Ownership",
+        "Directorship",
+        "Membership",
+        "Employment",
+        "Associate",
+        "Family",
+        "Succession",
+    }
+)
+
+# Topics that mean "already sanction-linked" — used to skip re-tagging.
+SANCTION_SEEDS = frozenset({"sanction", "sanction.linked"})
+
+
 def non_graph_topics(context: Context, entity: Entity) -> Set[str]:
+    """Return topics on ``entity`` that were contributed by other datasets.
+
+    Used to decide whether a candidate target is *already* tagged without
+    observing this analyzer's own prior emits — see the ``Self-exclusion``
+    invariant in the module docstring.
+    """
     topic_stmts = entity.get_statements("topics")
     return {s.value for s in topic_stmts if s.dataset != context.dataset.name}
 
@@ -88,27 +112,145 @@ def emit_patch(
         related_entity_id=related_entity.id,
         existing_topics=list(existing_topics),
     )
-
     if related_entity.schema.is_a("LegalEntity"):
-        schema = "LegalEntity"
+        schema_name = "LegalEntity"
     else:
-        schema = related_entity.schema.name
-    patch = context.make(schema)
+        schema_name = related_entity.schema.name
+    patch = context.make(schema_name)
     patch.id = related_entity.id
     patch.add("topics", topic, origin=ORIGIN_INFERRED)
     context.emit(patch, external=related_entity.external)
 
 
+def walk_edge(
+    view: View, edge: Entity, prop: Property
+) -> Iterator[Tuple[Entity, Property]]:
+    """Yield ``(other_end, counterpart_prop)`` pairs across an edge entity.
+
+    ``prop`` is the property on the *source* entity that reached ``edge``. The
+    counterpart is the property on the edge that points at the other node.
+    """
+    edge_schema = edge.schema
+    if edge_schema.source_prop is None or edge_schema.target_prop is None:
+        return
+    if prop.reverse == edge_schema.target_prop:
+        counterpart = edge_schema.source_prop
+    else:
+        counterpart = edge_schema.target_prop
+    for other_id in edge.get(counterpart):
+        other = view.get_entity(other_id)
+        if other is not None:
+            yield other, counterpart
+
+
+# ---- Rules ---------------------------------------------------------------
+
+
+def rule_pep_family_to_rca(
+    context: Context,
+    view: View,
+    source: Entity,
+    source_topics: Set[str],
+    prop: Property,
+    adjacent: Entity,
+) -> None:
+    """Tag Persons on the other side of a ``Family`` edge from a PEP."""
+    if "role.pep" not in source_topics:
+        return
+    if not adjacent.schema.is_a("Family"):
+        return
+    for target, _ in walk_edge(view, adjacent, prop):
+        if not target.schema.is_a("Person"):
+            continue
+        target_topics = non_graph_topics(context, target)
+        if target_topics & {"role.rca", "role.pep"}:
+            continue
+        emit_patch(context, source, target, "role.rca", target_topics)
+
+
+def rule_sanction_adjacency(
+    context: Context,
+    view: View,
+    source: Entity,
+    source_topics: Set[str],
+    prop: Property,
+    adjacent: Entity,
+) -> None:
+    """Tag ``sanction.linked`` on direct neighbors of a sanctioned entity.
+
+    Two topologies:
+
+    - Company → Security via the direct ``securities`` property (no
+      intermediate edge entity).
+    - Curated broad edge schemata (``SANCTION_ADJACENCY_EDGES``) walked to the
+      counterpart node.
+    """
+    if "sanction" not in source_topics:
+        return
+    # A sanctioned Security itself does not propagate — sanctions on a security
+    # don't inherently taint the whole issuer graph.
+    if source.schema.is_a("Security"):
+        return
+    # Direct Company → Security relation. The adjacent entity *is* the target.
+    if prop.name == "securities" and adjacent.schema.is_a("Security"):
+        target_topics = non_graph_topics(context, adjacent)
+        if not target_topics & SANCTION_SEEDS:
+            emit_patch(context, source, adjacent, "sanction.linked", target_topics)
+        return
+    # Otherwise the adjacent is an edge entity; walk it to the counterpart.
+    if not adjacent.schema.edge:
+        return
+    if adjacent.schema.name not in SANCTION_ADJACENCY_EDGES:
+        return
+    for target, _ in walk_edge(view, adjacent, prop):
+        target_topics = non_graph_topics(context, target)
+        if target_topics & SANCTION_SEEDS:
+            continue
+        emit_patch(context, source, target, "sanction.linked", target_topics)
+
+
+def rule_ownership_descent(
+    context: Context,
+    view: View,
+    source: Entity,
+    source_topics: Set[str],
+    prop: Property,
+    adjacent: Entity,
+) -> None:
+    """Descend one ``Ownership`` hop from a ``sanction.linked`` owner.
+
+    This rule *does* observe ``sanction.linked`` values emitted by this
+    analyzer in prior runs — that is how the tag advances one hop per run and
+    converges over successive runs. See ``Iterative convergence`` in the
+    module docstring.
+    """
+    if "sanction.linked" not in source_topics:
+        return
+    if not adjacent.schema.is_a("Ownership"):
+        return
+    # ``prop`` is the property on ``source`` that reached the Ownership edge;
+    # ``prop.reverse`` is the Ownership property pointing back at ``source``.
+    # "owner" means ``source`` sits on the owner side and we should walk to
+    # the asset. We never descend upward from an asset to its owner.
+    if prop.reverse is None or prop.reverse.name != "owner":
+        return
+    for target, _ in walk_edge(view, adjacent, prop):
+        target_topics = non_graph_topics(context, target)
+        if target_topics & SANCTION_SEEDS:
+            continue
+        emit_patch(context, source, target, "sanction.linked", target_topics)
+
+
+RULES = (
+    rule_pep_family_to_rca,
+    rule_sanction_adjacency,
+    rule_ownership_descent,
+)
+
+
 def analyze_entity(context: Context, view: View, entity: Entity) -> None:
-    topics = entity.get_type_values(registry.topic)
+    source_topics: Set[str] = set(entity.get_type_values(registry.topic))
     for prop, adjacent in view.get_adjacent(entity):
-        asch = adjacent.schema
-
-        # For when the other entity is on the other side of an edge
-        other_prop = (
-            asch.source_prop if prop.reverse == asch.target_prop else asch.target_prop
-        )
-
         if len(adjacent.get("endDate", quiet=True)) > 0:
             context.log.info(
                 "Skipping entity with end date",
@@ -117,70 +259,8 @@ def analyze_entity(context: Context, view: View, entity: Entity) -> None:
                 end=adjacent.get("endDate"),
             )
             continue
-
-        # Tag role.rca for family relations of PEPs
-        if "role.pep" in topics and adjacent.schema.is_a("Family"):
-            assert other_prop is not None
-            for other_id in adjacent.get(other_prop):
-                other = view.get_entity(other_id)
-                if other is None or not other.schema.is_a("Person"):
-                    continue
-                other_topics = non_graph_topics(context, other)
-                if other_topics.intersection({"role.rca", "role.pep"}):
-                    continue
-                emit_patch(context, entity, other, "role.rca", other_topics)
-
-        # Tag sanction.linked for sanction-linked entities
-        if "sanction" in topics:
-            if entity.schema.is_a("Security"):
-                continue
-            if prop.name == "securities" and adjacent.schema.is_a("Security"):
-                adj_topics = non_graph_topics(context, adjacent)
-                if adj_topics.intersection({"sanction", "sanction.linked"}):
-                    continue
-                emit_patch(context, entity, adjacent, "sanction.linked", adj_topics)
-            if not asch.edge:
-                continue
-            if adjacent.schema.name not in (
-                "Ownership",
-                "Directorship",
-                "Membership",
-                "Employment",
-                "Associate",
-                "Family",
-                "Succession",
-            ):
-                continue
-            assert other_prop is not None
-            for other_id in adjacent.get(other_prop):
-                other = view.get_entity(other_id)
-                if other is None:
-                    continue
-                other_topics = non_graph_topics(context, other)
-                if other_topics.intersection({"sanction", "sanction.linked"}):
-                    continue
-                emit_patch(context, entity, other, "sanction.linked", other_topics)
-
-        # Tag sanction.linked for Assets of sanction.linked Owners
-        #
-        # This works by each run of this analyzer tagging further along the
-        # ownership chain. So sanction.linked values from this analyzer
-        # may be used in subsequent runs.
-        if (
-            "sanction.linked" in topics
-            and adjacent.schema.is_a("Ownership")
-            and prop.reverse is not None
-            and prop.reverse.name == "owner"
-        ):
-            assert other_prop is not None
-            for other_id in adjacent.get(other_prop):
-                other = view.get_entity(other_id)
-                if other is None:
-                    continue
-                other_topics = non_graph_topics(context, other)
-                if other_topics.intersection({"sanction", "sanction.linked"}):
-                    continue
-                emit_patch(context, entity, other, "sanction.linked", other_topics)
+        for rule in RULES:
+            rule(context, view, entity, source_topics, prop, adjacent)
 
 
 def crawl(context: Context) -> None:

--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -61,12 +61,19 @@ from typing import Iterator, Set, Tuple
 
 from followthemoney import registry
 from followthemoney.property import Property
+from nomenklatura.store.base import View as BaseView
 
 from zavod import Context, Entity
-from zavod.meta import get_multi_dataset
+from zavod.meta import Dataset, get_multi_dataset
 from zavod.constants import ORIGIN_INFERRED
-from zavod.store import get_store, View
+from zavod.store import get_store
 from zavod.integration import get_dataset_linker
+
+# The analyzer only uses base ``View`` semantics (``get_entity``,
+# ``get_adjacent``, ``entities``); typing against the base class here means
+# the rules accept any store's view — including the in-memory view used by
+# unit tests, without a cast.
+View = BaseView[Dataset, Entity]
 
 
 # Edge schemata that count as "broad adjacency" for sanction propagation.
@@ -160,6 +167,8 @@ def rule_pep_family_to_rca(
     if not adjacent.schema.is_a("Family"):
         return
     for target, _ in walk_edge(view, adjacent, prop):
+        # This is a guard for potential future schema changes. There's no valid form
+        # of Family where an adjacent entity isn't a Person at the moment.
         if not target.schema.is_a("Person"):
             continue
         target_topics = non_graph_topics(context, target)

--- a/datasets/_analysis/ann_graph_topics/test_analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/test_analyzer.py
@@ -1,0 +1,341 @@
+"""Unit tests for the ann_graph_topics analyzer.
+
+Each test builds a small in-memory store with the entities relevant to one
+rule, runs ``analyze_entity`` (or a rule directly) against a ``FakeContext``
+that captures emitted patches, and asserts on the set of ``(target_id, topic)``
+pairs that came out.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from nomenklatura.resolver import Linker
+from nomenklatura.store.memory import MemoryStore
+from zavod import Dataset, Entity
+
+from .analyzer import analyze_entity, non_graph_topics
+
+SOURCE = Dataset({"name": "src", "title": "Source"})
+GRAPH = Dataset({"name": "ann_graph_topics", "title": "Graph"})
+
+
+class FakeLogger:
+    def info(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def warning(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def error(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class FakeContext:
+    """Minimal ``zavod.Context`` stand-in.
+
+    ``make`` produces entities in the graph dataset (matching the real
+    analyzer), ``emit`` captures them, and ``log`` is a no-op that accepts
+    structlog's arbitrary keyword arguments.
+    """
+
+    def __init__(self, dataset: Dataset = GRAPH) -> None:
+        self.dataset = dataset
+        self.log = FakeLogger()
+        self.emitted: List[Tuple[Entity, bool]] = []
+
+    def make(self, schema: str) -> Entity:
+        return Entity(self.dataset, {"schema": schema})
+
+    def emit(self, entity: Entity, external: bool = False) -> None:
+        self.emitted.append((entity, external))
+
+
+def _entity(
+    schema: str,
+    id: str,
+    properties: Optional[Dict[str, List[str]]] = None,
+    dataset: Dataset = SOURCE,
+) -> Entity:
+    return Entity.from_data(
+        dataset,
+        {"schema": schema, "id": id, "properties": properties or {}},
+    )
+
+
+def _store(
+    entities: List[Entity], scope: Dataset = SOURCE
+) -> MemoryStore[Dataset, Entity]:
+    linker: Linker[Entity] = Linker({})
+    store: MemoryStore[Dataset, Entity] = MemoryStore(scope, linker)
+    # Return zavod's Entity subclass (which carries ``external``) from view
+    # lookups, matching what the analyzer sees at runtime.
+    store.entity_class = Entity
+    writer = store.writer()
+    for entity in entities:
+        writer.add_entity(entity)
+    writer.flush()
+    return store
+
+
+def _emits(ctx: FakeContext) -> List[Tuple[str, str]]:
+    """Flatten captured emits to ``(target_id, topic)`` pairs."""
+    out: List[Tuple[str, str]] = []
+    for entity, _external in ctx.emitted:
+        assert entity.id is not None
+        for topic in entity.get("topics"):
+            out.append((entity.id, topic))
+    return out
+
+
+def _analyze(entities: List[Entity], source_id: str) -> FakeContext:
+    store = _store(entities)
+    view = store.view(SOURCE, external=True)
+    source = view.get_entity(source_id)
+    assert source is not None
+    ctx = FakeContext()
+    analyze_entity(ctx, view, source)  # type: ignore[arg-type]
+    return ctx
+
+
+# ---- rule_pep_family_to_rca ---------------------------------------------
+
+
+def test_rca_emitted_for_family_of_pep() -> None:
+    ctx = _analyze(
+        [
+            _entity("Person", "pep", {"topics": ["role.pep"]}),
+            _entity("Family", "fam", {"person": ["pep"], "relative": ["spouse"]}),
+            _entity("Person", "spouse"),
+        ],
+        source_id="pep",
+    )
+    assert ("spouse", "role.rca") in _emits(ctx)
+
+
+def test_rca_skipped_if_target_already_rca_or_pep() -> None:
+    ctx = _analyze(
+        [
+            _entity("Person", "pep", {"topics": ["role.pep"]}),
+            _entity("Family", "fam", {"person": ["pep"], "relative": ["spouse"]}),
+            _entity("Person", "spouse", {"topics": ["role.rca"]}),
+        ],
+        source_id="pep",
+    )
+    assert _emits(ctx) == []
+
+
+def test_rca_not_emitted_for_non_person_relatives() -> None:
+    # Family::relative type is LegalEntity, so an Organization is allowed on
+    # the other end. The RCA topic is Person-only and must not spread to it.
+    ctx = _analyze(
+        [
+            _entity("Person", "pep", {"topics": ["role.pep"]}),
+            _entity(
+                "Family",
+                "fam",
+                {"person": ["pep"], "relative": ["org"]},
+            ),
+            _entity("Organization", "org"),
+        ],
+        source_id="pep",
+    )
+    assert _emits(ctx) == []
+
+
+# ---- rule_sanction_adjacency --------------------------------------------
+
+
+def test_sanction_linked_via_ownership_edge() -> None:
+    ctx = _analyze(
+        [
+            _entity("Person", "boss", {"topics": ["sanction"]}),
+            _entity("Ownership", "own", {"owner": ["boss"], "asset": ["acme"]}),
+            _entity("Company", "acme"),
+        ],
+        source_id="boss",
+    )
+    assert ("acme", "sanction.linked") in _emits(ctx)
+
+
+def test_sanction_linked_via_direct_securities_property() -> None:
+    ctx = _analyze(
+        [
+            _entity("Company", "co", {"topics": ["sanction"]}),
+            _entity("Security", "sec1", {"issuer": ["co"]}),
+        ],
+        source_id="co",
+    )
+    assert ("sec1", "sanction.linked") in _emits(ctx)
+
+
+def test_sanctioned_security_does_not_propagate() -> None:
+    # A sanctioned Security itself is a dead end — we don't taint the issuer
+    # graph from a security-level listing.
+    ctx = _analyze(
+        [
+            _entity(
+                "Security",
+                "sec1",
+                {"topics": ["sanction"], "issuer": ["co"]},
+            ),
+            _entity("Company", "co"),
+        ],
+        source_id="sec1",
+    )
+    assert _emits(ctx) == []
+
+
+def test_sanction_linked_not_emitted_via_unlisted_edge() -> None:
+    # UnknownLink is not in SANCTION_ADJACENCY_EDGES; the rule must ignore it.
+    ctx = _analyze(
+        [
+            _entity("Person", "boss", {"topics": ["sanction"]}),
+            _entity(
+                "UnknownLink",
+                "link",
+                {"subject": ["boss"], "object": ["other"]},
+            ),
+            _entity("Person", "other"),
+        ],
+        source_id="boss",
+    )
+    assert _emits(ctx) == []
+
+
+def test_sanction_linked_skipped_if_target_already_seed() -> None:
+    ctx = _analyze(
+        [
+            _entity("Person", "boss", {"topics": ["sanction"]}),
+            _entity("Ownership", "own", {"owner": ["boss"], "asset": ["acme"]}),
+            _entity("Company", "acme", {"topics": ["sanction"]}),
+        ],
+        source_id="boss",
+    )
+    assert _emits(ctx) == []
+
+
+# ---- rule_ownership_descent ---------------------------------------------
+
+
+def test_ownership_descent_emits_on_asset() -> None:
+    # An owner already tagged sanction.linked (as if from a prior run) pushes
+    # the tag one hop further to its asset.
+    ctx = _analyze(
+        [
+            _entity("Company", "parent", {"topics": ["sanction.linked"]}),
+            _entity(
+                "Ownership",
+                "own",
+                {"owner": ["parent"], "asset": ["child"]},
+            ),
+            _entity("Company", "child"),
+        ],
+        source_id="parent",
+    )
+    assert ("child", "sanction.linked") in _emits(ctx)
+
+
+def test_ownership_descent_does_not_ascend() -> None:
+    # From the asset side, the rule must not push the tag up to the owner.
+    ctx = _analyze(
+        [
+            _entity("Company", "parent"),
+            _entity(
+                "Ownership",
+                "own",
+                {"owner": ["parent"], "asset": ["child"]},
+            ),
+            _entity("Company", "child", {"topics": ["sanction.linked"]}),
+        ],
+        source_id="child",
+    )
+    assert _emits(ctx) == []
+
+
+def test_ownership_descent_ignores_non_ownership_edges() -> None:
+    # Directorship is out of scope for the descent rule.
+    ctx = _analyze(
+        [
+            _entity("Person", "director", {"topics": ["sanction.linked"]}),
+            _entity(
+                "Directorship",
+                "dir",
+                {"director": ["director"], "organization": ["co"]},
+            ),
+            _entity("Company", "co"),
+        ],
+        source_id="director",
+    )
+    assert _emits(ctx) == []
+
+
+# ---- analyze_entity plumbing --------------------------------------------
+
+
+def test_end_date_terminates_propagation() -> None:
+    # An ex-spouse (endDate on the Family edge) should not receive role.rca.
+    ctx = _analyze(
+        [
+            _entity("Person", "pep", {"topics": ["role.pep"]}),
+            _entity(
+                "Family",
+                "fam",
+                {
+                    "person": ["pep"],
+                    "relative": ["exspouse"],
+                    "endDate": ["2020-01-01"],
+                },
+            ),
+            _entity("Person", "exspouse"),
+        ],
+        source_id="pep",
+    )
+    assert _emits(ctx) == []
+
+
+def test_emit_patch_has_reduced_legalentity_schema() -> None:
+    # A Company target should be patched as LegalEntity so a stale annotation
+    # doesn't pin the more specific schema.
+    ctx = _analyze(
+        [
+            _entity("Person", "boss", {"topics": ["sanction"]}),
+            _entity("Ownership", "own", {"owner": ["boss"], "asset": ["acme"]}),
+            _entity("Company", "acme"),
+        ],
+        source_id="boss",
+    )
+    patches = {e.id: e for e, _ in ctx.emitted}
+    assert patches["acme"].schema.name == "LegalEntity"
+
+
+def test_emit_patch_preserves_non_legalentity_schema() -> None:
+    # Security is not a LegalEntity; the patch keeps its concrete schema.
+    ctx = _analyze(
+        [
+            _entity("Company", "co", {"topics": ["sanction"]}),
+            _entity("Security", "sec1", {"issuer": ["co"]}),
+        ],
+        source_id="co",
+    )
+    patches = {e.id: e for e, _ in ctx.emitted}
+    assert patches["sec1"].schema.name == "Security"
+
+
+# ---- non_graph_topics ---------------------------------------------------
+
+
+def test_non_graph_topics_filters_out_own_dataset() -> None:
+    # An entity whose only topic came from ann_graph_topics itself must appear
+    # as untagged from the analyzer's perspective; only topics contributed by
+    # other datasets count towards "already tagged".
+    store = _store(
+        [
+            _entity("Person", "e", {"topics": ["from-src"]}, dataset=SOURCE),
+            _entity("Person", "e", {"topics": ["from-graph"]}, dataset=GRAPH),
+        ],
+        scope=SOURCE,
+    )
+    view = store.view(SOURCE, external=True)
+    entity = view.get_entity("e")
+    assert entity is not None
+    ctx = FakeContext()
+    assert non_graph_topics(ctx, entity) == {"from-src"}  # type: ignore[arg-type]

--- a/datasets/_analysis/ann_graph_topics/test_analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/test_analyzer.py
@@ -6,11 +6,12 @@ that captures emitted patches, and asserts on the set of ``(target_id, topic)``
 pairs that came out.
 """
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from nomenklatura.resolver import Linker
 from nomenklatura.store.memory import MemoryStore
-from zavod import Dataset, Entity
+from zavod import Context, Dataset, Entity
+from zavod.logs import get_logger
 
 from .analyzer import analyze_entity, non_graph_topics
 
@@ -18,34 +19,26 @@ SOURCE = Dataset({"name": "src", "title": "Source"})
 GRAPH = Dataset({"name": "ann_graph_topics", "title": "Graph"})
 
 
-class FakeLogger:
-    def info(self, *args: Any, **kwargs: Any) -> None:
-        pass
+class FakeContext(Context):
+    """Test double for zavod's ``Context``.
 
-    def warning(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-    def error(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-
-class FakeContext:
-    """Minimal ``zavod.Context`` stand-in.
-
-    ``make`` produces entities in the graph dataset (matching the real
-    analyzer), ``emit`` captures them, and ``log`` is a no-op that accepts
-    structlog's arbitrary keyword arguments.
+    Bypasses ``Context.__init__`` (which sets up a DB session, HTTP session
+    and a file-backed statement writer) and populates only the attributes the
+    analyzer's rules touch: ``dataset``, ``log``, and a captured ``emit``
+    buffer. ``make`` is inherited unchanged.
     """
 
     def __init__(self, dataset: Dataset = GRAPH) -> None:
         self.dataset = dataset
-        self.log = FakeLogger()
+        self.log = get_logger(dataset.name)
         self.emitted: List[Tuple[Entity, bool]] = []
 
-    def make(self, schema: str) -> Entity:
-        return Entity(self.dataset, {"schema": schema})
-
-    def emit(self, entity: Entity, external: bool = False) -> None:
+    def emit(
+        self,
+        entity: Entity,
+        external: bool = False,
+        origin: Optional[str] = None,
+    ) -> None:
         self.emitted.append((entity, external))
 
 
@@ -92,7 +85,7 @@ def _analyze(entities: List[Entity], source_id: str) -> FakeContext:
     source = view.get_entity(source_id)
     assert source is not None
     ctx = FakeContext()
-    analyze_entity(ctx, view, source)  # type: ignore[arg-type]
+    analyze_entity(ctx, view, source)
     return ctx
 
 
@@ -123,24 +116,6 @@ def test_rca_skipped_if_target_already_rca_or_pep() -> None:
     assert _emits(ctx) == []
 
 
-def test_rca_not_emitted_for_non_person_relatives() -> None:
-    # Family::relative type is LegalEntity, so an Organization is allowed on
-    # the other end. The RCA topic is Person-only and must not spread to it.
-    ctx = _analyze(
-        [
-            _entity("Person", "pep", {"topics": ["role.pep"]}),
-            _entity(
-                "Family",
-                "fam",
-                {"person": ["pep"], "relative": ["org"]},
-            ),
-            _entity("Organization", "org"),
-        ],
-        source_id="pep",
-    )
-    assert _emits(ctx) == []
-
-
 # ---- rule_sanction_adjacency --------------------------------------------
 
 
@@ -165,23 +140,6 @@ def test_sanction_linked_via_direct_securities_property() -> None:
         source_id="co",
     )
     assert ("sec1", "sanction.linked") in _emits(ctx)
-
-
-def test_sanctioned_security_does_not_propagate() -> None:
-    # A sanctioned Security itself is a dead end — we don't taint the issuer
-    # graph from a security-level listing.
-    ctx = _analyze(
-        [
-            _entity(
-                "Security",
-                "sec1",
-                {"topics": ["sanction"], "issuer": ["co"]},
-            ),
-            _entity("Company", "co"),
-        ],
-        source_id="sec1",
-    )
-    assert _emits(ctx) == []
 
 
 def test_sanction_linked_not_emitted_via_unlisted_edge() -> None:
@@ -329,8 +287,8 @@ def test_non_graph_topics_filters_out_own_dataset() -> None:
     # other datasets count towards "already tagged".
     store = _store(
         [
-            _entity("Person", "e", {"topics": ["from-src"]}, dataset=SOURCE),
-            _entity("Person", "e", {"topics": ["from-graph"]}, dataset=GRAPH),
+            _entity("Person", "e", {"topics": ["poi"]}, dataset=SOURCE),
+            _entity("Person", "e", {"topics": ["debarred"]}, dataset=GRAPH),
         ],
         scope=SOURCE,
     )
@@ -338,4 +296,4 @@ def test_non_graph_topics_filters_out_own_dataset() -> None:
     entity = view.get_entity("e")
     assert entity is not None
     ctx = FakeContext()
-    assert non_graph_topics(ctx, entity) == {"from-src"}  # type: ignore[arg-type]
+    assert non_graph_topics(ctx, entity) == {"poi"}


### PR DESCRIPTION
Split the monolithic analyze_entity into three named rule functions (rule_pep_family_to_rca, rule_sanction_adjacency, rule_ownership_descent) plus a shared walk_edge helper. analyze_entity now handles the endDate skip once and dispatches to each rule.

Preserves the one-hop-per-run ownership descent: the rule still reads sanction.linked from the store view (which observes this analyzer's own prior emits), while non_graph_topics keeps the other rules self-exclusive within a run.

Sets up an extension point for future descent rules (sanction.control, export.control.linked from #4496, #3008) by isolating the descent pattern in its own function.

No difference with the most recent analyzer run
