### PR TITLE
helpers: fix split_html_newline_tags emitting tag names as chunks

### DIFF
--- a/zavod/zavod/helpers/html.py
+++ b/zavod/zavod/helpers/html.py
@@ -11,7 +11,7 @@ from zavod.util import Element
 log = get_logger(__name__)
 
 
-BR_RE = re.compile(r"<(br|p)\s*/?>", re.IGNORECASE)
+BR_RE = re.compile(r"</?(?:br|p)\s*/?>", re.IGNORECASE)
 
 
 def element_text(el: Element | None, squash: bool = True) -> str:
@@ -215,8 +215,8 @@ def xpath_string(el: Element, xpath: str) -> str:
 
 def split_html_newline_tags(string: str) -> List[str]:
     """
-    Split a string on HTML <br> tags, returning a list of strings.
+    Split a string on HTML <br> and <p> tags, returning a list of strings.
 
-    Non-empty strings will not be returned.
+    Empty and whitespace-only strings are dropped from the result.
     """
     return [s for s in BR_RE.split(string) if s.strip()]

--- a/zavod/zavod/tests/helpers/test_html.py
+++ b/zavod/zavod/tests/helpers/test_html.py
@@ -70,3 +70,17 @@ def test_element_text_hash():
     assert h.element_text_hash(doc) == hash, (doc, hash)
     doc = html.fromstring("<span> HELLO, <div>WORLD</div> &nbsp;</span>")
     assert h.element_text_hash(doc) == hash, (doc, hash)
+
+
+def test_split_html_newline_tags():
+    split = h.split_html_newline_tags
+    assert split("John Smith<br>Jane Doe") == ["John Smith", "Jane Doe"]
+    assert split("<p>Ground one</p><p>Ground two</p>") == ["Ground one", "Ground two"]
+    # Self-closing and upper-case variants
+    assert split("one<br/>two") == ["one", "two"]
+    assert split("one<BR>two") == ["one", "two"]
+    assert split("one<br />two") == ["one", "two"]
+    # Empty and whitespace-only chunks are dropped
+    assert split("one<br>  <br>two") == ["one", "two"]
+    assert split("") == []
+    assert split("no tags here") == ["no tags here"]


### PR DESCRIPTION
`BR_RE` used a capturing group (`<(br|p)\s*/?>`), so `re.split` included the matched tag name ("br"/"p") as extra elements in the output of `split_html_newline_tags`:

```python
split_html_newline_tags("John Smith<br>Jane Doe")
# → ['John Smith', 'br', 'Jane Doe']
```

Changes:
- Make the group non-capturing and also match closing tags (`</?(?:br|p)\s*/?>`), so `</p>` remnants no longer survive inside chunks.
- Correct the inverted docstring ("Non-empty strings will not be returned").
- Add unit tests for the function (there were none).

The one caller, `datasets/eu/edes/crawler.py`, joins the result with newlines into `Sanction.summary`/`Sanction.reason`; dropping the stray tokens and `</p>` remnants is strictly an improvement, so it is left unchanged.

Fixes #4937

🤖 Generated with [Claude Code](https://claude.com/claude-code)