### PR TITLE
Make P580 a fallback for Position inceptionDate, not a second source

### DIFF
--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -174,9 +174,6 @@ def wikidata_position(
         if claim.property == "P571":
             claim.text.apply(position, "inceptionDate")
 
-        if claim.property == "P580":
-            claim.text.apply(position, "inceptionDate")
-
         # abolished date:
         if claim.property == "P576":
             claim.text.apply(position, "dissolutionDate")


### PR DESCRIPTION
`wikidata_position` applied both P571 (inception) and P580 (start time) to `inceptionDate` unconditionally in its first claims loop. That made the second-round fallback — `if claim.property == "P580" and not position.has("inceptionDate")` — dead code, and meant start-time values always landed in `inceptionDate` even when the item has a proper inception claim.

This drops the unconditional P580 application from the first loop, so P571 remains the primary source and P580 only fills in when no inception claim exists — which is what the staged two-round structure was clearly written to do.

Verified with `mypy zavod/shed/wikidata/position.py` (clean); there is no existing test coverage for this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)