### PR TITLE
Commit edge-dedupe resolver decisions in batches

### DIFF
--- a/zavod/zavod/cli/dedupe.py
+++ b/zavod/zavod/cli/dedupe.py
@@ -204,7 +204,7 @@ def dedupe_edges(dataset_paths: List[Path], rebuild_store: bool = False) -> None
             resolver.load_into_memory()
             store = get_store(dataset, resolver)
             store.sync(clear=rebuild_store)
-            edges.dedupe_edges(resolver, store.view(dataset, external=True))
+            edges.dedupe_edges(resolver, session, store.view(dataset, external=True))
     except Exception:
         log.exception("Failed to dedupe edge entities: %r" % dataset_paths)
         sys.exit(1)

--- a/zavod/zavod/integration/edges.py
+++ b/zavod/zavod/integration/edges.py
@@ -23,6 +23,7 @@ from datetime import date
 from typing import NamedTuple
 
 from nomenklatura import Resolver
+from nomenklatura.db import Session
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Identifier
 from normality import slugify
@@ -357,11 +358,20 @@ def group_edges(view: View) -> list[list[str]]:
 
 
 def merge_groups(
-    resolver: Resolver[Entity], view: View, groups: list[list[str]]
+    resolver: Resolver[Entity],
+    session: Session,
+    view: View,
+    groups: list[list[str]],
+    commit_every: int = 500,
 ) -> None:
-    """Write positive resolver decisions for deduped edge groups."""
+    """Write positive resolver decisions for deduped edge groups.
+
+    Decisions are committed in batches of ``commit_every`` so a large run does
+    not hold one long-lived transaction; the caller's final commit persists the
+    remainder."""
     merged_count = 0
     cluster_count = 0
+    uncommitted = 0
     dataset_counts: dict[str, int] = defaultdict(int)
 
     for values in groups:
@@ -392,16 +402,21 @@ def merge_groups(
             ).id
 
             merged_count += 1
+            uncommitted += 1
             for dataset in other.datasets:
                 dataset_counts[dataset] += 1
 
         cluster_count += 1
+        if uncommitted >= commit_every:
+            session.checkpoint()
+            log.info("Committed %s merge decisions..." % merged_count)
+            uncommitted = 0
     log.info("Merged %s edge entities into %s clusters" % (merged_count, cluster_count))
     for dataset, count in dataset_counts.items():
         log.info("Merged %s edges in dataset %s" % (count, dataset))
 
 
-def dedupe_edges(resolver: Resolver[Entity], view: View) -> None:
+def dedupe_edges(resolver: Resolver[Entity], session: Session, view: View) -> None:
     """Deduplicate edge entities from a store view into resolver decisions."""
     groups = group_edges(view)
-    merge_groups(resolver, view, groups)
+    merge_groups(resolver, session, view, groups)

--- a/zavod/zavod/tests/integration/test_edges.py
+++ b/zavod/zavod/tests/integration/test_edges.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import pytest
 from nomenklatura import Resolver, Store
+from nomenklatura.db import Session
 from nomenklatura.store import SimpleMemoryStore
 
 from zavod.entity import Entity
@@ -59,7 +60,9 @@ def assert_not_merged(resolver: Resolver, *ids: str) -> None:
     assert len(canonicals) == len(ids), canonicals
 
 
-def test_directed_edges_preserve_direction(store: Store, resolver: Resolver):
+def test_directed_edges_preserve_direction(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "Directorship",
@@ -74,11 +77,13 @@ def test_directed_edges_preserve_direction(store: Store, resolver: Resolver):
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_not_merged(resolver, "e1", "e2")
 
 
-def test_undirected_edges_canonicalize_endpoints(store: Store, resolver: Resolver):
+def test_undirected_edges_canonicalize_endpoints(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "UnknownLink",
@@ -93,11 +98,13 @@ def test_undirected_edges_canonicalize_endpoints(store: Store, resolver: Resolve
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "e1", "e2")
 
 
-def test_multi_ended_edges_are_skipped(store: Store, resolver: Resolver):
+def test_multi_ended_edges_are_skipped(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "Ownership",
@@ -112,11 +119,13 @@ def test_multi_ended_edges_are_skipped(store: Store, resolver: Resolver):
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_not_merged(resolver, "e1", "e2")
 
 
-def test_different_schemata_do_not_merge(store: Store, resolver: Resolver):
+def test_different_schemata_do_not_merge(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "Ownership",
@@ -131,11 +140,13 @@ def test_different_schemata_do_not_merge(store: Store, resolver: Resolver):
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_not_merged(resolver, "e1", "e2")
 
 
-def test_same_temporal_extent_merges(store: Store, resolver: Resolver):
+def test_same_temporal_extent_merges(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "UnknownLink",
@@ -154,11 +165,13 @@ def test_same_temporal_extent_merges(store: Store, resolver: Resolver):
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "e1", "e2")
 
 
-def test_missing_dates_are_temporally_compatible(store: Store, resolver: Resolver):
+def test_missing_dates_are_temporally_compatible(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset, "Ownership", "e1", None, None, {"owner": "a", "asset": "b"}
     )
@@ -167,11 +180,11 @@ def test_missing_dates_are_temporally_compatible(store: Store, resolver: Resolve
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "e1", "e2")
 
 
-def test_partial_dates_overlap(store: Store, resolver: Resolver):
+def test_partial_dates_overlap(store: Store, resolver: Resolver, session: Session):
     entity1 = e(
         store.dataset,
         "Directorship",
@@ -190,11 +203,13 @@ def test_partial_dates_overlap(store: Store, resolver: Resolver):
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "e1", "e2")
 
 
-def test_incompatible_dates_do_not_merge(store: Store, resolver: Resolver):
+def test_incompatible_dates_do_not_merge(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "Directorship",
@@ -213,11 +228,13 @@ def test_incompatible_dates_do_not_merge(store: Store, resolver: Resolver):
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_not_merged(resolver, "e1", "e2")
 
 
-def test_ambiguous_temporal_bridge_is_skipped(store: Store, resolver: Resolver):
+def test_ambiguous_temporal_bridge_is_skipped(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "Directorship",
@@ -244,12 +261,12 @@ def test_ambiguous_temporal_bridge_is_skipped(store: Store, resolver: Resolver):
     )
     add_entities(store, [entity1, entity2, entity3])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_not_merged(resolver, "e1", "e2", "e3")
 
 
 def test_ambiguous_bridge_does_not_block_unambiguous_merge(
-    store: Store, resolver: Resolver
+    store: Store, resolver: Resolver, session: Session
 ):
     # An ambiguous bridge (2025 overlaps both exact dates) and a conflicting edge
     # share a bucket with an identical, unambiguous pair. The bridge must not pull
@@ -261,13 +278,13 @@ def test_ambiguous_bridge_does_not_block_unambiguous_merge(
     conflict = e(store.dataset, "Directorship", "conflict", "2025-12-31", None, base)
     add_entities(store, [bridge, pair1, conflict, pair2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "pair1", "pair2")
     assert_not_merged(resolver, "bridge", "conflict", "pair1")
 
 
 def test_protected_props_match_on_shared_normalized_value(
-    store: Store, resolver: Resolver
+    store: Store, resolver: Resolver, session: Session
 ):
     entity1 = e(
         store.dataset,
@@ -291,11 +308,13 @@ def test_protected_props_match_on_shared_normalized_value(
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "e1", "e2")
 
 
-def test_protected_props_conflict_on_disjoint_values(store: Store, resolver: Resolver):
+def test_protected_props_conflict_on_disjoint_values(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "UnknownLink",
@@ -310,11 +329,13 @@ def test_protected_props_conflict_on_disjoint_values(store: Store, resolver: Res
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_not_merged(resolver, "e1", "e2")
 
 
-def test_empty_protected_props_do_not_block_merge(store: Store, resolver: Resolver):
+def test_empty_protected_props_do_not_block_merge(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "Directorship",
@@ -329,11 +350,13 @@ def test_empty_protected_props_do_not_block_merge(store: Store, resolver: Resolv
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "e1", "e2")
 
 
-def test_unprotected_props_do_not_block_merge(store: Store, resolver: Resolver):
+def test_unprotected_props_do_not_block_merge(
+    store: Store, resolver: Resolver, session: Session
+):
     entity1 = e(
         store.dataset,
         "Directorship",
@@ -358,12 +381,12 @@ def test_unprotected_props_do_not_block_merge(store: Store, resolver: Resolver):
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "e1", "e2")
 
 
 def test_payment_protected_props_allow_matching_payments(
-    store: Store, resolver: Resolver
+    store: Store, resolver: Resolver, session: Session
 ):
     entity1 = e(
         store.dataset,
@@ -395,12 +418,12 @@ def test_payment_protected_props_allow_matching_payments(
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_merged(resolver, "e1", "e2")
 
 
 def test_payment_protected_props_block_distinct_transactions(
-    store: Store, resolver: Resolver
+    store: Store, resolver: Resolver, session: Session
 ):
     entity1 = e(
         store.dataset,
@@ -430,11 +453,13 @@ def test_payment_protected_props_block_distinct_transactions(
     )
     add_entities(store, [entity1, entity2])
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_not_merged(resolver, "e1", "e2")
 
 
-def test_occupancy_period_regression(store: Store, resolver: Resolver):
+def test_occupancy_period_regression(
+    store: Store, resolver: Resolver, session: Session
+):
     entities = [
         e(
             store.dataset,
@@ -461,5 +486,5 @@ def test_occupancy_period_regression(store: Store, resolver: Resolver):
     ]
     add_entities(store, entities)
 
-    dedupe_edges(resolver, store.default_view())
+    dedupe_edges(resolver, session, store.default_view())
     assert_not_merged(resolver, "e1", "e2", "e3", "e4", "e5")


### PR DESCRIPTION
The `dedupe-edges` command previously wrote all merge decisions in a single transaction that only committed when the session closed at the end of the run. For a large store view that means holding one long-lived transaction over hundreds of thousands of resolver decisions.

This passes the `Session` into `dedupe_edges` / `merge_groups` (same pattern as `blocking_xref`) and calls `session.checkpoint()` every 500 decisions, committing without releasing the connection. The remainder is persisted by the caller's final commit as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)