### PR TITLE
helpers: fix extract_cryptos chain misattribution and address coverage

### DIFF
--- a/zavod/zavod/helpers/crypto.py
+++ b/zavod/zavod/helpers/crypto.py
@@ -8,11 +8,18 @@ from typing import Optional, Dict
 # addresses rather than substrings that would be cut off or invalid.
 CRYPTOS = {
     "ETH": r"\b0x[a-fA-F0-9]{40}\b",
-    "BTC": r"\b(?:bc1[a-zA-HJ-NP-Z0-9]{25,39}|[13][a-km-zA-HJ-NP-Z1-9]{25,39})\b",
+    # bech32/bech32m (P2WPKH, P2WSH and taproot, up to 62 chars) plus legacy
+    # base58 ("1..." P2PKH and "3..." P2SH). "3..." addresses are attributed
+    # to Bitcoin: Litecoin deprecated the shared "3" version byte in favour
+    # of "M..." addresses long ago, so ambiguity is resolved in BTC's favour.
+    "BTC": r"\b(?:bc1[a-zA-HJ-NP-Z0-9]{11,71}|[13][a-km-zA-HJ-NP-Z1-9]{25,39})\b",
     "DASH": r"\bX[1-9A-HJ-NP-Za-km-z]{33}\b",
-    "XMR": r"\b4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}\b",
-    "XRP": r"\br[0-9a-zA-Z]{24,34}\b",
-    "LTC": r"\b(?:ltc1[a-zA-HJ-NP-Z0-9]{25,39}|[LM3][a-km-zA-HJ-NP-Z1-9]{25,39})\b",
+    # Standard addresses ("4...") and subaddresses ("8...").
+    "XMR": r"\b[48][0-9ABC][1-9A-HJ-NP-Za-km-z]{93}\b",
+    # Restricted to the base58 alphabet (no 0, O, I, l), otherwise any prose
+    # word starting with "r" of the right length matches.
+    "XRP": r"\br[1-9A-HJ-NP-Za-km-z]{24,34}\b",
+    "LTC": r"\b(?:ltc1[a-zA-HJ-NP-Z0-9]{25,39}|[LM][a-km-zA-HJ-NP-Z1-9]{25,39})\b",
     "BCH": r"\bbitcoincash:q[a-z0-9]{41}\b",
     "DOGE": r"\bD{1}[5-9A-HJ-NP-U]{1}[1-9A-HJ-NP-Za-km-z]{32}\b",
     "TRON": r"\bT[1-9A-HJ-NP-Za-km-z]{33}\b",

--- a/zavod/zavod/tests/helpers/test_cryptos.py
+++ b/zavod/zavod/tests/helpers/test_cryptos.py
@@ -39,11 +39,29 @@ def test_extract_cryptos():
     assert "bc1qwsqdcas3llkcx53sx4lqrcrdpxmr5s4eke6d8y" in result
     assert result["bc1qwsqdcas3llkcx53sx4lqrcrdpxmr5s4eke6d8y"] == "BTC"
 
+    # Bitcoin P2SH ("3..." addresses are BTC, not LTC)
+    p2sh = "wallet 35hK24tcLEWcgNA4JxpvbkNkoAcDGqQPsP"
+    result = extract_cryptos(p2sh)
+    assert "35hK24tcLEWcgNA4JxpvbkNkoAcDGqQPsP" in result
+    assert result["35hK24tcLEWcgNA4JxpvbkNkoAcDGqQPsP"] == "BTC"
+
+    result = extract_cryptos("3E6ZCKRrsdPc35chA9Eftp1h3DLW18NFNV")
+    assert result["3E6ZCKRrsdPc35chA9Eftp1h3DLW18NFNV"] == "BTC"
+
+    # Bitcoin taproot (bech32m, 62 chars)
+    taproot = "P2TR: bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0"
+    result = extract_cryptos(taproot)
+    assert "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0" in result
+    assert (
+        result["bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0"]
+        == "BTC"
+    )
+
     # Litecoin
-    ltc = "LTC: 3E6ZCKRrsdPc35chA9Eftp1h3DLW18NFNV"
+    ltc = "LTC: MJRSgZ3UUFcTBTBAaN38XAXvZLwRe8WVw7"
     result = extract_cryptos(ltc)
-    assert "3E6ZCKRrsdPc35chA9Eftp1h3DLW18NFNV" in result
-    assert result["3E6ZCKRrsdPc35chA9Eftp1h3DLW18NFNV"] == "LTC"
+    assert "MJRSgZ3UUFcTBTBAaN38XAXvZLwRe8WVw7" in result
+    assert result["MJRSgZ3UUFcTBTBAaN38XAXvZLwRe8WVw7"] == "LTC"
 
     # Dash
     dash = "Dash: XyARKoupuArYtToA2S6yMdnoquDCDaBsaT"
@@ -59,11 +77,25 @@ def test_extract_cryptos():
         in result
     )
 
+    # Monero subaddress (8... prefix)
+    xmr_sub = "sub: 84LooD7i35SFppgf4tQ453Vi3q5WexSUXaVgut69ro8MFnmHwuezAArEZTZyLr9fS6QotjqkSAxSF6d1aDgsPoX849izJ7m"
+    result = extract_cryptos(xmr_sub)
+    assert (
+        result[
+            "84LooD7i35SFppgf4tQ453Vi3q5WexSUXaVgut69ro8MFnmHwuezAArEZTZyLr9fS6QotjqkSAxSF6d1aDgsPoX849izJ7m"
+        ]
+        == "XMR"
+    )
+
     # Ripple
     xrp = "Send XRP: rnXyVQzgxZe7TR1EPzTkGj2jxH4LMJYh66"
     result = extract_cryptos(xrp)
     assert "rnXyVQzgxZe7TR1EPzTkGj2jxH4LMJYh66" in result
     assert result["rnXyVQzgxZe7TR1EPzTkGj2jxH4LMJYh66"] == "XRP"
+
+    # Prose words starting with "r" must not match as XRP
+    prose = "see registration rechtsanwaltskanzleien2024x for details"
+    assert len(extract_cryptos(prose)) == 0
 
     # Bitcoin Cash
     bch = "BCH: bitcoincash:qqyuc9s700plhzr6awzru7g5z2d2p906uyrm6ht0r0"


### PR DESCRIPTION
Fixes #4932

## Changes to `zavod/zavod/helpers/crypto.py`

1. **BTC P2SH "3…" addresses are no longer misattributed as LTC.** The LTC base58 arm included the `3` prefix, and since `extract_cryptos` writes into a dict keyed by address while iterating currencies in insertion order, the LTC label overwrote BTC for *every* P2SH address. The `3` prefix is removed from the LTC arm: Litecoin deprecated the shared "3" version byte in favour of "M…" addresses long ago, so ambiguity is resolved in Bitcoin's favour deliberately (documented in a comment).
2. **Taproot / long P2WSH addresses now match.** The bech32 arm's data-char range is extended from `{25,39}` (42 chars total, which excluded all 62-char `bc1p…` taproot and P2WSH addresses) to `{11,71}`.
3. **Monero subaddresses (`8…`) now match** alongside `4…` standard addresses. The second-char class is widened to `[0-9ABC]` to cover the subaddress prefix range.
4. **XRP arm constrained to the base58 alphabet** (excludes `0`, `O`, `I`, `l`), so prose words like `rechtsanwaltskanzleien2024x` no longer match as XRP addresses. If this proves insufficient to kill the false-positive class in practice, dropping the XRP arm entirely remains an option — every currency's real-world addresses would need checksum validation for full precision.

## Tests

`zavod/zavod/tests/helpers/test_cryptos.py` previously *asserted* the wrong LTC attribution for a "3…" address; the expectation is fixed and new cases added: P2SH → BTC, a real taproot address (BIP-350 test vector, checksum-verified), an XMR `8…` subaddress, an "M…" Litecoin address, and the prose non-match.

## Reviewer note: entity ID impact

`datasets/jp/mof_sanctions/crawler.py` bakes the detected currency into both the wallet's `currency` property and its entity ID (`context.make_slug(curr, key)`). With this fix, sanctioned P2SH wallets previously emitted as LTC will re-emit with new BTC-keyed entity IDs. This is the intended correction (the old IDs encoded a wrong attribution and could never merge with correctly-attributed BTC wallets from other lists), but it does change published entity IDs — flagging for awareness.

Verification: `pytest zavod/tests/helpers/test_cryptos.py` passes; `mypy --strict` clean on `zavod/helpers/crypto.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)