### PR TITLE
[meta] AU sanctions program metadata review

### DIFF
--- a/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
+++ b/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
@@ -147,10 +147,13 @@ lookups:
         value: UN-SC2713
       - match: "2127 (Central African Republic)"
         value: UN-SC2127
+      # The 751 Committee was renamed the 2713 Committee in December 2023;
+      # legacy committee strings route to the same Somalia program.
       - match:
           - "2093 (2013)"
           - "751 (Somalia and Eritrea)"
-          - "None"
+        value: UN-SC2713
+      - match: "None"
         value: null
       - match:
           - 2048 (Guinea-Bissau)

--- a/datasets/au/listed_terrorist_orgs/au_listed_terrorist_orgs.yml
+++ b/datasets/au/listed_terrorist_orgs/au_listed_terrorist_orgs.yml
@@ -8,7 +8,7 @@ load_statements: true
 summary: >-
   Australia's list of terrorist organisations as listed under the Criminal Code Act 1995
 description: |
-  Under Australia's Criminal Code Act 1995, the Attorney-General may list an organisation as a terrorist organisation if they are satisfied on reasonable grounds that the organisation is directly or indirectly engaged in, preparing, planning, assisting in or fostering the doing of a terrorist act.
+  Under Australia's Criminal Code Act 1995, an organisation may be listed as a terrorist organisation if the minister responsible for the Australian Federal Police (the AFP Minister) is satisfied on reasonable grounds that the organisation is directly or indirectly engaged in, preparing, planning, assisting in or fostering the doing of a terrorist act.
 
   There are two ways in which an organisation is identified as a terrorist organisation:
 

--- a/meta/programs/AU-AFGHANISTAN.yml
+++ b/meta/programs/AU-AFGHANISTAN.yml
@@ -1,15 +1,23 @@
 id: 320
-title: Afghanistan Sanctions Framework
+title: Afghanistan sanctions framework
 key: AU-AFGHANISTAN
 url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/afghanistan-sanctions-framework
-summary: Australia introduced an autonomous sanctions framework in relation to Afghanistan
-  in December 2025. This framework was developed in response to the ongoing oppression
-  of women and girls, minority groups, and the general population in Afghanistan,
-  and the undermining of good governance or the rule of law, since the Taliban claimed
-  authority over the country in August 2021.
+summary: Targets persons and entities involved in the ongoing oppression of women
+  and girls, minority groups, and the general population of Afghanistan, or in
+  undermining good governance or the rule of law, since the Taliban claimed
+  authority over the country in August 2021. The Foreign Minister designates
+  persons and entities for targeted financial sanctions, freezing their assets,
+  and declares persons for travel bans under the Autonomous Sanctions Regulations
+  2011. The framework also imposes an arms embargo on Afghanistan, covering the
+  supply of arms and related military services.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (Afghanistan)
+  - Autonomous Sanctions (Designated Persons and Entities and Declared Persons – Afghanistan) List 2025
+target_territories:
+  - af
 measures:
-- Arms embargo
-- Financial restrictions
-- Travel ban
+  - Arms embargo
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/AU-CRP.yml
+++ b/meta/programs/AU-CRP.yml
@@ -1,12 +1,19 @@
 id: 203
-title: Serious Corruption Sanctions Regime
+title: Serious corruption sanctions framework
 key: AU-CRP
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/serious-corruption-sanctions-regime
-summary: Australia established a thematic autonomous sanctions regime in relation
-  to serious corruption on 21 December 2021. Unlike a country-specific autonomous
-  sanctions regime, a thematic autonomous sanctions regime applies to sanctionable
-  conduct wherever it occurs in the world.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/serious-corruption-sanctions-framework
+summary: Targets persons and entities that have engaged in, been responsible for,
+  or been complicit in serious corruption, defined as bribery or misappropriation
+  of property, wherever in the world the conduct occurs. Designation is reserved
+  for the most egregious situations of international concern. Designated persons
+  and entities are subject to an asset freeze, and declared natural persons are
+  barred from entering or transiting through Australia.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - "Autonomous (Thematic – Corruption)"
 target_territories:
-- zz
+  - zz
+measures:
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/AU-CYB.yml
+++ b/meta/programs/AU-CYB.yml
@@ -1,12 +1,19 @@
 id: 205
-title: Significant Cyber Incidents Sanctions Regime
+title: Significant cyber incidents sanctions framework
 key: AU-CYB
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/significant-cyber-incidents-sanctions-regime
-summary: Australia established a thematic autonomous sanctions regime in relation
-  to significant cyber incidents on 21 December 2021. Unlike a country-specific autonomous
-  sanctions regime, a thematic autonomous sanctions regime applies to sanctionable
-  conduct wherever it occurs in the world.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/significant-cyber-incidents-sanctions-framework
+summary: Targets persons and entities that have caused, attempted to cause, assisted
+  with, or otherwise been complicit in a significant cyber incident, meaning a
+  cyber-enabled event that results in or seeks to cause harm to Australia or another
+  country, wherever in the world the conduct occurs. Designated persons and entities
+  are subject to an asset freeze, and declared natural persons are barred from
+  entering or transiting through Australia.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - "Autonomous (Thematic - Cyber)"
 target_territories:
-- ip
+  - ip
+measures:
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/AU-DPRK.yml
+++ b/meta/programs/AU-DPRK.yml
@@ -1,14 +1,27 @@
 id: 196
-title: Democratic People's Republic Of Korea (North Korea) Sanctions Regime
+title: Democratic People's Republic of Korea (North Korea) sanctions framework
 key: AU-DPRK
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/democratic-peoples-republic-korea-sanctions-regime
-summary: Australia implements the United Nations Security Council (UNSC) related to
-  the Democratic People’s Republic of Korea (DPRK) by incorporating them into Australian
-  law. In addition, since 2006 Australia has imposed autonomous sanctions in relation
-  to the DPRK, which complement the UNSC sanctions. The autonomous sanctions were
-  imposed in response to Australia’s concerns about the nature of the DPRK’s nuclear,
-  weapons of mass destruction (WMD) and proliferation programs.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/democratic-peoples-republic-korea-sanctions-framework
+summary: >
+  Targets the Democratic People's Republic of Korea (DPRK) in response to
+  its nuclear, other weapons of mass destruction, and ballistic missile
+  programs, complementing the UN Security Council sanctions that Australia
+  implements separately. Persons and entities designated by the Foreign
+  Minister are subject to an asset freeze, and declared persons are barred
+  from entering or transiting Australia. The autonomous measures also
+  prohibit providing services to Air Koryo and services or commercial
+  activity relating to the DPRK's extractive industries, and allow vessels
+  linked to the DPRK to be designated and directed away from Australian
+  ports.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (DPRK)
+  - DPRK sanctions framework
 target_territories:
-- kp
+  - kp
+measures:
+  - Asset freeze
+  - Travel ban
+  - Sectoral sanctions
+  - Transportation restrictions

--- a/meta/programs/AU-HUMAN.yml
+++ b/meta/programs/AU-HUMAN.yml
@@ -1,12 +1,21 @@
 id: 204
-title: Serious Violations Or Serious Abuses Of Human Rights Sanctions Regime
+title: Serious violations or serious abuses of human rights sanctions framework
 key: AU-HUMAN
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/serious-violations-or-serious-abuses-human-rights-sanctions-regime
-summary: Australia established a thematic autonomous sanctions regime in relation
-  to serious violations or serious abuses of human rights on 21 December 2021. Unlike
-  a country-specific autonomous sanctions regime, a thematic autonomous sanctions
-  regime applies to sanctionable conduct wherever it occurs in the world.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/serious-violations-or-serious-abuses-human-rights-sanctions-framework
+summary: Targets persons and entities that have engaged in, been responsible for,
+  or been complicit in serious violations or serious abuses of the right to life,
+  the right not to be subjected to torture or cruel, inhuman or degrading treatment,
+  or the right not to be held in slavery or subjected to forced labour, wherever
+  in the world the conduct occurs. Designation is reserved for the most egregious
+  situations of international concern. Designated persons and entities are subject
+  to an asset freeze, and declared natural persons are barred from entering or
+  transiting through Australia.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - "Autonomous (Thematic - Human Rights)"
 target_territories:
-- zz
+  - zz
+measures:
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/AU-IRAN.yml
+++ b/meta/programs/AU-IRAN.yml
@@ -1,11 +1,26 @@
 id: 198
-title: Iran Sanctions Regime
+title: Iran sanctions framework
 key: AU-IRAN
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/iran-sanctions-regime
-summary: Australia imposes autonomous sanctions in relation to Iran, which complement
-  the United Nations Security Council resolutions that Australia incorporates into
-  local law.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/iran-sanctions-framework
+summary: >
+  Targets persons and entities contributing to Iran's nuclear or missile
+  programs, as well as those undermining good governance or the rule of law
+  in Iran, or assisting Iran to threaten the sovereignty or territorial
+  integrity of other countries. Designated persons and entities are subject
+  to an asset freeze, and declared persons are barred from entering or
+  transiting Australia. Country-wide measures prohibit supplying arms and
+  related matériel, as well as certain graphite, metals and
+  industrial-process software, to Iran. These autonomous measures complement
+  the UN Security Council sanctions on Iran, reimposed in September 2025
+  under the Resolution 2231 snapback, which Australia implements separately.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (Iran)
 target_territories:
-- ir
+  - ir
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo
+  - Export control

--- a/meta/programs/AU-LIBYA.yml
+++ b/meta/programs/AU-LIBYA.yml
@@ -1,11 +1,20 @@
 id: 200
-title: Libya Sanctions Regime
+title: Libya sanctions framework
 key: AU-LIBYA
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/libya-sanctions-regime
-summary: Australia imposes autonomous sanctions in relation to Libya, which complement
-  the United Nations Security Council resolutions that Australia incorporates into
-  local law.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/libya-sanctions-framework
+summary: Australia imposes autonomous sanctions in relation to Libya that complement
+  the UN Security Council's Libya sanctions framework. Under the Autonomous
+  Sanctions Regulations 2011, the Foreign Minister designates additional persons
+  and entities associated with the former Qadhafi regime. The assets of designated
+  persons and entities are frozen, and designated persons are prohibited from
+  travelling to or entering Australia.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (Libya)
+  - Autonomous Sanctions (Designated Persons and Entities and Declared Persons – Libya) List 2012
 target_territories:
-- ly
+  - ly
+measures:
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/AU-MYANMAR.yml
+++ b/meta/programs/AU-MYANMAR.yml
@@ -1,12 +1,22 @@
 id: 201
-title: Myanmar Sanctions Regime
+title: Myanmar sanctions framework
 key: AU-MYANMAR
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/myanmar-sanctions-regime
-summary: Australia imposes autonomous sanctions in relation to Myanmar in response
-  to the military's actions undermining democracy and committing human rights abuses.
-  These sanctions were first imposed in 2018 and have been extended in subsequent
-  years to include asset freezes, travel bans, and restrictions on financial services.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/myanmar-sanctions-framework
+summary: >
+  Targets members of Myanmar's military (the Tatmadaw) and military-linked
+  entities in response to serious human rights abuses, including against the
+  Rohingya, and to the February 2021 military coup. Designated persons and
+  entities are subject to an asset freeze, and declared persons are barred
+  from entering or transiting Australia. Australia also imposes a
+  country-wide arms embargo, prohibiting the supply of arms and related
+  matériel to Myanmar and the provision of related services.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (Myanmar)
 target_territories:
-- mm
+  - mm
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo

--- a/meta/programs/AU-RUSSIA.yml
+++ b/meta/programs/AU-RUSSIA.yml
@@ -1,11 +1,36 @@
 id: 202
-title: Russia Sanctions Regime
+title: Russia sanctions framework
 key: AU-RUSSIA
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/russia-sanctions-regime
-summary: Australia imposes autonomous sanctions in relation to Russia in response
-  to the Russian threat to the sovereignty and territorial integrity of Ukraine. They
-  were first imposed in 2014 and extended in 2015, 2022 and 2023.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/russia-sanctions-framework
+summary: >
+  Targets persons and entities of economic or strategic significance to
+  Russia, current or former Russian government ministers and senior
+  officials, and their immediate family members, in response to the Russian
+  threat to the sovereignty and territorial integrity of Ukraine. Designated
+  persons and entities are subject to an asset freeze, and declared persons
+  are barred from entering or transiting Australia. Country-wide measures
+  prohibit supplying arms and related matériel to Russia, exporting
+  aluminium ores, luxury goods, machinery and oil-exploration equipment,
+  importing Russian-origin arms, oil, gas, coal and gold, financing or
+  dealing in the financial instruments of specified Russian banks, military
+  companies and oil companies, and providing related services, including
+  drilling and well-testing services for certain Russian oil projects.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (Russia)
+  - Autonomous Sanctions (Russia, Crimea and Sevastopol) Specification 2015
+  - Autonomous Sanctions (Designated Persons and Entities and Declared
+    Persons – Russia and Ukraine) List 2014
+  - Autonomous Sanctions (Import Sanctioned Goods—Russia) Designation 2022
+  - Autonomous Sanctions (Export Sanctioned Goods—Russia) Designation 2022
 target_territories:
-- ru
+  - ru
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo
+  - Export control
+  - Import restrictions
+  - Financial restrictions
+  - Services ban

--- a/meta/programs/AU-SYRIA.yml
+++ b/meta/programs/AU-SYRIA.yml
@@ -1,13 +1,27 @@
 id: 194
-title: Syria Sanctions Regime
+title: Syria sanctions framework
 key: AU-SYRIA
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/syria-sanctions-regime
-summary: Since 2011, Australia has imposed autonomous sanctions in relation to Syria
-  to reflect Australia’s grave concern at the Syrian regime’s deeply disturbing and
-  unacceptable use of violence against its people. Australia also gives effect to
-  United Nations Security Council (UNSC) Resolution 2199, which prohibits the trade
-  in cultural property that has been illegally removed from Syria.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/syria-sanctions-framework
+summary: >
+  Targets persons and entities that provided support to the former Assad
+  government or are responsible for human rights abuses in Syria, in
+  response to the regime's violent repression of the Syrian population since
+  2011. Designated persons and entities are subject to an asset freeze, and
+  declared persons are barred from entering or transiting Australia.
+  Country-wide measures prohibit supplying arms and related matériel,
+  communications-interception equipment, luxury goods and other listed goods
+  to Syria. In November 2025, Australia eased sanctions on Syria's financial
+  and energy sectors to support the post-Assad transition, while maintaining
+  targeted financial sanctions on former members of the Assad regime.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (Syria)
 target_territories:
-- sy
+  - sy
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo
+  - Export control
+  - Import restrictions

--- a/meta/programs/AU-TERROR.yml
+++ b/meta/programs/AU-TERROR.yml
@@ -1,12 +1,15 @@
 id: 286
 title: Listed Terrorist Organisations
 key: AU-TERROR
-url: https://www.nationalsecurity.gov.au/what-australia-is-doing/terrorist-organisations/protocol-for-listing
-summary: Established under the Criminal Code Act 1995, Australia's regime designates
-  organisations as terrorist entities based on their involvement in terrorist activities.
-  Designations are made through court determinations or formal listings in Regulations,
-  following statutory procedures. The listing process now continues indefinitely,
-  reflecting amendments from the Counter-Terrorism Legislation Amendment (Prohibited
-  Hate Symbols and Other Measures) Act 2023.
+url: https://www.nationalsecurity.gov.au/what-australia-is-doing/terrorist-organisations/listed-terrorist-organisations
+summary: Australia specifies organisations that are directly or indirectly engaged
+  in preparing, planning, assisting in or fostering the doing of a terrorist act as
+  terrorist organisations in regulations under the Criminal Code Act 1995. Listing
+  is a criminal-law proscription rather than a financial sanction, and no asset
+  freeze follows from it. It supports offences including membership of, and training
+  with, funding, supporting or associating with a listed organisation. Listings
+  remain in force indefinitely unless revoked.
 issuer: au_home_affairs
 dataset: au_listed_terrorist_orgs
+aliases:
+  - Criminal Code Act 1995 Division 102

--- a/meta/programs/AU-UKRAINE.yml
+++ b/meta/programs/AU-UKRAINE.yml
@@ -1,26 +1,38 @@
 id: 207
-title: Ukraine Sanctions Regime
+title: Ukraine sanctions framework
 key: AU-UKRAINE
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/ukraine-sanctions-regime
-summary: 'Australia imposes autonomous sanctions in relation to Ukraine in response
-  to the Russian threat to the sovereignty and territorial integrity of Ukraine.
-
-
-  Sanctions listed under this regime may be part of two different regimes: The [Ukraine
-  sanctions regime](https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/ukraine-sanctions-regime)
-  or the [Specified Ukraine regions sanctions regime](https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/specified-ukraine-regions-sanctions-regime).
-  While these are technically different programs, they are not disambiguated in the
-  data provided by the issuer. For this reason, we also consolidate these programs
-  in our database.
-
-  '
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/ukraine-sanctions-framework
+summary: >
+  Targets persons and entities designated in response to the Russian threat
+  to the sovereignty and territorial integrity of Ukraine. Designated
+  persons and entities are subject to an asset freeze, and declared persons
+  are barred from entering or transiting Australia. This program also covers
+  Australia's Specified Ukraine regions sanctions framework, because the
+  DFAT Consolidated List does not distinguish the two frameworks. That
+  framework imposes region-wide measures on Crimea, Sevastopol, Donetsk and
+  Luhansk: a ban on importing goods originating there, export bans on
+  machinery and on goods for infrastructure in the transport,
+  telecommunications and energy sectors, prohibitions on loans, credit and
+  joint ventures relating to that infrastructure or to oil, gas and mineral
+  exploitation, and bans on related services.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (Ukraine)
+  - Specified Ukraine regions sanctions framework
+  - Autonomous Sanctions (Designated Persons and Entities and Declared
+    Persons – Russia and Ukraine) List 2014
+  - Autonomous Sanctions (Export Sanctioned Goods – Specified Ukraine
+    Regions) Designation 2023
 target_territories:
-- ru
-- ua-cri
-- ua-dpr
-- ua-lpr
+  - ru
+  - ua-cri
+  - ua-dpr
+  - ua-lpr
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban
+  - Export control
+  - Import restrictions
+  - Financial restrictions
+  - Investment ban

--- a/meta/programs/AU-UNSC1373.yml
+++ b/meta/programs/AU-UNSC1373.yml
@@ -1,16 +1,20 @@
 id: 281
-title: Australia's Counter-Terrorism (UNSCR 1373) Sanctions Regime
+title: Counter-Terrorism (UNSC 1373) sanctions framework
 key: AU-UNSC1373
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/counter-terrorism-unsc-1373-sanctions-regime
-summary: The United Nations Security Council adopted Resolution 1373 on 28 September
-  2001 in response to the 11 September 2001 terrorist attacks in the United States.
-  The resolution requires Australia, as a UN Member State, to suppress terrorism by
-  implementing targeted financial sanctions against entities involved in terrorist
-  activities. Australia implements these UNSC obligations by incorporating them into
-  Australian law.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/counter-terrorism-unsc-1373-sanctions-framework
+summary: Implements UN Security Council Resolution 1373 (2001), which requires member
+  states to suppress terrorism by applying targeted financial sanctions to persons
+  involved in terrorist activities. Australia's Foreign Minister designates persons
+  and entities who commit, attempt to commit, participate in or facilitate terrorist
+  acts under the Charter of the United Nations Act 1945. The assets of designated
+  persons and entities are frozen, and it is prohibited to make assets available to
+  them.
 issuer: au_dfat
 dataset: au_dfat_sanctions
 aliases:
-- Resolution 1373
+  - Resolution 1373
+  - "1373 (2001)"
+  - Charter of the United Nations (Dealing with Assets) Regulations 2008
+  - Charter of the United Nations (Listed Persons and Entities) Instrument 2022
 measures:
-- Asset freeze
+  - Asset freeze

--- a/meta/programs/AU-VESSELS.yml
+++ b/meta/programs/AU-VESSELS.yml
@@ -1,10 +1,17 @@
 id: 318
-title: Sanctioned Vessels Regime
+title: Sanctioned vessels framework
 key: AU-VESSELS
 url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctioned-vessels-framework
-summary: Australia has imposed sanctions on vessels in response to situations of international
-  concern, including in response to Russia's invasion of Ukraine and to increase pressure
-  on the Democratic People's Republic of Korea (DPRK) to comply with its nonproliferation
-  obligations.
+summary: Covers vessels designated as sanctioned vessels under Australia's autonomous
+  sanctions law in response to situations of international concern, including
+  Russia's invasion of Ukraine and the DPRK's non-compliance with its nonproliferation
+  obligations; vessels flagged to or registered in the DPRK are designated as a
+  class. A sanctioned vessel may be directed to leave Australia by a designated
+  route or barred from entering Australian ports, and a vessel that fails to comply
+  with such a direction is forfeited to the Commonwealth.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - "Autonomous (Vessels)"
+measures:
+  - Transportation restrictions

--- a/meta/programs/AU-YUGO.yml
+++ b/meta/programs/AU-YUGO.yml
@@ -1,12 +1,23 @@
 id: 197
-title: Former Federal Republic Of Yugoslavia Sanctions Regime
+title: Former Federal Republic of Yugoslavia sanctions framework
 key: AU-YUGO
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/former-federal-republic-yugoslavia-sanctions-regime
-summary: Australia imposes autonomous sanctions in relation to the Former Federal
-  Republic of Yugoslavia (FFRY) which target persons associated with the former Milosevic
-  regime, and persons indicted for or suspected of committing war crimes during the
-  Balkan wars in the early 1990s. Sanctions have been in place since 1992.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/former-federal-republic-yugoslavia-sanctions-framework
+summary: >
+  Targets persons associated with the former Milosevic regime and persons
+  indicted for or suspected of committing war crimes during the Balkan wars
+  of the early 1990s. Australia has maintained autonomous sanctions in
+  relation to the Former Federal Republic of Yugoslavia (FFRY) since 1992.
+  Designated persons are subject to an asset freeze and are barred from
+  travelling to, entering or remaining in Australia.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (FFRY)
+  - FFRY sanctions framework
+  - Autonomous Sanctions (Designated and Declared Persons – Former Federal
+    Republic of Yugoslavia) List 2012
 target_territories:
-- yucs
+  - yucs
+measures:
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/AU-ZIM.yml
+++ b/meta/programs/AU-ZIM.yml
@@ -1,11 +1,23 @@
 id: 208
-title: Zimbabwe Sanctions Regime
+title: Zimbabwe sanctions framework
 key: AU-ZIM
-url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/zimbabwe-sanctions-regime
-summary: Australia imposed autonomous sanctions in relation to Zimbabwe in 2002, reflecting
-  concerns about political violence and human rights violations. The sanctions were
-  adjusted in 2012 and 2013 in response to some progress.
+url: https://www.dfat.gov.au/international-relations/security/sanctions/sanctions-regimes/zimbabwe-sanctions-framework
+summary: >
+  Targets persons and entities engaging in, or that have engaged in,
+  activities that seriously undermine democracy, respect for human rights
+  and the rule of law in Zimbabwe. Designated persons and entities are
+  subject to an asset freeze, and designated persons are barred from
+  entering or transiting Australia. Australia also imposes a country-wide
+  arms embargo, prohibiting the supply of arms and related matériel to
+  Zimbabwe and the provision of related military services.
 issuer: au_dfat
 dataset: au_dfat_sanctions
+aliases:
+  - Autonomous (Zimbabwe)
+  - Autonomous Sanctions (Designated and Declared Persons – Zimbabwe) List 2012
 target_territories:
-- zw
+  - zw
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo


### PR DESCRIPTION
Systematic review of all 16 AU program files against the conventions in `meta/README.md`, done with parallel research agents verifying against DFAT framework pages (live browser where possible — dfat.gov.au blocks non-browser clients — cross-checked with Wayback captures) and the Federal Register of Legislation.

## Metadata review

- **URLs and titles**: DFAT renamed every "sanctions regime" page to "sanctions framework" in 2025; all stale slugs updated and titles aligned with DFAT's current framework names (spot-verified live in Chrome). AU-TERROR's URL moved from a near-empty protocol stub to Home Affairs' current list of the 31 proscribed organisations.
- **Summaries**: chronology boilerplate replaced with targeting basis and consequences. Substantive staleness fixed: AU-SYRIA now reflects the November 2025 easing of financial/energy measures (targeted sanctions on former Assad-regime figures retained); AU-MYANMAR's wrong "first imposed in 2018" claim corrected.
- **Measures** (previously empty on 13 of 16 files): populated from DFAT's per-framework measure tables, deliberately claiming only the *autonomous* column — UN-derived designations route to shared UN-SC\* keys and their measures stay there (e.g. AU-DPRK claims the extractives sectoral ban and vessel/Air Koryo transport restrictions, not the UNSC trade embargo). AU-AFGHANISTAN's `Financial restrictions` corrected to `Asset freeze`; AU-VESSELS records `Transportation restrictions` (port directions/forfeiture — its actual consequence); AU-TERROR honestly carries no measures, since Criminal Code Division 102 proscription creates criminal offences rather than sanctions.
- **Aliases**: exact DFAT Consolidated List regime strings ("Autonomous (Russia)", "Autonomous (Thematic – Corruption)" incl. the en-dash variant), the operative designation instruments (e.g. "Autonomous Sanctions (Russia, Crimea and Sevastopol) Specification 2015"), and COTUNA instruments for the 1373 program.
- AU-AFGHANISTAN gains `target_territories: af` (the only country program missing its code).
- **Lookup fix**: legacy Somalia committee strings ("751 (Somalia and Eritrea)", "2093 (2013)") now route to UN-SC2713 (the 751 Committee's successor) instead of silently mapping to null.

## Consistency assessment vs Australian sanctions policy

Coverage is complete: every framework on DFAT's current list and every regime string in the July 2026 Consolidated List resolves to a program key, in a clean two-track structure (Autonomous → AU-\*, UNSC committees → UN-SC\*, no mixing). AU-UNSC1373 follows the established country-prefix pattern for national 1373 lists; AU-VESSELS is a real standalone DFAT framework with distinct legal machinery; no AU key is orphaned or revoked (FFRY and Zimbabwe both verified still live).

## Flags for follow-up (not changed here)

- **Latent Lebanon gap**: DFAT has a Lebanon framework page but zero Consolidated List entries; `UN-SC1636.yml` exists but is unreferenced by the AU lookup. Same fragility class as the UK's dormant regimes — a first designation would only produce a crawler warning.
- No WMD thematic framework exists despite the 2021 Magnitsky-style amendments creating the ground — watch item, no key needed today.
- `au_listed_terrorist_orgs` dataset description still attributes listings to the Attorney-General; post-2023 machinery-of-government change moved this to the AFP Minister.
- AU-UNSC1373 could arguably carry `target_territories: zz` (worldwide thematic reach); left for a cross-country consistency decision with the other national 1373 programs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)