### PR TITLE
helpers: require word boundaries in strip_name_titles prefix stripping

### DIFF
--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -49,9 +49,18 @@ def _strip_title_prefixes(name: str, terms: List[str]) -> str:
     terms_ = _title_terms(terms)
     while True:
         for term in terms_:
-            if name.lower().startswith(term.lower()):
-                name = name[len(term) :].lstrip()
-                break
+            if not name.lower().startswith(term.lower()):
+                continue
+            remainder = name[len(term) :]
+            # A term ending in punctuation ("Hon.", "(Dr.)", "Dato' ") delimits
+            # itself. A bare word term ("Hon") must be followed by whitespace or
+            # the end of the name, so it cannot eat into names like "Honorata".
+            if term[-1].isalnum() and not (
+                len(remainder) == 0 or remainder[0].isspace()
+            ):
+                continue
+            name = remainder.lstrip()
+            break
         else:
             return name
 
@@ -60,9 +69,18 @@ def _strip_title_suffixes(name: str, terms: List[str]) -> str:
     terms_ = _title_terms(terms)
     while True:
         for term in terms_:
-            if name.lower().endswith(term.lower()):
-                name = name[: -len(term)].rstrip()
-                break
+            if not name.lower().endswith(term.lower()):
+                continue
+            remainder = name[: -len(term)]
+            # A term starting with punctuation (", MP", " (MP)") delimits
+            # itself. A bare word term ("MP") must be preceded by whitespace or
+            # the start of the name, so it cannot eat into names like "Kamp".
+            if term[0].isalnum() and not (
+                len(remainder) == 0 or remainder[-1].isspace()
+            ):
+                continue
+            name = remainder.rstrip()
+            break
         else:
             return name
 
@@ -76,14 +94,24 @@ def strip_name_titles(context: Context, name: Optional[str]) -> Optional[str]:
     as `"Dr."`, `"(Dr.)"`, or `", CS"`, rather than relying on punctuation
     variants. When storing the result directly, preserve provenance by passing
     the raw titled value as `original_value` if it differs from the cleaned name.
+
+    A term is only stripped at a word boundary: terms delimited by their own
+    punctuation (`"Hon."`, `"(Dr.)"`) match directly, while bare word terms
+    (`"Hon"`) must be followed (prefixes) or preceded (suffixes) by whitespace,
+    so they never truncate names like "Honorata". If stripping consumes the
+    entire name, a warning is emitted and `None` is returned so the affected
+    record surfaces in the issue log instead of silently losing its name.
     """
     if name is None:
         return None
 
     name = squash_spaces(name)
-    name = _strip_title_prefixes(name, context.dataset.names.prefixes_strip)
-    name = _strip_title_suffixes(name, context.dataset.names.suffixes_strip)
-    return name
+    stripped = _strip_title_prefixes(name, context.dataset.names.prefixes_strip)
+    stripped = _strip_title_suffixes(stripped, context.dataset.names.suffixes_strip)
+    if len(stripped) == 0 and len(name) > 0:
+        context.log.warning("Name consists only of title affixes", name=name)
+        return None
+    return stripped
 
 
 def make_name(

--- a/zavod/zavod/tests/helpers/names/test_title_stripping.py
+++ b/zavod/zavod/tests/helpers/names/test_title_stripping.py
@@ -1,3 +1,5 @@
+import structlog.testing
+
 from zavod.context import Context
 from zavod.helpers import strip_name_titles
 from zavod.meta.names import NamesSpec
@@ -89,6 +91,46 @@ def test_strip_leaves_unknown_comma_tail_visible(vcontext: Context) -> None:
     assert strip_name_titles(vcontext, "Jane Doe, CBS, Party Leader") == (
         "Jane Doe, CBS, Party Leader"
     )
+
+
+def test_strip_bare_prefix_requires_word_boundary(vcontext: Context) -> None:
+    # ug_parliament's production config: an unbounded "Hon" term must not
+    # truncate names that merely start with those letters.
+    configure_titles(vcontext, prefixes=["Hon.", "Hon"])
+
+    assert strip_name_titles(vcontext, "Honorata Nabakooza") == "Honorata Nabakooza"
+    assert strip_name_titles(vcontext, "Hon. Honey Kaggwa") == "Honey Kaggwa"
+    assert strip_name_titles(vcontext, "Hon Rebecca Kadaga") == "Rebecca Kadaga"
+    assert strip_name_titles(vcontext, "Hon. Hon Honorata Doe") == "Honorata Doe"
+
+
+def test_strip_bare_suffix_requires_word_boundary(vcontext: Context) -> None:
+    configure_titles(vcontext, suffixes=["MP"])
+
+    assert strip_name_titles(vcontext, "Jane Kamp") == "Jane Kamp"
+    assert strip_name_titles(vcontext, "Jane Doe MP") == "Jane Doe"
+
+
+def test_strip_stacked_titles(vcontext: Context) -> None:
+    configure_titles(vcontext, prefixes=["Hon.", "Hon", "Dr."])
+
+    assert strip_name_titles(vcontext, "Hon. Dr. Jane Doe") == "Jane Doe"
+    assert strip_name_titles(vcontext, "Hon Dr. Honorata Doe") == "Honorata Doe"
+
+
+def test_strip_all_title_name_warns_and_returns_none(vcontext: Context) -> None:
+    configure_titles(vcontext, prefixes=["Hon.", "Hon"], suffixes=[", MP"])
+
+    with structlog.testing.capture_logs() as caplogs:
+        assert strip_name_titles(vcontext, "Hon. Hon") is None
+    assert {
+        "event": "Name consists only of title affixes",
+        "name": "Hon. Hon",
+        "log_level": "warning",
+    } in caplogs
+
+    # An empty input string was never a name; it passes through unchanged.
+    assert strip_name_titles(vcontext, "") == ""
 
 
 def test_strip_is_idempotent_for_unmatched_names(vcontext: Context) -> None:


### PR DESCRIPTION
Fixes #4935

`_strip_title_prefixes` matched configured terms with `startswith` and sliced without requiring a word boundary, and the `while True` loop re-applied all terms after each strip. With ug_parliament's production config (`["Hon.", "Hon"]`), the bare `Hon` term truncated legitimate names: "Honorata Nabakooza" → "orata Nabakooza", "Hon. Honey Kaggwa" → "ey Kaggwa". A name consisting solely of configured titles also came back as `""`, which vanished silently in `entity.add`, leaving a nameless person entity with no warning.

## Changes

- **Word-boundary semantics** in `_strip_title_prefixes` / `_strip_title_suffixes`: a term that ends (prefixes) or starts (suffixes) in punctuation (`"Hon."`, `"(Dr.)"`, `", MP"`) delimits itself; a bare word term (`"Hon"`, `"MP"`) is only stripped when adjacent to whitespace or the string edge. Stacked titles (`"Hon. Dr. Jane Doe"`) still strip iteratively, but no term can re-match into the remaining name.
- **Fail loud on all-title names**: if stripping consumes the entire name, `strip_name_titles` emits a `context.log.warning` and returns `None` instead of `""`. `None` was chosen over raising because the function already returns `Optional[str]` and all three callers (ug_parliament, ke_senate, ke_national_assembly) feed the result into `h.apply_name(full=...)` / `entity.add("name", ...)`, which tolerate `None` — the warning surfaces the record in the dataset's issue log rather than crashing the whole crawl over one bad row.
- Tests for the reported cases: "Honorata Nabakooza" unchanged under `["Hon.", "Hon"]`, "Hon. Honey Kaggwa" → "Honey Kaggwa", bare-suffix boundary, stacked titles, and the warn-and-return-None path.

`datasets/ug/parliament/ug_parliament.yml` is deliberately untouched: the helper fix makes the existing `["Hon.", "Hon"]` config safe as-is.

## Could this be delegated to rigour?

Assessed, and no — not without new rigour API. rigour's prefix handling (`rigour/names/prefix.py`) has the *correct boundary semantics* (`^\W*((term1|term2|...)\.?\s+)*` — each term must be followed by an optional dot and mandatory whitespace), but:

- `remove_person_prefixes` / `remove_org_prefixes` / `remove_obj_prefixes` all operate on **fixed, built-in term lists** compiled into `rigour._core` from `resources/names/stopwords.yml` — there is no public function accepting caller-supplied terms; `_build_prefix_regex` is private and its regexes are `@cache`d per fixed list.
- rigour has **no suffix/post-nominal stripping** at all, while zavod's `suffixes_strip` config (`", CBS"`, `" MP"`) needs it.
- rigour's regex requires trailing whitespace even for dot-terminated terms, whereas zavod's config supports self-delimiting terms like `"(Dr.)"` and `"(Rtd)"` that may not be whitespace-separated from what follows.

A follow-up delegation would require adding something like `remove_name_prefixes(name: str, prefixes: Sequence[str]) -> str` (and a suffix counterpart) to `rigour.names`, building the boundary-aware regex from caller-supplied terms with an LRU cache keyed on the term tuple; zavod's `strip_name_titles` would keep the `NamesSpec` config plumbing and the empty-result warning and pass `context.dataset.names.prefixes_strip` / `suffixes_strip` through. Happy to file that against rigour as a follow-up, but it's out of scope for this bug fix.

## Verification

- `pytest zavod/tests/helpers/names/` — 44 passed (11 in `test_title_stripping.py`)
- `mypy --strict zavod/helpers/names.py` — clean
- ruff check / ruff format pre-commit hooks — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)