### PR TITLE
helpers: stop split_comma_names silently splitting realistic single names

### DIFF
--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -32,9 +32,20 @@ from zavod.stateful.review import (
 )
 
 REGEX_AND = re.compile(r"(\band\b|&|\+)", re.I)
-REGEX_LNAME_FNAME = re.compile(r"^\w+, \w+$", re.I)
+# A single person name written "Lastname(s), Firstname" — e.g. "Smith, John",
+# "Smith-Jones, Mary", "O'Brien, John", "Van Der Berg, Jan", "Smith, Jane B.".
+# Kept conservative: the surname may span at most three tokens, and the part
+# after the comma must be a single given name (optionally followed by dotted
+# initials), so that comma-separated lists of full names don't match and still
+# get split or warned about.
+REGEX_LNAME_FNAME = re.compile(
+    r"^[\w'’-]+(?: [\w'’-]+){0,2}, [\w'’-]+\.?(?: [^\W\d_]\.)*$",
+    re.I,
+)
+# The optional opening paren is captured separately so the alias markers also
+# match in parenthesised form, e.g. "John Smith, (A/K/A Smitty)".
 REGEX_CLEAN_COMMA = re.compile(
-    r", \b(LLC|L\.L\.C|Inc|Jr|INC|LLLP|L\.P|LP|Sr|III|II|IV|S\.A|LTD|USA INC|\(?A/K/A|\(?N\.K\.A|\(?N/K/A|\(?F\.K\.A|formerly known as|INCORPORATED)\b",  # noqa
+    r", (\(?)(LLC|L\.L\.C|Inc|Jr|INC|LLLP|L\.P|LP|Sr|III|II|IV|S\.A|LTD|USA INC|A/K/A|N\.K\.A|N/K/A|F\.K\.A|formerly known as|INCORPORATED)\b",  # noqa
     re.I,
 )
 REGEX_SPACES = re.compile(r"\s+")
@@ -292,14 +303,18 @@ def split_comma_names(context: Context, text: str) -> List[str]:
     if res:
         return cast(List[str], res.names)
 
-    text = REGEX_CLEAN_COMMA.sub(r" \1", text)
+    text = REGEX_CLEAN_COMMA.sub(r" \1\2", text)
     # If the string ends in a comma, the last comma is unnecessary (e.g. Goldman Sachs & Co. LLC,)
     if text.endswith(","):
         text = text[:-1]
 
-    if not REGEX_AND.search(text) and not REGEX_LNAME_FNAME.match(text):
+    # A single "Lastname, Firstname"-shaped person name: return as-is, no warning.
+    if REGEX_LNAME_FNAME.match(text):
+        return [text]
+
+    if not REGEX_AND.search(text):
         names = [n.strip() for n in text.split(",")]
-        return names
+        return [n for n in names if n != ""]
     else:
         if ("," in text) or (" and " in text):
             res = context.lookup("comma_names", text)

--- a/zavod/zavod/tests/helpers/names/test_names.py
+++ b/zavod/zavod/tests/helpers/names/test_names.py
@@ -139,6 +139,61 @@ def test_split_comma_names(vcontext: Context, caplog):
     assert "warning: Not sure how to split on comma or and." in logs
 
 
+def test_split_comma_names_single_person(vcontext: Context):
+    """Realistic "Lastname(s), Firstname" shapes are one name and don't warn."""
+    with capture_logs() as cap_logs:
+        assert split_comma_names(vcontext, "Smith, John") == ["Smith, John"]
+        assert split_comma_names(vcontext, "Smith-Jones, Mary") == ["Smith-Jones, Mary"]
+        assert split_comma_names(vcontext, "O'Brien, John") == ["O'Brien, John"]
+        assert split_comma_names(vcontext, "Van Der Berg, Jan") == ["Van Der Berg, Jan"]
+        assert split_comma_names(vcontext, "Smith, Jane B.") == ["Smith, Jane B."]
+        assert split_comma_names(vcontext, "de la Cruz, Maria") == ["de la Cruz, Maria"]
+    warnings = [e for e in cap_logs if e["log_level"] == "warning"]
+    assert warnings == []
+
+
+def test_split_comma_names_multiple_full_names(vcontext: Context):
+    """Strings that are plausibly lists of full names are not treated as one person."""
+    # Two full names: confident comma split, as before.
+    assert split_comma_names(vcontext, "John Smith, Mary Jones") == [
+        "John Smith",
+        "Mary Jones",
+    ]
+    # A list of "Lastname, Firstname" shaped names joined by "and" remains
+    # ambiguous and warns so it can be patched via the comma_names lookup.
+    with capture_logs() as cap_logs:
+        assert split_comma_names(vcontext, "Smith, John and Jones, Mary") == [
+            "Smith, John and Jones, Mary"
+        ]
+    logs = [f"{entry['log_level']}: {entry['event']}" for entry in cap_logs]
+    assert "warning: Not sure how to split on comma or and." in logs
+
+
+def test_split_comma_names_aka_parens(vcontext: Context):
+    """Parenthesised alias markers don't produce a bogus split-off name."""
+    assert split_comma_names(vcontext, "John Smith, (A/K/A Smitty)") == [
+        "John Smith (A/K/A Smitty)"
+    ]
+    assert split_comma_names(vcontext, "John Smith, A/K/A Smitty") == [
+        "John Smith A/K/A Smitty"
+    ]
+    assert split_comma_names(vcontext, "Acme Trading Corp, (F.K.A Acme Inc)") == [
+        "Acme Trading Corp (F.K.A Acme Inc)"
+    ]
+
+
+def test_split_comma_names_empty_fragments(vcontext: Context):
+    """Double or trailing commas don't yield empty names."""
+    assert split_comma_names(vcontext, "John Smith,, Mary Jones") == [
+        "John Smith",
+        "Mary Jones",
+    ]
+    assert split_comma_names(vcontext, "John Smith, Mary Jones,") == [
+        "John Smith",
+        "Mary Jones",
+    ]
+
+
 @patch("zavod.helpers.names.settings.OPENAI_API_KEY", None)  # For validity
 def test_apply_reviewed_names_no_cleaning_needed(vcontext: Context):
     """The original name is used."""


### PR DESCRIPTION
Fixes #4939

`split_comma_names` is designed to split confidently only where safe and warn on ambiguity so a dataset `comma_names` lookup can patch it. Three defects undermined this:

1. **Silent mis-splits of realistic single names.** `REGEX_LNAME_FNAME` (`^\w+, \w+$`) only protected single-token-surname + single-token-firstname, so "Smith-Jones, Mary", "O'Brien, John", "Van Der Berg, Jan" and "Smith, Jane B." were confidently comma-split into two entities with no warning. The pattern now allows hyphens, apostrophes, up to three surname tokens, and dotted middle initials. It stays conservative: the part after the comma must be a single given-name token (plus dotted initials), so comma-separated lists of full names ("John Smith, Mary Jones", "A B C, D E F") still split as before, and ambiguous `and`+comma strings ("Smith, John and Jones, Mary") still hit the warn/lookup path.

2. **Dead parenthesised alias alternatives in `REGEX_CLEAN_COMMA`.** The `\b` after `", "` could never match before `(`, so `\(?A/K/A` etc. never fired and "John Smith, (A/K/A Smitty)" was split into a bogus "(A/K/A Smitty)" entity. The optional paren is now captured separately and preserved in the substitution.

3. **Noise and empty fragments.** Safe "Lastname, Firstname" strings now return without the "Not sure how to split on comma or and." warning, and the confident-split path filters empty fragments from doubled/trailing commas ("A,,B" no longer yields an empty name).

Tests cover all shapes above, including that genuinely ambiguous multi-name strings still warn.

Verified: `pytest zavod/tests/helpers` (101 passed), `mypy --strict zavod/helpers/names.py`, black/ruff clean on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)