### PR TITLE
Review French sanctions program metadata

### DIFF
--- a/datasets/fr/tresor/fr_tresor_gels_avoir.yml
+++ b/datasets/fr/tresor/fr_tresor_gels_avoir.yml
@@ -62,6 +62,7 @@ lookups:
           - art L. 562-3 du code monétaire et financier
           - art L. 562-2 du code monétaire et financier
           - art L. 562-2-1 du code monétaire et financier
+          - art L. 562-2-2 du code monétaire et financier
         value: "FR-CMF-562"
       - contains: "ONU République démocratique du Congo - RCSNU 1533 (2004) et R (CE) 1183/2005"
         value: UN-SC1533

--- a/meta/issuers/fr_government.yml
+++ b/meta/issuers/fr_government.yml
@@ -1,0 +1,2 @@
+name: Government of France
+territory: fr

--- a/meta/programs/FR-CMF-562.yml
+++ b/meta/programs/FR-CMF-562.yml
@@ -1,12 +1,22 @@
 id: 156
-title: Art L. 562-2 And 562-3 Of The Monetary And Financial Code
+title: French National Asset-Freezing Measures
 key: FR-CMF-562
 url: https://www.tresor.economie.gouv.fr/services-aux-entreprises/sanctions-economiques/registre-national-des-gels-foire-aux-questions
-summary: This program involves the freezing of assets of individuals and entities
-  involved in terrorism, its financing, and other serious crimes. The measures include
-  prohibitions on transactions and asset freezes to prevent the use of funds for illicit
-  activities and enhance national security.
-issuer: fr_dgt
+summary: >
+  Allows France to freeze funds and economic resources owned or controlled by
+  persons and entities involved in terrorism, foreign interference, particularly
+  serious narcotics trafficking, or conduct and designations covered by UN or EU
+  sanctions. The measures also cover entities controlled by, or knowingly acting
+  for, those persons. Persons and organizations within French jurisdiction must
+  apply the freeze without delay and may not make funds or economic resources
+  available to or for the benefit of a designated person.
+issuer: fr_government
 dataset: fr_tresor_gels_avoir
 aliases:
-- Dispositif national de gel des avoirs - art L. 562-2 du code monétaire et financier
+  - Dispositif national de gel des avoirs
+  - Article L. 562-2 du code monétaire et financier
+  - Article L. 562-2-1 du code monétaire et financier
+  - Article L. 562-2-2 du code monétaire et financier
+  - Article L. 562-3 du code monétaire et financier
+measures:
+  - Asset freeze


### PR DESCRIPTION
## Summary

- rewrite the French national asset-freezing program around its statutory scope and practical effect
- cover Articles L. 562-2, L. 562-2-1, L. 562-2-2, and L. 562-3 of the Monetary and Financial Code
- assign the combined program to a French government issuer and add the Asset freeze measure
- recognize the new serious narcotics-trafficking basis under Article L. 562-2-2 in the dataset lookup

## Validation

- direct dataset metadata load passes for fr_tresor_gels_avoir
- program registry resolves FR-CMF-562, its issuer, and its controlled measure
- repository commit hooks pass