### PR TITLE
Add Niue Assembly (Fono Ekepule) PEP crawler

### DIFF
--- a/datasets/nu/assembly/crawler.py
+++ b/datasets/nu/assembly/crawler.py
@@ -1,0 +1,79 @@
+import re
+
+from lxml import html
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The parliament site is served behind a CDN that rejects non-browser clients.
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+# Cabinet members carry the honorific "Hon". Strip it so the emitted name is the person's
+# actual name.
+HONORIFIC_RE = re.compile(r"^Hon\.?\s+")
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    block: html.HtmlElement,
+) -> None:
+    constituency = h.element_text(h.xpath_element(block, './/p[@class="position"]'))
+    name = HONORIFIC_RE.sub("", h.element_text(h.xpath_element(block, ".//h4"))).strip()
+    assert name, "Empty member name"
+    assert constituency, f"Empty constituency for {name!r}"
+
+    person = context.make("Person")
+    person.id = context.make_id(name, constituency)
+    person.add("name", name)
+    # Members must be a New Zealand citizen or a Permanent Resident of Niue (Constitution
+    # of Niue, Article 17(1)(a)) — Niue is self-governing in free association with New
+    # Zealand and has no separate citizenship. We therefore record country rather than
+    # asserting a specific citizenship. https://faolex.fao.org/docs/pdf/niu132832.pdf
+    person.add("country", "nu")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", constituency)
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Niue Assembly",
+        country="nu",
+        wikidata_id="Q40011889",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+    blocks = h.xpath_elements(
+        doc,
+        '//div[contains(@class, "cabinet-member")][.//p[@class="position"] and .//h4]',
+    )
+    if not blocks:
+        raise ValueError("No member blocks found on the Niue government page")
+    for block in blocks:
+        crawl_member(context, position, categorisation, block)

--- a/datasets/nu/assembly/crawler.py
+++ b/datasets/nu/assembly/crawler.py
@@ -69,10 +69,9 @@ def crawl(context: Context) -> None:
     context.emit(position)
 
     doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
-    blocks = h.xpath_elements(
-        doc,
-        '//div[contains(@class, "cabinet-member")][.//p[@class="position"] and .//h4]',
-    )
+    # Select every member card and let crawl_member's xpath_element calls raise if one
+    # lacks a name or constituency, rather than filtering incomplete cards out silently.
+    blocks = h.xpath_elements(doc, '//div[contains(@class, "cabinet-member")]')
     if not blocks:
         raise ValueError("No member blocks found on the Niue government page")
     for block in blocks:

--- a/datasets/nu/assembly/crawler.py
+++ b/datasets/nu/assembly/crawler.py
@@ -1,5 +1,3 @@
-import re
-
 from lxml import html
 
 from zavod import Context
@@ -17,10 +15,6 @@ HEADERS = {
     "Accept-Language": "en-US,en;q=0.9",
 }
 
-# Cabinet members carry the honorific "Hon". Strip it so the emitted name is the person's
-# actual name.
-HONORIFIC_RE = re.compile(r"^Hon\.?\s+")
-
 
 def crawl_member(
     context: Context,
@@ -29,13 +23,16 @@ def crawl_member(
     block: html.HtmlElement,
 ) -> None:
     constituency = h.element_text(h.xpath_element(block, './/p[@class="position"]'))
-    name = HONORIFIC_RE.sub("", h.element_text(h.xpath_element(block, ".//h4"))).strip()
+    # Members carry the honorific "Hon"; strip the affixes declared under
+    # `names.prefixes_strip` in the metadata, keeping the raw value as provenance.
+    raw_name = h.element_text(h.xpath_element(block, ".//h4"))
+    name = h.strip_name_titles(context, raw_name)
     assert name, "Empty member name"
     assert constituency, f"Empty constituency for {name!r}"
 
     person = context.make("Person")
     person.id = context.make_id(name, constituency)
-    person.add("name", name)
+    person.add("name", name, original_value=raw_name if name != raw_name else None)
     # Members must be a New Zealand citizen or a Permanent Resident of Niue (Constitution
     # of Niue, Article 17(1)(a)) — Niue is self-governing in free association with New
     # Zealand and has no separate citizenship. We therefore record country rather than

--- a/datasets/nu/assembly/crawler.py
+++ b/datasets/nu/assembly/crawler.py
@@ -5,16 +5,6 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The parliament site is served behind a CDN that rejects non-browser clients.
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-    ),
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-    "Accept-Language": "en-US,en;q=0.9",
-}
-
 
 def crawl_member(
     context: Context,
@@ -59,17 +49,16 @@ def crawl(context: Context) -> None:
         name="Member of the Niue Assembly",
         country="nu",
         wikidata_id="Q40011889",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+    doc = context.fetch_html(context.data_url, cache_days=14)
     # Select every member card and let crawl_member's xpath_element calls raise if one
     # lacks a name or constituency, rather than filtering incomplete cards out silently.
     blocks = h.xpath_elements(doc, '//div[contains(@class, "cabinet-member")]')
-    if not blocks:
-        raise ValueError("No member blocks found on the Niue government page")
     for block in blocks:
         crawl_member(context, position, categorisation, block)

--- a/datasets/nu/assembly/nu_assembly.yml
+++ b/datasets/nu/assembly/nu_assembly.yml
@@ -33,6 +33,11 @@ data:
 tags:
   - list.pep
 
+names:
+  prefixes_strip:
+    - "Hon "
+    - Hon.
+
 assertions:
   min:
     schema_entities:

--- a/datasets/nu/assembly/nu_assembly.yml
+++ b/datasets/nu/assembly/nu_assembly.yml
@@ -1,0 +1,46 @@
+title: Niue Fono Ekepule
+name: nu_assembly
+prefix: nu-fono
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-17
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Niue Assembly (Fono Ekepule), the unicameral legislature of Niue.
+description: |
+  The Niue Assembly (Fono Ekepule) is the unicameral legislature of Niue, a self-governing
+  state in free association with New Zealand. It has twenty members: fourteen elected from
+  village constituencies and six elected on a common roll. Members serve non-partisan.
+
+  This dataset records each sitting member with their name and the village constituency or
+  common-roll seat they represent.
+url: https://www.gov.nu/government
+publisher:
+  name: Government of Niue
+  description: >
+    The Government of Niue publishes the roster of the Niue Assembly (Fono Ekepule), the
+    territory's unicameral legislature.
+  url: https://www.gov.nu/
+  country: nu
+  official: true
+data:
+  url: https://www.gov.nu/government
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 16
+      Position: 1
+    country_entities:
+      nu: 16
+  max:
+    schema_entities:
+      Person: 24
+      Position: 1

--- a/datasets/nu/assembly/nu_assembly.yml
+++ b/datasets/nu/assembly/nu_assembly.yml
@@ -1,4 +1,4 @@
-title: Niue Fono Ekepule
+title: Niue Members of the Assembly
 name: nu_assembly
 prefix: nu-fono
 entry_point: crawler.py
@@ -10,9 +10,11 @@ ci_test: false
 summary: >-
   Members of the Niue Assembly (Fono Ekepule), the unicameral legislature of Niue.
 description: |
-  The Niue Assembly (Fono Ekepule) is the unicameral legislature of Niue, a self-governing
-  state in free association with New Zealand. It has twenty members: fourteen elected from
-  village constituencies and six elected on a common roll. Members serve non-partisan.
+  Current members of the Niue Assembly (Fono Ekepule), the unicameral legislature of Niue, a
+  self-governing state in free association with New Zealand. Its 20 members — 14 elected from
+  village constituencies and 6 on a common roll — serve on a non-partisan basis for a
+  three-year term and hold the territory's legislative power, including passing laws and
+  approving the budget.
 
   This dataset records each sitting member with their name and the village constituency or
   common-roll seat they represent.

--- a/datasets/nu/assembly/nu_assembly.yml
+++ b/datasets/nu/assembly/nu_assembly.yml
@@ -31,6 +31,11 @@ data:
   url: https://www.gov.nu/government
   format: HTML
   lang: eng
+http:
+  # The parliament site is served behind a CDN that can reject non-browser clients.
+  user_agent: >-
+    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+    like Gecko) Chrome/124.0.0.0 Safari/537.36
 
 tags:
   - list.pep


### PR DESCRIPTION
Adds a PEP crawler for the **Niue Assembly (Fono Ekepule)**, the unicameral legislature of Niue.

## Source
Official Government of Niue website (`gov.nu/government`), which lists all 20 members (14 village constituencies + 6 common roll) as `cabinet-member` blocks pairing a constituency and a name.

## Output
- Position: *Member of the Niue Assembly* (`Q40011889`)
- 20 members emitted as PEPs with their village constituency / common-roll seat.
- Honorific `Hon` stripped from ministers' names.
- Niue is self-governing in free association with NZ and has no separate citizenship; members must be an NZ citizen **or** a Permanent Resident of Niue (Constitution Art. 17(1)(a)), so the crawler records `country=nu` rather than asserting a specific citizenship (see code comment).

Closes opensanctions/crawler-planning#729

🤖 Generated with [Claude Code](https://claude.com/claude-code)