### PR TITLE
[jp_mof_sanctions] Raw names to review + LLM cleaning (follow-up to #4716)

### DIFF
--- a/datasets/jp/mof_sanctions/crawler.py
+++ b/datasets/jp/mof_sanctions/crawler.py
@@ -145,18 +145,37 @@ def emit_row(
     raw_old_name = row.pop("old_name", [])
     raw_weak_alias = row.pop("weak_alias", [])
     raw_nickname = row.pop("nickname", [])
-    original = h.Names()
-    for n in name_english:
-        original.add("name", n, lang="eng")
-    for n in name_japanese:
-        original.add("name", n, lang="jpn")
-    for n in chain(raw_alias, raw_known_alias):
-        original.add("alias", n)
-    for n in chain(raw_past_alias, raw_old_name):
-        original.add("previousName", n)
-    for n in chain(raw_weak_alias, raw_nickname):
-        original.add("weakAlias", n)
-    h.apply_reviewed_names(context, entity, original=original)
+    # Exception: we normally never enable llm_cleaning on a sanctions dataset, but
+    # this list mixes English and Japanese names and none of our reviewers read
+    # Japanese - so a non-speaker can't reliably tell a name from embedded
+    # commentary or an original-script appendage. The LLM proposes splits/cleanups
+    # that a human still has to accept (nothing is auto-applied), which is safer
+    # here than eyeballing an unreadable script. Names are cleaned per language
+    # because llm_cleaning returns plain strings and drops per-value language.
+    for name in name_english:
+        h.apply_reviewed_name_string(
+            context, entity, string=name, lang="eng", llm_cleaning=True
+        )
+    for name in name_japanese:
+        h.apply_reviewed_name_string(
+            context, entity, string=name, lang="jpn", llm_cleaning=True
+        )
+    for name in chain(raw_alias, raw_known_alias):
+        h.apply_reviewed_name_string(
+            context, entity, string=name, original_prop="alias", llm_cleaning=True
+        )
+    for name in chain(raw_past_alias, raw_old_name):
+        h.apply_reviewed_name_string(
+            context,
+            entity,
+            string=name,
+            original_prop="previousName",
+            llm_cleaning=True,
+        )
+    for name in chain(raw_weak_alias, raw_nickname):
+        h.apply_reviewed_name_string(
+            context, entity, string=name, original_prop="weakAlias", llm_cleaning=True
+        )
     entity.add_cast("Person", "position", row.pop("position", []), lang="eng")
 
     birth_date = parse_date(row.pop("birth_date", []))

--- a/datasets/jp/mof_sanctions/crawler.py
+++ b/datasets/jp/mof_sanctions/crawler.py
@@ -24,6 +24,26 @@ SPLITS = SPLITS + ["（a）", "（b）", "（c）", "\n"]
 SPLITS = SPLITS + ["(i)", "(ii)", "(iii)", "(iv)", "(v)", "(vi)", "(vii)", "(viii)"]
 SPLITS = SPLITS + ["; a.k.a.", "; a.k.a ", ", a.k.a.", ", f.k.a."]
 
+# Columns whose values are names. These are handed to the review system as raw
+# strings so that splitting and cleaning (brackets, "a.k.a.", enumeration markers,
+# original-script appendages, ...) happen there rather than through brittle
+# crawler-side rules. See datasets/jp/mof_sanctions/jp_mof_sanctions.yml `names`
+# for the namespec rules that flag these for review.
+NAME_COLUMNS = {
+    "name_english",
+    "name_japanese",
+    "alias",
+    "known_alias",
+    "past_alias",
+    "old_name",
+    "weak_alias",
+    "nickname",
+}
+# We only split name cells on newlines: a single cell often stacks several
+# distinct names on separate lines, and that structure can't be recovered later
+# because whitespace is squashed before names reach the review system.
+NAME_SPLITS = ["\n"]
+
 ADDR_SPLITS = ["; and ", ";"]
 DATE_SPLITS = SPLITS + [
     "、",
@@ -72,17 +92,6 @@ def parse_date(text: List[str]) -> List[str]:
             if normal:
                 dates.append(normal)
     return dates
-
-
-def split_english_names(names: List[str]) -> tuple[List[str], List[str]]:
-    """Split the English-column values into truly-English names and others.
-
-    The source's English name column sometimes appends the original-script name
-    (e.g. the Arabic script version) after the English transliteration. Only the
-    first value is reliably in English; the remainder are language-undetermined
-    and should not be tagged as English.
-    """
-    return names[:1], names[1:]
 
 
 def parse_notes(context: Context, entity: Entity, notes: List[str]) -> None:
@@ -136,12 +145,9 @@ def emit_row(
     raw_old_name = row.pop("old_name", [])
     raw_weak_alias = row.pop("weak_alias", [])
     raw_nickname = row.pop("nickname", [])
-    english_first, english_rest = split_english_names(name_english)
     original = h.Names()
-    for n in english_first:
+    for n in name_english:
         original.add("name", n, lang="eng")
-    for n in english_rest:
-        original.add("name", n)
     for n in name_japanese:
         original.add("name", n, lang="jpn")
     for n in chain(raw_alias, raw_known_alias):
@@ -303,8 +309,12 @@ def crawl_sheets(
                 for header, cell in zip(headers, row):
                     if header is None:
                         continue
+                    # Name columns keep their raw content (only newline-split) and
+                    # are cleaned by the review system; all other columns keep the
+                    # existing SPLITS-based splitting.
+                    splits = NAME_SPLITS if header in NAME_COLUMNS else SPLITS
                     values: list[str] = []
-                    for value in h.multi_split(stringify(cell), SPLITS):
+                    for value in h.multi_split(stringify(cell), splits):
                         if value is None:
                             continue
                         if value == "不明":

--- a/datasets/jp/mof_sanctions/jp_mof_sanctions.yml
+++ b/datasets/jp/mof_sanctions/jp_mof_sanctions.yml
@@ -92,11 +92,15 @@ names:
       reject_strings:
         - "_x000D_"
         - "original script:"
+        - "a.k.a."
+        - "f.k.a."
     Person:
       reject_chars: "()（）:：;；、"
       reject_strings:
         - "_x000D_"
         - "original script:"
+        - "a.k.a."
+        - "f.k.a."
 
 lookups:
   schema:


### PR DESCRIPTION
Follow-up to #4716 addressing the reviewer feedback on name splitting. Stacked on the step-3 branch, so the diff here is only the incremental change; it will retarget to `main` once #4716 merges.

## What changed

1. **Stop pre-splitting names before review** (@pudo, @jbothma). `crawl_sheets` no longer runs `SPLITS` on name columns — they are split **only on newlines** (structural; unrecoverable later because whitespace is squashed before names reach review) and otherwise passed raw. Dates/IDs/addresses keep their splitting.
2. **Cover the split markers in the namespec** (@jbothma). `reject_chars` already flags brackets/colons/semicolons; added `a.k.a.` / `f.k.a.` to `names.schema_rules.reject_strings` for the comma-form alias markers.
3. **Dropped `split_english_names`** — the English column is passed as-is; original-script appendages are handled in review.
4. **Enabled `llm_cleaning` on the name fields** (@pudo's "little devil"). This is a **deliberate, inline-flagged exception** to the "no llm_cleaning on sanctions datasets" rule: the list mixes English and Japanese names and no reviewer reads Japanese, so a non-speaker can't reliably tell a name from embedded commentary. The LLM proposes splits/cleanups that a human still accepts — nothing is auto-applied. Implemented as per-value `apply_reviewed_name_string` calls per language (llm_cleaning returns plain strings and drops per-value language).

## Verification

`zavod crawl` runs clean locally (7206 entities, exit 0). LLM path is wired correctly — without a key it logs `LLM cleaning enabled but OPENAI_API_KEY not configured, falling back to non-LLM review` and degrades to raw review.

## Why draft — not merge-ready as-is

- Changing `original` changes the **review keys**, so the accepted step-2 reviews from #4716 no longer match → everything reverts to unaccepted (~3k items) and falls back to the raw string until re-reviewed. This effectively resets the migration to a step-1/step-2 cycle for this dataset.
- While unaccepted, long combined alias cells (e.g. `(a)…(z) a.k.a.…`) exceed the property length limit and are dropped; they return once reviews are accepted and split.
- `entity.id` is derived from the name values, so IDs shift for entities whose names contained split markers — needs a look before merge.
- The sanctions LLM-cleaning exception should get explicit sign-off and a note in `zavod/docs`.

Needs: policy sign-off on the LLM exception, a decision on the ID shift, and a fresh step-2 review pass (ideally with the LLM key configured so reviewers see suggestions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)