### PR TITLE
helpers: reject unknown original_prop in apply_reviewed_name_string

### DIFF
--- a/zavod/zavod/extract/names/clean.py
+++ b/zavod/zavod/extract/names/clean.py
@@ -39,6 +39,12 @@ class Names(BaseModel):
 
     Cleaning might include splitting or re-combining parts, and stripping punctuation
     which does not form part of the name.
+
+    Unknown keys are deliberately tolerated on validation (pydantic's default
+    ``extra="ignore"``): stored review payloads are re-validated with the current
+    model, and reviewer-edited or legacy payloads can carry keys that are not
+    (or no longer) fields. Construction sites that build a Names from dynamic
+    keys must validate them against ``Names.model_fields`` instead.
     """
 
     name: NamesValues = None

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -788,9 +788,18 @@ def apply_reviewed_name_string(
         entity: The entity to apply names to.
         string: The raw name(s) string.
         original_prop: The original property for the name according to the data source.
+            Must be one of the ``Names`` model fields, e.g. "name" or "alias".
         lang: The language of the name, if known.
         llm_cleaning: Whether to use LLM-based name cleaning.
     """
+    # Names tolerates unknown keys on validation (stored review payloads may carry
+    # them), so a typo'd prop would otherwise silently produce an empty Names and
+    # the entity would be emitted without any name.
+    if original_prop not in Names.model_fields:
+        raise ValueError(
+            f"Invalid original_prop {original_prop!r}. "
+            f"Expected one of: {', '.join(sorted(Names.model_fields))}"
+        )
     original = Names(**{original_prop: string})
 
     apply_reviewed_names(

--- a/zavod/zavod/tests/extract/names/test_clean.py
+++ b/zavod/zavod/tests/extract/names/test_clean.py
@@ -61,3 +61,22 @@ def test_names_simplified():
 
     # Empty list simplifies to None
     assert Names(name=[]).simplified().name is None
+
+
+def test_names_tolerates_unknown_keys_on_validation():
+    """Stored review payloads are re-validated with the current model, and
+    reviewer-edited or legacy payloads can carry keys that are not (or no
+    longer) fields — loading them must not raise. Fail-loud protection against
+    typo'd keys lives at the dynamic construction sites instead, e.g.
+    apply_reviewed_name_string."""
+    # A reviewer-edited payload with an unknown key.
+    names = Names.model_validate({"name": ["John Doe"], "fullName": ["J. Doe"]})
+    assert names.name == ["John Doe"]
+
+    # A legacy payload keyed with fields that no longer exist on the model.
+    names = Names.model_validate({"name": ["John Doe"], "firstName": "John"})
+    assert names.name == ["John Doe"]
+
+    # A stored-review-shaped dump round-trips.
+    names = Names(name=["John Doe"], alias="Johnny")
+    assert Names.model_validate(names.model_dump()) == names

--- a/zavod/zavod/tests/helpers/names/test_names.py
+++ b/zavod/zavod/tests/helpers/names/test_names.py
@@ -10,6 +10,7 @@ from zavod.extract.names.clean import Names, LangText
 from zavod.stateful.model import review_table
 from zavod.helpers import (
     apply_name,
+    apply_reviewed_name_string,
     apply_reviewed_names,
     make_name,
     split_comma_names,
@@ -324,6 +325,36 @@ def test_apply_reviewed_names_suggested_original(vcontext: Context):
         vcontext, entity, original=original, suggested=suggested, is_irregular=True
     )
     assert count_review_rows(vcontext.db, key) == 1
+
+
+def test_apply_reviewed_name_string_valid_prop(vcontext: Context):
+    """Valid original_prop values construct the Names payload and apply the name."""
+    entity = vcontext.make("Person")
+    entity.id = "bla"
+
+    apply_reviewed_name_string(
+        vcontext, entity, string="Jim Doe", original_prop="alias"
+    )
+    assert entity.get("alias") == ["Jim Doe"]
+    assert entity.get("name") == []
+
+
+def test_apply_reviewed_name_string_invalid_prop_raises(vcontext: Context):
+    """A typo'd original_prop must raise instead of silently building an empty
+    Names payload and emitting the entity without a name."""
+    entity = vcontext.make("Person")
+    entity.id = "bla"
+
+    with pytest.raises(ValueError, match="Invalid original_prop 'fullName'"):
+        apply_reviewed_name_string(
+            vcontext, entity, string="John Doe", original_prop="fullName"
+        )
+    # Even a None string must not mask the typo.
+    with pytest.raises(ValueError, match="Invalid original_prop 'firstName'"):
+        apply_reviewed_name_string(
+            vcontext, entity, string=None, original_prop="firstName"
+        )
+    assert entity.get("name") == []
 
 
 def test_apply_names_with_lang_argument(vcontext: Context):


### PR DESCRIPTION
Fixes #4946

`apply_reviewed_name_string` builds its payload as `Names(**{original_prop: string})`. Because the `Names` model uses pydantic's default `extra='ignore'`, a typo'd `original_prop` (e.g. `"fullName"`) silently constructed an **empty** model — `review_names` returned `None` at its `is_empty()` gate, `apply_names` applied nothing, and the entity was emitted with no name and no error.

## Chosen fix: validate at the construction site, not `extra="forbid"` on the model

The issue suggested `extra="forbid"` on `Names`, conditional on stored review payloads and the LLM path being round-trip-safe. They are **not**, so this PR instead validates `original_prop` against `Names.model_fields` in `apply_reviewed_name_string` and raises a clear `ValueError`:

```
ValueError: Invalid original_prop 'fullName'. Expected one of: abbreviation, alias, name, previousName, weakAlias
```

### Round-trip safety analysis

Stored review payloads are lazily re-validated with the **current** model on every access (`Review.original_extraction` / `Review.extracted_data` call `data_model.model_validate(...)` in `zavod/zavod/stateful/review.py`). Two paths can put extra keys into those stored payloads:

1. **Reviewer edits are not schema-enforced server-side.** The review UI is a free-form YAML editor (`ui/app/review/dataset/[dataset]/[key]/ExtractionView.tsx`) validated client-side against the *stored per-row* `extraction_schema`, and the save endpoint (`ui/app/api/extraction/save/route.ts`) stores the parsed YAML with **no validation at all**. Since schemas generated from the `extra='ignore'` model don't set `additionalProperties: false` (and JSON Schema permits extra properties by default), a reviewer can save `extracted_data` containing unknown keys today — and every existing row keeps its permissive stored schema forever. With `extra="forbid"`, such a row would crash the crawl at review-load time on data the crawler maintainer can't fix.
2. **Schema evolution has already happened.** The model was previously `CleanNames` with `full_name`/`weak_alias`/`previous_name` fields (pre-#3512), and `firstName`/`middleName`/`lastName` existed as fields on a feature branch. The old `CleanNames`-era rows are orphaned by the review-key change in #3512 (old keys hashed `[schema] + strings`, new keys include the prop), so they aren't loaded — but the pattern shows field sets drift while rows persist, and `crawler_version` was never bumped for it. Forbidding extras on the model makes every future field removal a latent crawl-crash.

The **LLM structured-output path** (`run_typed_text_prompt` with `SimpleNames`) would have been safe either way: OpenAI strict structured outputs enforce `additionalProperties: false`, and the response cache is keyed on the model's JSON schema hash, so a schema change can't replay stale cached payloads against the new model. But path 1 alone rules out model-level `forbid`.

The other dynamic-key construction sites are safe: `simplified()` and `check_names_regularity` iterate `model_fields`, and `Regularity.suggested_prop` only takes the hardcoded literals `"weakAlias"` / `"abbreviation"`.

## Changes

- `zavod/zavod/helpers/names.py`: validate `original_prop` against `Names.model_fields` before constructing the payload; document the constraint in the docstring.
- `zavod/zavod/extract/names/clean.py`: document on `Names` why unknown keys are deliberately tolerated on validation, so `extra="forbid"` doesn't get "fixed in" later.
- Tests: typo'd `original_prop` raises (including with `string=None`); valid props still apply; unknown-key payloads (reviewer-edited and legacy-shaped) still validate; a stored-review-shaped dump round-trips.

## Verification

- `pytest zavod/tests/ -k "names or review"` — 60 passed
- `mypy --strict zavod/extract/names/clean.py zavod/helpers/names.py` — clean
- ruff check / ruff format — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)