### PR TITLE
[jp_mof_sanctions] Convert _x000D_ carriage-return artifacts to newlines

### DIFF
--- a/datasets/jp/mof_sanctions/crawler.py
+++ b/datasets/jp/mof_sanctions/crawler.py
@@ -59,7 +59,14 @@ def str_cell(cell: Cell | MergedCell) -> str | None:
         return value.isoformat()
     if isinstance(value, bool):
         return str(value).lower()
-    return stringify(value)
+    text = stringify(value)
+    if text is None:
+        return None
+    # `_x000D_` is the OOXML escape for a carriage return (0x0D). openpyxl surfaces
+    # it verbatim instead of un-escaping it, so cells with in-cell line breaks arrive
+    # carrying the literal artifact. Turn it back into a newline so the `\n` token in
+    # SPLITS separates multi-value cells cleanly (rather than leaving it in the text).
+    return text.replace("_x000D_", "\n")
 
 
 def parse_date(text: List[str]) -> List[str]:
@@ -207,8 +214,8 @@ def emit_row(
         suggested=suggested,
         is_irregular=is_irregular,
         # Only auto-accept clean names. Names still flagged as irregular (e.g. ones that
-        # contain brackets, colons or an _x000D_ carriage-return artifact) are held back
-        # for human review instead of being locked in as accepted. The weak_alias and
+        # contain brackets or colons) are held back for human review instead of being
+        # locked in as accepted. The weak_alias and
         # nickname fields often hold notes/descriptions rather than names, so they are
         # held back too.
         default_accepted=not is_irregular and not (raw_weak_alias or raw_nickname),


### PR DESCRIPTION
`_x000D_` is the OOXML escape for a carriage return (0x0D). openpyxl surfaces it
verbatim instead of un-escaping it, so cells with in-cell line breaks were dragging
the literal artifact into names, addresses, notes and other fields.

Fix in `str_cell`: replace `_x000D_` with a newline so the existing `\n` token in
SPLITS separates multi-value cells cleanly (rather than dfat's approach of deleting
it and smushing values together).

Verified against a live crawl: `_x000D_` occurrences in statements.pack go 171 → 0,
and multi-value cells like `NAME_x000D_\n<arabic>` now split into separate name values.

Note: this re-keys some entities, since `make_id` derives from the name cells we're
now cleaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)