### PR TITLE
[ir_uani_business_registry] Typed HTML helpers; fix fetch_html retry dropping options

### DIFF
--- a/datasets/ir/uani_business_registry/crawler.py
+++ b/datasets/ir/uani_business_registry/crawler.py
@@ -1,43 +1,57 @@
 from urllib.parse import urljoin
 
 from lxml import etree
-from lxml.html import HtmlElement
 from normality import slugify
-
-from zavod import Context, Entity, helpers as h
 from zavod.extract.zyte_api import fetch_html
 from zavod.util import Element
 
+from zavod import Context, Entity
+from zavod import helpers as h
 
-def parse_facts_list(container: HtmlElement) -> dict[str, list[HtmlElement]]:
+
+def parse_facts_list(container: Element) -> dict[str, list[Element]]:
     """
-    Parse a list of facts into a dictionary.
+    Parse the company page's facts list into a dict keyed by slugified label.
 
-    Args:
-        container: The HtmlElement containing the description list rows
-
-    Returns:
-        Dictionary where the slugified text content of each data list label is the key,
-          and the value element is the value.
+    Values are the raw `<span>` cell elements so callers can extract text or
+    links as appropriate for each field.
     """
-    rows_xpath = './/div[contains(@class, "c-full-node__info--row")]'
-    key_xpath = './/label[contains(@class, "field__label")]'
-    values_xpath = "./span"
-    data: dict[str, list[HtmlElement]] = {}
-    for row in container.xpath(rows_xpath):
-        key_els = row.xpath(key_xpath)
-        assert len(key_els) == 1, (key_xpath, row.text_content())
-        label = key_els[0].text_content()
-        key = slugify(label, sep="_")
-        assert key
+    data: dict[str, list[Element]] = {}
+    rows = h.xpath_elements(
+        container, './/div[contains(@class, "c-full-node__info--row")]'
+    )
+    for row in rows:
+        label = h.xpath_element(row, './/label[contains(@class, "field__label")]')
+        key = slugify(h.element_text(label), sep="_")
+        assert key, h.element_text(label)
         assert key not in data, (key, data)
-        value_els = row.xpath(values_xpath)
-        data[key] = value_els
+        data[key] = h.xpath_elements(row, "./span")
     return data
 
 
+def emit_related_company(context: Context, cell: Element) -> Entity:
+    """Emit a Company referenced by name and link(s) in a facts-list cell."""
+    # squash=False + strip() preserves the exact strings previously produced by
+    # text_content().strip() — these feed make_id, so squashing internal
+    # whitespace would change entity IDs.
+    name = h.element_text(cell, squash=False).strip()
+    # Some links on the source page are relative (e.g. /company/fortis-bank-sanv);
+    # resolve them against the data URL so the url type cleaner accepts them and
+    # entity IDs stay consistent. urljoin is a no-op on already-absolute URLs.
+    urls = [
+        urljoin(context.data_url, url) for url in h.xpath_strings(cell, ".//a/@href")
+    ]
+    company = context.make("Company")
+    company.id = context.make_id(name, *urls, prefix="ir-br-co")
+    assert company.id
+    company.add("name", name)
+    company.add("sourceUrl", urls)
+    context.emit(company)
+    return company
+
+
 def crawl_subpage(context: Context, url: str, entity: Entity, entity_id: str) -> None:
-    context.log.info(f"Starting to crawl company page: {url}")
+    context.log.info("Crawling company page", url=url)
     # In the past we've gotten an error message
     # "The website encountered an unexpected error. Try again later."
     # In that case this validator doesn't match.
@@ -48,6 +62,8 @@ def crawl_subpage(context: Context, url: str, entity: Entity, entity_id: str) ->
     # to the unblock validator and then invalidate the cache and log the error.
     # BEWARE skipping pages with this error means intermittent data loss
     # and we've had complaints about that on this dataset in the past.
+    # An exact @class match is deliberate here (and for the facts list below):
+    # contains() would also match the c-full-node__info--row divs.
     validator_xpath = './/div[@class="c-full-node__info"]'
     doc = fetch_html(
         context,
@@ -62,38 +78,27 @@ def crawl_subpage(context: Context, url: str, entity: Entity, entity_id: str) ->
     facts = parse_facts_list(facts_list)
 
     for industry in facts.pop("industry", []):
-        entity.add("sector", industry.text_content().strip())
+        entity.add("sector", h.element_text(industry, squash=False).strip())
 
     for sources in facts.pop("sources", []):
-        for source in sources.xpath(".//p"):
+        for source in sources.findall(".//p"):
             # Sometimes, the tree contains some weird CSS elements
             # with something that looks like an HTML comment - get rid of those.
             etree.strip_elements(source, "style", "script")
-            source_text = source.text_content()
+            # squash=False: the type.text lookups in the .yml match the raw
+            # text, non-breaking spaces included.
+            source_text = h.element_text(source, squash=False)
             if "initWindowFocus" in source_text:
                 continue
-            for a in source.xpath(".//a"):
-                source_url = a.get("href")
-                if source_url:
-                    source_text += f" ({source_url})"
+            for source_url in h.xpath_strings(source, ".//a/@href"):
+                source_text += f" ({source_url})"
             entity.add("notes", source_text)
 
     for website in facts.pop("website", []):
-        entity.add("website", website.xpath(".//a/@href"))
+        entity.add("website", h.xpath_strings(website, ".//a/@href"))
 
     for owner in facts.pop("parent_company", []):
-        parent_company = owner.text_content().strip()
-        # Some links on the source page are relative (e.g. /company/fortis-bank-sanv);
-        # resolve them against the data URL so the url type cleaner accepts them and
-        # entity IDs stay consistent. urljoin is a no-op on already-absolute URLs.
-        parent_urls = [
-            urljoin(context.data_url, url) for url in owner.xpath(".//a/@href")
-        ]
-        parent = context.make("Company")
-        parent.id = context.make_id(parent_company, *parent_urls, prefix="ir-br-co")
-        parent.add("name", parent_company)
-        parent.add("sourceUrl", parent_urls)
-        context.emit(parent)
+        parent = emit_related_company(context, owner)
         ownership = context.make("Ownership")
         ownership.id = context.make_id(entity_id, parent.id, prefix="ir-br-own")
         ownership.add("asset", entity.id)
@@ -103,19 +108,8 @@ def crawl_subpage(context: Context, url: str, entity: Entity, entity_id: str) ->
     # Most of the time this is the subsidiary, but JX Nippon Oil & Energy
     # and Japan Energy Corporation are only affiliates
     for affiliate in facts.pop("affiliates_subsidiaries", []):
-        affiliate_name = affiliate.text_content().strip()
-        # Resolve relative links to absolute (see parent_company handling above).
-        affiliates_urls = [
-            urljoin(context.data_url, url) for url in affiliate.xpath(".//a/@href")
-        ]
-        subsidiary = context.make("Company")
-        subsidiary.id = context.make_id(
-            affiliate_name, *affiliates_urls, prefix="ir-br-co"
-        )
+        subsidiary = emit_related_company(context, affiliate)
         assert subsidiary.id
-        subsidiary.add("name", affiliate_name)
-        subsidiary.add("sourceUrl", affiliates_urls)
-        context.emit(subsidiary)
 
         link = context.make("UnknownLink")
         left = min(entity_id, subsidiary.id)
@@ -139,19 +133,27 @@ def crawl_subpage(context: Context, url: str, entity: Entity, entity_id: str) ->
 
 
 def get_end_page(doc: Element) -> int:
-    last_page_xpath = ".//li[@class='c-pager__item c-pager__last']/a/@href"
+    last_page_xpath = ".//li[contains(@class, 'c-pager__last')]/a/@href"
     last_page_link = h.xpath_string(doc, last_page_xpath)
     last_page_num = int(last_page_link.split("=")[-1])
     return last_page_num
 
 
-def crawl_row(context: Context, row: dict[str, HtmlElement]) -> None:
+def crawl_row(context: Context, row: dict[str, Element]) -> None:
     str_row = h.cells_to_str(row)
 
     # skip entities that have been withdrawn
-    withdrawn_elem = row.pop("withdrawn")
-    is_withdrawn = bool(withdrawn_elem.xpath('.//div[@class="featured"]'))
-    if is_withdrawn is True:
+    withdrawn_cell = row.pop("withdrawn")
+    withdrawn_text = str_row.pop("withdrawn")
+    withdrawn_marker = h.xpath_elements(
+        withdrawn_cell, './/div[contains(@class, "featured")]'
+    )
+    is_withdrawn = len(withdrawn_marker) > 0
+    # The cell carries text if and only if it holds the withdrawn marker; if the
+    # site renames the marker class, fail here rather than silently re-emitting
+    # withdrawn companies.
+    assert (withdrawn_text is not None) == is_withdrawn, withdrawn_text
+    if is_withdrawn:
         return
 
     company_elem = row.pop("company_sort_descending")

--- a/zavod/zavod/extract/zyte_api.py
+++ b/zavod/zavod/extract/zyte_api.py
@@ -490,11 +490,13 @@ def fetch_html(
                 actions,
                 html_source=html_source,
                 javascript=javascript,
+                geolocation=geolocation,
                 request_cookies=request_cookies,
                 cache_days=cache_days,
                 retries=retries,
                 backoff_factor=backoff_factor,
                 previous_retries=previous_retries + 1,
+                absolute_links=absolute_links,
             )
         context.log.debug("Unblocking failed", url=url, html=zyte_result.response_text)
         raise UnblockFailedException(url, unblock_validator)

--- a/zavod/zavod/tests/extract/test_zyte_api.py
+++ b/zavod/zavod/tests/extract/test_zyte_api.py
@@ -129,6 +129,50 @@ def test_unblock_failed(testdataset1: Dataset):
     context.close()
 
 
+def test_unblock_retry_preserves_request_options(testdataset1: Dataset):
+    context = Context(testdataset1)
+
+    # First response fails the unblock validator, second succeeds. The retry
+    # must re-request with the same options (geolocation) and post-process the
+    # final document the same way (absolute_links).
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://api.zyte.com/v1/extract",
+            [
+                {
+                    "json": {
+                        "browserHtml": "<html><h1>Enable JS</h1></html>",
+                        "statusCode": 200,
+                    }
+                },
+                {
+                    "json": {
+                        "browserHtml": (
+                            '<html><div id="content">'
+                            '<a href="/company/foo">Foo</a>'
+                            "</div></html>"
+                        ),
+                        "statusCode": 200,
+                    }
+                },
+            ],
+        )
+        doc = fetch_html(
+            context,
+            "https://test.com/bla",
+            './/div[@id="content"]',
+            geolocation="us",
+            absolute_links=True,
+            backoff_factor=0,
+        )
+        assert m.call_count == 2
+        for request in m.request_history:
+            assert request.json()["geolocation"] == "us", request.json()
+        assert doc.xpath(".//a/@href") == ["https://test.com/company/foo"]
+
+    context.close()
+
+
 def test_caching(testdataset1: Dataset):
     context = Context(testdataset1)
 


### PR DESCRIPTION
## fetch_html retry fix (zavod)

`fetch_html`'s recursive retry on unblock-validation failure dropped `absolute_links` and `geolocation`. Any page that failed unblocking once was returned with relative hrefs (the intermittent relative-link issue this crawler worked around in b167e43e7 / 4c9d29d5b) and re-requested without its geolocation. Both are now forwarded; a regression test covers the retry path.

## Crawler refactor

- Raw `.xpath()` / `.text_content()` replaced with the typed helpers (`h.xpath_elements`, `h.xpath_element`, `h.xpath_strings`, `h.element_text`); signatures unified on `zavod.util.Element`.
- `parse_facts_list` label extraction now uses `h.xpath_element`'s exactly-one guard instead of a manual count assert.
- Parent-company and affiliate emission deduplicated into `emit_related_company` (identical `make_id` inputs, IDs unchanged).
- Strict-interpretation guard: the withdrawn-marker check is cross-checked against the cell text, so a renamed `featured` class fails loudly instead of silently re-emitting withdrawn companies.
- Pager selector uses `contains(@class, 'c-pager__last')` (the `<li>` carries multiple classes). The `c-full-node__info` selectors deliberately keep exact `@class` matches — `contains()` would also match the `__info--row` divs.
- Structured logging instead of f-string interpolation.

Text extraction uses `squash=False` + `.strip()` to stay byte-identical with the previous `text_content().strip()` — several of these strings feed `make_id`, and notes must keep matching the `type.text` lookups.

Deliberately untouched: the 2026-02-13 topics work-around, name handling, entity ID scheme, lookups.

## Verification

- `mypy --strict` clean on the crawler and on zavod; zavod test suite for `zyte_api` passes.
- Draft until a bounded smoke crawl (first listing page) is diffed against a same-scope baseline — full crawls take tens of hours via Zyte, so output parity is checked on page 1, and production validates the rest via assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)