### PR TITLE
helpers: don't store redundant original_value for exact-match reviewed names

### DIFF
--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -468,8 +468,8 @@ def derive_original_values(original: Names, extracted: Names) -> Dict[str, str]:
     Derive an original_value for each value in extracted based on the values in original.
 
     For each value in extracted:
-        (1) If there's exactly one value in original, use that for all names.
-        (2) If some value in original matches it exactly, leave blank - no original_value needed.
+        (1) If some value in original matches it exactly, leave blank - no original_value needed.
+        (2) If there's exactly one value in original, use that for all names.
         (3) If some value in original contains it, we can use that the value from original as original_value.
         Otherwise leave blank - this is best-effort only.
     """
@@ -484,12 +484,12 @@ def derive_original_values(original: Names, extracted: Names) -> Dict[str, str]:
         for extracted_value in extracted_values:
             extracted_string = extracted_value.text
 
-            if len(original_values) == 1:
-                # (1) If there's exactly one value in original, use that for all names.
-                derived_originals[extracted_string] = original_values[0]
-            elif extracted_string in original_values:
-                # (2) Exact match exists, no original_value needed.
+            if extracted_string in original_values:
+                # (1) Exact match exists, no original_value needed.
                 continue
+            elif len(original_values) == 1:
+                # (2) If there's exactly one value in original, use that for all names.
+                derived_originals[extracted_string] = original_values[0]
             else:
                 for original_string in original_values:
                     if extracted_string in original_string:

--- a/zavod/zavod/tests/helpers/names/test_derive_originals.py
+++ b/zavod/zavod/tests/helpers/names/test_derive_originals.py
@@ -14,6 +14,27 @@ def test_derive_original_values_single_original():
     }
 
 
+def test_derive_original_values_identical_single_original():
+    """An extracted value identical to the sole original gets no original_value."""
+    original = Names(name="Jim Doe")
+    extracted = Names(name="Jim Doe")
+
+    result = derive_original_values(original, extracted)
+
+    assert result == {}
+
+
+def test_derive_original_values_single_original_partial_exact_match():
+    """With one original, only extracted values that differ from it get an original_value."""
+    original = Names(name="Jim Doe")
+    extracted = Names(name="Jim Doe", alias="Jim")
+
+    result = derive_original_values(original, extracted)
+
+    # "Jim Doe" matches the original exactly, so only "Jim" gets an original_value.
+    assert result == {"Jim": "Jim Doe"}
+
+
 def test_derive_original_values_exact_match():
     """When an extracted value exactly matches an original, no mapping is needed."""
     original = Names(name=["John/Jon .. Doe", "John Doe"])


### PR DESCRIPTION
Fixes #4954

`derive_original_values` checked the single-original case (1) before the exact-match case (2), so with exactly one original value an extracted value identical to it still got `original_value` set to itself:

```python
derive_original_values(Names(name="Jim Doe"), Names(name="Jim Doe"))
# → {'Jim Doe': 'Jim Doe'}
```

Since `apply_reviewed_names`' fallback path calls `apply_names(entity, original=original, names=original)`, every clean single-name entity in reviewed-names crawlers emitted a name statement with a redundant self-referential `original_value` — bloating statements and breaking the invariant that `original_value` signals "value was modified".

## Changes

- Reorder the cases in `derive_original_values` so an exact match is checked first and never produces an `original_value`; the single-original case still applies when the extracted value genuinely differs (pinned by `test_derive_original_values_single_original`). Docstring updated to match the new priority.
- Add the missing tests: identical single original → no entry; single original with one exact-match and one differing extracted value → only the differing value gets an `original_value`.

Deterministic ordering (sorted originals, substring preference) is unchanged.

## Verification

- `pytest zavod/tests/helpers/names/` — 42 passed (includes the reviewed-names tests in `test_names.py`)
- `mypy --strict --exclude zavod/tests zavod/helpers/names.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)