### PR TITLE
helpers: fix greedy remove_bracketed and newline-crossing clean_note regexes

### DIFF
--- a/zavod/zavod/helpers/text.py
+++ b/zavod/zavod/helpers/text.py
@@ -10,9 +10,9 @@ log = get_logger(__name__)
 PREFIX_ = r"INTERPOL-UN\s*Security\s*Council\s*Special\s*Notice\s*web\s*link:?"
 PREFIX = re.compile(PREFIX_, re.IGNORECASE)
 
-INTERPOL_URL_ = r"https?:\/\/www\.interpol\.int\/[^ ]*(\s\d+)?"
+INTERPOL_URL_ = r"https?:\/\/www\.interpol\.int\/\S*(\s\d+)?"
 INTERPOL_URL = re.compile(INTERPOL_URL_, re.IGNORECASE)
-BRACKETED = re.compile(r"\(.*\)")
+BRACKETED = re.compile(r"\(.*?\)")
 
 
 def clean_note(text: Union[Optional[str], Sequence[Optional[str]]]) -> List[str]:

--- a/zavod/zavod/tests/helpers/test_text.py
+++ b/zavod/zavod/tests/helpers/test_text.py
@@ -51,6 +51,19 @@ def test_remove_bracketed():
     assert out, text
     assert out.strip() == "banana"
 
+    # Multiple bracket groups: text between the groups must be preserved
+    out = remove_bracketed("John (aka Jack) Smith (born 1970)")
+    assert out is not None
+    assert out.split() == ["John", "Smith"]
+    out = remove_bracketed("Acme Corp (Cayman) Ltd (in liquidation)")
+    assert out is not None
+    assert out.split() == ["Acme", "Corp", "Ltd"]
+
+    # Single groups keep being removed entirely
+    out = remove_bracketed("Russia (former USSR)")
+    assert out is not None
+    assert out.strip() == "Russia"
+
 
 def test_is_empty():
     assert is_empty(None) is True
@@ -65,3 +78,8 @@ def test_clean_note():
     assert clean_note(None) == []
     assert clean_note(["hello"]) == ["hello"]
     assert clean_note(["hello", None]) == ["hello"]
+
+    # INTERPOL URL removal stops at a newline instead of swallowing the
+    # start of the next line
+    note = "See https://www.interpol.int/en/notice/123\nSubject is armed"
+    assert clean_note(note) == ["See Subject is armed"]


### PR DESCRIPTION
Fixes #4936.

Two one-line regex fixes in `zavod/zavod/helpers/text.py`:

1. `BRACKETED` was greedy (`\(.*\)`), so inputs with multiple bracket groups matched from the first `(` to the last `)`, deleting the legitimate text in between — `"John (aka Jack) Smith (born 1970)"` became `"John"`. Now non-greedy (`\(.*?\)`), each group is removed individually and `"John Smith"` is preserved.

2. The `INTERPOL_URL_` pattern used `[^ ]*`, which excludes only the ASCII space and therefore consumes across newlines — a note like `"...interpol.int/en/notice/123\nSubject is armed"` lost the word `"Subject"`. Replaced with `\S*`, which stops at any whitespace.

Unit tests added in `zavod/zavod/tests/helpers/test_text.py` covering multi-group bracket removal preserving between-group text, single groups still removed, and `clean_note` stopping the URL match at a newline.

Verified with `pytest zavod/tests/ -k text` (24 passed) and `mypy --strict` on the module (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)