### PR TITLE
[wd_categories] Memoize position evaluation; cache holder queries for 5 days

### DIFF
--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -6,7 +6,7 @@ from io import StringIO
 from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urlencode
 
-from nomenklatura.wikidata import Claim, WikidataClient
+from nomenklatura.wikidata import Claim, Item, WikidataClient
 from nomenklatura.wikidata.value import clean_wikidata_name
 from rigour.time import iso_datetime
 
@@ -54,7 +54,10 @@ class CrawlState(object):
             reference_time=settings.RUN_TIME,
         )
         self.log = context.log
-        self.ignore_positions: Set[str] = set()
+        # Position QID -> evaluated position entity, None if the item is not
+        # a usable PEP position. Positions recur across the whole person set,
+        # so each distinct QID is fetched and categorised only once per run.
+        self.positions: Dict[str, Optional[Entity]] = {}
 
         self.persons: Dict[str, FoundRecord] = defaultdict(FoundRecord)
         self.persons.update({qid: FoundRecord() for qid in ALWAYS_PERSONS})
@@ -80,40 +83,56 @@ def title_name(title: str) -> Optional[str]:
     return clean_wikidata_name(title.replace("_", " "))
 
 
-def crawl_position(state: CrawlState, person: Entity, claim: Claim) -> None:
-    item = state.client.fetch_item(claim.qid)
+def get_position(state: CrawlState, qid: str) -> Optional[Entity]:
+    """Fetch and evaluate a position item, memoized on `state.positions` so
+    that each distinct position is fetched, categorised and crawled for
+    officeholders only once per run."""
+    if qid in state.positions:
+        return state.positions[qid]
+    item = state.client.fetch_item(qid)
     if item is None:
-        if claim.qid is not None:
-            state.ignore_positions.add(claim.qid)
-        return
+        state.positions[qid] = None
+        return None
     position = wikidata_position(state.context, state.client, item)
     if position is None or position.id is None:
-        state.ignore_positions.add(item.id)
-        return
-    if item.id != claim.qid and claim.qid is not None:
-        state.context.resolver.rename_node(claim.qid, item.id)
+        state.positions[qid] = None
+        state.positions[item.id] = None
+        return None
+    if item.id != qid:
+        state.context.resolver.rename_node(qid, item.id)
         state.context.flush()
+    state.positions[qid] = position
+    state.positions[item.id] = position
+    crawl_officeholders(state, item, position)
+    return position
 
+
+def crawl_officeholders(state: CrawlState, item: Item, position: Entity) -> None:
+    # persons via position --( P1308 officeholder )--> person
+    for claim in item.claims:
+        if claim.property != "P1308" or claim.qid is None:
+            continue
+        holder = crawl_person(state, claim.qid, recurse=False)
+        if holder is None:
+            continue
+        occupancy = wikidata_occupancy(state.context, holder, position, claim)
+        if occupancy is not None:
+            state.emit_position(position)
+            state.context.emit(occupancy)
+            state.context.emit(holder)
+
+
+def crawl_position(state: CrawlState, person: Entity, claim: Claim) -> None:
+    if claim.qid is None:
+        return
+    position = get_position(state, claim.qid)
+    if position is None:
+        return
     occupancy = wikidata_occupancy(state.context, person, position, claim)
     if occupancy is not None:
         state.log.info("  -> %s (%s)" % (position.first("name"), position.id))
         state.emit_position(position)
         state.context.emit(occupancy)
-
-    # TODO: implement support for 'officeholder' (P1308) here
-    for officeholder_claim in item.claims:
-        if officeholder_claim.property == "P1308":  # officeholder
-            if officeholder_claim.qid is None:
-                continue
-            holder = crawl_person(state, officeholder_claim.qid, recurse=False)
-            if holder is not None:
-                occupancy = wikidata_occupancy(
-                    state.context, holder, position, officeholder_claim
-                )
-                if occupancy is not None:
-                    state.emit_position(position)
-                    state.context.emit(occupancy)
-                    state.context.emit(holder)
 
 
 def crawl_person(state: CrawlState, qid: str, recurse: bool = True) -> Optional[Entity]:
@@ -206,15 +225,12 @@ def crawl_category(state: CrawlState, category_crawl_spec: Dict[str, Any]) -> No
 def crawl_position_holder(state: CrawlState, position_qid: str) -> Set[str]:
     persons: Set[str] = set([])
 
-    if position_qid in state.ignore_positions:
+    position = get_position(state, position_qid)
+    if position is None:
         return persons
+    # Cheap re-fetch: get_position just pulled this item into the client LRU.
     item = state.client.fetch_item(position_qid)
     if item is None:
-        state.ignore_positions.add(position_qid)
-        return persons
-    position = wikidata_position(state.context, state.client, item)
-    if position is None:
-        state.ignore_positions.add(position_qid)
         return persons
 
     # find person QIDs such that person --( P39 position held )--> position_qid
@@ -307,7 +323,7 @@ def crawl_persons(state: CrawlState) -> None:
 
         positions: set[Entity] = state.person_positions.get(person_qid, set())
         for position in positions:
-            if position.id is None or position.id in state.ignore_positions:
+            if position.id is None:
                 continue
             occupancy = h.make_occupancy(
                 state.context, entity, position, no_end_implies_current=False

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -67,6 +67,7 @@ class CrawlState(object):
         self.person_topics: Dict[str, Set[str]] = {}
         self.person_positions: Dict[str, Set[Entity]] = {}
         self._emitted_positions: Set[str] = set()
+        self._crawled_officeholder_positions: Set[str] = set()
         exc = [str(x) for x in context.dataset.config.get("exclusion_checks", [])]
         self.exclusion_checks: Set[str] = set(exc)
         self.person_modified_at: Dict[str, datetime] = {}
@@ -84,9 +85,7 @@ def title_name(title: str) -> Optional[str]:
 
 
 def get_position(state: CrawlState, qid: str) -> Optional[Entity]:
-    """Fetch and evaluate a position item, memoized on `state.positions` so
-    that each distinct position is fetched, categorised and crawled for
-    officeholders only once per run."""
+    """Reuse evaluated positions across people who hold the same office."""
     if qid in state.positions:
         return state.positions[qid]
     item = state.client.fetch_item(qid)
@@ -103,11 +102,14 @@ def get_position(state: CrawlState, qid: str) -> Optional[Entity]:
         state.context.flush()
     state.positions[qid] = position
     state.positions[item.id] = position
-    crawl_officeholders(state, item, position)
     return position
 
 
 def crawl_officeholders(state: CrawlState, item: Item, position: Entity) -> None:
+    if position.id is None or position.id in state._crawled_officeholder_positions:
+        return
+    state._crawled_officeholder_positions.add(position.id)
+
     # persons via position --( P1308 officeholder )--> person
     for claim in item.claims:
         if claim.property != "P1308" or claim.qid is None:
@@ -128,6 +130,9 @@ def crawl_position(state: CrawlState, person: Entity, claim: Claim) -> None:
     position = get_position(state, claim.qid)
     if position is None:
         return
+    item = state.client.fetch_item(claim.qid)
+    if item is not None:
+        crawl_officeholders(state, item, position)
     occupancy = wikidata_occupancy(state.context, person, position, claim)
     if occupancy is not None:
         state.log.info("  -> %s (%s)" % (position.first("name"), position.id))
@@ -239,6 +244,10 @@ def crawl_position_holder(state: CrawlState, position_qid: str) -> Set[str]:
     for person_qid, modified_at in holders.items():
         if modified_at is not None:
             state.person_modified_at[person_qid] = modified_at
+
+    # Crawl direct officeholders only after their modification dates can
+    # invalidate stale person items from the cache.
+    crawl_officeholders(state, item, position)
 
     # find person QIDs such that position_qid --( P1308 officeholder )--> person
     for claim in item.claims:

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -45,8 +45,8 @@ coverage:
   start: 2024-09-10
 deploy:
   cpu: "800m"
-  memory: "2300Mi"
-  memory_limit: "3000Mi"
+  memory: "2800Mi"
+  memory_limit: "4000Mi"
   schedule: "0 0 * * 0,1,3,5"
   # This job takes 7 hours. Restarting it for scale-down is probably not worth it.
   premium: true

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 requires-python = ">= 3.12"
 dependencies = [
     "followthemoney == 4.10.0",
-    "nomenklatura == 4.12.0",
+    "nomenklatura == 4.12.1",
     "plyvel == 1.5.1", # Also update macOS install docs
     "rigour == 2.2.3",
     "datapatch >= 1.2.4, < 1.3",

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -253,7 +253,10 @@ def position_holders(
     }}
     """
     holders: Dict[str, Optional[datetime]] = {}
-    response = client.query(query, client.CACHE_SHORT)
+    # Holder lists (and the dateModified values that drive person cache
+    # invalidation) change slowly; at 1 day, every crawl re-runs tens of
+    # thousands of WDQS queries.
+    response = client.query(query, cache_days=5)
     for result in response.results:
         person_qid = result.plain("person")
         modified_at = result.plain("modifiedAt")


### PR DESCRIPTION
The wikidata crawlers have slowed sharply (wd_categories: ~7h historically, ~36h for the 2026-07-15 run) since the `modified_at` cache-invalidation work. CPU sits at ~0.1 core for the whole run — the job is almost entirely serialized network roundtrips. This PR takes the two smallest, highest-leverage fixes.

### Memoize position evaluation in wd_categories

Positions recur across the whole person set, but `crawl_position` re-fetched and re-evaluated the position item once per P39 claim of every person — each time paying a `fetch_item` (LRU-thrashed → SQL cache get + JSON parse), a full `wikidata_position()` evaluation including a live `categorise()` SELECT, and translation cache lookups. The seeds phase then evaluated the same positions all over again. With ~300k persons this is millions of redundant roundtrips.

`get_position()` now owns fetch → redirect renaming → `wikidata_position()`, memoized on `CrawlState.positions` under both the requested and resolved QID; `None` records evaluated-and-rejected items (replacing `ignore_positions`, including the previously-unmemoized rejections, which are the majority).

Behavior notes:
- P1308 officeholder handling runs once per distinct position instead of once per holder. Positions reached only via the seeds phase now emit officeholder occupancies deterministically; previously those only appeared if some person's P39 claim later referenced the same position.
- Retained accepted-position entities measured at ~4.3–5.1KB deep × ~70–90k ≈ 350–450MB, so the deploy memory request/limit go to 2800Mi/4000Mi. (Repeat holders only read id/topics/country; if this ever bites, a slim-record + rebuild-on-emit variant gets it to ~25MB.)

### Cache position holder queries for 5 days

`position_holders` ran its per-position WDQS query at `CACHE_SHORT` (1 day), so on the 3–4×/week schedules essentially every query was cold: tens of thousands of serial SPARQL roundtrips per run, in both wd_categories and wd_peps. At 5 days (jittered ~2.5–6.5), each run refreshes roughly a quarter of them.

**Freshness trade-off to be aware of:** the `dateModified` values from this query drive person item cache invalidation, so upstream person edits now propagate within ~a week instead of every run. Given the run currently takes ~36h, published data was ~1.5 days stale anyway.

### Verification

- `mypy --strict` passes on the crawler and on all of zavod.
- Smoke-tested against live Wikidata with a dry-run Context: Q11696 evaluates correctly; a second `get_position` call returns the identical object with `fetch_item` patched to fail (pure memo hit); a rejected item (Q937) memoizes `None` under both keys; `crawl_position` emits an occupancy through the memoized position (Q76 → Q11696), exercising the P1308 path along the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)