### PR TITLE
[meta] Remap OFAC and DDTC program attributions

### DIFF
--- a/datasets/_wikidata/oligarchs/crawler.py
+++ b/datasets/_wikidata/oligarchs/crawler.py
@@ -6,6 +6,7 @@ from zavod import Context
 from zavod import helpers as h
 
 CAATSA_URL = "https://prod-upp-image-read.ft.com/40911a30-057c-11e8-9650-9c0ad2d7c5b5"
+CAATSA_PROGRAM = "US-CAATSA-241"
 
 
 def crawl_row(context: Context, row: Dict[str, str]) -> None:
@@ -24,6 +25,7 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
         msg = "Mentioned in 2018 CAATSA report on Russian oligarchs"
         entity.add("notes", msg, lang="eng")
         entity.add("sourceUrl", CAATSA_URL)
+        entity.add("programId", CAATSA_PROGRAM)
     # context.inspect(entity)
     context.emit(entity)
 

--- a/datasets/us/ddtc_debarred/crawler.py
+++ b/datasets/us/ddtc_debarred/crawler.py
@@ -7,14 +7,12 @@ from zavod import helpers as h
 
 STATUTORY_XLSX_URL = "https://www.pmddtc.state.gov/sys_attachment.do?sys_id=27c46b251baf29102b6ca932f54bcb20"
 ADMINISTRATIVE_XLSX_URL = "https://www.pmddtc.state.gov/sys_attachment.do?sys_id=9f8bbc2f1b8f29d0c6c3866ae54bcbdb"
-US_DDTC_SD = "US-DDTC-SD"
-US_DDTC_AD = "US-DDTC-AD"
 
 
 def crawl_debarment(
     context: Context,
     row: dict[str, Any],
-    program_key: str,
+    program_name: str,
     name_field: str,
     notice_date_field: str,
 ) -> None:
@@ -41,7 +39,14 @@ def crawl_debarment(
         llm_cleaning=True,
     )
 
-    sanction = h.make_sanction(context, entity, program_key=program_key)
+    # Statutory and administrative debarment are two entry paths into the same
+    # ITAR § 127.7 regime, so both lists map to the US-AECA-DEBARRED program.
+    sanction = h.make_sanction(
+        context,
+        entity,
+        program_name=program_name,
+        program_key="US-AECA-DEBARRED",
+    )
     sanction.add("listingDate", row.pop(notice_date_field))
     sanction.add("listingDate", row.pop("corrected_notice_date", None))
     sanction.add(
@@ -66,10 +71,14 @@ def crawl(context: Context) -> None:
     context.export_resource(path, XLSX, title="Statutory Debarments")
     wb = openpyxl.load_workbook(path, read_only=True)
     for row in h.parse_xlsx_sheet(context, wb.worksheets[0]):
-        crawl_debarment(context, row, US_DDTC_SD, "party_name", "notice_date")
+        crawl_debarment(
+            context, row, "Statutorily Debarred Parties", "party_name", "notice_date"
+        )
 
     path = context.fetch_resource("administrative.xlsx", ADMINISTRATIVE_XLSX_URL)
     context.export_resource(path, XLSX, title="Administrative Debarments")
     wb = openpyxl.load_workbook(path, read_only=True)
     for row in h.parse_xlsx_sheet(context, wb.worksheets[0]):
-        crawl_debarment(context, row, US_DDTC_AD, "name", "date")
+        crawl_debarment(
+            context, row, "Administratively Debarred Parties", "name", "date"
+        )

--- a/datasets/us/ofac/us_ofac_cons.yml
+++ b/datasets/us/ofac/us_ofac_cons.yml
@@ -80,6 +80,11 @@ lookups:
         value: US-NS-PLC
       - match: Sectoral Sanctions Identifications List
         value: US-SSI
+      - match: HKAA
+        # Hong Kong Autonomy Act designations live on the NS-MBS list since
+        # the EO 13936 emergency expired in July 2026; the authority stays
+        # US-HONGKONG.
+        value: US-HONGKONG
   script.lang:
     options:
       # - match: Arab

--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -136,10 +136,13 @@ lookups:
           - BPI-Sudan-14098
           - SUDAN-EO14098
         value: US-DARFUR
-      - match: PAARSSR-EO13894
+      - match:
+          # OFAC groups HRIT-SY (EO 13606) under PAARSS since the 2025
+          # revocation of the country-wide Syria program.
+          - HRIT-SY
+          - PAARSSR-EO13894
         value: US-SYR-REL
       - match:
-          - HRIT-SY
           - SYRIA
           - SYRIA-CAESAR
         value: US-SYR
@@ -191,7 +194,11 @@ lookups:
         value: US-FORINT
       - match: HOSTAGES-EO14078
         value: US-HOSTAGE
-      - match: HK-EO13936
+      - match:
+          # HKAA designations moved to the NS-MBS list when the EO 13936
+          # emergency expired in July 2026; the authority stays US-HONGKONG.
+          - HKAA
+          - HK-EO13936
         value: US-HONGKONG
       - match:
           - FTO

--- a/meta/programs/US-AECA-DEBARRED.yml
+++ b/meta/programs/US-AECA-DEBARRED.yml
@@ -2,12 +2,22 @@ id: 46
 title: AECA Debarred List
 key: US-AECA-DEBARRED
 url: https://www.pmddtc.state.gov/ddtc_public?id=ddtc_kb_article_page&sys_id=c22d1833dbb8d300d0a370131f9619f0
-summary: This list, maintained by the U.S. Department of State under the Arms Export
-  Control Act (AECA), identifies individuals and entities that are debarred from participating
-  in defense exports and services. Debarment is imposed for violations of the AECA
-  and the International Traffic in Arms Regulations (ITAR), aiming to enforce compliance
-  and safeguard U.S. national security interests.
+summary: Identifies persons debarred by the US Department of State from
+  participating, directly or indirectly, in the export of defense articles,
+  defense services, and related technical data regulated under the International
+  Traffic in Arms Regulations. Statutory debarment follows automatically from a
+  conviction for violating or conspiring to violate the Arms Export Control Act,
+  while administrative debarment is imposed through civil enforcement
+  proceedings. Debarred persons are generally ineligible for export licenses and
+  other approvals from the Directorate of Defense Trade Controls.
 issuer: us_state
-dataset: us_trade_csl
+dataset: us_ddtc_debarred
+aliases:
+  - Debarred Parties
+  - Statutorily Debarred Parties
+  - Administratively Debarred Parties
+  - ITAR Debarred (DTC)
+  - AECA Section 38(g)(4)
+  - 22 CFR § 127.7
 measures:
-- Export control
+  - Arms restrictions

--- a/meta/programs/US-CAATSA-241.yml
+++ b/meta/programs/US-CAATSA-241.yml
@@ -1,0 +1,19 @@
+title: CAATSA Section 241 Report on Russian Oligarchs and Parastatal Entities
+key: US-CAATSA-241
+url: https://home.treasury.gov/news/press-releases/sm0271
+summary: >
+  Identifies senior Russian political figures, oligarchs, and parastatal
+  entities in a report submitted by the US Department of the Treasury to Congress
+  under Section 241 of CAATSA. Inclusion is informational: it imposes no sanctions
+  or other restrictions and is not a determination that a person meets the criteria
+  for designation under any sanctions program.
+issuer: us_treasury
+dataset: wd_oligarchs
+aliases:
+  - CAATSA Section 241 Report
+  - Report on Senior Foreign Political Figures and Oligarchs in the Russian
+    Federation
+  - Public Law 115-44, Section 241
+target_territories:
+  - ru
+measures: []

--- a/meta/programs/US-CAATSA.yml
+++ b/meta/programs/US-CAATSA.yml
@@ -1,25 +1,24 @@
 id: 210
-title: US Countering America's Adversaries Through Sanctions Act (CAATSA)
+title: OFAC CAATSA-Related Sanctions
 key: US-CAATSA
 url: https://ofac.treasury.gov/sanctions-programs-and-country-information/countering-americas-adversaries-through-sanctions-act-related-sanctions
-summary: 'On August 2, 2017, the President signed into law the "Countering America’s
-  Adversaries Through Sanctions Act" (Public Law 115-44) (CAATSA), which among other
-  things, imposes new sanctions on Iran, Russia, and North Korea.
-
-
-  The CAATSA-Related Sanctions represent the implementation of multiple legal authorities.
-  Some of these authorities are in the form of executive orders issued by the President.
-  Other authorities are public laws (statutes) passed by The Congress. These authorities
-  are further codified by OFAC in its regulations which are published the in Code
-  of Federal Regulations (CFR). Modifications to these regulations are posted in the
-  Federal Register.
-
-
-  [Source: U.S. DEPARTMENT OF THE TREASURY](https://ofac.treasury.gov/sanctions-programs-and-country-information/countering-americas-adversaries-through-sanctions-act-related-sanctions)'
-issuer: us_treasury
-dataset: wd_oligarchs
+summary: Imposes blocking sanctions on persons connected to Iran's ballistic
+  missile programme or the Islamic Revolutionary Guard Corps, and on specified
+  Russian defence and intelligence actors, sanctions evaders, and persons
+  conducting significant transactions with them. Designated persons have their
+  US assets frozen, and US persons are generally prohibited from dealing with
+  them.
+issuer: us_ofac
+dataset: us_ofac_sdn
 aliases:
-- CAATSA
+  - CAATSA
+  - Countering America's Adversaries Through Sanctions Act of 2017
+  - Public Law 115-44
+  - CAATSA - IRAN
+  - CAATSA - RUSSIA
+  - EO 13849
 target_territories:
-- ir
-- ru
+  - ir
+  - ru
+measures:
+  - Asset freeze

--- a/meta/programs/US-DDTC-AD.yml
+++ b/meta/programs/US-DDTC-AD.yml
@@ -1,12 +1,23 @@
+# DEPRECATED — do not reference. Statutory and administrative ITAR debarments
+# are both recorded under US-AECA-DEBARRED as of July 2026; no crawler emits
+# this key anymore. The file is kept only so the key stays resolvable while
+# published statements age out. Delete it once none remain.
 id: 289
 title: US DDTC Administrative Debarment List
 key: US-DDTC-AD
 url: https://www.pmddtc.state.gov/ddtc_public?id=ddtc_kb_article_page&sys_id=8a89528adb3cd30044f9ff621f961931
-summary: The US Department of State's Directorate of Defense Trade Controls (DDTC)
-  maintains the Administrative Debarment List under 22 CFR Section 127.7(a) of the
-  International Traffic in Arms Regulations (ITAR). This list includes persons subject
-  to administrative debarment. Unlike statutory debarments which result from criminal
-  convictions, administrative debarments are civil enforcement actions that prohibit
-  designated persons from participating in defense trade activities.
+summary: Lists persons administratively debarred by the US Department of State's
+  Directorate of Defense Trade Controls following civil enforcement proceedings
+  for violations of the Arms Export Control Act or the International Traffic in
+  Arms Regulations. Unlike statutory debarment, which follows automatically from
+  a criminal conviction, administrative debarment is imposed by administrative
+  order. Debarred persons are prohibited from participating, directly or
+  indirectly, in the export of defense articles, defense services, and related
+  technical data.
 issuer: us_state
 dataset: us_ddtc_debarred
+aliases:
+  - Administratively Debarred Parties
+  - 22 CFR § 127.7(a)
+measures:
+  - Arms restrictions

--- a/meta/programs/US-DDTC-SD.yml
+++ b/meta/programs/US-DDTC-SD.yml
@@ -1,13 +1,23 @@
+# DEPRECATED — do not reference. Statutory and administrative ITAR debarments
+# are both recorded under US-AECA-DEBARRED as of July 2026; no crawler emits
+# this key anymore. The file is kept only so the key stays resolvable while
+# published statements age out. Delete it once none remain.
 id: 288
 title: US DDTC Statutory Debarment List
 key: US-DDTC-SD
 url: https://www.pmddtc.state.gov/ddtc_public?id=ddtc_kb_article_page&sys_id=7188dac6db3cd30044f9ff621f961914
-summary: The US Department of State's Directorate of Defense Trade Controls (DDTC)
-  maintains the Statutory Debarment List pursuant to Section 38(g)(4) of the Arms
-  Export Control Act (AECA) and Section 127.7 of the International Traffic in Arms
-  Regulations (ITAR). Persons listed have been convicted of violating or conspiracy
-  to violate the AECA, resulting in automatic statutory debarment that prohibits them
-  from participating directly or indirectly in the export of defense articles, technical
-  data, and defense services.
+summary: Lists persons statutorily debarred by the US Department of State
+  following a criminal conviction for violating, or conspiring to violate, the
+  Arms Export Control Act. Debarment is automatic upon conviction and prohibits
+  the person from participating, directly or indirectly, in the export of
+  defense articles, defense services, and related technical data regulated under
+  the International Traffic in Arms Regulations. Reinstatement requires a
+  separate decision by the Department of State.
 issuer: us_state
 dataset: us_ddtc_debarred
+aliases:
+  - Statutorily Debarred Parties
+  - AECA Section 38(g)(4)
+  - 22 CFR § 127.7
+measures:
+  - Arms restrictions


### PR DESCRIPTION
The data-affecting half of the US program-metadata review (#4978 carries the metadata-only half). Everything here changes `programId` values on entities:

- **ITAR debarment consolidation** — `us_ddtc_debarred` emits `US-AECA-DEBARRED` for both the statutory and administrative sheets (one legal regime, 22 CFR § 127.7, two entry paths); the source-list distinction stays on `Sanction:program`. `US-DDTC-SD`/`US-DDTC-AD` are deprecated with a header comment, deletable once published statements age out. Verified by full crawl: 1502 statements on the new key, 0 on the old.
- **CAATSA split** — the § 241 oligarchs report becomes the informational `US-CAATSA-241` (no measures), referenced by `wd_oligarchs`; `US-CAATSA` covers the OFAC designations and points at `us_ofac_sdn`.
- **`HRIT-SY` → `US-SYR-REL`** — OFAC regrouped EO 13606 under PAARSS after revoking the country-wide Syria program (1 affected entry on the live SDN list).
- **`HKAA` → `US-HONGKONG`** — the tag appeared on NS-MBS entries when the EO 13936 emergency expired (July 14, 2026). Mapped to the authority-shaped program per the direction in #4980, in both OFAC lookups.

### Known gap, follow-up on this branch

The cons crawler currently derives the program from the *list name* for non-SDN entries, so the `HKAA` mapping in `us_ofac_cons.yml` does not fire yet — the 39 HKAA entries still get `US-NS-MBS`, and their new `'HKAA Section 6 Information:'` feature is dropped with "Missing feature" warnings. Fixing this properly means letting cons entries use their Program-type `SanctionsMeasure` comment (the slot SDN entries already use), which starts the #4980 migration for the multi-authority lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)