### PR TITLE
helpers: make sanction status consistent with is_active; diagnostic error on unparseable end_date

### DIFF
--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -36,6 +36,11 @@ def make_sanction(
     The country, authority, sourceUrl, and subject entity properties
     are automatically set.
 
+    If an ``end_date`` is given, a ``status`` of "active" or "inactive" is
+    derived using the same semantics as `is_active`. Note that the status is
+    only computed at construction time: dates applied to the sanction
+    afterwards (e.g. via `h.apply_date`) do not update it.
+
     Args:
         context: The runner context with dataset metadata.
         entity: The entity to which the sanctions object will be linked.
@@ -83,9 +88,13 @@ def make_sanction(
         h.apply_date(sanction, "startDate", start_date)
     if end_date:
         h.apply_date(sanction, "endDate", end_date)
-        iso_end_date = max(sanction.get("endDate"))
-        is_active = iso_end_date >= settings.RUN_TIME_ISO
-        sanction.add("status", "active" if is_active else "inactive")
+        if not sanction.get("endDate"):
+            raise ValueError(
+                f"Sanction end_date {end_date!r} could not be parsed as a date "
+                f"(entity {entity.id!r}). Add a datepatterns entry or a lookup "
+                "to clean the value."
+            )
+        sanction.add("status", "active" if is_active(sanction) else "inactive")
 
     return sanction
 

--- a/zavod/zavod/tests/helpers/test_sanctions.py
+++ b/zavod/zavod/tests/helpers/test_sanctions.py
@@ -58,6 +58,44 @@ def test_sanctions_helper_with_unknown_program(vcontext: Context):
     } in caplogs
 
 
+def test_sanctions_status_agrees_with_is_active(vcontext: Context):
+    person = vcontext.make("Person")
+    person.id = "jeff"
+
+    # Future start and end date: not yet active, status must agree.
+    future_start = (settings.RUN_TIME + timedelta(days=20)).date().isoformat()
+    future_end = (settings.RUN_TIME + timedelta(days=30)).date().isoformat()
+    sanction = make_sanction(
+        vcontext, person, start_date=future_start, end_date=future_end
+    )
+    assert not is_active(sanction)
+    assert sanction.get("status") == ["inactive"]
+
+    # Started in the past, ends in the future: active.
+    past_start = (settings.RUN_TIME - timedelta(days=20)).date().isoformat()
+    sanction = make_sanction(
+        vcontext, person, key="b", start_date=past_start, end_date=future_end
+    )
+    assert is_active(sanction)
+    assert sanction.get("status") == ["active"]
+
+    # Ended in the past: inactive.
+    past_end = (settings.RUN_TIME - timedelta(days=10)).date().isoformat()
+    sanction = make_sanction(
+        vcontext, person, key="c", start_date=past_start, end_date=past_end
+    )
+    assert not is_active(sanction)
+    assert sanction.get("status") == ["inactive"]
+
+
+def test_sanctions_unparseable_end_date_raises(vcontext: Context):
+    person = vcontext.make("Person")
+    person.id = "jeff"
+
+    with pytest.raises(ValueError, match=r"'see annex'.*'jeff'"):
+        make_sanction(vcontext, person, end_date="see annex")
+
+
 @pytest.fixture
 def person(vcontext: Context):
     person = vcontext.make("Person")


### PR DESCRIPTION
Fixes #4938

Two fixes in `zavod/zavod/helpers/sanctions.py`:

**1. Diagnostic error on unparseable `end_date`.** When `h.apply_date` cannot parse the `end_date` passed to `make_sanction`, the crawl previously died with a bare `ValueError: max() iterable argument is empty` — no entity ID, no offending value. This deliberately **stays a hard failure** (crash-on-uncertainty is policy; converting it to a warning would let unparsed dates slip through silently). It now raises an explicit `ValueError` that includes the raw value and the entity ID, so a lookup or datepatterns entry can be written straight from the traceback:

```
ValueError: Sanction end_date 'see annex' could not be parsed as a date (entity 'jeff'). Add a datepatterns entry or a lookup to clean the value.
```

**2. `status` now agrees with `is_active`.** `make_sanction` computed the construction-time `status` from `endDate` alone, so a sanction with a future `start_date` was marked "active" while `is_active` returned `False` for the same entity. The status is now derived by calling `is_active` on the sanction, so the two share one code path. The underlying prefix-date-vs-timestamp comparison mechanics are unchanged — that is tracked separately in #4929.

**Known limitation (documented, not changed):** `status` is only computed at construction time. Dates applied to the sanction afterwards via `h.apply_date(sanction, "endDate", ...)` — a common crawler pattern — still produce no status / a stale status. Fixing that would require either post-hoc hooks on the entity or a status-setting pass at emit time, both of which are beyond the scope of this change; the limitation is now called out in the `make_sanction` docstring.

Tests added: status/`is_active` agreement for future-start+future-end, active, and expired sanctions; unparseable `end_date` raising with the entity ID and raw value in the message. `mypy --strict` passes on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)