### PR TITLE
[ir_uani_business_registry] Fix withdrawn cross-check assert crashing on marker rows

### DIFF
--- a/datasets/ir/uani_business_registry/crawler.py
+++ b/datasets/ir/uani_business_registry/crawler.py
@@ -149,10 +149,10 @@ def crawl_row(context: Context, row: dict[str, Element]) -> None:
         withdrawn_cell, './/div[contains(@class, "featured")]'
     )
     is_withdrawn = len(withdrawn_marker) > 0
-    # The cell carries text if and only if it holds the withdrawn marker; if the
-    # site renames the marker class, fail here rather than silently re-emitting
-    # withdrawn companies.
-    assert (withdrawn_text is not None) == is_withdrawn, withdrawn_text
+    # Withdrawn status is only conveyed by the empty marker div, never as cell
+    # text; if the cell starts carrying text, the column semantics have changed
+    # and the marker check needs review.
+    assert withdrawn_text is None, withdrawn_text
     if is_withdrawn:
         return
 


### PR DESCRIPTION
Production has been failing since #4918 merged (3 consecutive runs, `AssertionError: None` at `crawl_row`).

The cross-check added there assumed the Withdrawn cell carries text exactly when the marker div is present. On the live site the marker is an empty `<div class="featured"></div>` — the cell never carries text — so the assert crashed on the first withdrawn row of the listing (page 0, "A.P. van den Berg"). This is also why the pre-#4918 code never warned about the column: `audit_data` skips empty values.

The fix keeps the marker-presence check and asserts instead that the cell text is always empty, which still fails loudly if the column ever starts conveying status as text.

Verified against a fresh Zyte fetch of the live listing page 0: all 1,000 data rows parse cleanly — 149 withdrawn (every one would have crashed the old assert), 851 active. `mypy --strict` clean.

Note: the renamed-marker-class scenario #4918 aimed to guard against is not detectable via cell text (there is none); if the class is ever renamed, withdrawn companies would be re-emitted and the `max: 3000` entity assertion is the backstop. A withdrawn-count-must-be-nonzero guard could be added if we want a hard failure there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)