### PR TITLE
[us_ofac] Fix Hong Kong program attribution

### DIFF
--- a/datasets/us/ofac/ofac_advanced.py
+++ b/datasets/us/ofac/ofac_advanced.py
@@ -576,6 +576,9 @@ def emit_sanctions_entry(
     # HKAA entries are published on the multi-authority NS-MBS list. Use the
     # source program tag for their program ID without changing how other
     # consolidated-list entries are attributed.
+    # TODO(#4980): other CONS entries (SSI/CMIC/NS-PLC/NS-MBS) also carry Program-type
+    # source tags (e.g. RUSSIA-EO14024, CMIC-EO13959) but stay attributed to their list
+    # program. Generalize to prefer a resolvable source tag and drop this HKAA special case.
     program_lookup_key = "HKAA" if source_program == "HKAA" else program
     # For us_ofac_sdn, only process entries with list_id 'SDN List'
     if dataset == "us_ofac_sdn" and list_id != "SDN List":

--- a/datasets/us/ofac/ofac_advanced.py
+++ b/datasets/us/ofac/ofac_advanced.py
@@ -65,6 +65,7 @@ SANCTION_FEATURES = {
     # https://www.ecfr.gov/current/title-31/part-594/section-594.201
     # "affiliates of the IRGC are identified by a special reference to the “IRGC” at the end of their entries"
     "Additional Program Tags -": "program",
+    "HKAA Section 6 Information:": "summary",
     "Secondary sanctions risk:": "summary",
     "Transactions Prohibited For Persons Owned or Controlled By U.S. Financial Institutions:": "summary",  # noqa
     "IFCA Determination -": "summary",
@@ -542,18 +543,8 @@ def parse_id_reg_document(
         context.emit(identification)
 
 
-def extract_sdn_sanctions_measure_name(entry: Element, refs: Element) -> Optional[str]:
-    """
-    Extracts the program name associated with a sanctions entry on the SDN List.
-
-    Returns:
-        A string representing the program name (e.g., "IRAN-EO13876")
-    """
-    list_name = get_ref_text(refs, "List", entry.get("ListID"))
-    assert list_name == "SDN List"
-
-    # The SDN List may include multiple SanctionsMeasures, and the actual program name is inside
-    # the <Comment> tag of a <SanctionsMeasure> element where SanctionsTypeID resolves to "Program".
+def extract_sanctions_measure_name(entry: Element, refs: Element) -> Optional[str]:
+    """Extract the source program tag from a sanctions entry."""
     for measure in entry.findall("./SanctionsMeasure"):
         sanctions_type_id = measure.get("SanctionsTypeID")
         sanctions_type = get_ref_text(refs, "SanctionsType", sanctions_type_id)
@@ -580,11 +571,12 @@ def emit_sanctions_entry(
     list_id = get_ref_text(refs, "List", entry.get("ListID"))
     # For entries on the SDN list, the XML contains a more specific sanctions program designation
     # For the various lists that are part of the Consolidated List, we use the list name as the program.
-    program = (
-        extract_sdn_sanctions_measure_name(entry, refs)
-        if list_id == "SDN List"
-        else list_id
-    )
+    source_program = extract_sanctions_measure_name(entry, refs)
+    program = source_program if list_id == "SDN List" else list_id
+    # HKAA entries are published on the multi-authority NS-MBS list. Use the
+    # source program tag for their program ID without changing how other
+    # consolidated-list entries are attributed.
+    program_lookup_key = "HKAA" if source_program == "HKAA" else program
     # For us_ofac_sdn, only process entries with list_id 'SDN List'
     if dataset == "us_ofac_sdn" and list_id != "SDN List":
         return None
@@ -604,11 +596,13 @@ def emit_sanctions_entry(
         proxy,
         key=entry.get("ID"),
         program_name=program,
-        source_program_key=program,
+        source_program_key=program_lookup_key,
         # For entries on the SDN list, the XML contains a more specific sanctions program designation
         # For the various lists that are part of the Consolidated List, we use the list name as the program.
         program_key=(
-            h.lookup_sanction_program_key(context, program) if program else None
+            h.lookup_sanction_program_key(context, program_lookup_key)
+            if program_lookup_key
+            else None
         ),
     )
     sanction.set("authorityId", entry.get("ProfileID"))

--- a/datasets/us/ofac/us_ofac_cons.yml
+++ b/datasets/us/ofac/us_ofac_cons.yml
@@ -80,6 +80,8 @@ lookups:
         value: US-NS-PLC
       - match: Sectoral Sanctions Identifications List
         value: US-SSI
+      - match: HKAA
+        value: US-HONGKONG
   script.lang:
     options:
       # - match: Arab

--- a/datasets/us/ofac/us_ofac_cons.yml
+++ b/datasets/us/ofac/us_ofac_cons.yml
@@ -81,6 +81,8 @@ lookups:
       - match: Sectoral Sanctions Identifications List
         value: US-SSI
       - match: HKAA
+        # Hong Kong Autonomy Act designations moved to the NS-MBS list when the
+        # EO 13936 national emergency expired in July 2026; the authority stays US-HONGKONG.
         value: US-HONGKONG
   script.lang:
     options:

--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -191,7 +191,9 @@ lookups:
         value: US-FORINT
       - match: HOSTAGES-EO14078
         value: US-HOSTAGE
-      - match: HK-EO13936
+      - match:
+          - HKAA
+          - HK-EO13936
         value: US-HONGKONG
       - match:
           - FTO
@@ -467,6 +469,7 @@ lookups:
           - "PAIPA Section 2 Information:"
           - "Additional Sanctions Information -"
           - "Additional Program Tags -"
+          - "HKAA Section 6 Information:"
           - "Secondary sanctions risk:"
           - "Transactions Prohibited For Persons Owned or Controlled By U.S. Financial Institutions:"
           - Effective Date (CMIC)

--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -192,6 +192,8 @@ lookups:
       - match: HOSTAGES-EO14078
         value: US-HOSTAGE
       - match:
+          # HKAA designations moved to the NS-MBS list when the EO 13936 national
+          # emergency expired in July 2026; the authority stays US-HONGKONG.
           - HKAA
           - HK-EO13936
         value: US-HONGKONG


### PR DESCRIPTION
## Summary

OFAC moved 39 Hong Kong Autonomy Act designations onto the Non-SDN Menu-Based Sanctions List after the EO 13936 emergency expired. The advanced XML identifies these entries with the source program tag `HKAA`, while the crawler currently attributes all CONS entries using only their list name. This assigned the generic `US-NS-MBS` program and produced 39 warnings for the new `HKAA Section 6 Information:` feature.

This change:

- extracts the Program-type sanctions measure for both SDN and CONS entries;
- uses `HKAA` as the program lookup key only when that exact source tag is present, while retaining `Non-SDN Menu-Based Sanctions List` as `Sanction:program`;
- maps `HKAA` to `US-HONGKONG` in both OFAC dataset configurations;
- treats `HKAA Section 6 Information:` as a sanction summary and registers it in the shared feature allowlist.

The special case deliberately avoids changing the attribution model for other multi-authority CONS entries. It is the Hong Kong-only subset of the broader program work in #4981.

## Validation

Both datasets were crawled in full using the current OFAC advanced XML sources. Both completed with zero issues.

### SDN

Compared the local output with production archive `20260720081029-iyc` using `ftm-stmt diff`:

- 698,331 statements parsed on each side;
- 0 statements added;
- 0 statements removed.

The additional `HKAA` lookup therefore has no effect on the current SDN output.

### CONS

Compared the local output with production archive `20260720063501-jnm` using `ftm-stmt diff`:

- exactly 39 source entries are tagged `HKAA`;
- exactly those 39 persons and their 39 linked sanctions change;
- 117 statements are removed and 156 are added.

For each of the 39 records, the complete diff is:

- Person `programId`: `US-NS-MBS` -> `US-HONGKONG`;
- Sanction `programId`: `US-NS-MBS` -> `US-HONGKONG`, with original value `HKAA`;
- Sanction `programUrl`: generic NS-MBS page -> Hong Kong program page;
- one `HKAA Section 6 Information` sanction summary added.

No `Sanction:program` statements change. All 39 sanction `authorityId` values were checked against the corresponding changed person IDs.

The source also contains 12 non-HKAA NS-MBS records across five other program tags. All 12 retain `US-NS-MBS`, none gain `US-HONGKONG`, and none appear in the production diff.

## Checks

- full `us_ofac_cons` crawl: passed, zero issues;
- full `us_ofac_sdn` crawl: passed, zero issues;
- `ftm-stmt` production comparisons: passed;
- exact statement-shape and source-membership assertions: passed;
- Ruff and formatting: passed;
- YAML lint and dataset mypy checks: passed;
- `git diff --check`: passed.

Issue: https://www.opensanctions.org/issues/us_ofac_cons/