### PR TITLE
Bucket edge IDs instead of entities in edge dedupe

### DIFF
--- a/zavod/zavod/integration/edges.py
+++ b/zavod/zavod/integration/edges.py
@@ -321,8 +321,13 @@ def props_compatible(entities: list[Entity]) -> bool:
 
 
 def group_edges(view: View) -> list[list[str]]:
-    """Group edge IDs that should become positive resolver decisions."""
-    buckets: dict[BucketKey, list[Entity]] = defaultdict(list)
+    """Group edge IDs that should become positive resolver decisions.
+
+    Buckets hold entity IDs rather than entities: keeping every hydrated edge
+    entity in memory scales with the size of the whole graph. Multi-member
+    buckets are re-fetched from the view one bucket at a time.
+    """
+    buckets: dict[BucketKey, list[str]] = defaultdict(list)
     groups: list[list[str]] = []
 
     for idx, entity in enumerate(view.entities()):
@@ -332,9 +337,17 @@ def group_edges(view: View) -> list[list[str]]:
         key = bucket_key(entity)
         if key is None:
             continue
-        buckets[key].append(entity)
+        assert entity.id is not None
+        buckets[key].append(entity.id)
 
-    for entities in buckets.values():
+    for ids in buckets.values():
+        if len(ids) < 2:
+            continue
+        entities: list[Entity] = []
+        for entity_id in ids:
+            member = view.get_entity(entity_id)
+            assert member is not None
+            entities.append(member)
         for group in temporal_candidate_groups(entities):
             if not props_compatible(group):
                 continue


### PR DESCRIPTION
## Summary

The redesigned edge deduper (#4718) accumulates the full hydrated `Entity` object for every edge entity in the collection into its endpoint/schema buckets and holds them all until the scan finishes. That footprint scales with the total number of edges in the graph — not with the number of pending merges — and OOMed at 7GB in production. It would recur on every run, not just the first.

## Change

`group_edges()` now buckets entity IDs instead of entities. Singleton buckets (the overwhelming majority) are skipped without ever being re-read; multi-member buckets are re-hydrated via `view.get_entity()` one bucket at a time, immediately before the temporal-compatibility and protected-property checks, and discarded once grouped. This is the same fetch-by-ID pattern `merge_groups()` already uses, and the store view is a static snapshot for the duration of the run, so the re-fetch round-trips exactly.

Per-edge resident memory during the scan drops from kilobytes (hydrated entity) to tens of bytes (ID string plus a shared bucket key). The extra cost is random-access reads for edges in multi-member buckets (~1M at current scale) — acceptable for a weekly batch job.

No behavior change: identical candidate groups, identical resolver decisions.

## Verification

- All 17 tests in `zavod/tests/integration/test_edges.py` pass unchanged.
- `mypy --strict` clean for this file (one pre-existing unrelated error in `zavod/shed/wikidata/position.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)