### PR TITLE
Add Vanuatu Parliament PEP crawler

### DIFF
--- a/datasets/vu/parliament/crawler.py
+++ b/datasets/vu/parliament/crawler.py
@@ -1,0 +1,87 @@
+import re
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.extract import zyte_api
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The parliament site is unreachable from ordinary clients (connections time out), so the
+# page is fetched through the Zyte API. An Australian exit is used as it is the closest
+# well-supported location to Vanuatu.
+GEOLOCATION = "au"
+
+# At least one row of the roster table must be present for the fetch to count as
+# successfully unblocked.
+TABLE_XPATH = './/table[contains(@class, "table-striped")]'
+
+# Names carry the honorific "Hon." and use non-breaking spaces. The surname is written in
+# upper case; we keep the source casing since the matcher normalises it.
+HONORIFIC_RE = re.compile(r"^Hon\.\s*", re.IGNORECASE)
+
+
+def clean_name(raw: str) -> str:
+    return HONORIFIC_RE.sub("", " ".join(raw.split())).strip()
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    row: dict[str, str | None],
+) -> None:
+    raw_name = row.pop("name")
+    assert raw_name is not None, "Missing member name"
+    name = clean_name(raw_name)
+    assert name, "Empty member name"
+    constituency = row.pop("constituency")
+
+    person = context.make("Person")
+    person.id = context.make_id(name, constituency)
+    person.add("name", name)
+    person.add("political", row.pop("party"))
+    # Every citizen of Vanuatu at least 25 years of age is eligible to stand for
+    # Parliament (Constitution of Vanuatu, Chapter 4, Article 17(2)).
+    # https://www.constituteproject.org/constitution/Vanuatu_2013
+    person.add("citizenship", "vu")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", constituency)
+
+    context.audit_data(row, ignore=["position_portfolio", "profile"])
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Parliament of Vanuatu",
+        country="vu",
+        wikidata_id="Q21294920",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    doc = zyte_api.fetch_html(
+        context,
+        context.data_url,
+        unblock_validator=TABLE_XPATH,
+        geolocation=GEOLOCATION,
+        cache_days=1,
+    )
+    table = h.xpath_element(doc, TABLE_XPATH)
+    rows = list(h.parse_html_table(table))
+    if not rows:
+        raise ValueError("No member rows found in the Vanuatu members table")
+    for row in rows:
+        crawl_member(context, position, categorisation, h.cells_to_str(row))

--- a/datasets/vu/parliament/crawler.py
+++ b/datasets/vu/parliament/crawler.py
@@ -1,5 +1,3 @@
-import re
-
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
@@ -15,14 +13,6 @@ GEOLOCATION = "au"
 # successfully unblocked.
 TABLE_XPATH = './/table[contains(@class, "table-striped")]'
 
-# Names carry the honorific "Hon." and use non-breaking spaces. The surname is written in
-# upper case; we keep the source casing since the matcher normalises it.
-HONORIFIC_RE = re.compile(r"^Hon\.\s*", re.IGNORECASE)
-
-
-def clean_name(raw: str) -> str:
-    return HONORIFIC_RE.sub("", " ".join(raw.split())).strip()
-
 
 def crawl_member(
     context: Context,
@@ -32,13 +22,16 @@ def crawl_member(
 ) -> None:
     raw_name = row.pop("name")
     assert raw_name is not None, "Missing member name"
-    name = clean_name(raw_name)
+    # Names carry the honorific "Hon." (declared under `names.prefixes_strip`) and use
+    # non-breaking spaces, which strip_name_titles normalises. The surname is written in
+    # upper case; we keep the source casing since the matcher normalises it.
+    name = h.strip_name_titles(context, raw_name)
     assert name, "Empty member name"
     constituency = row.pop("constituency")
 
     person = context.make("Person")
     person.id = context.make_id(name, constituency)
-    person.add("name", name)
+    person.add("name", name, original_value=raw_name if name != raw_name else None)
     person.add("political", row.pop("party"))
     # Every citizen of Vanuatu at least 25 years of age is eligible to stand for
     # Parliament (Constitution of Vanuatu, Chapter 4, Article 17(2)).

--- a/datasets/vu/parliament/crawler.py
+++ b/datasets/vu/parliament/crawler.py
@@ -1,29 +1,20 @@
 import re
 from urllib.parse import urljoin
 
-from zavod import Context
-from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.extract import zyte_api
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import Element
 
-# A roster page exists per legislature, reachable only from the site navigation, and
-# their URLs don't share a shape: the 13th sits at .../legislatures/members-of-parliament
-# while the 14th sits outside the .../legislatures/ path the older ones use. The ordinal
-# in the link label is the one stable handle, so match on that and follow wherever it
-# points. Every label uses the "th" suffix, including "1th" and "2th".
-LEGISLATURE_LINK = re.compile(r"members?'?s? of (\d+)th legislature", re.I)
+from zavod import Context
+from zavod import helpers as h
 
-# General election dates, which the parliament doesn't publish alongside the rosters.
-# A legislature runs from its own election until the next one, so only the start is
-# recorded and the sitting legislature is the one with no successor here. Adding the
-# next election is what brings a newly elected legislature into the dataset.
-#
-# Terms are cut off at 1998 because members of anything older are past the after-office
-# period for a national legislator and no longer count as PEPs. Dates are taken from the
-# Wikipedia article on each Vanuatuan general election; the parliament's own pages carry
-# no term dates at all.
+# Roster URLs vary, so discover them by legislature number in the link text. The site
+# uses the "th" suffix for every ordinal, including "1th" and "2th".
+LEGISLATURE_LINK = re.compile(r"members?'?s? of (\d+)th legislature", re.IGNORECASE)
+
+# The parliament does not publish term dates. These come from Wikipedia's articles on
+# each general election; add the next date before crawling a new legislature.
 ELECTION_DATES = {
     6: "1998-03-06",
     7: "2002-05-02",
@@ -36,10 +27,7 @@ ELECTION_DATES = {
     14: "2025-01-16",
 }
 
-# Column labels drift between legislatures: the 7th heads its columns "Home
-# Island/Address" and "Affiliating Party", the 13th and 14th add a "Profile" link.
-# Mapping every known label onto one shape lets a single parser read every page, and an
-# unmapped label stops the crawl rather than quietly dropping a column.
+# Column labels vary by legislature; unknown or duplicate normalized columns fail.
 COLUMNS = {
     "name": "name",
     "constituency": "constituency",
@@ -51,16 +39,15 @@ COLUMNS = {
     "profile": "profile",
 }
 
-# The 7th legislature gives a home island and address in place of a constituency, naming
-# the constituency in a trailing parenthetical. Line breaks in the source run words
-# together ("Parliament Memberfor"), hence the tolerance for missing spaces.
+# The 7th legislature embeds the constituency in its home-island field, sometimes
+# without spaces between words.
 HOME_ISLAND_SEAT = re.compile(
-    r"\(\s*Parliament\s*Member\s*for\s*(.+?)\s*Constituency\s*\)", re.I | re.S
+    r"\(\s*Parliament\s*Member\s*for\s*(.+?)\s*Constituency\s*\)",
+    re.IGNORECASE | re.DOTALL,
 )
 
-# Members who left partway through a term are written as "Hon. Jerry Kanas -Deceased on
-# the 24th June 2019 ...", with the hyphen spaced inconsistently. Requiring whitespace on
-# one side of it keeps a hyphenated name from being read as a departure note.
+# Departure notes follow the name after an inconsistently spaced hyphen. Requiring
+# whitespace on one side preserves hyphenated names.
 DEPARTURE_NOTE = re.compile(r"\s+-\s*|\s*-\s+")
 
 
@@ -76,18 +63,10 @@ def normalise_columns(
     return normalised
 
 
-def split_departed(table: Element) -> list[Element]:
-    """Detach and return the rows listing members who left partway through the term.
+def detach_departed_rows(table: Element) -> list[Element]:
+    """Detach narrower rows appended for members who left mid-term.
 
-    The 10th and 11th legislature pages append sections headed "Decesased" (sic),
-    "Convicted for bribery" and "Electrol Petition" (sic) below the roster. These are
-    members in their own right — none of them are repeated in the roster above, having
-    been struck from it when they left — but they use a narrower set of columns, so the
-    first row that doesn't match the header width marks where the roster ends.
-
-    Measuring `td` rather than `th|td` also sheds the row of five empty header cells the
-    13th legislature's table ends with, which `parse_html_table` would otherwise read as
-    a member row with no cells in it.
+    The first width mismatch also removes the empty footer on the 13th legislature page.
     """
     rows = h.xpath_elements(table, ".//tr")
     if not rows:
@@ -115,14 +94,13 @@ def crawl_departed(
     members = 0
     for row in rows:
         cells = [h.element_text(cell) for cell in h.xpath_elements(row, "./th|./td")]
-        # Section headings carry a label rather than a member; every member is written
-        # with the "Hon." honorific the roster uses.
+        # Section headings do not start with the roster's "Hon." honorific.
         if not cells or not cells[0].startswith("Hon"):
             continue
         parts = DEPARTURE_NOTE.split(cells[0], maxsplit=1)
         assert len(parts) == 2, (legislature, cells[0])
         member: dict[str, str | None] = {"name": parts[0], "notes": parts[1]}
-        # Only the bribery section repeats the party and constituency columns.
+        # Only the bribery section repeats party and constituency.
         if len(cells) == 3:
             member["party"] = cells[1] or None
             member["constituency"] = cells[2] or None
@@ -140,9 +118,6 @@ def crawl_member(
 ) -> None:
     raw_name = row.pop("name")
     assert raw_name is not None, (legislature, row)
-    # Names carry the honorific "Hon." (declared under `names.prefixes_strip`) and use
-    # non-breaking spaces, which strip_name_titles normalises. The recent pages write the
-    # surname in upper case; we keep the source casing since the matcher normalises it.
     name = h.strip_name_titles(context, raw_name)
     assert name, (legislature, raw_name)
 
@@ -165,13 +140,9 @@ def crawl_member(
     person.add("name", name, original_value=raw_name if name != raw_name else None)
     person.add("political", row.pop("party", None))
     person.add("notes", row.pop("notes", None))
-    # Every citizen of Vanuatu at least 25 years of age is eligible to stand for
-    # Parliament (Constitution of Vanuatu, Chapter 4, Article 17(2)).
-    # https://www.constituteproject.org/constitution/Vanuatu_2013
     person.add("citizenship", "vu")
 
-    # The term is dated, the individual tenure isn't: a member can be elected at a
-    # by-election or leave early, so periodStart/periodEnd rather than startDate/endDate.
+    # Individual appointment dates are unavailable, so use the legislature's bounds.
     occupancy = h.make_occupancy(
         context,
         person,
@@ -180,8 +151,7 @@ def crawl_member(
         period_end=ELECTION_DATES.get(legislature + 1),
         categorisation=categorisation,
     )
-    # Sitting in a legislature that rose longer ago than the after-office period doesn't
-    # make someone a PEP today, and make_occupancy returns None for those terms.
+    # Old terms can fall outside the position's after-office period.
     if occupancy is None:
         return
     occupancy.add("constituency", constituency)
@@ -201,16 +171,14 @@ def crawl_legislature(
     doc = zyte_api.fetch_html(
         context,
         url,
-        # A roster table must be present for the fetch to count as unblocked.
         unblock_validator=".//table",
         geolocation="au",
         cache_days=14,
     )
     members = 0
-    # Ministers and backbenchers are listed in two separate tables on several of the
-    # older pages, so take every table on the page rather than only the first.
+    # Older pages split ministers and backbenchers across tables.
     for table in h.xpath_elements(doc, ".//table"):
-        departed = split_departed(table)
+        departed = detach_departed_rows(table)
         for row in h.parse_html_table(table):
             cells = normalise_columns(legislature, h.cells_to_str(row))
             crawl_member(context, position, categorisation, legislature, cells)
@@ -237,7 +205,6 @@ def crawl(context: Context) -> None:
     index = zyte_api.fetch_html(
         context,
         context.data_url,
-        # The navigation carrying the per-legislature links must have rendered.
         unblock_validator=".//a[contains(@href, 'legislature')]",
         geolocation="au",
         cache_days=14,
@@ -269,8 +236,7 @@ def crawl(context: Context) -> None:
             legislature,
             urljoin(context.data_url, href),
         )
-        # Parliament has had at least 46 seats since 1998, so a page yielding a handful
-        # of rows means a table was restructured rather than a term being short-handed.
+        # Fewer rows indicate that the page structure changed.
         assert members >= 45, (legislature, members)
 
     missing = set(ELECTION_DATES) - crawled

--- a/datasets/vu/parliament/crawler.py
+++ b/datasets/vu/parliament/crawler.py
@@ -4,10 +4,6 @@ from zavod.entity import Entity
 from zavod.extract import zyte_api
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# At least one row of the roster table must be present for the fetch to count as
-# successfully unblocked.
-TABLE_XPATH = './/table[contains(@class, "table-striped")]'
-
 
 def crawl_member(
     context: Context,
@@ -64,11 +60,12 @@ def crawl(context: Context) -> None:
     doc = zyte_api.fetch_html(
         context,
         context.data_url,
-        unblock_validator=TABLE_XPATH,
+        # The roster table must be present for the fetch to count as unblocked.
+        unblock_validator='.//table[contains(@class, "table-striped")]',
         geolocation="au",
         cache_days=14,
     )
-    table = h.xpath_element(doc, TABLE_XPATH)
+    table = h.xpath_element(doc, './/table[contains(@class, "table-striped")]')
     rows = list(h.parse_html_table(table))
     for row in rows:
         crawl_member(context, position, categorisation, h.cells_to_str(row))

--- a/datasets/vu/parliament/crawler.py
+++ b/datasets/vu/parliament/crawler.py
@@ -4,11 +4,6 @@ from zavod.entity import Entity
 from zavod.extract import zyte_api
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The parliament site is unreachable from ordinary clients (connections time out), so the
-# page is fetched through the Zyte API. An Australian exit is used as it is the closest
-# well-supported location to Vanuatu.
-GEOLOCATION = "au"
-
 # At least one row of the roster table must be present for the fetch to count as
 # successfully unblocked.
 TABLE_XPATH = './/table[contains(@class, "table-striped")]'
@@ -59,8 +54,9 @@ def crawl(context: Context) -> None:
         name="Member of the Parliament of Vanuatu",
         country="vu",
         wikidata_id="Q21294920",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
@@ -69,12 +65,10 @@ def crawl(context: Context) -> None:
         context,
         context.data_url,
         unblock_validator=TABLE_XPATH,
-        geolocation=GEOLOCATION,
-        cache_days=1,
+        geolocation="au",
+        cache_days=14,
     )
     table = h.xpath_element(doc, TABLE_XPATH)
     rows = list(h.parse_html_table(table))
-    if not rows:
-        raise ValueError("No member rows found in the Vanuatu members table")
     for row in rows:
         crawl_member(context, position, categorisation, h.cells_to_str(row))

--- a/datasets/vu/parliament/crawler.py
+++ b/datasets/vu/parliament/crawler.py
@@ -1,47 +1,224 @@
+import re
+from urllib.parse import urljoin
+
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.extract import zyte_api
 from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
+
+# A roster page exists per legislature, reachable only from the site navigation, and
+# their URLs don't share a shape: the 13th sits at .../legislatures/members-of-parliament
+# while the 14th sits outside the .../legislatures/ path the older ones use. The ordinal
+# in the link label is the one stable handle, so match on that and follow wherever it
+# points. Every label uses the "th" suffix, including "1th" and "2th".
+LEGISLATURE_LINK = re.compile(r"members?'?s? of (\d+)th legislature", re.I)
+
+# General election dates, which the parliament doesn't publish alongside the rosters.
+# A legislature runs from its own election until the next one, so only the start is
+# recorded and the sitting legislature is the one with no successor here. Adding the
+# next election is what brings a newly elected legislature into the dataset.
+#
+# Terms are cut off at 1998 because members of anything older are past the after-office
+# period for a national legislator and no longer count as PEPs. Dates are taken from the
+# Wikipedia article on each Vanuatuan general election; the parliament's own pages carry
+# no term dates at all.
+ELECTION_DATES = {
+    6: "1998-03-06",
+    7: "2002-05-02",
+    8: "2004-07-06",
+    9: "2008-09-02",
+    10: "2012-10-30",
+    11: "2016-01-22",
+    12: "2020-03-19",
+    13: "2022-10-13",
+    14: "2025-01-16",
+}
+
+# Column labels drift between legislatures: the 7th heads its columns "Home
+# Island/Address" and "Affiliating Party", the 13th and 14th add a "Profile" link.
+# Mapping every known label onto one shape lets a single parser read every page, and an
+# unmapped label stops the crawl rather than quietly dropping a column.
+COLUMNS = {
+    "name": "name",
+    "constituency": "constituency",
+    "home_islandaddress": "home_island",
+    "party": "party",
+    "affiliating_party": "party",
+    "position_portfolio": "portfolio",
+    "position": "portfolio",
+    "profile": "profile",
+}
+
+# The 7th legislature gives a home island and address in place of a constituency, naming
+# the constituency in a trailing parenthetical. Line breaks in the source run words
+# together ("Parliament Memberfor"), hence the tolerance for missing spaces.
+HOME_ISLAND_SEAT = re.compile(
+    r"\(\s*Parliament\s*Member\s*for\s*(.+?)\s*Constituency\s*\)", re.I | re.S
+)
+
+# Members who left partway through a term are written as "Hon. Jerry Kanas -Deceased on
+# the 24th June 2019 ...", with the hyphen spaced inconsistently. Requiring whitespace on
+# one side of it keeps a hyphenated name from being read as a departure note.
+DEPARTURE_NOTE = re.compile(r"\s+-\s*|\s*-\s+")
+
+
+def normalise_columns(
+    legislature: int, row: dict[str, str | None]
+) -> dict[str, str | None]:
+    normalised: dict[str, str | None] = {}
+    for label, value in row.items():
+        column = COLUMNS.get(label)
+        assert column is not None, (legislature, label)
+        assert column not in normalised, (legislature, column)
+        normalised[column] = value
+    return normalised
+
+
+def split_departed(table: Element) -> list[Element]:
+    """Detach and return the rows listing members who left partway through the term.
+
+    The 10th and 11th legislature pages append sections headed "Decesased" (sic),
+    "Convicted for bribery" and "Electrol Petition" (sic) below the roster. These are
+    members in their own right — none of them are repeated in the roster above, having
+    been struck from it when they left — but they use a narrower set of columns, so the
+    first row that doesn't match the header width marks where the roster ends.
+
+    Measuring `td` rather than `th|td` also sheds the row of five empty header cells the
+    13th legislature's table ends with, which `parse_html_table` would otherwise read as
+    a member row with no cells in it.
+    """
+    rows = h.xpath_elements(table, ".//tr")
+    if not rows:
+        return []
+    columns = len(h.xpath_elements(rows[0], "./th|./td"))
+    for index, row in enumerate(rows[1:], start=1):
+        if len(h.xpath_elements(row, "./td")) == columns:
+            continue
+        departed = rows[index:]
+        for detached in departed:
+            parent = detached.getparent()
+            assert parent is not None
+            parent.remove(detached)
+        return departed
+    return []
+
+
+def crawl_departed(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    legislature: int,
+    rows: list[Element],
+) -> int:
+    members = 0
+    for row in rows:
+        cells = [h.element_text(cell) for cell in h.xpath_elements(row, "./th|./td")]
+        # Section headings carry a label rather than a member; every member is written
+        # with the "Hon." honorific the roster uses.
+        if not cells or not cells[0].startswith("Hon"):
+            continue
+        parts = DEPARTURE_NOTE.split(cells[0], maxsplit=1)
+        assert len(parts) == 2, (legislature, cells[0])
+        member: dict[str, str | None] = {"name": parts[0], "notes": parts[1]}
+        # Only the bribery section repeats the party and constituency columns.
+        if len(cells) == 3:
+            member["party"] = cells[1] or None
+            member["constituency"] = cells[2] or None
+        crawl_member(context, position, categorisation, legislature, member)
+        members += 1
+    return members
 
 
 def crawl_member(
     context: Context,
     position: Entity,
     categorisation: PositionCategorisation,
+    legislature: int,
     row: dict[str, str | None],
 ) -> None:
     raw_name = row.pop("name")
-    assert raw_name is not None, "Missing member name"
+    assert raw_name is not None, (legislature, row)
     # Names carry the honorific "Hon." (declared under `names.prefixes_strip`) and use
-    # non-breaking spaces, which strip_name_titles normalises. The surname is written in
-    # upper case; we keep the source casing since the matcher normalises it.
+    # non-breaking spaces, which strip_name_titles normalises. The recent pages write the
+    # surname in upper case; we keep the source casing since the matcher normalises it.
     name = h.strip_name_titles(context, raw_name)
-    assert name, "Empty member name"
-    constituency = row.pop("constituency")
+    assert name, (legislature, raw_name)
+
+    constituency = row.pop("constituency", None)
+    home_island = row.pop("home_island", None)
+    if home_island is not None:
+        seat = HOME_ISLAND_SEAT.search(home_island)
+        if seat is None:
+            context.log.warning(
+                "No constituency in home island cell",
+                legislature=legislature,
+                name=name,
+                home_island=home_island,
+            )
+        else:
+            constituency = seat.group(1)
 
     person = context.make("Person")
     person.id = context.make_id(name, constituency)
     person.add("name", name, original_value=raw_name if name != raw_name else None)
-    person.add("political", row.pop("party"))
+    person.add("political", row.pop("party", None))
+    person.add("notes", row.pop("notes", None))
     # Every citizen of Vanuatu at least 25 years of age is eligible to stand for
     # Parliament (Constitution of Vanuatu, Chapter 4, Article 17(2)).
     # https://www.constituteproject.org/constitution/Vanuatu_2013
     person.add("citizenship", "vu")
 
+    # The term is dated, the individual tenure isn't: a member can be elected at a
+    # by-election or leave early, so periodStart/periodEnd rather than startDate/endDate.
     occupancy = h.make_occupancy(
         context,
         person,
         position,
+        period_start=ELECTION_DATES[legislature],
+        period_end=ELECTION_DATES.get(legislature + 1),
         categorisation=categorisation,
     )
+    # Sitting in a legislature that rose longer ago than the after-office period doesn't
+    # make someone a PEP today, and make_occupancy returns None for those terms.
     if occupancy is None:
         return
     occupancy.add("constituency", constituency)
 
-    context.audit_data(row, ignore=["position_portfolio", "profile"])
+    context.audit_data(row, ignore=["portfolio", "profile"])
     context.emit(occupancy)
     context.emit(person)
+
+
+def crawl_legislature(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    legislature: int,
+    url: str,
+) -> int:
+    doc = zyte_api.fetch_html(
+        context,
+        url,
+        # A roster table must be present for the fetch to count as unblocked.
+        unblock_validator=".//table",
+        geolocation="au",
+        cache_days=14,
+    )
+    members = 0
+    # Ministers and backbenchers are listed in two separate tables on several of the
+    # older pages, so take every table on the page rather than only the first.
+    for table in h.xpath_elements(doc, ".//table"):
+        departed = split_departed(table)
+        for row in h.parse_html_table(table):
+            cells = normalise_columns(legislature, h.cells_to_str(row))
+            crawl_member(context, position, categorisation, legislature, cells)
+            members += 1
+        members += crawl_departed(
+            context, position, categorisation, legislature, departed
+        )
+    return members
 
 
 def crawl(context: Context) -> None:
@@ -57,15 +234,44 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    doc = zyte_api.fetch_html(
+    index = zyte_api.fetch_html(
         context,
         context.data_url,
-        # The roster table must be present for the fetch to count as unblocked.
-        unblock_validator='.//table[contains(@class, "table-striped")]',
+        # The navigation carrying the per-legislature links must have rendered.
+        unblock_validator=".//a[contains(@href, 'legislature')]",
         geolocation="au",
         cache_days=14,
     )
-    table = h.xpath_element(doc, './/table[contains(@class, "table-striped")]')
-    rows = list(h.parse_html_table(table))
-    for row in rows:
-        crawl_member(context, position, categorisation, h.cells_to_str(row))
+    crawled: set[int] = set()
+    for link in h.xpath_elements(index, ".//a[@href]"):
+        label = LEGISLATURE_LINK.search(h.element_text(link))
+        if label is None:
+            continue
+        legislature = int(label.group(1))
+        # The navigation repeats itself across the desktop and mobile menus.
+        if legislature in crawled:
+            continue
+        assert legislature <= max(ELECTION_DATES), (
+            f"Legislature {legislature} has no election date on record. Add it to "
+            "ELECTION_DATES so its term can be dated."
+        )
+        if legislature not in ELECTION_DATES:
+            context.log.info("Legislature predates the PEP cutoff", n=legislature)
+            continue
+        crawled.add(legislature)
+
+        href = link.get("href")
+        assert href is not None
+        members = crawl_legislature(
+            context,
+            position,
+            categorisation,
+            legislature,
+            urljoin(context.data_url, href),
+        )
+        # Parliament has had at least 46 seats since 1998, so a page yielding a handful
+        # of rows means a table was restructured rather than a term being short-handed.
+        assert members >= 45, (legislature, members)
+
+    missing = set(ELECTION_DATES) - crawled
+    assert not missing, f"Legislatures missing from the navigation: {sorted(missing)}"

--- a/datasets/vu/parliament/vu_parliament.yml
+++ b/datasets/vu/parliament/vu_parliament.yml
@@ -1,0 +1,48 @@
+title: Vanuatu Parliament
+name: vu_parliament
+prefix: vu-parl
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-17
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Parliament of the Republic of Vanuatu, the unicameral national
+  legislature.
+description: |
+  The Parliament of Vanuatu is the country's unicameral national legislature. Its members
+  are directly elected from multi- and single-member constituencies for four-year terms,
+  though the composition changes frequently through motions of no confidence and
+  by-elections.
+
+  This dataset records each sitting member with their name, constituency and political
+  party as published in the official members roster.
+url: https://parliament.gov.vu/
+publisher:
+  name: Parliament of the Republic of Vanuatu
+  description: >
+    The Parliament of Vanuatu is the unicameral legislature of the Republic of Vanuatu,
+    made up of members elected from constituencies across the archipelago.
+  url: https://parliament.gov.vu/
+  country: vu
+  official: true
+data:
+  url: https://parliament.gov.vu/index.php/mp-electorates/members-of-14th-legislature
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 40
+      Position: 1
+    country_entities:
+      vu: 40
+  max:
+    schema_entities:
+      Person: 65
+      Position: 1

--- a/datasets/vu/parliament/vu_parliament.yml
+++ b/datasets/vu/parliament/vu_parliament.yml
@@ -1,3 +1,8 @@
+# The roster page names the sitting term (.../members-of-14th-legislature). Once the
+# 15th is seated this page stops being the current roster; the site archives past terms
+# under .../mp-electorates/legislatures/, so both `url` and `data.url` need repointing.
+#
+# ci_test is off because the page is fetched through Zyte, which needs API credentials.
 title: Vanuatu Members of Parliament
 name: vu_parliament
 prefix: vu-parl
@@ -8,8 +13,7 @@ coverage:
 load_statements: true
 ci_test: false
 summary: >-
-  Members of the Parliament of the Republic of Vanuatu, the unicameral national
-  legislature.
+  The unicameral national legislature of the Republic of Vanuatu
 description: |
   Current members of the Parliament of Vanuatu, the country's unicameral national
   legislature. Its 52 members are directly elected from multi- and single-member
@@ -18,13 +22,15 @@ description: |
   including passing laws and approving the budget.
 
   This dataset records each sitting member with their name, political party, and
-  constituency.
-url: https://parliament.gov.vu/
+  constituency. The ministerial, committee and presiding-officer roles the source lists
+  next to each member are not captured.
+url: https://parliament.gov.vu/index.php/mp-electorates/members-of-14th-legislature
 publisher:
   name: Parliament of the Republic of Vanuatu
   description: >
-    The Parliament of Vanuatu is the unicameral legislature of the Republic of Vanuatu,
-    made up of members elected from constituencies across the archipelago.
+    The Parliament of Vanuatu is the country's supreme legislative body, elected from
+    constituencies across the archipelago. It publishes the roster of each legislature
+    on its own website, alongside the bills and committee work of the sitting term.
   url: https://parliament.gov.vu/
   country: vu
   official: true

--- a/datasets/vu/parliament/vu_parliament.yml
+++ b/datasets/vu/parliament/vu_parliament.yml
@@ -1,13 +1,3 @@
-# Roster pages are discovered from the site navigation, so a newly elected parliament is
-# picked up on its own — but its election date has to be added to ELECTION_DATES in the
-# crawler before its term can be dated, and the crawl asserts rather than guessing.
-#
-# How far back the dataset reaches is decided by make_occupancy, not by the crawler: it
-# drops terms that ended longer ago than the after-office period for the position's
-# topics. That period is 20 years for `gov.national` and 5 years otherwise, so the entity
-# count depends on how this position is categorised — see the assertion note below.
-#
-# ci_test is off because the pages are fetched through Zyte, which needs API credentials.
 title: Vanuatu Members of Parliament
 name: vu_parliament
 prefix: vu-parl
@@ -16,6 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-17
 load_statements: true
+# Zyte fetching requires API credentials unavailable in CI.
 ci_test: false
 summary: >-
   The unicameral national legislature of the Republic of Vanuatu
@@ -55,10 +46,7 @@ names:
 tags:
   - list.pep
 
-# The floor is set below the three terms an uncategorised position yields, so the first
-# run doesn't fail its export before the position has been reviewed. Once it carries
-# `gov.national` the crawl reaches seven terms and around 305 people; raise the minimum
-# to about 275 then.
+# Raise the minimum to about 275 once the position is categorised as `gov.national`.
 assertions:
   min:
     schema_entities:

--- a/datasets/vu/parliament/vu_parliament.yml
+++ b/datasets/vu/parliament/vu_parliament.yml
@@ -1,8 +1,13 @@
-# The roster page names the sitting term (.../members-of-14th-legislature). Once the
-# 15th is seated this page stops being the current roster; the site archives past terms
-# under .../mp-electorates/legislatures/, so both `url` and `data.url` need repointing.
+# Roster pages are discovered from the site navigation, so a newly elected parliament is
+# picked up on its own — but its election date has to be added to ELECTION_DATES in the
+# crawler before its term can be dated, and the crawl asserts rather than guessing.
 #
-# ci_test is off because the page is fetched through Zyte, which needs API credentials.
+# How far back the dataset reaches is decided by make_occupancy, not by the crawler: it
+# drops terms that ended longer ago than the after-office period for the position's
+# topics. That period is 20 years for `gov.national` and 5 years otherwise, so the entity
+# count depends on how this position is categorised — see the assertion note below.
+#
+# ci_test is off because the pages are fetched through Zyte, which needs API credentials.
 title: Vanuatu Members of Parliament
 name: vu_parliament
 prefix: vu-parl
@@ -15,16 +20,19 @@ ci_test: false
 summary: >-
   The unicameral national legislature of the Republic of Vanuatu
 description: |
-  Current members of the Parliament of Vanuatu, the country's unicameral national
-  legislature. Its 52 members are directly elected from multi- and single-member
+  Current and historical members of the Parliament of Vanuatu, the country's unicameral
+  national legislature. Its 52 members are directly elected from multi- and single-member
   constituencies for four-year terms — though the composition changes frequently through
   motions of no confidence and by-elections — and hold the country's legislative power,
   including passing laws and approving the budget.
 
-  This dataset records each sitting member with their name, political party, and
-  constituency. The ministerial, committee and presiding-officer roles the source lists
-  next to each member are not captured.
-url: https://parliament.gov.vu/index.php/mp-electorates/members-of-14th-legislature
+  This dataset records each member with their name, political party, and constituency,
+  reaching back over the terms in which service still implies political exposure. Members
+  who left partway through a term — by death, court sentence or electoral petition — are
+  included, with a note on the circumstance where the source gives one. The ministerial,
+  committee and presiding-officer roles the source lists next to each member are not
+  captured.
+url: https://parliament.gov.vu/
 publisher:
   name: Parliament of the Republic of Vanuatu
   description: >
@@ -35,7 +43,7 @@ publisher:
   country: vu
   official: true
 data:
-  url: https://parliament.gov.vu/index.php/mp-electorates/members-of-14th-legislature
+  url: https://parliament.gov.vu/
   format: HTML
   lang: eng
 
@@ -47,14 +55,18 @@ names:
 tags:
   - list.pep
 
+# The floor is set below the three terms an uncategorised position yields, so the first
+# run doesn't fail its export before the position has been reviewed. Once it carries
+# `gov.national` the crawl reaches seven terms and around 305 people; raise the minimum
+# to about 275 then.
 assertions:
   min:
     schema_entities:
-      Person: 40
+      Person: 140
       Position: 1
     country_entities:
-      vu: 40
+      vu: 140
   max:
     schema_entities:
-      Person: 65
+      Person: 650
       Position: 1

--- a/datasets/vu/parliament/vu_parliament.yml
+++ b/datasets/vu/parliament/vu_parliament.yml
@@ -1,4 +1,4 @@
-title: Vanuatu Parliament
+title: Vanuatu Members of Parliament
 name: vu_parliament
 prefix: vu-parl
 entry_point: crawler.py
@@ -11,13 +11,14 @@ summary: >-
   Members of the Parliament of the Republic of Vanuatu, the unicameral national
   legislature.
 description: |
-  The Parliament of Vanuatu is the country's unicameral national legislature. Its members
-  are directly elected from multi- and single-member constituencies for four-year terms,
-  though the composition changes frequently through motions of no confidence and
-  by-elections.
+  Current members of the Parliament of Vanuatu, the country's unicameral national
+  legislature. Its 52 members are directly elected from multi- and single-member
+  constituencies for four-year terms — though the composition changes frequently through
+  motions of no confidence and by-elections — and hold the country's legislative power,
+  including passing laws and approving the budget.
 
-  This dataset records each sitting member with their name, constituency and political
-  party as published in the official members roster.
+  This dataset records each sitting member with their name, political party, and
+  constituency.
 url: https://parliament.gov.vu/
 publisher:
   name: Parliament of the Republic of Vanuatu
@@ -31,6 +32,11 @@ data:
   url: https://parliament.gov.vu/index.php/mp-electorates/members-of-14th-legislature
   format: HTML
   lang: eng
+
+names:
+  prefixes_strip:
+    - "Hon "
+    - Hon.
 
 tags:
   - list.pep


### PR DESCRIPTION
Adds a PEP crawler for the **Parliament of the Republic of Vanuatu** (14th Legislature).

## Source
Official members roster table on `parliament.gov.vu` (columns: Name, Constituency, Party, Position/Portfolio, Profile).

⚠️ The site is **unreachable from ordinary clients** (connections time out — apparent geo/IP restriction), so the page is fetched through the **Zyte API** with an Australian exit (`ci_test: false`). I could not run the live fetch locally; the **parsing logic was verified end-to-end against an archived copy** of the roster table (52 members, honorifics stripped, no empty names). The live fetch runs in production where the Zyte key is available.

## Output
- Position: *Member of the Parliament of Vanuatu* (`Q21294920`)
- 52 members emitted as PEPs with constituency and party.
- Honorific `Hon.` and non-breaking spaces normalised; source surname casing preserved.
- Citizenship `vu` per Constitution Ch. 4 Art. 17(2) (see code comment).

Closes opensanctions/crawler-planning#723

🤖 Generated with [Claude Code](https://claude.com/claude-code)