### PR TITLE
Guard against birth dates parsing into the future

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "followthemoney == 4.10.0",
     "nomenklatura == 4.11.4",
     "plyvel == 1.5.1", # Also update macOS install docs
-    "rigour == 2.2.0",
+    "rigour == 2.2.2",
     "datapatch >= 1.2.4, < 1.3",
     "banal >= 1.1.2, < 2.0",
     "certifi",

--- a/zavod/zavod/runtime/cleaning.py
+++ b/zavod/zavod/runtime/cleaning.py
@@ -1,6 +1,7 @@
 import unicodedata
 from typing import TYPE_CHECKING
 from typing import Optional, Generator, Tuple
+from rigour.dates import starts_after
 from rigour.ids import get_identifier_format
 from rigour.names import is_name
 from prefixdate.precision import Precision
@@ -8,6 +9,7 @@ from followthemoney import registry, Property, model
 from followthemoney.statement.util import NON_LANG_TYPE_NAMES
 
 from zavod.constants import ORIGIN_INFERRED, ORIGIN_LOOKUP
+from zavod.settings import RUN_TIME
 from zavod.logs import get_logger
 from zavod.runtime.lookups import is_type_lookup_value, prop_lookup
 from zavod.runtime.safety import check_xss_html_smell
@@ -134,6 +136,25 @@ def value_clean(
         if prop_.type == registry.date and clean is not None:
             # none of the information in OpenSanctions is time-critical
             clean = clean[: Precision.DAY.value]
+            if prop_.name == "birthDate":
+                # A birth date in the future is always a parsing error, most
+                # commonly a %y format pivoting a pre-1969 two-digit year
+                # into 20xx.
+                try:
+                    is_future = starts_after(clean, RUN_TIME)
+                except ValueError:
+                    # Not a canonical date (e.g. added with cleaned=True);
+                    # leave it to the validity checks below.
+                    is_future = False
+                if is_future:
+                    log.warning(
+                        f"Rejecting future birth date: {value}",
+                        entity_id=entity.id,
+                        prop=prop_.name,
+                        value=value,
+                        clean=clean,
+                    )
+                    continue
         if clean is not None:
             if len(clean) > prop_.max_length:
                 log.warning(

--- a/zavod/zavod/runtime/cleaning.py
+++ b/zavod/zavod/runtime/cleaning.py
@@ -1,6 +1,7 @@
 import unicodedata
 from typing import TYPE_CHECKING
 from collections.abc import Generator
+from rigour.dates import starts_after
 from rigour.ids import get_identifier_format
 from rigour.names import is_name
 from prefixdate.precision import Precision
@@ -8,6 +9,7 @@ from followthemoney import registry, Property, model
 from followthemoney.statement.util import NON_LANG_TYPE_NAMES
 
 from zavod.constants import ORIGIN_INFERRED, ORIGIN_LOOKUP
+from zavod.settings import RUN_TIME
 from zavod.logs import get_logger
 from zavod.runtime.lookups import is_type_lookup_value, prop_lookup
 from zavod.runtime.safety import check_xss_html_smell
@@ -134,6 +136,23 @@ def value_clean(
         if prop_.type == registry.date and clean is not None:
             # none of the information in OpenSanctions is time-critical
             clean = clean[: Precision.DAY.value]
+            if prop_.name == "birthDate":
+                # A birth date in the future is always a parsing error.
+                try:
+                    is_future = starts_after(clean, RUN_TIME)
+                except ValueError:
+                    # Not a canonical date (e.g. added with cleaned=True);
+                    # leave it to the validity checks below.
+                    is_future = False
+                if is_future:
+                    log.warning(
+                        f"Rejecting future birth date: {value}",
+                        entity_id=entity.id,
+                        prop=prop_.name,
+                        value=value,
+                        clean=clean,
+                    )
+                    continue
         if clean is not None:
             if len(clean) > prop_.max_length:
                 log.warning(

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -114,3 +114,34 @@ def test_apply_date(testdataset1: Dataset):
 def test_backdate():
     assert backdate(datetime(2023, 8, 3), timedelta(days=0)) == "2023-08-03"
     assert backdate(datetime(2023, 8, 3), timedelta(days=182)) == "2023-02-02"
+
+
+def test_apply_date_future_birth_date(testdataset1: Dataset):
+    data = {"id": "doe", "schema": "Person", "properties": {"name": ["John Doe"]}}
+    person = Entity(testdataset1, data)
+
+    # strptime's %y pivot maps 00-68 to 20xx: a 1968 birth date parses into
+    # the future and must not be stored.
+    with capture_logs() as cap_logs:
+        apply_date(person, "birthDate", "16-07-68", formats=("%d-%m-%y",))
+    assert person.get("birthDate") == []
+    assert len(cap_logs) == 1, cap_logs
+    assert cap_logs[0]["prop"] == "birthDate", cap_logs
+
+    # Two-digit years 69-99 pivot to 19xx and are kept.
+    with capture_logs() as cap_logs:
+        apply_date(person, "birthDate", "16-07-71", formats=("%d-%m-%y",))
+    assert "1971-07-16" in person.pop("birthDate")
+    assert cap_logs == [], cap_logs
+
+    # Explicit future dates are rejected too.
+    with capture_logs() as cap_logs:
+        apply_date(person, "birthDate", "2999-01-01")
+    assert person.get("birthDate") == []
+    assert len(cap_logs) == 1, cap_logs
+
+    # The guard applies only to birth dates.
+    with capture_logs() as cap_logs:
+        apply_date(person, "deathDate", "2999-01-01")
+    assert "2999-01-01" in person.pop("deathDate")
+    assert cap_logs == [], cap_logs

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -179,3 +179,34 @@ def test_within_max_age(vcontext: Context):
     # The year before the cutoff year has fully elapsed.
     assert not within_max_age(vcontext, str(cutoff_year - 1))
     assert not within_max_age(vcontext, "1999-01-01")
+
+
+def test_apply_date_future_birth_date(testdataset1: Dataset):
+    data = {"id": "doe", "schema": "Person", "properties": {"name": ["John Doe"]}}
+    person = Entity(testdataset1, data)
+
+    # strptime's %y pivot maps 00-68 to 20xx: a 1968 birth date parses into
+    # the future and must not be stored.
+    with capture_logs() as cap_logs:
+        apply_date(person, "birthDate", "16-07-68", formats=("%d-%m-%y",))
+    assert person.get("birthDate") == []
+    assert len(cap_logs) == 1, cap_logs
+    assert cap_logs[0]["prop"] == "birthDate", cap_logs
+
+    # Two-digit years 69-99 pivot to 19xx and are kept.
+    with capture_logs() as cap_logs:
+        apply_date(person, "birthDate", "16-07-71", formats=("%d-%m-%y",))
+    assert "1971-07-16" in person.pop("birthDate")
+    assert cap_logs == [], cap_logs
+
+    # Explicit future dates are rejected too.
+    with capture_logs() as cap_logs:
+        apply_date(person, "birthDate", "2999-01-01")
+    assert person.get("birthDate") == []
+    assert len(cap_logs) == 1, cap_logs
+
+    # The guard applies only to birth dates.
+    with capture_logs() as cap_logs:
+        apply_date(person, "deathDate", "2999-01-01")
+    assert "2999-01-01" in person.pop("deathDate")
+    assert cap_logs == [], cap_logs

--- a/zavod/zavod/tests/test_entity.py
+++ b/zavod/zavod/tests/test_entity.py
@@ -63,6 +63,23 @@ def test_extra_functions():
     assert entity.to_dict()["properties"]["birthDate"][0] == "1988"
 
 
+def test_future_birth_date_rejected():
+    catalog = get_catalog()
+    test_ds = catalog.make_dataset(TEST_DATASET)
+    entity = Entity(test_ds, {"schema": "Person"})
+    entity.id = "test_entity"
+
+    entity.add("birthDate", "2999-01-01")
+    assert entity.get("birthDate") == []
+
+    entity.add("birthDate", "1988-07-16")
+    assert "1988-07-16" in entity.get("birthDate")
+
+    # The guard applies only to birth dates.
+    entity.add("deathDate", "2999-01-01")
+    assert "2999-01-01" in entity.get("deathDate")
+
+
 def test_target_logic():
     catalog = get_catalog()
     test_ds = catalog.make_dataset(TEST_DATASET)


### PR DESCRIPTION
`strptime`'s `%y` pivot maps two-digit years 00–68 to 20xx, so historical dates near the pivot silently parse into the future: `"16-07-68"` with format `%d-%m-%y` becomes **2068**-07-16, and is stored as a fully valid FtM date. Silently wrong is worse than crashing — this is corrupting production data in `be_fod_sanctions` today, with more datasets configuring `%y` and exposed.

Closes #4930.

## Changes

- `runtime/cleaning.py`: entity property cleaning rejects any `birthDate` value that starts after `RUN_TIME`, with a loud warning. Living in `value_clean` (rather than `h.apply_date`), the guard covers every path that sets a birth date — `apply_date`, direct `entity.add`, enrichment. Non-canonical values skip the check and fall through to the existing validity handling. Uses `starts_after` from `rigour.dates` (rigour 2.2.2).
- `zavod/pyproject.toml`: rigour pinned to 2.2.2.

The datasets currently configuring `%y` formats are inventoried in #4974; the dataset-level fix for `be_fod_sanctions` (explicit century handling in the crawler) is tracked separately in #4940.

🤖 Generated with [Claude Code](https://claude.com/claude-code)