### PR TITLE
Adopt claim end-date semantics from the nomenklatura wikidata fixes

### DIFF
--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -18,7 +18,7 @@ from zavod.shed.wikidata.position import (
 )
 from zavod.stateful.positions import categorised_position_qids
 
-from zavod import Context, Entity
+from zavod import Context, Entity, settings
 from zavod import helpers as h
 
 URL = "https://petscan.wmcloud.org/"
@@ -48,7 +48,10 @@ class CrawlState(object):
     def __init__(self, context: Context):
         self.context = context
         self.client = WikidataClient(
-            context.cache, session=context.http, cache_days=WIKIDATA_CACHE_DAYS
+            context.cache,
+            session=context.http,
+            cache_days=WIKIDATA_CACHE_DAYS,
+            reference_time=settings.RUN_TIME,
         )
         self.log = context.log
         self.ignore_positions: Set[str] = set()

--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -6,7 +6,7 @@ from rigour.ids.wikidata import is_qid
 from rigour.territories import get_territories, get_territory_by_qid
 from nomenklatura.wikidata import WikidataClient, SparqlBinding
 
-from zavod import Context
+from zavod import Context, settings
 from zavod.entity import Entity
 from zavod.shed.wikidata.human import wikidata_basic_human
 from zavod.shed.wikidata.position import wikidata_occupancy, wikidata_position
@@ -215,7 +215,12 @@ def crawl(context: Context) -> None:
     # return
     seen_positions: Set[str] = set()
     cache_days = context.dataset.config.get("cache_days", 14)
-    client = WikidataClient(context.cache, context.http, cache_days=cache_days)
+    client = WikidataClient(
+        context.cache,
+        context.http,
+        cache_days=cache_days,
+        reference_time=settings.RUN_TIME,
+    )
     position_classes = query_position_classes(context, client)
     for country in all_countries():
         context.log.info(f"Crawling country: {country.qid} ({country.label})")

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -18,9 +18,9 @@ classifiers = [
 requires-python = ">= 3.12"
 dependencies = [
     "followthemoney == 4.10.0",
-    "nomenklatura == 4.11.4",
+    "nomenklatura == 4.12.0",
     "plyvel == 1.5.1", # Also update macOS install docs
-    "rigour == 2.2.2",
+    "rigour == 2.2.3",
     "datapatch >= 1.2.4, < 1.3",
     "banal >= 1.1.2, < 2.0",
     "certifi",

--- a/zavod/zavod/shed/wikidata/country.py
+++ b/zavod/zavod/shed/wikidata/country.py
@@ -45,7 +45,7 @@ def _crawl_item_countries(
     for claim in item.claims:
         # country:
         if claim.property in ("P17", "P27"):
-            if claim.qualifiers.get("P582"):
+            if claim.is_ended():
                 continue
             if claim.qid is None or claim.qid in next_seen:
                 continue
@@ -58,7 +58,7 @@ def _crawl_item_countries(
         for claim in item.claims:
             if claim.property != prop:
                 continue
-            if claim.qualifiers.get("P582") or claim.qid is None:
+            if claim.is_ended() or claim.qid is None:
                 continue
             if claim.qid in next_seen:
                 continue

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -174,9 +174,6 @@ def wikidata_position(
         if claim.property == "P571":
             claim.text.apply(position, "inceptionDate")
 
-        if claim.property == "P580":
-            claim.text.apply(position, "inceptionDate")
-
         # abolished date:
         if claim.property == "P576":
             claim.text.apply(position, "dissolutionDate")


### PR DESCRIPTION
Downstream companion to the nomenklatura wikidata PR stack (opensanctions/nomenklatura#335 → #336 → #337). Draft until those merge and a nomenklatura release exists — zavod pins `nomenklatura == 4.11.4` exactly, so this needs the pin bumped to the release carrying `Claim.is_ended()` and `WikidataClient.reference_time` before CI can go green.

Changes:

- **`zavod/shed/wikidata/country.py`**: `_crawl_item_countries` skipped "ended" country claims by raw P582 qualifier presence, which misreads a "no value" end time — Wikidata's explicit assertion that a claim is *current* — as ended, wrongly pruning countries during traversal. Both checks now use `claim.is_ended()`, which discriminates snak types (novalue = current, somevalue = ended) and evaluates dated ends as spans, so scheduled future ends and current-period imprecise ends no longer count as ended either.

- **`datasets/_wikidata/peps/crawler.py`**, **`datasets/_wikidata/categories/crawler.py`**: both crawlers construct their `WikidataClient` with `reference_time=settings.RUN_TIME`, so everything in a crawl — type pruning via `item.types`, country traversal — resolves "ended" against the pinned run time rather than the wall clock.

- **`zavod/shed/wikidata/position.py`** (folded in from #4986): `wikidata_position` applied both P571 (inception) and P580 (start time) to `inceptionDate` unconditionally in its first claims loop, making the second-round fallback guard dead code. P571 stays the primary source; P580 only fills in when no inception claim exists. This part has no nomenklatura dependency.

Not included: the upstream behavior changes that flow in automatically via the nomenklatura release (transient API errors raising `WikidataAPIError` instead of being cached as missing items, deprecated-rank claims filtered out of `item.claims`). Note the loud-failure semantics from opensanctions/nomenklatura#335: a persistent Wikidata API outage now aborts a crawl run instead of silently dropping entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)