### PR TITLE
Review Canadian sanctions program metadata

### DIFF
--- a/meta/issuers/ca_ised.yml
+++ b/meta/issuers/ca_ised.yml
@@ -1,0 +1,4 @@
+name: Innovation, Science and Economic Development Canada
+acronym: ISED
+organisation: Government of Canada
+territory: ca

--- a/meta/programs/CA-FACFOA-TUN.yml
+++ b/meta/programs/CA-FACFOA-TUN.yml
@@ -2,11 +2,18 @@ id: 145
 title: Freezing Assets of Corrupt Foreign Officials (Tunisia) Regulations (SOR/2011-78)
 key: CA-FACFOA-TUN
 url: https://laws-lois.justice.gc.ca/eng/regulations/SOR-2011-78/index.html
-summary: The Canadian governments maintains a small, Magnitsky-style list of government
-  officials that it alleges to be involved in corruption.
+summary: >
+  Freezes property belonging to politically exposed foreign persons
+  whom Tunisia alleges misappropriated state property or acquired property
+  inappropriately through their office or relationships. Canadians may not deal
+  in that property, facilitate related financial transactions, or provide related
+  financial services.
 issuer: ca_mfa
 dataset: ca_facfoa
 aliases:
-- FAAE
+  - FACFOA Tunisia Regulations
+  - SOR/2011-78
 target_territories:
-- tn
+  - tn
+measures:
+  - Asset freeze

--- a/meta/programs/CA-FACFOA-UKR.yml
+++ b/meta/programs/CA-FACFOA-UKR.yml
@@ -2,11 +2,18 @@ id: 217
 title: Freezing Assets of Corrupt Foreign Officials (Ukraine) Regulations (SOR/2014-44)
 key: CA-FACFOA-UKR
 url: https://laws-lois.justice.gc.ca/eng/regulations/SOR-2014-44/index.html
-summary: The Canadian governments maintains a small, Magnitsky-style list of government
-  officials that it alleges to be involved in corruption.
+summary: >
+  Freezes property belonging to politically exposed foreign persons
+  whom Ukraine alleges misappropriated state property or acquired property
+  inappropriately through their office or relationships. Canadians may not deal
+  in that property, facilitate related financial transactions, or provide related
+  financial services.
 issuer: ca_mfa
 dataset: ca_facfoa
 aliases:
-- FAAE
+  - FACFOA Ukraine Regulations
+  - SOR/2014-44
 target_territories:
-- ua
+  - ua
+measures:
+  - Asset freeze

--- a/meta/programs/CA-JVCFOA.yml
+++ b/meta/programs/CA-JVCFOA.yml
@@ -1,14 +1,19 @@
 id: 3
-title: ' Justice For Victims Of Corrupt Foreign Officials Act'
+title: Justice for Victims of Corrupt Foreign Officials Act
 key: CA-JVCFOA
 url: https://www.international.gc.ca/world-monde/international_relations-relations_internationales/sanctions/victims_corrupt-victimes_corrompus.aspx?lang=eng
-summary: Pursuant to the Justice for Victims of Corrupt Foreign Officials Act, Canada
-  has imposed targeted measures against foreign nationals who are, in the opinion
-  of the Governor in Council, responsible for or complicit in gross violations of
-  human rights; or are public officials or an associate of such an official, who are
-  responsible for or complicit in acts of significant corruption.
+summary: >
+  Targets foreign nationals responsible for or complicit in gross human rights
+  violations or significant corruption, as well as persons who assist such conduct.
+  Canadians may not deal in listed persons' property or make property or related
+  financial services available to them, and listed foreign nationals are inadmissible
+  to Canada.
 issuer: ca_mfa
 dataset: ca_dfatd_sema_sanctions
+aliases:
+  - JVCFOA
+  - Sergei Magnitsky Law
+  - S.C. 2017, c. 21
 measures:
-- Financial restrictions
-- Investment ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/CA-NRO.yml
+++ b/meta/programs/CA-NRO.yml
@@ -1,14 +1,23 @@
 id: 147
-title: Policy On Sensitive Technology Research And Affiliations Of Concern
+title: Named Research Organizations
 key: CA-NRO
 url: https://science.gc.ca/site/science/en/safeguarding-your-research/guidelines-and-tools-implement-research-security/sensitive-technology-research-and-affiliations-concern/named-research-organizations
-summary: A list of universities, research institutes and/or laboratories connected
-  to military, national defence, or state security entities that could pose a risk
-  to Canada’s national security.
-issuer: ca_mfa
+summary: >
+  Identifies universities, research institutes, and laboratories connected to
+  military, national defence, or state security entities that could pose a risk
+  to Canada's national security. Federal grant applications that advance a
+  sensitive technology research area will not be funded if a participating
+  researcher is affiliated with, or receives funding or in-kind support from,
+  a named organization; the list has no independent exclusionary effect outside
+  that policy context.
+issuer: ca_ised
 dataset: ca_named_research_orgs
 aliases:
-- Named Research Organizations
+  - NRO list
+  - Policy on Sensitive Technology Research and Affiliations of Concern
 target_territories:
-- cn
-- ir
+  - cn
+  - ir
+  - ru
+measures:
+  - Debarment

--- a/meta/programs/CA-SEMA.yml
+++ b/meta/programs/CA-SEMA.yml
@@ -1,22 +1,28 @@
 id: 4
-title: Special Economic Measures Act
+title: Sanctions under the Special Economic Measures Act
 key: CA-SEMA
-url: https://www.international.gc.ca/world-monde/international_relations-relations_internationales/sanctions/legislation-lois.aspx?lang=eng
-summary: The purpose of this Act is to enable the Government of Canada to take economic
-  measures against certain persons in circumstances where an international organization
-  of states or association of states of which Canada is a member calls on its members
-  to do so, a grave breach of international peace and security has occurred, gross
-  and systematic human rights violations have been committed in a foreign state or
-  acts of significant corruption involving a national of a foreign state have been
-  committed.
+url: https://laws-lois.justice.gc.ca/eng/acts/S-14.5/FullText.html
+summary: >
+  Covers Canada's autonomous sanctions regulations responding to grave breaches
+  of international peace and security, gross and systematic human rights violations,
+  significant corruption, or calls for economic measures by an international
+  organization of states. Listed persons are generally subject to dealings
+  prohibitions and an asset freeze, while individual regulations also impose
+  country- or sector-specific trade, financial, investment, services, arms, and
+  transportation restrictions. The applicable measures vary by regulation and
+  designation.
 issuer: ca_mfa
 dataset: ca_dfatd_sema_sanctions
+aliases:
+  - SEMA
+  - Special Economic Measures Act
+  - S.C. 1992, c. 17
 measures:
-- Arms restrictions
-- Asset freeze
-- Export control
-- Financial restrictions
-- Import restrictions
-- Investment ban
-- Services ban
-- Transportation restrictions
+  - Arms restrictions
+  - Asset freeze
+  - Export control
+  - Financial restrictions
+  - Import restrictions
+  - Investment ban
+  - Services ban
+  - Transportation restrictions

--- a/meta/programs/CA-UNSC1373.yml
+++ b/meta/programs/CA-UNSC1373.yml
@@ -1,12 +1,18 @@
 id: 313
-title: Canada Counter-Terrorism (Criminal Code) Sanctions Regime
+title: Canada Criminal Code List of Terrorist Entities
 key: CA-UNSC1373
-url: https://laws-lois.justice.gc.ca/eng/acts/A-11.7/index.html
-summary: Canada's Criminal Code terrorist entity list was enacted through the Anti-Terrorism
-  Act of 2001 in response to UN Security Council Resolution 1373, which required all
-  UN Member States to suppress terrorism financing following the September 11 attacks.
-  The Governor in Council may list individuals, groups, trusts, partnerships, funds,
-  or unincorporated organizations that have knowingly carried out, participated in,
-  or facilitated terrorist activities.
+url: https://www.publicsafety.gc.ca/cnt/ntnl-scrt/cntr-trrrsm/lstd-ntts/index-en.aspx
+summary: >
+  Identifies individuals and organizations that knowingly carried out, attempted,
+  participated in, or facilitated terrorist activity, or acted on behalf of such
+  an entity. Listing is not itself a criminal offence, but listed property may be
+  restrained, seized, or forfeited, and financial institutions must not allow a
+  listed entity to access or deal with its property.
 issuer: ca_ps
 dataset: ca_listed_terrorists
+aliases:
+  - Criminal Code section 83.05
+  - UN Security Council Resolution 1373
+  - UNSCR 1373
+measures:
+  - Asset freeze


### PR DESCRIPTION
## Summary

- rewrite the six Canadian program summaries around scope and practical consequences
- correct program measures, aliases, titles, territories, and authoritative URLs
- assign the Named Research Organizations policy to a new ISED issuer
- retain CA-SEMA as an umbrella while documenting that measures vary by regulation and designation

## Validation

- program registry loads 251 programs
- issuer, territory, and controlled-measure validation passes
- repository commit hooks pass