### PR TITLE
Update Chinese sanctions program URLs

### DIFF
--- a/meta/programs/CN-CML.yml
+++ b/meta/programs/CN-CML.yml
@@ -1,7 +1,7 @@
 id: 153
 title: Chinese Counter-Measures List
 key: CN-CML
-url: https://www.gov.cn/zhengce/content/202604/content_7065398.htm
+url: https://xzfg.moj.gov.cn/front/law/detail?LawID=1763
 summary: This list includes individuals and entities subject to counter-measures by
   China in response to foreign sanctions. The measures include asset freezes, prohibitions
   on transactions, and travel bans to protect China's national interests and counteract

--- a/meta/programs/CN-CML.yml
+++ b/meta/programs/CN-CML.yml
@@ -1,7 +1,7 @@
 id: 153
 title: Chinese Counter-Measures List
 key: CN-CML
-url: https://docs.google.com/spreadsheets/d/1DhQqlm2MHv3VpVjEJGstbBWlHV0eBJo-omMwn26TQw4/edit#gid=1070466538
+url: https://www.gov.cn/zhengce/content/202604/content_7065398.htm
 summary: This list includes individuals and entities subject to counter-measures by
   China in response to foreign sanctions. The measures include asset freezes, prohibitions
   on transactions, and travel bans to protect China's national interests and counteract
@@ -9,6 +9,6 @@ summary: This list includes individuals and entities subject to counter-measures
 issuer: cn_npc
 dataset: cn_sanctions
 target_territories:
-- eu
-- gb
-- us
+  - eu
+  - gb
+  - us

--- a/meta/programs/CN-UEL.yml
+++ b/meta/programs/CN-UEL.yml
@@ -1,7 +1,7 @@
 id: 154
 title: Chinese Unreliable Entities List (UEL)
 key: CN-UEL
-url: https://docs.google.com/spreadsheets/d/1DhQqlm2MHv3VpVjEJGstbBWlHV0eBJo-omMwn26TQw4/edit#gid=1070466538
+url: https://english.mofcom.gov.cn/Policies/AnnouncementsOrders/art/2020/art_26e3c471536d443c944d60c91bacaf9a.html
 summary: This list includes foreign entities and individuals deemed unreliable by
   the Chinese government for actions that violate market rules or contractual obligations.
   The measures include restrictions on trade, investment, and other commercial activities


### PR DESCRIPTION
## Summary

- replace the shared Google Sheet link for CN-CML with the official State Council legal instrument
- replace the shared Google Sheet link for CN-UEL with the official MOFCOM provisions
- normalize the MOFCOM URL to HTTPS
- fix existing list indentation in CN-CML so the metadata passes yamllint

## Verification

- confirmed both official URLs resolve and describe the corresponding legal regimes
- loaded and validated all 251 program metadata records
- commit hooks pass, including YAML validation and yamllint