### PR TITLE
[ann_graph_topics] Phase 2: remove transitive sanction.linked descent

### DIFF
--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -282,6 +282,8 @@ def rule_sanction_control_descent(
         if target_topics & SANCTION_CONTROL_SEEDS:
             continue
         emit_patch(context, source, target, "sanction.control", target_topics)
+        if target_topics & SANCTION_SEEDS:
+            continue
         # Anything that's under sanctioned control is also sanction-linked.
         emit_patch(context, source, target, "sanction.linked", target_topics)
 

--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -16,14 +16,15 @@ Propagation rules are applied per (entity, adjacent) pair:
   through a curated set of edge schemata (Ownership, Directorship, Membership,
   Employment, Associate, Family, Succession); Securities issued by a
   sanctioned entity; and the issuer of a sanctioned Security — tagged
-  ``sanction.linked``.
-- ``rule_ownership_descent`` — an asset owned by an already ``sanction.linked``
-  owner is itself tagged ``sanction.linked``, pushing the tag one ownership hop
-  further per run.
+  ``sanction.linked``. This rule is non-transitive: it walks exactly one
+  broad-adjacency hop from a directly sanctioned entity and stops.
 - ``rule_sanction_control_descent`` — an asset or organization controlled by a
   ``sanction`` or ``sanction.control`` entity (via ``Ownership`` owner→asset)
   is tagged ``sanction.control`` and co-emitted ``sanction.linked``.
-  No 50% ownership threshold is applied.
+  No 50% ownership threshold is applied; one hop per run, converging across
+  successive runs. Also the way ``sanction.linked`` reaches multi-tier
+  hierarchies now that ``sanction.linked`` no longer propagates on its own —
+  see the note on Phase 2 below.
 - ``rule_export_control_descent`` — an asset owned by an ``export.control`` or
   ``export.control.linked`` entity is itself tagged ``export.control.linked``.
     Ownership-only, downward-only, one hop per run.
@@ -33,9 +34,18 @@ Requirements and invariants that make this correct:
 - **Self-exclusion.** ``non_graph_topics`` ignores topic statements contributed
   by this dataset itself, so a tag this analyzer emits does not, on its own,
   re-trigger the rules that produced it. The deliberate exceptions are the
-  descent rules (``rule_ownership_descent``, ``rule_sanction_control_descent``,
+  descent rules (``rule_sanction_control_descent`` and
   ``rule_export_control_descent``), which read their emitted topics back from
   the store in order to walk one hop at a time.
+- **``sanction.linked`` is no longer transitive by itself.** Before Phase 2 of
+  the ``sanction.control`` roll-out (#4496), an ownership-only rule walked
+  ``sanction.linked → sanction.linked`` down chains — meaning a company two
+  hops below a sanctioned owner would be tagged. That rule has been removed:
+  ``sanction.linked`` now means *directly adjacent to a sanction seed* (via
+  broad-edge or securities), plus every entity in a ``sanction.control``
+  chain via the lockstep co-emit. Multi-tier reach is now expressed
+  exclusively through ``sanction.control``, and downstream filters on
+  ``sanction.linked`` still see every controlled entity via the co-emit.
 - **Iterative convergence.** Because ownership propagation advances a single
   hop per run, a multi-tier corporate hierarchy only materializes over
   successive runs. The dataset must be re-run for the graph to converge; a
@@ -257,38 +267,6 @@ def rule_sanction_adjacency(
         emit_patch(context, source, target, "sanction.linked", target_topics)
 
 
-def rule_ownership_descent(
-    context: Context,
-    view: View,
-    source: Entity,
-    source_topics: set[str],
-    prop: Property,
-    adjacent: Entity,
-) -> None:
-    """Descend one ``Ownership`` hop from a ``sanction.linked`` owner.
-
-    This rule observes ``sanction.linked`` values emitted by this
-    analyzer in prior runs — that is how the tag advances one hop per run and
-    converges over successive runs. See ``Iterative convergence`` in the
-    module docstring.
-    """
-    if "sanction.linked" not in source_topics:
-        return
-    if not adjacent.schema.is_a("Ownership"):
-        return
-    # ``prop`` is the property on ``source`` that reached the Ownership edge;
-    # ``prop.reverse`` is the Ownership property pointing back at ``source``.
-    # "owner" means ``source`` sits on the owner side and we should walk to
-    # the asset. We never descend upward from an asset to its owner.
-    if prop.reverse is None or prop.reverse.name != "owner":
-        return
-    for target, _ in walk_edge(view, adjacent, prop):
-        target_topics = non_graph_topics(context, target)
-        if target_topics & SANCTION_SEEDS:
-            continue
-        emit_patch(context, source, target, "sanction.linked", target_topics)
-
-
 def rule_sanction_control_descent(
     context: Context,
     view: View,
@@ -326,9 +304,9 @@ def rule_export_control_descent(
 ) -> None:
     """Descend one ``Ownership`` hop and tag ``export.control.linked``.
 
-    Structurally the export-control twin of ``rule_ownership_descent``:
-    ownership-only, downward-only (owner → asset), and self-observing so that
-    the tag advances one hop per run and converges across successive runs.
+    Ownership-only, downward-only (owner → asset), and self-observing so that
+    the tag advances one hop per run and converges across successive runs —
+    the ownership-only sibling of ``rule_sanction_control_descent``.
 
     NOTE on the asymmetric naming: ``export.control.linked`` carries the
     ownership-*descent* semantics — it is the export-control analogue of
@@ -356,7 +334,6 @@ def rule_export_control_descent(
 RULES = (
     rule_pep_family_to_rca,
     rule_sanction_adjacency,
-    rule_ownership_descent,
     rule_sanction_control_descent,
     rule_export_control_descent,
 )

--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -36,11 +36,8 @@ Requirements and invariants that make this correct:
   ``rule_export_control_descent``), which read their emitted topics back from
   the store in order to walk one hop at a time.
 - **``sanction.linked`` is non-transitive.** It means *directly adjacent to
-  a sanction seed* (via broad edge or the direct Company↔Security relation),
-  plus every entity in a ``sanction.control`` chain via the lockstep
-  co-emit. Multi-tier reach is expressed exclusively through
-  ``sanction.control``; downstream filters on ``sanction.linked`` still see
-  every controlled entity via that co-emit.
+  a 'sanction' tagged entity* (via broad edge or the direct Company↔Security relation),
+  plus every entity in a ``sanction.control`` chain.
 - **Iterative convergence.** Because ownership propagation advances a single
   hop per run, a multi-tier corporate hierarchy only materializes over
   successive runs. The dataset must be re-run for the graph to converge; a

--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -16,8 +16,7 @@ Propagation rules are applied per (entity, adjacent) pair:
   through a curated set of edge schemata (Ownership, Directorship, Membership,
   Employment, Associate, Family, Succession); Securities issued by a
   sanctioned entity; and the issuer of a sanctioned Security — tagged
-  ``sanction.linked``. Non-transitive: walks exactly one broad-adjacency hop
-  from a directly sanctioned entity.
+  ``sanction.linked``.
 - ``rule_sanction_control_descent`` — an asset or organization controlled by a
   ``sanction`` or ``sanction.control`` entity (via ``Ownership`` owner→asset)
   is tagged ``sanction.control`` and co-emitted ``sanction.linked`` (so
@@ -35,9 +34,6 @@ Requirements and invariants that make this correct:
   descent rules (``rule_sanction_control_descent`` and
   ``rule_export_control_descent``), which read their emitted topics back from
   the store in order to walk one hop at a time.
-- **``sanction.linked`` is non-transitive.** It means *directly adjacent to
-  a 'sanction' tagged entity* (via broad edge or the direct Company↔Security relation),
-  plus every entity in a ``sanction.control`` chain.
 - **Iterative convergence.** Because ownership propagation advances a single
   hop per run, a multi-tier corporate hierarchy only materializes over
   successive runs. The dataset must be re-run for the graph to converge; a
@@ -299,8 +295,7 @@ def rule_export_control_descent(
     """Descend one ``Ownership`` hop and tag ``export.control.linked``.
 
     Ownership-only, downward-only (owner → asset), and self-observing so that
-    the tag advances one hop per run and converges across successive runs —
-    the ownership-only sibling of ``rule_sanction_control_descent``.
+    the tag advances one hop per run and converges across successive runs.
 
     NOTE on the asymmetric naming: ``export.control.linked`` carries the
     ownership-*descent* semantics — it is the export-control analogue of

--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -16,15 +16,13 @@ Propagation rules are applied per (entity, adjacent) pair:
   through a curated set of edge schemata (Ownership, Directorship, Membership,
   Employment, Associate, Family, Succession); Securities issued by a
   sanctioned entity; and the issuer of a sanctioned Security — tagged
-  ``sanction.linked``. This rule is non-transitive: it walks exactly one
-  broad-adjacency hop from a directly sanctioned entity and stops.
+  ``sanction.linked``. Non-transitive: walks exactly one broad-adjacency hop
+  from a directly sanctioned entity.
 - ``rule_sanction_control_descent`` — an asset or organization controlled by a
   ``sanction`` or ``sanction.control`` entity (via ``Ownership`` owner→asset)
-  is tagged ``sanction.control`` and co-emitted ``sanction.linked``.
-  No 50% ownership threshold is applied; one hop per run, converging across
-  successive runs. Also the way ``sanction.linked`` reaches multi-tier
-  hierarchies now that ``sanction.linked`` no longer propagates on its own —
-  see the note on Phase 2 below.
+  is tagged ``sanction.control`` and co-emitted ``sanction.linked`` (so
+  ``sanction.linked`` is a superset of ``sanction.control``). No 50% ownership
+  threshold is applied; one hop per run, converging across successive runs.
 - ``rule_export_control_descent`` — an asset owned by an ``export.control`` or
   ``export.control.linked`` entity is itself tagged ``export.control.linked``.
     Ownership-only, downward-only, one hop per run.
@@ -37,15 +35,12 @@ Requirements and invariants that make this correct:
   descent rules (``rule_sanction_control_descent`` and
   ``rule_export_control_descent``), which read their emitted topics back from
   the store in order to walk one hop at a time.
-- **``sanction.linked`` is no longer transitive by itself.** Before Phase 2 of
-  the ``sanction.control`` roll-out (#4496), an ownership-only rule walked
-  ``sanction.linked → sanction.linked`` down chains — meaning a company two
-  hops below a sanctioned owner would be tagged. That rule has been removed:
-  ``sanction.linked`` now means *directly adjacent to a sanction seed* (via
-  broad-edge or securities), plus every entity in a ``sanction.control``
-  chain via the lockstep co-emit. Multi-tier reach is now expressed
-  exclusively through ``sanction.control``, and downstream filters on
-  ``sanction.linked`` still see every controlled entity via the co-emit.
+- **``sanction.linked`` is non-transitive.** It means *directly adjacent to
+  a sanction seed* (via broad edge or the direct Company↔Security relation),
+  plus every entity in a ``sanction.control`` chain via the lockstep
+  co-emit. Multi-tier reach is expressed exclusively through
+  ``sanction.control``; downstream filters on ``sanction.linked`` still see
+  every controlled entity via that co-emit.
 - **Iterative convergence.** Because ownership propagation advances a single
   hop per run, a multi-tier corporate hierarchy only materializes over
   successive runs. The dataset must be re-run for the graph to converge; a

--- a/datasets/_analysis/ann_graph_topics/ann_graph_topics.yml
+++ b/datasets/_analysis/ann_graph_topics/ann_graph_topics.yml
@@ -23,11 +23,28 @@ summary: >
   Automatically generated graph-based topic annotations
 description: |
   This data sources stores annotations of entities which are adjacent to other
-  risk-linked entities. For example, a person linked via a family bond to a PEP
-  is considered a "relative or close associate" (RCA). Similarly, entities
-  linked to sanctioned entities (especially subsidiaries) are tagges as
-  "sanction-linked".
-url: https://opensanctions.org/datasets/graphtopics
+  risk-linked entities
+
+  Derived risk topics, computed by walking the resolved entity graph. Each
+  annotation is a patch carrying only a `topics` value; it is merged into the
+  target entity, which takes its name and other properties from its own sources.
+
+  * `role.rca` — a person on the other side of a family relationship from a
+    `role.pep` entity.
+  * `sanction.linked` — an entity one relationship away from a sanctioned
+    entity, via ownership, directorship, membership, employment, association,
+    family or succession; a security issued by a sanctioned entity; and the
+    issuer of a sanctioned security. Also applied to every `sanction.control`
+    entity.
+  * `sanction.control` — an entity owned by a sanctioned or `sanction.control`
+    entity, down the full ownership chain, regardless of the size of the stake.
+  * `export.control.linked` — an entity owned by an `export.control` or
+    `export.control.linked` entity, down the full ownership chain, regardless of
+    the size of the stake.
+
+  Relationships carrying an end date are ignored, so a former director or
+  ex-spouse does not carry derived risk topics.
+url: https://www.opensanctions.org/docs/topics/
 publisher:
   name: OpenSanctions
   description: |

--- a/datasets/_analysis/ann_graph_topics/test_ann_graph_topics.py
+++ b/datasets/_analysis/ann_graph_topics/test_ann_graph_topics.py
@@ -191,12 +191,10 @@ def test_sanction_linked_skipped_if_target_already_seed() -> None:
 
 
 def test_sanction_linked_does_not_propagate_transitively() -> None:
-    # Phase 2 of #4496: the old rule_ownership_descent (sanction.linked →
-    # sanction.linked down ownership) has been removed. An entity that only
-    # carries sanction.linked (i.e. isn't directly a sanction seed and isn't
-    # in the sanction.control chain) must NOT push sanction.linked to its
-    # asset. Multi-tier reach for sanction.linked now comes exclusively
-    # from the sanction.control co-emit.
+    # An entity carrying only sanction.linked (not a sanction seed, not in
+    # a sanction.control chain) must not push sanction.linked to its asset.
+    # Multi-tier reach for sanction.linked comes exclusively from the
+    # sanction.control co-emit.
     ctx = _analyze(
         [
             _entity("Company", "parent", {"topics": ["sanction.linked"]}),

--- a/datasets/_analysis/ann_graph_topics/test_ann_graph_topics.py
+++ b/datasets/_analysis/ann_graph_topics/test_ann_graph_topics.py
@@ -187,12 +187,16 @@ def test_sanction_linked_skipped_if_target_already_seed() -> None:
     assert _emits(ctx) == []
 
 
-# ---- rule_ownership_descent ---------------------------------------------
+# ---- sanction.linked is non-transitive ---------------------------------
 
 
-def test_ownership_descent_emits_on_asset() -> None:
-    # An owner already tagged sanction.linked (as if from a prior run) pushes
-    # the tag one hop further to its asset.
+def test_sanction_linked_does_not_propagate_transitively() -> None:
+    # Phase 2 of #4496: the old rule_ownership_descent (sanction.linked →
+    # sanction.linked down ownership) has been removed. An entity that only
+    # carries sanction.linked (i.e. isn't directly a sanction seed and isn't
+    # in the sanction.control chain) must NOT push sanction.linked to its
+    # asset. Multi-tier reach for sanction.linked now comes exclusively
+    # from the sanction.control co-emit.
     ctx = _analyze(
         [
             _entity("Company", "parent", {"topics": ["sanction.linked"]}),
@@ -204,40 +208,6 @@ def test_ownership_descent_emits_on_asset() -> None:
             _entity("Company", "child"),
         ],
         source_id="parent",
-    )
-    assert ("child", "sanction.linked") in _emits(ctx)
-
-
-def test_ownership_descent_does_not_ascend() -> None:
-    # From the asset side, the rule must not push the tag up to the owner.
-    ctx = _analyze(
-        [
-            _entity("Company", "parent"),
-            _entity(
-                "Ownership",
-                "own",
-                {"owner": ["parent"], "asset": ["child"]},
-            ),
-            _entity("Company", "child", {"topics": ["sanction.linked"]}),
-        ],
-        source_id="child",
-    )
-    assert _emits(ctx) == []
-
-
-def test_ownership_descent_ignores_non_ownership_edges() -> None:
-    # Directorship is out of scope for the descent rule.
-    ctx = _analyze(
-        [
-            _entity("Person", "director", {"topics": ["sanction.linked"]}),
-            _entity(
-                "Directorship",
-                "dir",
-                {"director": ["director"], "organization": ["co"]},
-            ),
-            _entity("Company", "co"),
-        ],
-        source_id="director",
     )
     assert _emits(ctx) == []
 


### PR DESCRIPTION
Removes rule_ownership_descent and its tests. sanction.linked is now strictly non-transitive on its own: it means "direct broad-edge adjacency to a sanctioned entity" (rule_sanction_adjacency), plus every entity in a sanction.control chain via the lockstep co-emit (rule_sanction_control_descent). Multi-tier reach for sanction.linked now flows exclusively through sanction.control.

Adds a regression test test_sanction_linked_does_not_propagate_transitively that pins the new behavior: an entity carrying only sanction.linked must not push sanction.linked to its asset.

Phase 2 of #4496.