### PR TITLE
Compare prefix dates as intervals in status helpers

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "followthemoney == 4.10.0",
     "nomenklatura == 4.11.4",
     "plyvel == 1.5.1", # Also update macOS install docs
-    "rigour == 2.2.0",
+    "rigour == 2.2.2",
     "datapatch >= 1.2.4, < 1.3",
     "banal >= 1.1.2, < 2.0",
     "certifi",

--- a/zavod/zavod/helpers/dates.py
+++ b/zavod/zavod/helpers/dates.py
@@ -2,6 +2,7 @@ import re
 from functools import lru_cache
 from normality import stringify
 from prefixdate import parse_formats
+from rigour.dates import ended_before
 from datetime import datetime, date, timedelta, timezone
 from typing import Tuple, Union, Iterable, Set, Optional, List, TYPE_CHECKING
 from followthemoney import registry
@@ -182,4 +183,4 @@ def within_max_age(
     if isinstance(date, str):
         date = date.strip()
     cleaned_date = extract_date(context.dataset, date, fallback_to_original=False)[0]
-    return cleaned_date > backdate(RUN_TIME, timedelta(days=max_age_days))
+    return not ended_before(cleaned_date, RUN_TIME - timedelta(days=max_age_days))

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from rigour.dates import ended_before, starts_after
+
 from zavod import helpers as h
 from zavod import settings
 from zavod.constants import ORIGIN_METADATA
@@ -110,6 +112,6 @@ def is_active(sanction: Entity) -> bool:
     iso_start_date = min(sanction.get("startDate"), default=None)
     iso_end_date = max(sanction.get("endDate"), default=None)
     is_active = (
-        iso_start_date is None or iso_start_date <= settings.RUN_TIME_ISO
-    ) and (iso_end_date is None or iso_end_date >= settings.RUN_TIME_ISO)
+        iso_start_date is None or not starts_after(iso_start_date, settings.RUN_TIME)
+    ) and (iso_end_date is None or not ended_before(iso_end_date, settings.RUN_TIME))
     return is_active

--- a/zavod/zavod/stateful/positions.py
+++ b/zavod/zavod/stateful/positions.py
@@ -3,6 +3,7 @@ from enum import Enum
 from functools import lru_cache
 from typing import List, Optional
 
+from rigour.dates import ended_before, starts_after
 from rigour.ids.wikidata import is_qid
 from sqlalchemy import select
 
@@ -173,18 +174,21 @@ def occupancy_status(
     - ``periodEnd`` (term/period end): past implies ENDED, future implies UNKNOWN
       (e.g. a parliamentary term may still be running but the person may have left)
 
+    A death date in the past caps the status at ENDED: a deceased person is never
+    emitted as a CURRENT or UNKNOWN office-holder.
+
     If the person should not be considered a PEP, return None.
     """
-    from zavod import helpers as h
-
-    current_iso = current_time.isoformat()
-    if death_date is not None and death_date < h.backdate(current_time, AFTER_DEATH):
+    if death_date is not None and ended_before(death_date, current_time - AFTER_DEATH):
         # If they died longer ago than AFTER_DEATH threshold, don't consider a PEP.
         return None
 
-    if birth_date is not None and birth_date < h.backdate(current_time, MAX_AGE):
+    if birth_date is not None and ended_before(birth_date, current_time - MAX_AGE):
         # If they're unrealistically old, assume they're not a PEP.
         return None
+
+    # A death date entirely in the future is a data error and is ignored here.
+    died = death_date is not None and not starts_after(death_date, current_time)
 
     # Determine effective start date (most specific first)
     effective_start_date = max(occupancy.get("startDate"), default=None)
@@ -216,8 +220,8 @@ def occupancy_status(
 
     # Individual end date is the most specific signal
     if end_date is not None:
-        if end_date < current_iso:  # end_date is in the past
-            if end_date < h.backdate(current_time, after_office):
+        if ended_before(end_date, current_time):  # end_date is in the past
+            if ended_before(end_date, current_time - after_office):
                 # end_date is beyond after-office threshold
                 return None
             else:
@@ -226,7 +230,7 @@ def occupancy_status(
         elif (
             context.dataset.model.coverage
             and context.dataset.model.coverage.end
-            and context.dataset.model.coverage.end < current_iso
+            and ended_before(context.dataset.model.coverage.end, current_time)
         ):  # end_date is in the future and dataset is beyond its coverage.
             # Don't trust future end dates beyond the known coverage date of the dataset
             context.log.warning(
@@ -236,15 +240,15 @@ def occupancy_status(
                 position=position.id,
                 end_date=end_date,
             )
-            return OccupancyStatus.UNKNOWN
+            return OccupancyStatus.ENDED if died else OccupancyStatus.UNKNOWN
         else:  # end_date is in the future and coverage is unspecified or active
-            return OccupancyStatus.CURRENT
+            return OccupancyStatus.ENDED if died else OccupancyStatus.CURRENT
 
     # Period end date: less specific — a future period end does not imply the person
     # is still in office. An MP could leave a term early
     if period_end is not None:
-        if period_end < current_iso:  # period_end is in the past
-            if period_end < h.backdate(current_time, after_office):
+        if ended_before(period_end, current_time):  # period_end is in the past
+            if ended_before(period_end, current_time - after_office):
                 # period_end is beyond after-office threshold
                 return None
             else:
@@ -254,16 +258,22 @@ def occupancy_status(
     # No end date of any kind
     dis_date = max(position.get("dissolutionDate"), default=None)
     # dissolution date is in the past:
-    if dis_date is not None and dis_date < current_iso:
-        if dis_date > h.backdate(current_time, after_office):
-            return OccupancyStatus.ENDED
-        else:
+    if dis_date is not None and ended_before(dis_date, current_time):
+        if ended_before(dis_date, current_time - after_office):
             return None
+        else:
+            return OccupancyStatus.ENDED
 
-    max_office_threshold = h.backdate(current_time, MAX_OFFICE)
-    if effective_start_date is not None and effective_start_date < max_office_threshold:
+    if effective_start_date is not None and ended_before(
+        effective_start_date, current_time - MAX_OFFICE
+    ):
         # start_date is older than MAX_OFFICE threshold - probably not a PEP
         return None
+
+    if died:
+        # A deceased person no longer holds the position, even if the source
+        # hasn't recorded an end date.
+        return OccupancyStatus.ENDED
 
     if no_end_implies_current:
         # This is for sources we are really confident will provide an end date or

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timedelta, timezone
 from structlog.testing import capture_logs
 
+from zavod.context import Context
 from zavod.entity import Entity
 from zavod.meta.dataset import Dataset
 from zavod.helpers.dates import extract_years, extract_date, backdate
 from zavod.helpers.dates import replace_months, apply_date, apply_dates
+from zavod.helpers.dates import within_max_age
+from zavod.settings import RUN_TIME
 
 FORMATS = ["%b %Y", "%d.%m.%Y", "%Y-%m"]
 
@@ -114,3 +117,14 @@ def test_apply_date(testdataset1: Dataset):
 def test_backdate():
     assert backdate(datetime(2023, 8, 3), timedelta(days=0)) == "2023-08-03"
     assert backdate(datetime(2023, 8, 3), timedelta(days=182)) == "2023-02-02"
+
+
+def test_within_max_age(vcontext: Context):
+    assert within_max_age(vcontext, RUN_TIME.date().isoformat())
+    # A year-precision date whose year straddles the cutoff may be as late as
+    # Dec 31 of that year, so it stays within the age window.
+    cutoff_year = (RUN_TIME - timedelta(days=5 * 365)).year
+    assert within_max_age(vcontext, str(cutoff_year))
+    # The year before the cutoff year has fully elapsed.
+    assert not within_max_age(vcontext, str(cutoff_year - 1))
+    assert not within_max_age(vcontext, "1999-01-01")

--- a/zavod/zavod/tests/helpers/test_sanctions.py
+++ b/zavod/zavod/tests/helpers/test_sanctions.py
@@ -138,3 +138,46 @@ def test_sanctions_is_active_with_future_start_date(sanction: Entity):
     sanction.set("startDate", future_date)
     sanction.set("endDate", far_future_date)
     assert not is_active(sanction)
+
+
+def test_sanctions_is_active_with_end_date_today(sanction: Entity):
+    today = settings.RUN_TIME.date().isoformat()
+    sanction.set("endDate", today)
+    assert is_active(sanction)
+
+
+def test_sanctions_is_active_with_prefix_end_dates(sanction: Entity):
+    # A sanction ending some time this year is still active today.
+    sanction.set("endDate", str(settings.RUN_TIME.year))
+    assert is_active(sanction)
+    # Same for month precision in the current month.
+    sanction.set("endDate", settings.RUN_TIME.date().isoformat()[:7])
+    assert is_active(sanction)
+    # A sanction ending last year is over.
+    sanction.set("endDate", str(settings.RUN_TIME.year - 1))
+    assert not is_active(sanction)
+    # A start date in the current year (at year precision) may have passed already.
+    sanction.set("endDate", None)
+    sanction.set("startDate", str(settings.RUN_TIME.year))
+    assert is_active(sanction)
+    sanction.set("startDate", str(settings.RUN_TIME.year + 1))
+    assert not is_active(sanction)
+
+
+def test_make_sanction_prefix_end_date_status(vcontext: Context, person: Entity):
+    # endDate="<current year>" means the sanction runs until some point this
+    # year - it must not be reported inactive from the 1st of January.
+    sanction = make_sanction(
+        vcontext, person, key="this-year", end_date=str(settings.RUN_TIME.year)
+    )
+    assert sanction.get("status") == ["active"]
+
+    sanction = make_sanction(
+        vcontext, person, key="today", end_date=settings.RUN_TIME.date().isoformat()
+    )
+    assert sanction.get("status") == ["active"]
+
+    sanction = make_sanction(
+        vcontext, person, key="last-year", end_date=str(settings.RUN_TIME.year - 1)
+    )
+    assert sanction.get("status") == ["inactive"]

--- a/zavod/zavod/tests/stateful/test_positions.py
+++ b/zavod/zavod/tests/stateful/test_positions.py
@@ -122,10 +122,40 @@ def test_occupancy_status(testdataset1: Dataset):
     # Current when the source is really good (no end implies current)
     assert status(True, "1981-01-15", None) == OccupancyStatus.CURRENT
 
+    # --- Prefix (year/month precision) date semantics ---
+    # A year-precision end date in the current year must not flip to ENDED
+    # on the 1st of January.
+    assert status(True, "2020-01-01", "2021") == OccupancyStatus.CURRENT
+    assert status(True, "2020-01-01", "2021-01") == OccupancyStatus.CURRENT
+    # An end date of today has not elapsed yet.
+    assert status(True, "2020-01-01", "2021-01-01") == OccupancyStatus.CURRENT
+    # A year-precision end date at the after-office boundary: the office may
+    # have ended as late as 2016-12-31, which is within the 5-year window.
+    assert status(False, "2010-01-01", "2016") == OccupancyStatus.ENDED
+
     # Not a PEP if they died longer than AFTER_DEATH ago
     assert status(True, "2020-01-01", None, None, "2016-01-01") is None
     assert status(True, "1950-01-01", "2021-01-02", None, "2016-01-01") is None
     assert status(True, "1950-01-01", "2020-12-31", None, "2016-01-01") is None
+    # A year-precision death date is only beyond AFTER_DEATH once the whole
+    # year is: death in "2016" may have been in December 2016.
+    assert status(True, "2014-01-01", None, None, "2016") == OccupancyStatus.ENDED
+    assert status(True, "2014-01-01", None, None, "2015") is None
+
+    # --- Death date caps the status at ENDED ---
+    # A person who died within AFTER_DEATH is never a CURRENT office-holder,
+    # even without an end date and with a well-maintained source.
+    assert status(True, "2018-01-01", None, None, "2019-06-01") == OccupancyStatus.ENDED
+    assert (
+        status(False, "2018-01-01", None, None, "2019-06-01") == OccupancyStatus.ENDED
+    )
+    # Death overrides an end date in the future.
+    assert (
+        status(True, "1950-01-01", "2021-01-02", None, "2019-06-01")
+        == OccupancyStatus.ENDED
+    )
+    # But death does not resurrect an occupancy that is already disqualified.
+    assert status(False, "1950-01-01", "2015-01-01", None, "2019-06-01") is None
 
     # Not a PEP if they were born longer than MAX_AGE ago
     assert status(True, "2020-01-01", None, "1910-01-01") is None


### PR DESCRIPTION
FtM date values are prefix dates (`"2026"`, `"2026-06"`), but the sanction and occupancy status helpers compared them lexicographically against full timestamps, treating a prefix as the *earliest* instant of its range. A sanction with `endDate="2026"` was reported inactive from the 1st of January, and year-precision occupancy end dates flipped to ENDED a year early — false negatives, the dangerous direction for screening.

Closes #4929, closes #4931.

## Changes

- `helpers/sanctions.py`: `make_sanction` status and `is_active()` use `ended_before` / `starts_after` from `rigour.dates` (new in rigour 2.2.2, opensanctions/rigour#252): "is this over?" now compares against the *latest* instant of the prefix range. An end date of today, or a year-precision end date in the current year, counts as active.
- `stateful/positions.py`: all date comparisons in `occupancy_status` switched to interval comparators; age/recency gates compare against a shifted reference (`current_time - delta`). Year-precision Wikidata P582 end dates no longer flip to ENDED on Jan 1.
- `stateful/positions.py` (#4931): a death date in the past now caps the status at ENDED — a deceased person is never emitted as a CURRENT or UNKNOWN office-holder, per `docs/peps.md`. The death check never resurrects occupancies already disqualified by the retention gates (e.g. office ended 30 years ago stays not-a-PEP).
- `helpers/dates.py`: `within_max_age` no longer excludes month/year-precision dates whose range straddles the cutoff.
- `zavod/pyproject.toml`: rigour pinned to 2.2.2.

## Note for reviewers

Emitted `Sanction.status` and occupancy status values **will change** for year- and month-precision dates — that is the point of the fix. Expect diff noise in dataset outputs, especially wd_peps and the US med-exclusion/debarment lists gating topics on `is_active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)