### PR TITLE
[pk_senate_members] Add Pakistan Senate PEP crawler

### DIFF
--- a/datasets/pk/senate_members/crawler.py
+++ b/datasets/pk/senate_members/crawler.py
@@ -10,10 +10,6 @@ from zavod.stateful.positions import PositionCategorisation, categorise
 # opaque source identifier we key the person entity on.
 UID_RE = re.compile(r"profile\.php\?uid=(\d+)")
 
-# Names may carry an honorific prefix ("Mr.", "Ms.", "Dr."). Strip it so the emitted
-# name is the person's actual name; the matcher normalises case anyway.
-HONORIFIC_RE = re.compile(r"^(mr|mrs|ms|dr)\.?\s+", re.IGNORECASE)
-
 
 def crawl_member(
     context: Context,
@@ -44,12 +40,14 @@ def crawl_member(
         if label:
             data[label] = value
 
-    name = HONORIFIC_RE.sub("", data.pop("Name")).strip()
+    raw_name = data.pop("Name")
+    name = h.strip_name_titles(context, raw_name)
+    original_name = raw_name if name != raw_name else None
     assert name
 
     person = context.make("Person")
     person.id = context.make_slug(uid)
-    person.add("name", name)
+    person.add("name", name, lang="eng", original_value=original_name)
     person.add("sourceUrl", member_url)
 
     party = data.pop("Party", None)
@@ -85,7 +83,6 @@ def crawl_member(
             "Seat Description",
             "Designation",
             "In Vice of",
-            "Father's Name",
             "Committee Member",
         ],
     )

--- a/datasets/pk/senate_members/crawler.py
+++ b/datasets/pk/senate_members/crawler.py
@@ -1,0 +1,113 @@
+import re
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+
+# Member profile links look like ``profile.php?uid=1017``; the uid is a stable,
+# opaque source identifier we key the person entity on.
+UID_RE = re.compile(r"profile\.php\?uid=(\d+)")
+
+# Names may carry an honorific prefix ("Mr.", "Ms.", "Dr."). Strip it so the emitted
+# name is the person's actual name; the matcher normalises case anyway.
+HONORIFIC_RE = re.compile(r"^(mr|mrs|ms|dr)\.?\s+", re.IGNORECASE)
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    uid: str,
+) -> None:
+    member_url = (
+        "https://senate.gov.pk/en/profile.php?uid=%s&catid=0&subcatid=0&cattitle=0"
+        % uid
+    )
+    doc = context.fetch_html(member_url, cache_days=7)
+
+    # The profile info table carries no class/id, so identify it as the table that
+    # contains the "Name:" row. It is a vertical label/value table where td[1] is the
+    # label (with a trailing colon) and td[2] is the value.
+    table = h.xpath_element(
+        doc,
+        '//div[@id="printableArea"]'
+        '//table[.//td[starts-with(normalize-space(.), "Name:")]]',
+    )
+    data: dict[str, str] = {}
+    for row in h.xpath_elements(table, "./tr[td[2]]"):
+        label = h.element_text(h.xpath_element(row, "./td[1]")).rstrip(":").strip()
+        value = h.element_text(h.xpath_element(row, "./td[2]"))
+        if label:
+            data[label] = value
+
+    name = HONORIFIC_RE.sub("", data.pop("Name")).strip()
+    assert name, member_url
+
+    person = context.make("Person")
+    person.id = context.make_slug(uid)
+    person.add("name", name)
+    person.add("sourceUrl", member_url)
+
+    # "Independent (IND)" denotes an independent (no party), not a political affiliation.
+    party = data.pop("Party", None)
+    if party is not None and not party.startswith("Independent"):
+        person.add("political", party)
+
+    # A member of Majlis-e-Shoora (Parliament), which includes the Senate, must be a
+    # citizen of Pakistan under Article 62(1)(a) of the Constitution of Pakistan, 1973
+    # ("he is a citizen of Pakistan").
+    # https://www.pakistani.org/pakistan/constitution/part3.ch2.html
+    person.add("citizenship", "pk")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        no_end_implies_current=True,
+        start_date=data.pop("Oath Taking Date", None),
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+
+    # Senators represent a province rather than a single-member constituency.
+    province = data.pop("Province", None)
+    if province is not None:
+        occupancy.add("constituency", province)
+
+    context.audit_data(
+        data,
+        ignore=[
+            "Tenure",
+            "Seat Description",
+            "Designation",
+            "In Vice of",
+            "Father's Name",
+            "Committee Member",
+        ],
+    )
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Senate of Pakistan",
+        country="pk",
+        wikidata_id="Q20081441",
+    )
+    categorisation = categorise(context, position)
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    hrefs = h.xpath_strings(doc, '//a[contains(@href, "profile.php?uid=")]/@href')
+    uids = {match.group(1) for href in hrefs if (match := UID_RE.search(href))}
+    if not uids:
+        raise ValueError("No member profile links found on %s" % context.data_url)
+
+    for uid in sorted(uids, key=int):
+        crawl_member(context, position, categorisation, uid)

--- a/datasets/pk/senate_members/crawler.py
+++ b/datasets/pk/senate_members/crawler.py
@@ -22,7 +22,9 @@ def crawl_member(
     uid: str,
 ) -> None:
     member_url = (
-        "https://senate.gov.pk/en/profile.php?uid=%s&catid=0&subcatid=0&cattitle=0"
+        context.data_url.replace(
+            "current_members.php", "profile.php?uid=%s&catid=0&subcatid=0&cattitle=0"
+        )
         % uid
     )
     doc = context.fetch_html(member_url, cache_days=7)
@@ -43,14 +45,13 @@ def crawl_member(
             data[label] = value
 
     name = HONORIFIC_RE.sub("", data.pop("Name")).strip()
-    assert name, member_url
+    assert name
 
     person = context.make("Person")
     person.id = context.make_slug(uid)
     person.add("name", name)
     person.add("sourceUrl", member_url)
 
-    # "Independent (IND)" denotes an independent (no party), not a political affiliation.
     party = data.pop("Party", None)
     if party is not None and not party.startswith("Independent"):
         person.add("political", party)
@@ -106,8 +107,6 @@ def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url, cache_days=1)
     hrefs = h.xpath_strings(doc, '//a[contains(@href, "profile.php?uid=")]/@href')
     uids = {match.group(1) for href in hrefs if (match := UID_RE.search(href))}
-    if not uids:
-        raise ValueError("No member profile links found on %s" % context.data_url)
 
     for uid in sorted(uids, key=int):
         crawl_member(context, position, categorisation, uid)

--- a/datasets/pk/senate_members/pk_senate_members.yml
+++ b/datasets/pk/senate_members/pk_senate_members.yml
@@ -1,0 +1,53 @@
+title: Pakistan Members of Senate
+name: pk_senate_members
+prefix: pk-sen
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-17
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Senate of Pakistan, the indirectly-elected
+  upper house of the Parliament.
+description: |
+  Current members of the Senate, the upper house of the bicameral Majlis-e-Shoora
+  (Parliament) of Pakistan. Senators are elected by the members of the provincial
+  assemblies and the National Assembly to six-year terms, with roughly half the seats
+  contested every three years. The Senate provides equal provincial representation and
+  shares legislative power with the National Assembly.
+
+  This dataset records each sitting senator with their name, political party, province,
+  and the date they took their oath of office.
+url: https://senate.gov.pk/en/current_members.php
+publisher:
+  name: Senate of Pakistan
+  acronym: Senate
+  description: >
+    The Senate is the indirectly-elected upper house of the Parliament of Pakistan,
+    providing equal representation to the federating units and sharing legislative
+    power with the National Assembly.
+  url: https://senate.gov.pk
+  country: pk
+  official: true
+data:
+  url: https://senate.gov.pk/en/current_members.php
+  format: HTML
+  lang: eng
+dates:
+  formats: ["%d-%m-%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 80
+      Position: 1
+    country_entities:
+      pk: 80
+  max:
+    schema_entities:
+      Person: 150
+      Position: 1

--- a/datasets/pk/senate_members/pk_senate_members.yml
+++ b/datasets/pk/senate_members/pk_senate_members.yml
@@ -37,6 +37,17 @@ data:
 dates:
   formats: ["%d-%m-%Y"]
 
+names:
+  prefixes_strip:
+    - Mr.
+    - Mr
+    - Mrs.
+    - Mrs
+    - Ms.
+    - Ms
+    - Dr.
+    - Dr
+
 tags:
   - list.pep
 


### PR DESCRIPTION
Adds a PEP crawler for the current members of the **Senate of Pakistan** (the upper house of the Majlis-e-Shoora), completing the second half of the issue alongside the existing National Assembly crawler.

## Source
- Roster: https://senate.gov.pk/en/current_members.php (server-rendered HTML, ~95 senators, each linking to a profile page)
- No API, no CNIC, no date-of-birth in the source.

## What it emits
- One `Position` — "Member of the Senate of Pakistan" (`wikidata_id=Q20081441`, distinct from the NA position).
- One `Person` + `Occupancy` per senator, capturing name, political party (skipping independents), province (as occupancy constituency), and oath-taking date where published.
- `citizenship=pk` per Article 62(1)(a) of the Constitution of Pakistan (applies to the whole Majlis-e-Shoora, including the Senate).

## Scope — current members only
The site exposes no reliable former-members listing (candidate URLs 404; the menu links only to the current roster; old profiles are reachable only by blind uid guessing). Scoped to sitting members, mirroring the National Assembly crawler.

## Verification
- `mypy --strict` clean; all pre-commit hooks pass.
- `zavod crawl` → 191 entities (95 Person + 95 Occupancy + 1 Position), no issues logged.
- `zavod validate` passed.
- Integrity checks: no dangling Occupancy refs; every PEP has an occupancy and a country.

Ref: opensanctions/crawler-planning#827

🤖 Generated with [Claude Code](https://claude.com/claude-code)