### PR TITLE
Add Kiribati Maneaba ni Maungatabu PEP crawler

### DIFF
--- a/datasets/ki/maneaba/crawler.py
+++ b/datasets/ki/maneaba/crawler.py
@@ -1,0 +1,81 @@
+import re
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Names carry honorific prefixes: "Hon." for members, "H.E" for the President, and
+# occasionally "Dr". Strip them (repeatedly, e.g. "Hon. Dr ...") so the emitted name is
+# the person's actual name. The matcher normalises case anyway.
+HONORIFIC_RE = re.compile(r"^\s*(?:Hon|H\.E|Dr)\.?\s*", re.IGNORECASE)
+
+
+def clean_name(raw: str) -> str:
+    name = raw
+    while True:
+        stripped = HONORIFIC_RE.sub("", name)
+        if stripped == name:
+            return stripped.strip()
+        name = stripped
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    row: dict[str, str | None],
+) -> None:
+    raw_name = row.pop("member")
+    assert raw_name is not None, "Missing member name"
+    name = clean_name(raw_name)
+    assert name, "Empty member name"
+    constituency = row.pop("constituency")
+    assert constituency is not None, "Missing constituency"
+
+    person = context.make("Person")
+    person.id = context.make_id(name, constituency)
+    person.add("name", name)
+    person.add("political", row.pop("party"))
+    # A member of the Maneaba ni Maungatabu must be a citizen of Kiribati under
+    # Chapter V, Section 55(a) of the Constitution of Kiribati.
+    # https://www.constituteproject.org/constitution/Kiribati_2013
+    person.add("citizenship", "ki")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", constituency)
+
+    context.audit_data(row)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Maneaba ni Maungatabu",
+        country="ki",
+        wikidata_id="Q21296447",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    table = h.xpath_element(
+        doc, '//table[.//tr[1][.//*[contains(text(), "Constituency")]]]'
+    )
+    rows = list(h.parse_html_table(table))
+    if not rows:
+        raise ValueError("No member rows found in the Kiribati members table")
+    for row in rows:
+        cells = h.cells_to_str(row)
+        crawl_member(context, position, categorisation, cells)

--- a/datasets/ki/maneaba/crawler.py
+++ b/datasets/ki/maneaba/crawler.py
@@ -1,23 +1,7 @@
-import re
-
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
-
-# Names carry honorific prefixes: "Hon." for members, "H.E" for the President, and
-# occasionally "Dr". Strip them (repeatedly, e.g. "Hon. Dr ...") so the emitted name is
-# the person's actual name. The matcher normalises case anyway.
-HONORIFIC_RE = re.compile(r"^\s*(?:Hon|H\.E|Dr)\.?\s*", re.IGNORECASE)
-
-
-def clean_name(raw: str) -> str:
-    name = raw
-    while True:
-        stripped = HONORIFIC_RE.sub("", name)
-        if stripped == name:
-            return stripped.strip()
-        name = stripped
 
 
 def crawl_member(
@@ -28,14 +12,17 @@ def crawl_member(
 ) -> None:
     raw_name = row.pop("member")
     assert raw_name is not None, "Missing member name"
-    name = clean_name(raw_name)
-    assert name, "Empty member name"
+    # Members carry the honorific "Hon.", the President "H.E", and some also "Dr";
+    # strip the affixes declared under `names.prefixes_strip` in the metadata, keeping
+    # the raw value as provenance.
+    name = h.strip_name_titles(context, raw_name)
+    assert name, f"Empty member name from {raw_name!r}"
     constituency = row.pop("constituency")
     assert constituency is not None, "Missing constituency"
 
     person = context.make("Person")
     person.id = context.make_id(name, constituency)
-    person.add("name", name)
+    person.add("name", name, original_value=raw_name if name != raw_name else None)
     person.add("political", row.pop("party"))
     # A member of the Maneaba ni Maungatabu must be a citizen of Kiribati under
     # Chapter V, Section 55(a) of the Constitution of Kiribati.

--- a/datasets/ki/maneaba/ki_maneaba.yml
+++ b/datasets/ki/maneaba/ki_maneaba.yml
@@ -1,0 +1,50 @@
+title: Kiribati Maneaba ni Maungatabu
+name: ki_maneaba
+prefix: ki-mnb
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-17
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Maneaba ni Maungatabu, the unicameral House of Assembly of
+  Kiribati.
+description: |
+  The Maneaba ni Maungatabu is the unicameral House of Assembly of Kiribati. Members
+  are directly elected from the island constituencies for four-year terms; the President
+  of Kiribati is also a sitting member. The Speaker is elected from outside the House and
+  the Attorney General serves ex officio (non-voting); neither appears on the members
+  listing crawled here.
+
+  This dataset records each sitting member with their name, the island constituency they
+  represent, and their political party where the source states one.
+url: https://www.parliament.gov.ki/
+publisher:
+  name: Maneaba ni Maungatabu
+  acronym: Maneaba
+  description: >
+    The Maneaba ni Maungatabu is the House of Assembly of Kiribati, the country's
+    unicameral national legislature.
+  url: https://www.parliament.gov.ki/
+  country: ki
+  official: true
+data:
+  url: https://www.parliament.gov.ki/index.php/members/current-members
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 36
+      Position: 1
+    country_entities:
+      ki: 36
+  max:
+    schema_entities:
+      Person: 60
+      Position: 1

--- a/datasets/ki/maneaba/ki_maneaba.yml
+++ b/datasets/ki/maneaba/ki_maneaba.yml
@@ -1,4 +1,4 @@
-title: Kiribati Maneaba ni Maungatabu
+title: Kiribati Members of the Maneaba ni Maungatabu
 name: ki_maneaba
 prefix: ki-mnb
 entry_point: crawler.py
@@ -11,17 +11,18 @@ summary: >-
   Members of the Maneaba ni Maungatabu, the unicameral House of Assembly of
   Kiribati.
 description: |
-  The Maneaba ni Maungatabu is the unicameral House of Assembly of Kiribati. Members
-  are directly elected from the island constituencies for four-year terms; the President
-  of Kiribati is also a sitting member. The Speaker is elected from outside the House and
-  the Attorney General serves ex officio (non-voting); neither appears on the members
-  listing crawled here.
+  Current members of the Maneaba ni Maungatabu (House of Assembly), the unicameral
+  national legislature of Kiribati. Members are directly elected from the island
+  constituencies for a four-year term, joined by a nominated representative of the
+  Banaban community, and hold the country's legislative power, including passing laws
+  and approving the budget. The President of Kiribati is also a sitting member.
 
-  This dataset records each sitting member with their name, the island constituency they
-  represent, and their political party where the source states one.
+  The Speaker is elected from outside the Maneaba and the Attorney-General serves ex
+  officio (non-voting); neither appears in the members listing crawled here.
 url: https://www.parliament.gov.ki/
 publisher:
   name: Maneaba ni Maungatabu
+  name_en: House of Assembly of Kiribati
   acronym: Maneaba
   description: >
     The Maneaba ni Maungatabu is the House of Assembly of Kiribati, the country's
@@ -36,6 +37,15 @@ data:
 
 tags:
   - list.pep
+
+names:
+  prefixes_strip:
+    - Hon.
+    - "Hon "
+    - "H.E "
+    - H.E.
+    - Dr.
+    - "Dr "
 
 assertions:
   min:

--- a/datasets/ki/maneaba/ki_maneaba.yml
+++ b/datasets/ki/maneaba/ki_maneaba.yml
@@ -6,7 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-17
 load_statements: true
-ci_test: false
+ci_test: true
 summary: >-
   Members of the Maneaba ni Maungatabu, the unicameral House of Assembly of
   Kiribati.


### PR DESCRIPTION
Adds a PEP crawler for the **Maneaba ni Maungatabu**, the unicameral House of Assembly of Kiribati.

## Source
Single roster table on the official parliament site (`parliament.gov.ki`) — server-rendered HTML, no JS/auth. Columns: Member, Constituency, Party.

## Output
- Position: *Member of the Maneaba ni Maungatabu* (`Q21296447`)
- ~45 members emitted as PEPs with island constituency and party (where stated).
- Honorific prefixes (`Hon.`, `H.E` for the President, `Dr`) stripped from names.
- Citizenship `ki` set per Constitution of Kiribati Ch. V §55(a) (see code comment).

Closes opensanctions/crawler-planning#726

🤖 Generated with [Claude Code](https://claude.com/claude-code)