### PR TITLE
[meta] EU sanctions program metadata review

### DIFF
--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -101,9 +101,10 @@ lookups:
       # Belarus
       - match: BLR # implementing Article 8a of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus
         value: EU-BLR
-      # Bosnia & Herzegovina
-      - match:
-        value: EU-BOSNIA
+      # Bosnia & Herzegovina: EU-BOSNIA is an empty framework (no designations
+      # to date) and has no FSF programme code; activate a mapping here when a
+      # first designation appears.
+      # - value: EU-BOSNIA
       # Burundi
       - match: BDI # implementing Regulation (EU) 2015/1755 concerning restrictive measures in view of the situation in Burundi
         value: EU-BDI
@@ -145,9 +146,10 @@ lookups:
       # Iraq
       - match: IRQ
         value: EU-IRQ
-      # Lebanon
-      - match:
-        value: EU-LEBANON
+      # Lebanon: EU-LEBANON is an empty framework (no designations to date)
+      # and has no FSF programme code; activate a mapping here when a first
+      # designation appears.
+      # - value: EU-LEBANON
       # Libya
       - match: LBY # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
         value: EU-LBY
@@ -163,9 +165,10 @@ lookups:
       # Nicaragua
       - match: NIC # implementing Regulation (EU) 2019/1716 concerning restrictive measures in view of the situation in Nicaragua
         value: EU-NIC
-      # Niger
-      - match:
-        value: EU-NIGER
+      # Niger: EU-NIGER is an empty framework (no designations to date) and
+      # has no FSF programme code; activate a mapping here when a first
+      # designation appears.
+      # - value: EU-NIGER
       # Russia
       - match: RUS # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
         value: EU-RUS
@@ -203,9 +206,9 @@ lookups:
       # Ukraine
       - match: UKR
         value: EU-UKR
-      # United States
-      - match:
-        value: EU-US-LEG
+      # United States: EU-US-LEG is the Blocking Statute, which lists US laws
+      # rather than designating persons, so no FSF programme code exists.
+      # - value: EU-US-LEG
       # Venezuela
       - match: VEN # implementing Regulation (EU) 2017/2063 concerning restrictive measures in view of the situation in Venezuela
         value: EU-VEN

--- a/datasets/eu/fsf/eu_fsf.yml
+++ b/datasets/eu/fsf/eu_fsf.yml
@@ -119,9 +119,10 @@ lookups:
       # Belarus
       - match: BLR # implementing Article 8a of Regulation (EC) No 765/2006 concerning restrictive measures in view of the situation in Belarus
         value: EU-BLR
-      # Bosnia & Herzegovina
-      - match:
-        value: EU-BOSNIA
+      # Bosnia & Herzegovina: EU-BOSNIA is an empty framework (no designations
+      # to date) and has no FSF programme code; activate a mapping here when a
+      # first designation appears.
+      # - value: EU-BOSNIA
       # Burundi
       - match: BDI # implementing Regulation (EU) 2015/1755 concerning restrictive measures in view of the situation in Burundi
         value: EU-BDI
@@ -163,9 +164,10 @@ lookups:
       # Iraq
       - match: IRQ
         value: EU-IRQ
-      # Lebanon
-      - match:
-        value: EU-LEBANON
+      # Lebanon: EU-LEBANON is an empty framework (no designations to date)
+      # and has no FSF programme code; activate a mapping here when a first
+      # designation appears.
+      # - value: EU-LEBANON
       # Libya
       - match: LBY # implementing Article 21(5) of Regulation (EU) 2016/44 concerning restrictive measures in view of the situation in Libya
         value: EU-LBY
@@ -181,9 +183,10 @@ lookups:
       # Nicaragua
       - match: NIC # implementing Regulation (EU) 2019/1716 concerning restrictive measures in view of the situation in Nicaragua
         value: EU-NIC
-      # Niger
-      - match:
-        value: EU-NIGER
+      # Niger: EU-NIGER is an empty framework (no designations to date) and
+      # has no FSF programme code; activate a mapping here when a first
+      # designation appears.
+      # - value: EU-NIGER
       # Russia
       - match: RUS # implementing Regulation (EU) 2024/1485 concerning restrictive measures in view of the situation in Russia
         value: EU-RUS
@@ -221,9 +224,9 @@ lookups:
       # Ukraine
       - match: UKR
         value: EU-UKR
-      # United States
-      - match:
-        value: EU-US-LEG
+      # United States: EU-US-LEG is the Blocking Statute, which lists US laws
+      # rather than designating persons, so no FSF programme code exists.
+      # - value: EU-US-LEG
       # Venezuela
       - match: VEN # implementing Regulation (EU) 2017/2063 concerning restrictive measures in view of the situation in Venezuela
         value: EU-VEN

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -173,7 +173,11 @@ lookups:
           - 2018/1542
           - 2018/1544
         value: EU-CHEM
-      - match: 881/2002
+      - match:
+          - 881/2002
+          # autonomous ISIL/Al-Qaida track of the same program
+          - 2016/1686
+          - 2016/1693
         value: EU-TAQA-EUAQ
       - match: 2022/2319
         value: EU-HTI
@@ -194,6 +198,9 @@ lookups:
       - match:
           - 2001/931
           - 2580/2001
+          # Decision (CFSP) 2026/455 replaced the operative articles of
+          # Common Position 2001/931 in February 2026
+          - 2026/455
         value: EU-TERR
       - match: 1210/2003
         value: EU-IRQ

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -188,7 +188,11 @@ lookups:
           - 2018/1542
           - 2018/1544
         value: EU-CHEM
-      - match: 881/2002
+      - match:
+          - 881/2002
+          # autonomous ISIL/Al-Qaida track of the same program
+          - 2016/1686
+          - 2016/1693
         value: EU-TAQA-EUAQ
       - match: 2022/2319
         value: EU-HTI
@@ -209,6 +213,9 @@ lookups:
       - match:
           - 2001/931
           - 2580/2001
+          # Decision (CFSP) 2026/455 replaced the operative articles of
+          # Common Position 2001/931 in February 2026
+          - 2026/455
         value: EU-TERR
       - match: 1210/2003
         value: EU-IRQ

--- a/meta/issuers/eu_eeas.yml
+++ b/meta/issuers/eu_eeas.yml
@@ -1,5 +1,0 @@
-id: 3
-name: European External Action Service
-acronym: EEAS
-organisation: European Union
-territory: eu

--- a/meta/issuers/eu_eeas.yml
+++ b/meta/issuers/eu_eeas.yml
@@ -1,5 +1,5 @@
 id: 3
 name: European External Action Service
 acronym: EEAS
-organisation: 'European Commission '
+organisation: European Union
 territory: eu

--- a/meta/programs/EU-AFG.yml
+++ b/meta/programs/EU-AFG.yml
@@ -2,20 +2,27 @@ id: 259
 title: EU Restrictive measures imposed with respect to the Taliban
 key: EU-AFG
 url: https://sanctionsmap.eu/#/main/details/1/
-summary: 'The measures were initially imposed on 15 October 1999. On 17 June 2011,
-  the United Nations'' Security Council adopted resolutions 1988 (2011) and 1989 (2011)
-  and decided that the list of individuals and entities subject to restrictive measures
-  originally imposed by resolution 1267 (1999) would be split in two. The original
-  resolution 1267 (1999) concerns Afganistan and the Taliban. Now the resolution is
-  concerning ISIL (Da''esh), Al-Qaida and associated individuals, groups, undertakings
-  and entities. The measures imposed with respect to the Taliban are described under
-  this restrictive measures regime. The measures imposed on ISIL (Da''esh) and Al-Qaida
-  are described under the thematic restrictive measures section.
-
-
-  Derogations to the restrictive measures are possible as well as exemptions for humanitarian
-  purposes.'
+summary: Targets individuals, groups, undertakings and entities associated with
+  the Taliban in constituting a threat to the peace, stability and security of
+  Afghanistan, as designated by the UN Security Council committee established
+  under Resolution 1988 (2011). The EU implements the UN list through Decision
+  2011/486/CFSP and Regulation (EU) No 753/2011. Designated persons and
+  entities are subject to an asset freeze and to a prohibition on supplying
+  them with arms and related technical assistance or financing, and designated
+  natural persons are barred from entering or transiting EU territory.
+  Derogations and humanitarian exemptions apply.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 753/2011
+  - Decision 2011/486/CFSP
+  - Restrictive measures imposed with respect to the Taliban
+  - UNSCR 1988
+  - UNSCR 1267
+  - AFG
 target_territories:
-- af
+  - af
+measures:
+  - Arms restrictions
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-BDI.yml
+++ b/meta/programs/EU-BDI.yml
@@ -1,15 +1,26 @@
 id: 60
-title: EU Restrictive Measures In View Of The Situation In Burundi
+title: EU Restrictive measures in view of the situation in Burundi
 key: EU-BDI
 url: https://sanctionsmap.eu/#/main/details/7/
-summary: These sanctions target individuals and entities in Burundi involved in human
-  rights abuses, corruption, and actions undermining democracy. The measures include
-  asset freezes, travel bans, and trade restrictions to promote democratic governance
-  and respect for human rights in Burundi.
+summary: An EU-autonomous framework established in October 2015 in response to
+  the political crisis in Burundi. It targets persons undermining democracy,
+  obstructing the search for a political solution, or involved in serious
+  violations of international human rights law in Burundi, under Council
+  Decision (CFSP) 2015/1763 and Regulation (EU) 2015/1755. Designation entails
+  an asset freeze and a ban on entry into or transit through the EU, and claims
+  by designated persons in connection with the measures may not be satisfied.
+  The framework remains in force until 31 October 2026, but the last remaining
+  listing was removed in September 2025 and no persons or entities are
+  currently designated.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2015/1755
+  - Decision (CFSP) 2015/1763
+  - BDI
 target_territories:
-- bi
+  - bi
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Prohibition to satisfy claims
+  - Travel ban

--- a/meta/programs/EU-BLR.yml
+++ b/meta/programs/EU-BLR.yml
@@ -1,13 +1,37 @@
 id: 58
-title: EU Restrictive measures in view of the situation in Belarus and the involvement
-  of Belarus in the Russian aggression against Ukraine
+title: EU Restrictive measures in view of the situation in Belarus and the
+  involvement of Belarus in the Russian aggression against Ukraine
 key: EU-BLR
 url: https://sanctionsmap.eu/#/main/details/2/
-summary: These sanctions target individuals and entities in Belarus involved in human
-  rights abuses, undermining democracy, and supporting Russia's aggression against
-  Ukraine. The measures include asset freezes, travel bans, and trade restrictions
-  to pressure Belarus to respect international norms and support Ukraine's sovereignty.
+summary: Targets those responsible for the repression of civil society and the
+  democratic opposition in Belarus, persons and entities benefiting from or
+  supporting the Lukashenka government, and those supporting Belarus's
+  involvement in Russia's aggression against Ukraine. Designations under
+  Council Decision 2012/642/CFSP and Regulation (EC) No 765/2006 result in an
+  asset freeze, a prohibition on making funds or economic resources available,
+  and, for individuals, a ban on entry into or transit through the EU. These
+  designation-level measures combine with wide-ranging country-level
+  restrictions that largely mirror the EU's sanctions on Russia, including an
+  arms embargo, export controls on dual-use, advanced-technology and
+  industrial goods, import bans on commodities such as potash, wood, steel,
+  gold and diamonds, financial-sector and investment restrictions, a
+  prohibition on professional services to Belarusian public bodies, and
+  airspace and road-transport bans.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EC) No 765/2006
+  - Decision 2012/642/CFSP
+  - BLR
 target_territories:
-- by
+  - by
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo
+  - Export control
+  - Import restrictions
+  - Financial restrictions
+  - Investment ban
+  - Services ban
+  - Transportation restrictions

--- a/meta/programs/EU-BOSNIA.yml
+++ b/meta/programs/EU-BOSNIA.yml
@@ -1,15 +1,24 @@
 id: 59
-title: EU Restrictive Measures In View Of The Situation In Bosnia And Herzegovina
+title: EU Restrictive measures in view of the situation in Bosnia and
+  Herzegovina
 key: EU-BOSNIA
 url: https://sanctionsmap.eu/#/main/details/4/
-summary: These sanctions target individuals and entities in Bosnia and Herzegovina
-  involved in activities undermining the peace, security, and stability of the country.
-  The measures include asset freezes, travel bans, and trade restrictions to promote
-  peace and stability in Bosnia and Herzegovina.
+summary: A framework regime enabling the EU to designate persons and entities
+  whose activities undermine the sovereignty, territorial integrity,
+  constitutional order or international personality of Bosnia and
+  Herzegovina, seriously threaten its security situation, or undermine the
+  Dayton/Paris General Framework Agreement for Peace. Designation under
+  Council Decision 2011/173/CFSP would result in an asset freeze and, for
+  individuals, a ban on entry into or transit through the EU. The
+  EU-autonomous framework is renewed annually, most recently until 31 March
+  2027, but has never been used; no persons or entities have been listed,
+  and no implementing EU regulation has been adopted.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Decision 2011/173/CFSP
 target_territories:
-- ba
+  - ba
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-CAF.yml
+++ b/meta/programs/EU-CAF.yml
@@ -2,17 +2,28 @@ id: 260
 title: Restrictive measures in view of the situation in the Central African Republic
 key: EU-CAF
 url: https://sanctionsmap.eu/#/main/details/9/
-summary: 'On 5 December 2013, the UN Security Council adopted Resolution 2127 (2013),
-  which imposes an arms embargo against the Central African Republic (CAR). The EU
-  implemented this decision on 23 December 2013. On 28 January 2014, the UN Security
-  Council adopted Resolution 2134 (2014) imposing also targeted restrictive measures
-  on persons or entities that undermine the peace, stability or security of the CAR,
-  or that threaten or impede the political transition process, or that fuel violence.
-
-
-  Derogations to the restrictive measures are possible as well as exemptions for humanitarian
-  purposes.'
+summary: Implements the UN sanctions regime on the Central African Republic
+  established by UN Security Council Resolution 2127 (2013). Persons and
+  entities designated by the UN Sanctions Committee for engaging in or
+  supporting acts that undermine the peace, stability or security of the
+  country are subject to an asset freeze, and natural persons to a travel ban.
+  The regime also prohibits the supply of arms and related services to armed
+  groups and associated individuals operating in the Central African Republic;
+  following UN Security Council Resolution 2745 (2024), the arms embargo no
+  longer applies to the country's government forces.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 224/2014
+  - Decision 2013/798/CFSP
+  - Council Decision concerning restrictive measures against the Central African Republic
+  - UNSCR 2127
+  - UNSCR 2134
+  - CAF
 target_territories:
-- cf
+  - cf
+measures:
+  - Arms restrictions
+  - Asset freeze
+  - Prohibition to satisfy claims
+  - Travel ban

--- a/meta/programs/EU-CHEM.yml
+++ b/meta/programs/EU-CHEM.yml
@@ -1,13 +1,23 @@
 id: 61
-title: EU Restrictive Measures Against The Proliferation And Use Of Chemical Weapons
+title: EU Restrictive measures against the proliferation and use of chemical
+  weapons
 key: EU-CHEM
 url: https://sanctionsmap.eu/#/main/details/46/
-summary: These sanctions target individuals and entities involved in the proliferation
-  and use of chemical weapons. The measures include asset freezes, travel bans, and
-  restrictions on trade to prevent the spread and use of chemical weapons and to hold
-  accountable those responsible for their use.
+summary: Targets persons and entities who are responsible for, provide
+  financial, technical or material support for, or are otherwise involved in
+  the development or use of chemical weapons, regardless of their nationality
+  or location. Under Council Decision (CFSP) 2018/1544 and Regulation (EU)
+  2018/1542, designated persons and entities are subject to an asset freeze
+  and a prohibition on making funds or economic resources available to them,
+  and designated individuals are banned from entering or transiting the EU.
+  The regime is thematic and applies worldwide; it imposes no country- or
+  sector-wide restrictions.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2018/1542
+  - Decision (CFSP) 2018/1544
+  - CHEM
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-CHEM.yml
+++ b/meta/programs/EU-CHEM.yml
@@ -18,6 +18,8 @@ aliases:
   - Regulation (EU) 2018/1542
   - Decision (CFSP) 2018/1544
   - CHEM
+target_territories:
+  - zz
 measures:
   - Asset freeze
   - Travel ban

--- a/meta/programs/EU-COD.yml
+++ b/meta/programs/EU-COD.yml
@@ -2,17 +2,29 @@ id: 65
 title: EU Restrictive measures in view of the situation in the Democratic Republic of the Congo
 key: EU-COD
 url: https://sanctionsmap.eu/#/main/details/11/
-summary: Targets individuals and entities responsible for serious human rights violations,
-  obstruction of the electoral process, and sustaining the armed conflict in the DRC.
-  Designated persons are subject to an asset freeze and travel ban. The regime also
-  implements the UN arms embargo against those supplying or transferring arms in violation
-  of UN Security Council resolutions.
+summary: Combines the EU implementation of the UN sanctions regime on the
+  Democratic Republic of the Congo established under UN Security Council
+  Resolution 1533 (2004) with an EU-autonomous track, introduced in 2016 in
+  response to electoral repression and broadened in 2022 to cover those
+  sustaining, supporting or exploiting the armed conflict in the DRC, including
+  through the illicit trade in natural resources. Designated persons and
+  entities under both tracks are subject to an asset freeze, and natural
+  persons to a travel ban. The regime also prohibits the supply of arms and
+  related services to non-governmental entities and individuals operating in
+  the DRC.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EC) No 1183/2005
+  - Decision 2010/788/CFSP
+  - Council Decision concerning restrictive measures in view of the situation in the Democratic Republic of the Congo
+  - Restrictive measures in view of the situation in the Democratic Republic of the Congo
+  - UNSCR 1533
+  - COD
 target_territories:
-- cd
+  - cd
 measures:
-- Arms restrictions
-- Asset freeze
-- Prohibition to satisfy claims
-- Travel ban
+  - Arms restrictions
+  - Asset freeze
+  - Prohibition to satisfy claims
+  - Travel ban

--- a/meta/programs/EU-CYB.yml
+++ b/meta/programs/EU-CYB.yml
@@ -1,16 +1,27 @@
 id: 63
-title: EU Restrictive Measures Against Cyber-Attacks Threatening The Union Or Its
-  Member States
+title: EU Restrictive measures against cyber-attacks threatening the Union or
+  its Member States
 key: EU-CYB
 url: https://sanctionsmap.eu/#/main/details/47/
-summary: These sanctions target individuals and entities responsible for cyber-attacks
-  that threaten the security of the European Union or its member states. The measures
-  include asset freezes and prohibitions on transactions to deter and respond to malicious
-  cyber activities.
+summary: Targets persons and entities responsible for cyber-attacks or
+  attempted cyber-attacks with a significant effect which constitute an
+  external threat to the EU or its member states, including attacks against
+  third states or international organisations, as well as those who provide
+  support for or are otherwise involved in such attacks. Under Council
+  Decision (CFSP) 2019/797 and Regulation (EU) 2019/796, designated persons
+  and entities are subject to an asset freeze and a prohibition on making
+  funds or economic resources available to them, and designated individuals
+  are banned from entering or transiting the EU. The regime is thematic and
+  applies regardless of where the attackers are located; it imposes no
+  country- or sector-wide restrictions.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2019/796
+  - Decision (CFSP) 2019/797
+  - CYB
 target_territories:
-- ip
+  - ip
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-ESMA.yml
+++ b/meta/programs/EU-ESMA.yml
@@ -1,18 +1,20 @@
 id: 292
-title: Markets in Financial Instruments Directive II
+title: MiFID II Suspensions and Removals
 key: EU-ESMA
-url: https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mifid-ii
-summary: 'The MiFID II Suspensions and Removals Register is established under Articles
-  32 and 52 of Directive 2014/65/EU (Markets in Financial Instruments Directive II),
-  which came into force in January 2018. This regulatory framework empowers national
-  competent authorities and ESMA to suspend or remove financial instruments from trading
-  to maintain market integrity and protect investors.
-
-
-  The regime serves to provide transparency on trading restrictions imposed due to
-  regulatory concerns, market manipulation, or other circumstances that may harm investor
-  interests. Inclusion in this register indicates that specific financial instruments
-  are either temporarily suspended from trading or permanently removed from regulated
-  markets across the EU.'
+url: https://registers.esma.europa.eu/publication/searchRegister?core=esma_registers_saris_new
+summary: Lists financial instruments that trading venues or national competent
+  authorities have suspended or removed from trading in the EU under Articles
+  32 and 52 of the Markets in Financial Instruments Directive (2014/65/EU).
+  Grounds include suspected market abuse, a take-over bid, or non-disclosure
+  of inside information, as well as instruments that no longer comply with a
+  venue's rules. This is a market-integrity transparency register rather than
+  a sanctions regime; an entry restricts trading in the instrument concerned
+  and imposes no measures on persons or entities.
 issuer: eu_esma
 dataset: eu_esma_saris
+aliases:
+  - Markets in Financial Instruments Directive II
+  - MiFID II
+  - Directive 2014/65/EU
+  - Suspensions and Removals Register
+  - SARIS

--- a/meta/programs/EU-GIN.yml
+++ b/meta/programs/EU-GIN.yml
@@ -1,15 +1,25 @@
 id: 67
-title: EU Restrictive Measures In View Of The Situation In Guinea
+title: EU Restrictive measures in view of the situation in Guinea
 key: EU-GIN
 url: https://sanctionsmap.eu/#/main/details/14/
-summary: These sanctions target individuals and entities in Guinea involved in human
-  rights abuses, corruption, and actions undermining democracy. The measures include
-  asset freezes, travel bans, and restrictions on trade to promote democratic governance
-  and respect for human rights in Guinea.
+summary: EU-autonomous regime adopted in response to the violent crackdown by
+  security forces on political demonstrators in Conakry, Guinea, on
+  28 September 2009. It targets persons identified by the International
+  Commission of Inquiry as responsible for those events, together with
+  individuals associated with them. Designated persons are subject to an asset
+  freeze and a travel ban. The arms embargo and the ban on exporting equipment
+  usable for internal repression initially imposed under the regime were
+  lifted in 2014.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 1284/2009
+  - Decision 2010/638/CFSP
+  - Council Decision concerning restrictive measures in view of the situation in Guinea
+  - Restrictive measures in view of the situation in Guinea
+  - GIN
 target_territories:
-- gn
+  - gn
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-GNB.yml
+++ b/meta/programs/EU-GNB.yml
@@ -2,25 +2,24 @@ id: 261
 title: EU Restrictive measures in view of the situation in Guinea-Bissau
 key: EU-GNB
 url: https://sanctionsmap.eu/#/main/details/15/
-summary: 'EU restrictive measures against Guinea-Bissau were introduced on 3 May 2012.
-  Travel restrictions and an asset freeze were imposed targeting those who sought
-  to prevent or block a peaceful political process or who took action that undermined
-  stability in the Republic of Guinea-Bissau, in particular those who played a leading
-  role in the mutiny of 1 April 2010 and the coup d’état of 12 April 2012. The measures
-  also target those who sought to undermine the rule of law, curtailing the primacy
-  of civilian power and furthering impunity and instability in the country.
-
-
-  On 18 May 2012, the UN Security Council adopted a Resolution 2048 (2012), which
-  imposed a travel ban on persons seeking to prevent the restoration of the constitutional
-  order or taking action that undermines stability in the Republic of Guinea-Bissau.
-  This restrictive measures regime includes both Council of the EU and UN Security
-  Council designations.
-
-
-  Derogations to the restrictive measures are possible as well as exemptions for humanitarian
-  purposes.'
+summary: Targets persons who threaten the peace, security or stability of
+  Guinea-Bissau, in particular those who played a leading role in the
+  April 2010 mutiny and the April 2012 coup d'etat, and those who undermine
+  the rule of law or the primacy of civilian power. The regime implements the
+  travel ban imposed by UN Security Council Resolution 2048 (2012) and adds
+  EU-autonomous designations. Designated persons are subject to a travel ban,
+  and persons listed under the EU regulation additionally to an asset freeze.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 377/2012
+  - Decision 2012/285/CFSP
+  - Council Decision concerning restrictive measures in view of the situation in Guinea-Bissau and repealing Decision 2012/237/CFSP
+  - Restrictive measures in view of the situation in Guinea-Bissau
+  - UNSCR 2048
+  - GNB
 target_territories:
-- gw
+  - gw
+measures:
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-GTM.yml
+++ b/meta/programs/EU-GTM.yml
@@ -1,15 +1,25 @@
 id: 66
-title: EU Restrictive Measures In View Of The Situation In Guatemala
+title: EU Restrictive measures in view of the situation in Guatemala
 key: EU-GTM
 url: https://sanctionsmap.eu/#/main/details/59/
-summary: These sanctions target individuals and entities in Guatemala involved in
-  human rights abuses, corruption, and undermining democratic processes. The measures
-  include asset freezes, travel bans, and restrictions on trade to promote democratic
-  governance and respect for human rights in Guatemala.
+summary: Targets persons and entities responsible for actions undermining
+  democracy, the rule of law or the peaceful transfer of power in Guatemala,
+  a framework adopted in January 2024 in response to attempts to obstruct
+  the transition following the country's 2023 general elections. The
+  EU-autonomous regime is established by Decision (CFSP) 2024/254 and
+  Regulation (EU) 2024/287. Designated persons and entities are subject to
+  an asset freeze and a prohibition on making funds or economic resources
+  available to them, and designated natural persons are barred from entering
+  or transiting EU territory.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2024/287
+  - Decision (CFSP) 2024/254
+  - Restrictive measures in view of the situation in Guatemala
+  - GTM
 target_territories:
-- gt
+  - gt
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-HAM.yml
+++ b/meta/programs/EU-HAM.yml
@@ -1,14 +1,25 @@
 id: 90
-title: EU Restrictive Measures Against Supporters Of Hamas And The Palestinian Islamic
-  Jihad
+title: EU Restrictive measures against supporters of Hamas and the Palestinian
+  Islamic Jihad
 key: EU-HAM
 url: https://sanctionsmap.eu/#/main/details/60/
-summary: These sanctions target individuals and entities that support, facilitate,
-  or enable violent actions by Hamas and the Palestinian Islamic Jihad. The measures
-  include asset freezes, travel bans, and restrictions on financial transactions to
-  prevent the financing and support of terrorist activities by these groups.
+summary: Targets those who support, facilitate or enable violent actions by Hamas
+  and the Palestinian Islamic Jihad, under the dedicated framework of Decision
+  (CFSP) 2024/385 and Regulation (EU) 2024/386 adopted in response to the
+  attacks of 7 October 2023 against Israel. Since May 2026, the framework also
+  covers members of the Political Bureau of Hamas who promote, defend or
+  justify such violent actions. Designated persons and entities are subject to
+  an asset freeze and a prohibition on making funds or economic resources
+  available to them, and designated natural persons are barred from entering
+  or transiting EU territory.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2024/386
+  - Decision (CFSP) 2024/385
+  - Restrictive measures against those who support, facilitate or enable violent
+    actions by Hamas and the Palestinian Islamic Jihad
+  - HAM
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-HR.yml
+++ b/meta/programs/EU-HR.yml
@@ -21,6 +21,8 @@ aliases:
   - Regulation (EU) 2020/1998
   - Decision (CFSP) 2020/1999
   - HR
+target_territories:
+  - zz
 measures:
   - Asset freeze
   - Travel ban

--- a/meta/programs/EU-HR.yml
+++ b/meta/programs/EU-HR.yml
@@ -1,12 +1,26 @@
 id: 69
-title: EU Restrictive Measures Against Serious Human Rights Violations And Abuses
+title: EU Restrictive measures against serious human rights violations and
+  abuses
 key: EU-HR
 url: https://sanctionsmap.eu/#/main/details/50/
-summary: These sanctions target individuals and entities responsible for serious human
-  rights violations and abuses worldwide. The measures include asset freezes and travel
-  bans to hold perpetrators accountable and deter further abuses.
+summary: Targets individuals, entities and bodies, including state and
+  non-state actors, responsible for, involved in, or associated with serious
+  human rights violations and abuses worldwide, such as genocide, crimes
+  against humanity, torture, extrajudicial killings, enforced disappearances,
+  and systematic abuses of the freedoms of peaceful assembly, expression, or
+  religion. Under Council Decision (CFSP) 2020/1999 and Regulation (EU)
+  2020/1998, designated persons and entities are subject to an asset freeze
+  and a prohibition on making funds or economic resources available to them,
+  and designated individuals are banned from entering or transiting the EU.
+  The regime is thematic and applies worldwide; it imposes no country- or
+  sector-wide restrictions.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - EU Global Human Rights Sanctions Regime
+  - Regulation (EU) 2020/1998
+  - Decision (CFSP) 2020/1999
+  - HR
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-HTI.yml
+++ b/meta/programs/EU-HTI.yml
@@ -1,16 +1,33 @@
 id: 68
-title: EU Restrictive Measures In View Of The Situation In Haiti
+title: EU Restrictive measures in view of the situation in Haiti
 key: EU-HTI
 url: https://sanctionsmap.eu/#/main/details/54/
-summary: These sanctions target individuals and entities in Haiti involved in human
-  rights abuses, corruption, and actions undermining democracy. The measures include
-  asset freezes, travel bans, and restrictions on trade to promote democratic governance
-  and respect for human rights in Haiti.
+summary: Targets persons and entities engaging in or supporting criminal
+  activities and violence involving armed groups and criminal networks that
+  threaten the peace, security or stability of Haiti, including gang leaders
+  responsible for killings, kidnappings and sexual violence. Decision (CFSP)
+  2022/2319 and Regulation (EU) 2022/2309 implement the UN sanctions
+  established by Security Council Resolution 2653 (2022); since July 2023 a
+  complementary EU-autonomous strand also allows the EU to designate persons
+  undermining democracy or the rule of law in Haiti. Designated persons and
+  entities are subject to an asset freeze and a prohibition on making funds
+  or economic resources available to them, and designated natural persons
+  are barred from entering or transiting EU territory. These
+  designation-level measures combine with an embargo on small arms, light
+  weapons and ammunition applying to the whole territory of Haiti,
+  implementing UN Security Council Resolution 2700 (2023).
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2022/2309
+  - Decision (CFSP) 2022/2319
+  - UNSCR 2653
+  - UNSCR 2700
+  - Restrictive measures in view of the situation in Haiti
+  - HTI
 target_territories:
-- ht
+  - ht
 measures:
-- Arms restrictions
-- Asset freeze
-- Travel ban
+  - Arms embargo
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-IRN.yml
+++ b/meta/programs/EU-IRN.yml
@@ -2,35 +2,48 @@ id: 267
 title: EU sanctions against Iran
 key: EU-IRN
 url: https://sanctionsmap.eu/#/main/details/17,18,56/
-summary: 'The EU has imposed sanctions against Iran in response to its human rights
-  abuses, nuclear proliferation activities and military support for Russia''s war
-  of aggression against Ukraine.
-
-
-  Entities may only be sanctioned under one specific program, such as those related
-  to human rights violations or non-proliferation of weapons of mass destruction.
-
-
-  Human Rights Violations: EU sanctions since 2011 target individuals involved in
-  repressing peaceful protests, journalists, and human rights defenders in Iran, with
-  travel bans, asset freezes, and restrictions on repressive equipment.
-
-
-  Non-Proliferation of WMD: Sanctions, aligned with UN measures, restrict Iran’s nuclear
-  and missile activities. Some sanctions were lifted after the 2015 JCPoA but remain
-  in place due to non-compliance.
-
-
-  Military Support to Russia and Armed Groups: In 2023, the EU imposed sanctions on
-  Iran for supplying UAVs to Russia and supporting armed groups, including travel
-  bans, asset freezes, and export restrictions.'
+summary: Covers the EU's three sanctions regimes concerning Iran, targeting
+  those responsible for serious human rights violations, persons and entities
+  involved in Iran's nuclear and ballistic-missile programmes, and those
+  involved in Iran's military support to Russia's war of aggression against
+  Ukraine and to armed groups in the Middle East and the Red Sea region.
+  Designated persons and entities are subject to an asset freeze, and natural
+  persons to a ban on entry into or transit through the EU. After the UN
+  snapback procedure was triggered, the Council re-imposed on 29 September
+  2025 the nuclear-related sanctions lifted in 2016, so designation-level
+  measures under the non-proliferation regime again combine with country-wide
+  restrictions, including an arms embargo, export controls on
+  proliferation-sensitive and dual-use goods, import bans on Iranian crude
+  oil, gas and petrochemical products, and wide-ranging banking, insurance,
+  investment and transport restrictions. The human rights and military-support
+  regimes additionally restrict exports of equipment usable for internal
+  repression or telecommunications interception and of components for drones
+  and missiles.
 issuer: eu_council
 dataset: eu_fsf
 aliases:
-- Restrictive measures in relation to serious human rights violations in Iran
-- Restrictive measures in relation to the non-proliferation of weapons of mass destruction
-- Restrictive measures in view of Iran’s military support to Russia’s war of aggression
-  against Ukraine and to armed groups and entities in the Middle East and the Red
-  Sea region
+  - Restrictive measures in relation to serious human rights violations in Iran
+  - Restrictive measures in relation to the non-proliferation of weapons of mass
+    destruction
+  - Restrictive measures in view of Iran’s military support to Russia’s war of
+    aggression against Ukraine and to armed groups and entities in the Middle
+    East and the Red Sea region
+  - Regulation (EU) No 267/2012
+  - Decision 2010/413/CFSP
+  - Regulation (EU) No 359/2011
+  - Decision 2011/235/CFSP
+  - Regulation (EU) 2023/1529
+  - Decision (CFSP) 2023/1532
+  - IRN
 target_territories:
-- ir
+  - ir
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo
+  - Export control
+  - Import restrictions
+  - Financial restrictions
+  - Investment ban
+  - Transportation restrictions
+  - Prohibition to satisfy claims

--- a/meta/programs/EU-IRQ.yml
+++ b/meta/programs/EU-IRQ.yml
@@ -2,20 +2,29 @@ id: 262
 title: EU Restrictive measures on Iraq
 key: EU-IRQ
 url: https://sanctionsmap.eu/#/main/details/19/
-summary: 'A financial and trade embargo was adopted by the UN Security Council in
-  1990 after the invasion of Kuwait on 2 August 1990 by the military forces of Iraq
-  (see Resolution 661 (1990)).
-
-
-  Recognising and welcoming the efforts made by Iraq to form a government based on
-  the rule of law that affords equal rights and justice to all Iraqi citizens, on
-  22 May 2003 the Security Council lifted all restrictive measures against Iraq, except
-  for the arms embargo (see Resolution 1483 (2003)). Currently, only specific restrictions
-  apply in the areas of trade in goods belonging to Iraq’s cultural heritage and an
-  asset freeze specifically targeting former Iraqi President Saddam Hussein, his immediate
-  family, and senior officials of his regime.'
+summary: Implements the residual UN sanctions on Iraq adopted under UN
+  Security Council Resolution 1483 (2003) through Common Position
+  2003/495/CFSP and Regulation (EC) No 1210/2003. It freezes funds of the
+  previous Government of Iraq and of senior officials of the former Saddam
+  Hussein regime and their immediate family members, as listed by the UN
+  sanctions committee, with frozen state funds earmarked for transfer to
+  Iraq's development arrangements. Beyond the designation-level asset freeze,
+  the regime prohibits trade in Iraqi cultural property illegally removed from
+  the country and maintains an arms embargo, with exemptions for supplies
+  required by the Government of Iraq. Claims by Iraqi persons and entities in
+  connection with contracts affected by the UN embargo may not be satisfied.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EC) No 1210/2003
+  - Common Position 2003/495/CFSP
+  - Regulation (EEC) No 3541/92
+  - UNSCR 1483
+  - UNSCR 1518
+  - Restrictive measures on Iraq
+  - IRQ
 measures:
-- Arms embargo
-- Asset freeze
+  - Arms embargo
+  - Asset freeze
+  - Import restrictions
+  - Prohibition to satisfy claims

--- a/meta/programs/EU-IRQ.yml
+++ b/meta/programs/EU-IRQ.yml
@@ -23,6 +23,8 @@ aliases:
   - UNSCR 1518
   - Restrictive measures on Iraq
   - IRQ
+target_territories:
+  - iq
 measures:
   - Arms embargo
   - Asset freeze

--- a/meta/programs/EU-LBY.yml
+++ b/meta/programs/EU-LBY.yml
@@ -1,12 +1,31 @@
 id: 74
-title: EU Restrictive Measures In View Of The Situation In Libya
+title: EU Restrictive measures in view of the situation in Libya
 key: EU-LBY
 url: https://sanctionsmap.eu/#/main/details/23/
-summary: These sanctions target individuals and entities involved in the ongoing conflict
-  and human rights abuses in Libya. The measures include asset freezes, travel bans,
-  and restrictions on trade to promote peace, security, and democratic governance
-  in Libya.
+summary: Targets persons and entities that threaten Libya's peace, security or
+  stability, obstruct its political transition, or are responsible for human
+  rights abuses, under Council Decision (CFSP) 2015/1333 and Council Regulation
+  (EU) 2016/44. The regime implements the UN measures adopted under Security
+  Council Resolution 1970 (2011) and successor resolutions, and adds
+  EU-autonomous listings alongside the UN-designated ones. Designated persons
+  and entities are subject to an asset freeze, and listed natural persons to an
+  entry ban. Designation-level measures combine with a country-wide arms
+  embargo, export controls on internal-repression equipment and on goods usable
+  for migrant smuggling, and restrictions on flights and on listed vessels.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2016/44
+  - Decision (CFSP) 2015/1333
+  - UNSCR 1970
+  - UNSCR 1973
+  - LBY
 target_territories:
-- ly
+  - ly
+measures:
+  - Arms embargo
+  - Asset freeze
+  - Export control
+  - Prohibition to satisfy claims
+  - Transportation restrictions
+  - Travel ban

--- a/meta/programs/EU-LEBANON.yml
+++ b/meta/programs/EU-LEBANON.yml
@@ -1,15 +1,25 @@
 id: 73
-title: EU Restrictive Measures In View Of The Situation In Lebanon
+title: EU Restrictive measures in view of the situation in Lebanon
 key: EU-LEBANON
 url: https://sanctionsmap.eu/#/main/details/51/
-summary: These sanctions target individuals and entities in Lebanon involved in activities
-  undermining peace, security, and stability. The measures include asset freezes,
-  travel bans, and trade restrictions to support Lebanon's sovereignty and promote
-  stability in the region.
+summary: Provides a framework for targeted sanctions against persons and
+  entities responsible for undermining democracy or the rule of law in
+  Lebanon, including by persistently hampering the formation of a government,
+  obstructing elections or an agreed political solution, or through serious
+  financial misconduct concerning public funds. The framework was established
+  in 2021 by Decision (CFSP) 2021/1277 and Regulation (EU) 2021/1275 and has
+  been renewed annually since, most recently until 31 July 2026. Designation
+  would result in an asset freeze and, for natural persons, a ban on entry
+  into or transit through the EU; no persons or entities have been designated
+  under the framework to date.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2021/1275
+  - Decision (CFSP) 2021/1277
+  - Restrictive measures in view of the situation in Lebanon
 target_territories:
-- lb
+  - lb
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-LEBANON.yml
+++ b/meta/programs/EU-LEBANON.yml
@@ -8,7 +8,7 @@ summary: Provides a framework for targeted sanctions against persons and
   obstructing elections or an agreed political solution, or through serious
   financial misconduct concerning public funds. The framework was established
   in 2021 by Decision (CFSP) 2021/1277 and Regulation (EU) 2021/1275 and has
-  been renewed annually since, most recently until 31 July 2026. Designation
+  been renewed annually since, most recently until 31 July 2027. Designation
   would result in an asset freeze and, for natural persons, a ban on entry
   into or transit through the EU; no persons or entities have been designated
   under the framework to date.
@@ -17,6 +17,7 @@ dataset: eu_fsf
 aliases:
   - Regulation (EU) 2021/1275
   - Decision (CFSP) 2021/1277
+  - Decision (CFSP) 2026/1767
   - Restrictive measures in view of the situation in Lebanon
 target_territories:
   - lb

--- a/meta/programs/EU-MARE.yml
+++ b/meta/programs/EU-MARE.yml
@@ -13,9 +13,11 @@ summary: Covers vessels listed in Annex XLII to Council Regulation (EU)
   services such as bunkering, ship-to-ship transfers, technical assistance,
   financing, or insurance.
 issuer: eu_council
-dataset: null
+dataset: eu_sanctions_map
 aliases:
   - Annex XLII to Regulation (EU) No 833/2014
   - EU designated vessels
+target_territories:
+  - ru
 measures:
   - Transportation restrictions

--- a/meta/programs/EU-MARE.yml
+++ b/meta/programs/EU-MARE.yml
@@ -2,13 +2,20 @@ id: 300
 title: EU Designated Vessels (Council Regulation 833/2014)
 key: EU-MARE
 url: http://data.europa.eu/eli/reg/2014/833
-summary: Vessels designated under Annex XLII of Council Regulation (EU) 833/2014 concerning
-  restrictive measures in view of Russia's actions destabilising the situation in
-  Ukraine. These vessels are subject to port access bans and maritime service restrictions
-  for activities including transporting military goods to Russia, carrying Russian
-  oil with irregular shipping practices, supporting Russia's energy sector, or transporting
-  stolen Ukrainian grain. The designation triggers prohibitions on providing port
-  access, technical assistance, financing, insurance, bunkering, and other maritime
-  services to listed vessels throughout the EU.
+summary: Covers vessels listed in Annex XLII to Council Regulation (EU)
+  No 833/2014, part of the EU's sectoral measures adopted in view of Russia's
+  actions destabilising the situation in Ukraine. Vessels can be designated
+  for activities including transporting military equipment for Russia or
+  stolen Ukrainian grain, carrying Russian crude oil or petroleum products
+  while engaging in irregular and high-risk shipping practices, or supporting
+  Russia's energy sector. Designated vessels are denied access to ports,
+  locks and anchorages in the EU and may not be provided with maritime
+  services such as bunkering, ship-to-ship transfers, technical assistance,
+  financing, or insurance.
 issuer: eu_council
 dataset: null
+aliases:
+  - Annex XLII to Regulation (EU) No 833/2014
+  - EU designated vessels
+measures:
+  - Transportation restrictions

--- a/meta/programs/EU-MDA.yml
+++ b/meta/programs/EU-MDA.yml
@@ -1,14 +1,28 @@
 id: 77
-title: EU Restrictive Measures In View Of Actions Destabilising The Republic Of Moldova
+title: EU Restrictive measures in view of actions destabilising the Republic of Moldova
 key: EU-MDA
 url: https://sanctionsmap.eu/#/main/details/55/
-summary: These sanctions target individuals and entities involved in actions destabilizing
-  Moldova. The measures include asset freezes, travel bans, and trade restrictions
-  to promote stability, democracy, and the rule of law in Moldova.
+summary: Targets individuals and entities responsible for actions
+  destabilising, undermining or threatening the sovereignty and independence
+  of the Republic of Moldova, including obstructing the democratic political
+  process and elections, and planning, directing or participating in violent
+  demonstrations. The regime was established in 2023 at the request of the
+  Moldovan government under Council Decision (CFSP) 2023/891 and Regulation
+  (EU) 2023/888, and listings have focused on Russia-linked actors and
+  networks interfering in Moldovan elections; it is currently extended until
+  April 2027. Designated persons and entities are subject to an asset freeze
+  and a prohibition on making funds or economic resources available to them,
+  and designated individuals are banned from entering or transiting EU
+  territory.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Restrictive measures in view of actions destabilising the Republic of Moldova
+  - Regulation (EU) 2023/888
+  - Decision (CFSP) 2023/891
+  - MDA
 target_territories:
-- md
+  - md
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-MLI.yml
+++ b/meta/programs/EU-MLI.yml
@@ -1,15 +1,26 @@
 id: 75
-title: EU Restrictive Measures In View Of The Situation In Mali
+title: EU Restrictive measures in view of the situation in Mali
 key: EU-MLI
 url: https://sanctionsmap.eu/#/main/details/42/
-summary: These sanctions target individuals and entities involved in the conflict
-  and destabilizing activities in Mali, including terrorism and human rights abuses.
-  The measures include asset freezes and prohibitions on transactions to support peace,
-  security, and governance in Mali.
+summary: Targets individuals and entities responsible for threatening the
+  peace, security or stability of Mali, or for obstructing or undermining its
+  political transition. Established in 2017 to implement the UN sanctions
+  regime under UN Security Council Resolution 2374 (2017), with an
+  EU-autonomous track added after the 2021 coup d'etat; after a Russian veto
+  ended the UN regime in August 2023, the EU converted the framework into a
+  fully autonomous regime in April 2024. Designated persons and entities are
+  subject to an asset freeze, and natural persons to a travel ban.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2017/1770
+  - Decision (CFSP) 2017/1775
+  - Council Decision concerning restrictive measures in view of the situation in Mali
+  - Restrictive measures in view of the situation in Mali
+  - UNSCR 2374
+  - MLI
 target_territories:
-- ml
+  - ml
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-MMR.yml
+++ b/meta/programs/EU-MMR.yml
@@ -1,12 +1,32 @@
 id: 79
-title: EU Restrictive Measures In View Of The Situation In Myanmar And Burma
+title: EU Restrictive measures in view of the situation in Myanmar/Burma
 key: EU-MMR
 url: https://sanctionsmap.eu/#/main/details/8/
-summary: These sanctions target individuals and entities in Myanmar involved in human
-  rights abuses, undermining democracy, and contributing to instability. The measures
-  include asset freezes, travel bans, and restrictions on trade to pressure the Myanmar
-  government to respect human rights and restore democracy.
+summary: Targets those responsible for the February 2021 military coup in
+  Myanmar and for serious human rights violations, including senior officers
+  of the Myanmar Armed Forces (Tatmadaw), military-controlled companies, and
+  persons and entities supplying revenue, arms or aviation fuel to the
+  military regime. The regime is EU-autonomous; designations under Council
+  Decision 2013/184/CFSP and Regulation (EU) No 401/2013 result in
+  an asset freeze and, for individuals, a ban on entry into or transit
+  through the EU. The designation-level measures combine with a
+  country-wide arms embargo, export bans on dual-use goods destined for the
+  military or border guard police, on equipment which might be used for
+  internal repression and on communications-interception equipment, and a
+  prohibition on military training of and military cooperation with the
+  Tatmadaw.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 401/2013
+  - Decision 2013/184/CFSP
+  - Council Decision concerning restrictive measures in view of the
+    situation in Myanmar/Burma
+  - MMR
 target_territories:
-- mm
+  - mm
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo
+  - Export control

--- a/meta/programs/EU-NIC.yml
+++ b/meta/programs/EU-NIC.yml
@@ -1,15 +1,25 @@
 id: 80
-title: EU Restrictive Measures In View Of The Situation In Nicaragua
+title: EU Restrictive measures in view of the situation in Nicaragua
 key: EU-NIC
 url: https://sanctionsmap.eu/#/main/details/48/
-summary: These sanctions target individuals and entities in Nicaragua involved in
-  human rights abuses, corruption, and actions undermining democracy. The measures
-  include asset freezes, travel bans, and trade restrictions to promote democratic
-  governance and respect for human rights in Nicaragua.
+summary: Targets persons and entities responsible for serious human rights
+  violations or abuses, for the repression of civil society and democratic
+  opposition, and for undermining democracy or the rule of law in Nicaragua,
+  under the EU-autonomous framework of Decision (CFSP) 2019/1720 and
+  Regulation (EU) 2019/1716. Designated persons and entities are subject to
+  an asset freeze and a prohibition on making funds or economic resources
+  available to them, and designated natural persons are barred from entering
+  or transiting EU territory. The regime imposes no country-wide trade or
+  sectoral restrictions.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2019/1716
+  - Decision (CFSP) 2019/1720
+  - Restrictive measures in view of the situation in Nicaragua
+  - NIC
 target_territories:
-- ni
+  - ni
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-NIGER.yml
+++ b/meta/programs/EU-NIGER.yml
@@ -1,14 +1,24 @@
 id: 81
-title: EU Restrictive Measures In View Of The Situation In Niger
+title: EU Restrictive measures in view of the situation in Niger
 key: EU-NIGER
 url: https://sanctionsmap.eu/#/main/details/58/
-summary: These sanctions target individuals and entities in Niger involved in actions
-  that undermine peace, security, and stability. The measures include asset freezes,
-  travel bans, and restrictions on trade to promote stability and security in Niger.
+summary: EU-autonomous framework adopted in October 2023 in response to the
+  military coup d'etat of 26 July 2023 in Niger and the detention of the
+  democratically elected President, Mohamed Bazoum. It provides for an asset
+  freeze on individuals and entities, and a travel ban on individuals,
+  responsible for actions that threaten the peace, stability and security of
+  Niger, undermine its constitutional order, democracy or the rule of law, or
+  constitute serious human rights violations or abuses. The framework has been
+  renewed through October 2026, but no persons or entities have been
+  designated under it to date.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2023/2406
+  - Decision (CFSP) 2023/2287
+  - Restrictive measures in view of the situation in Niger
 target_territories:
-- ne
+  - ne
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-PRK.yml
+++ b/meta/programs/EU-PRK.yml
@@ -1,13 +1,42 @@
 id: 64
-title: EU Restrictive Measures In Relation To The Non-Proliferation Of The Weapons
-  Of Mass Destruction (WMD)
+title: EU Restrictive measures against the Democratic People's Republic of
+  Korea (North Korea)
 key: EU-PRK
 url: https://sanctionsmap.eu/#/main/details/20/
-summary: These sanctions target individuals and entities in North Korea involved in
-  the development and proliferation of weapons of mass destruction. The measures include
-  asset freezes, travel bans, and restrictions on trade to prevent North Korea from
-  advancing its WMD programs.
+summary: Implements the United Nations sanctions on North Korea adopted under
+  the Security Council Resolution 1718 (2006) line and supplements them with
+  EU-autonomous listings and trade restrictions. Persons and entities
+  designated under Council Decision (CFSP) 2016/849 and Regulation (EU)
+  2017/1509 for involvement in the DPRK's nuclear, ballistic-missile and
+  other weapons-of-mass-destruction programmes are subject to an asset
+  freeze and, for individuals, a ban on entry into or transit through the
+  EU. The designation-level measures sit within near-comprehensive
+  country-wide restrictions, including a full arms embargo, export controls
+  on dual-use items and luxury goods, import bans on coal, minerals,
+  textiles, seafood and other commodities, bans on supplying crude oil,
+  refined petroleum and aviation fuel, restrictions on financial transfers
+  and banking relationships, a prohibition on new investment and on
+  providing computer and certain other services, a suspension of aid
+  commitments, and port, shipping and aviation restrictions.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2017/1509
+  - Decision (CFSP) 2016/849
+  - Council Decision concerning restrictive measures against the Democratic
+    People's Republic of Korea and repealing Decision 2013/183/CFSP
+  - UNSCR 1718
+  - PRK
 target_territories:
-- kp
+  - kp
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms embargo
+  - Export control
+  - Import restrictions
+  - Financial restrictions
+  - Investment ban
+  - Aid suspension
+  - Services ban
+  - Transportation restrictions

--- a/meta/programs/EU-RUS.yml
+++ b/meta/programs/EU-RUS.yml
@@ -2,34 +2,42 @@ id: 263
 title: EU Sanctions against Russia
 key: EU-RUS
 url: https://sanctionsmap.eu/#/main/details/61,26/
-summary: 'Entities listed under these programs may be subject to only one of them.
-
-  This regime covers the European Union''s sanctions imposed on Russia under two main
-  frameworks:
-
-
-  Restrictive measures in view of the situation in Russia:
-
-  In response to the accelerating repression, deteriorating human rights situation,
-  and the death of opposition politician Alexei Navalny, the EU adopted a framework
-  targeting individuals and entities responsible for serious human rights violations,
-  repression of civil society, and undermining democracy and the rule of law. Measures
-  include asset freezes, travel bans, and restrictions on equipment for internal repression.
-
-
-  Restrictive measures in view of Russia''s actions destabilising the situation in
-  Ukraine:
-
-  Adopted progressively since 2014, and expanded following Russia’s 2022 military
-  aggression, these measures target Russia’s economic and military capabilities. Sanctions
-  include restrictions on dual-use goods, financial transactions, oil imports, trade
-  in Russian diamonds, and advanced technologies, alongside measures to prevent circumvention
-  of sanctions.'
+summary: Covers two EU regimes concerning Russia. Under Council Decision (CFSP)
+  2024/1484 and Regulation (EU) 2024/1485, the EU designates individuals and
+  entities responsible for serious human rights violations, the repression of
+  civil society and democratic opposition, or the undermining of the rule of
+  law in Russia; designated persons are subject to an asset freeze, designated
+  individuals to a travel ban, and exports of equipment for internal repression
+  or for telecommunications interception are restricted. Under Decision
+  2014/512/CFSP and Regulation (EU) No 833/2014, adopted in view of Russia's
+  actions destabilising the situation in Ukraine, the EU also imposes
+  country-wide sectoral measures, including an arms embargo, export controls
+  on dual-use and advanced-technology items and luxury goods, import bans on
+  Russian oil, coal, gold, diamonds, and iron and steel, capital-market,
+  banking and financial-messaging restrictions, port, airspace and
+  road-transport closures, an investment ban in the Russian energy and mining
+  sectors, and a ban on providing professional services to Russia.
 issuer: eu_council
 dataset: eu_fsf
 aliases:
-- Restrictive measures in view of the situation in Russia
-- Restrictive measures in view of Russia's actions destabilising the situation in
-  Ukraine (sectoral restrictive measures)
+  - Restrictive measures in view of the situation in Russia
+  - Restrictive measures in view of Russia's actions destabilising the
+    situation in Ukraine (sectoral restrictive measures)
+  - Regulation (EU) 2024/1485
+  - Decision (CFSP) 2024/1484
+  - Regulation (EU) No 833/2014
+  - Decision 2014/512/CFSP
+  - RUS
 target_territories:
-- ru
+  - ru
+measures:
+  - Arms embargo
+  - Asset freeze
+  - Export control
+  - Financial restrictions
+  - Import restrictions
+  - Investment ban
+  - Prohibition to satisfy claims
+  - Services ban
+  - Transportation restrictions
+  - Travel ban

--- a/meta/programs/EU-RUSDA.yml
+++ b/meta/programs/EU-RUSDA.yml
@@ -2,26 +2,28 @@ id: 269
 title: EU Restrictive measures in view of Russia's destabilising activities
 key: EU-RUSDA
 url: https://sanctionsmap.eu/#/main/details/63/
-summary: 'In several of its Conclusions in 2022 and 2023 the Council strongly condemned
-  Russian hybrid attacks threatening democracy, the rule of law, stability or security
-  in the Union, its Member States and its partners, in the context of Russia’s war
-  of aggression against Ukraine.
-
-
-  In view of Russia’s continued hybrid campaign operations on European soil intended
-  to harm, weaken and divide the Member States and its neighbourhood, on 8 October
-  2024, the Council established a new framework of targeted sanctions against Russia-driven
-  persons and entities engaged in destabilising activities. the new sanctions framework
-  covers activities such as, sabotage, foreign information manipulation, electoral
-  interference, disinformation, malicious cyber activities and the instrumentalization
-  of migrants by third countries.
-
-
-  These restrictive measures consist of a travel ban to the EU for designated individuals
-  and an asset freeze applying to both designated individuals and entities. Additionally,
-  EU persons and entities are prohibited from making funds and economic resources
-  available to those listed, either directly or indirectly.'
+summary: Targets individuals and entities responsible for, supporting, or
+  benefitting from Russian hybrid activities that undermine the security,
+  independence and integrity of the EU, its member states, international
+  organisations or third countries, including sabotage, foreign information
+  manipulation and interference, electoral interference, malicious cyber
+  activities, and the instrumentalisation of migrants. The framework was
+  established in October 2024 by Council Decision (CFSP) 2024/2643 and
+  Regulation (EU) 2024/2642 and was broadened in May 2025 to allow the
+  targeting of tangible assets, such as vessels and aircraft, used in
+  destabilising activities. Designated persons and entities are subject to an
+  asset freeze and a prohibition on making funds or economic resources
+  available to them, and designated individuals are banned from entering or
+  transiting EU territory.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Restrictive measures in view of Russia's destabilising activities
+  - Regulation (EU) 2024/2642
+  - Decision (CFSP) 2024/2643
+  - RUSDA
 target_territories:
-- ru
+  - ru
+measures:
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-SDN.yml
+++ b/meta/programs/EU-SDN.yml
@@ -1,16 +1,26 @@
 id: 86
-title: EU Restrictive Measures In View Of The Situation In Sudan
+title: EU Restrictive measures in view of the situation in Sudan
 key: EU-SDN
 url: https://sanctionsmap.eu/#/main/details/31/
-summary: These sanctions target individuals and entities in Sudan involved in human
-  rights abuses, conflict, and actions that undermine peace and security. The measures
-  include asset freezes, travel bans, and trade restrictions to pressure the Sudanese
-  government to engage in peaceful negotiations and respect human rights.
+summary: Targets individuals and entities obstructing the peace process in Sudan
+  or committing violations of international humanitarian and human rights law,
+  implementing the UN Darfur sanctions line established by UN Security Council
+  Resolutions 1556 (2004) and 1591 (2005). Designated persons are subject to an
+  asset freeze under Regulation (EU) No 747/2014, and natural persons are barred
+  from entry or transit under Council Decision 2014/450/CFSP. These
+  designation-level measures combine with an EU arms embargo covering the whole
+  of Sudan, which is broader than the UN embargo focused on Darfur.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 747/2014
+  - Decision 2014/450/CFSP
+  - UNSCR 1556
+  - UNSCR 1591
+  - SDN
 target_territories:
-- sd
+  - sd
 measures:
-- Arms restrictions
-- Asset freeze
-- Travel ban
+  - Arms embargo
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-SDNZ.yml
+++ b/meta/programs/EU-SDNZ.yml
@@ -1,16 +1,25 @@
 id: 85
-title: EU Restrictive Measures In View Of Activities Undermining The Stability And
-  The Political Transition Of Sudan
+title: EU Restrictive measures in view of activities undermining the stability
+  and the political transition of Sudan
 key: EU-SDNZ
 url: https://sanctionsmap.eu/#/main/details/57/
-summary: These sanctions target individuals and entities in Sudan involved in actions
-  that undermine stability and the political transition. The measures include asset
-  freezes, travel bans, and restrictions on trade to support Sudan's transition to
-  a stable and democratic governance.
+summary: An EU-autonomous framework adopted in October 2023 in response to the
+  armed conflict between the Sudanese Armed Forces and the Rapid Support Forces.
+  It targets persons and entities responsible for activities undermining the
+  stability and the political transition of Sudan, including obstruction of the
+  peace process and serious human rights violations, under Council Decision
+  (CFSP) 2023/2135 and Regulation (EU) 2023/2147. Designated persons and
+  entities are subject to an asset freeze, and natural persons to a ban on
+  entry into or transit through the EU. The regime operates alongside the older
+  EU framework on Sudan that implements the UN Darfur measures.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2023/2147
+  - Decision (CFSP) 2023/2135
+  - SDNZ
 target_territories:
-- sd
+  - sd
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-SOM.yml
+++ b/meta/programs/EU-SOM.yml
@@ -2,22 +2,33 @@ id: 264
 title: EU Restrictive measures in view of the situation in Somalia
 key: EU-SOM
 url: https://sanctionsmap.eu/#/main/details/29/
-summary: 'Measures imposed at UN level since UN Security Council Resolution 733 (1992)
-  of 23 January 1992 and subsequent Resolutions are transposed into EU sanctions law.
-  The measures include an arms embargo, which is partial and allows under certain
-  conditions arms supplies for the development of Somalia''s security and police institutions.
-  In addition the measures include a ban on the direct or indirect import of charcoal
-  from Somalia and a prohibition of the direct or indirect sale, supply or transfer
-  to Somalia of listed items if there is sufficient evidence to demonstrate that the
-  item(s) will be used, or a significant risk they may be used, in the manufacture
-  in Somalia of improvised explosive devices (IEDs). The measures also cover targeted
-  individual sanctions on designated persons and entities (asset freeze and prohibition
-  from making funds and economic resources available as well as travel restrictions).
-
-
-  Derogations to the restrictive measures are possible as well as exemptions for humanitarian
-  purposes.'
+summary: Transposes the UN sanctions regime on Somalia, established by UN Security
+  Council Resolution 733 (1992) and refocused on Al-Shabaab by Resolution 2713
+  (2023), through Council Decision 2010/231/CFSP, Regulation (EC) No 147/2003 and
+  Regulation (EU) No 356/2010. Persons and entities designated for threatening
+  peace and security in Somalia or supporting Al-Shabaab are subject to an asset
+  freeze, and natural persons are barred from entry or transit. These
+  designation-level measures combine with targeted arms restrictions directed at
+  Al-Shabaab (the blanket embargo on the Somali government was lifted in December
+  2023), a ban on importing charcoal from Somalia, and restrictions on supplying
+  listed items that could be used to manufacture improvised explosive devices.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Decision 2010/231/CFSP
+  - Regulation (EC) No 147/2003
+  - Regulation (EU) No 356/2010
+  - Council Decision concerning restrictive measures against Somalia and repealing Common Position 2009/138/CFSP
+  - UNSCR 733
+  - UNSCR 751
+  - UNSCR 1844
+  - UNSCR 2713
+  - SOM
 target_territories:
-- so
+  - so
+measures:
+  - Arms restrictions
+  - Asset freeze
+  - Export control
+  - Import restrictions
+  - Travel ban

--- a/meta/programs/EU-SSD.yml
+++ b/meta/programs/EU-SSD.yml
@@ -1,16 +1,27 @@
 id: 84
-title: EU Restrictive Measures In View Of The Situation In South Sudan
+title: EU Restrictive measures in view of the situation in South Sudan
 key: EU-SSD
 url: https://sanctionsmap.eu/#/main/details/30/
-summary: These sanctions target individuals and entities involved in actions that
-  threaten the peace, security, and stability of South Sudan. The measures include
-  asset freezes, travel bans, and trade restrictions to promote peace and stability
-  in South Sudan.
+summary: Targets persons and entities threatening the peace, security or
+  stability of South Sudan, including those obstructing the political process or
+  responsible for serious human rights violations. The regime implements the UN
+  sanctions line established by UN Security Council Resolution 2206 (2015) and
+  the UN arms embargo under Resolution 2428 (2018), and the EU also designates
+  persons autonomously under Council Decision (CFSP) 2015/740 and Regulation
+  (EU) 2015/735. Designated persons are subject to an asset freeze, and natural
+  persons are barred from entry or transit; these measures combine with a
+  country-wide embargo on arms and related materiel.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2015/735
+  - Decision (CFSP) 2015/740
+  - UNSCR 2206
+  - UNSCR 2428
+  - SSD
 target_territories:
-- ss
+  - ss
 measures:
-- Arms restrictions
-- Asset freeze
-- Travel ban
+  - Arms embargo
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-SYR.yml
+++ b/meta/programs/EU-SYR.yml
@@ -1,12 +1,35 @@
 id: 87
-title: EU Restrictive Measures Against Syria
+title: EU Restrictive measures against Syria
 key: EU-SYR
 url: https://sanctionsmap.eu/#/main/details/32/
-summary: These sanctions target the Syrian government and entities involved in human
-  rights abuses, terrorism, and other destabilizing activities. The measures include
-  asset freezes, prohibitions on transactions, and restrictions on trade to pressure
-  Syria to comply with international norms and cease its destabilizing actions.
+summary: Targets persons and entities linked to the former al-Assad government
+  of Syria, including those responsible for the violent repression of the
+  civilian population, the Syrian chemical weapons programme, and the trade in
+  captagon and other illicit drugs, under Decision 2013/255/CFSP and
+  Regulation (EU) No 36/2012. Designated persons are subject to an asset
+  freeze and natural persons to a ban on entry into or transit through the EU;
+  the listings targeting the former regime were most recently renewed until
+  1 June 2027. After the fall of the Assad government, the EU lifted almost
+  all of its sectoral economic sanctions on Syria on 28 May 2025, including
+  the banking, energy and transport restrictions. A small set of
+  security-related measures remains in force, prohibiting the purchase or
+  import of arms from Syria and trade in Syrian cultural heritage goods, and
+  restricting exports of equipment usable for internal repression or for
+  telecommunications monitoring and interception.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 36/2012
+  - Decision 2013/255/CFSP
+  - Restrictive measures against Syria
+  - Council Decision concerning restrictive measures against Syria
+  - SYR
 target_territories:
-- sy
+  - sy
+measures:
+  - Asset freeze
+  - Travel ban
+  - Arms restrictions
+  - Export control
+  - Import restrictions
+  - Prohibition to satisfy claims

--- a/meta/programs/EU-TAQA-EUAQ.yml
+++ b/meta/programs/EU-TAQA-EUAQ.yml
@@ -28,6 +28,8 @@ aliases:
   - UNSCR 2253
   - TAQA
   - EUAQ
+target_territories:
+  - zz
 measures:
   - Arms restrictions
   - Asset freeze

--- a/meta/programs/EU-TAQA-EUAQ.yml
+++ b/meta/programs/EU-TAQA-EUAQ.yml
@@ -1,16 +1,35 @@
 id: 89
-title: EU Restrictive Measures With Respect To ISIL (Da'esh) And Al-Qaida (ISIL/Daesh
-  & Al-Qaida)
+title: EU Restrictive measures with respect to ISIL (Da'esh) and Al-Qaida
 key: EU-TAQA-EUAQ
 url: https://sanctionsmap.eu/#/main/details/5/
-summary: These sanctions target individuals and entities associated with ISIL (Da'esh)
-  and Al-Qaida. The measures include asset freezes, travel bans, and restrictions
-  on financial transactions to disrupt the operations and funding of these terrorist
-  organizations and enhance global security.
+summary: Targets persons, groups, undertakings and entities associated with ISIL
+  (Da'esh) and Al-Qaida. It combines two lists under one regime, the EU
+  implementation of the UN Security Council's ISIL (Da'esh) and Al-Qaida
+  sanctions list under Regulation (EC) No 881/2002, derived from the UNSCR 1267
+  (1999), 1989 (2011) and 2253 (2015) line of resolutions, and the EU's
+  autonomous designations under Decision (CFSP) 2016/1693 and Regulation (EU)
+  2016/1686, which allow the Council to list associated persons on its own
+  initiative. Designated persons and entities are subject to an asset freeze
+  and to a prohibition on supplying them with arms and related assistance, and
+  designated natural persons are barred from entering or transiting EU
+  territory. Claims by designated persons in connection with contracts affected
+  by the measures may not be satisfied.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EC) No 881/2002
+  - Regulation (EU) 2016/1686
+  - Decision (CFSP) 2016/1693
+  - Common Position 2002/402/CFSP
+  - Restrictive measures with respect to ISIL (Da'esh) and Al-Qaida
+  - UN ISIL (Da'esh) and Al-Qaida Sanctions List
+  - UNSCR 1267
+  - UNSCR 1989
+  - UNSCR 2253
+  - TAQA
+  - EUAQ
 measures:
-- Arms restrictions
-- Asset freeze
-- Prohibition to satisfy claims
-- Travel ban
+  - Arms restrictions
+  - Asset freeze
+  - Prohibition to satisfy claims
+  - Travel ban

--- a/meta/programs/EU-TERR.yml
+++ b/meta/programs/EU-TERR.yml
@@ -1,12 +1,27 @@
 id: 88
-title: EU Specific Measures To Combat Terrorism
+title: EU Specific measures to combat terrorism
 key: EU-TERR
 url: https://sanctionsmap.eu/#/main/details/6
-summary: These sanctions target individuals and entities involved in terrorism and
-  related activities. The measures include asset freezes, travel bans, and restrictions
-  on trade and financial transactions to prevent the financing and support of terrorist
-  activities, aiming to enhance international security and combat global terrorism.
+summary: Targets persons, groups and entities involved in terrorist acts, listed
+  on the EU's autonomous terrorist list established under Common Position
+  2001/931/CFSP in response to UN Security Council Resolution 1373 (2001) and
+  reviewed at least every six months; since February 2026, leading members of
+  listed groups and entities can also be designated. Under Regulation (EC)
+  No 2580/2001, the funds of listed persons are frozen and it is prohibited to
+  make funds, economic resources or financial services available to them. The
+  regime imposes no EU-level travel ban, and listed persons and groups whose
+  terrorist activities are confined to the EU are subject only to enhanced
+  police and judicial cooperation rather than the asset freeze.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Common Position 2001/931/CFSP
+  - Regulation (EC) No 2580/2001
+  - Decision (CFSP) 2026/455
+  - Specific measures to combat terrorism
+  - EU terrorist list
+  - CP 931 list
+  - UNSCR 1373
+  - TERR
 measures:
-- Financial restrictions
+  - Asset freeze

--- a/meta/programs/EU-TERR.yml
+++ b/meta/programs/EU-TERR.yml
@@ -23,5 +23,7 @@ aliases:
   - CP 931 list
   - UNSCR 1373
   - TERR
+target_territories:
+  - zz
 measures:
   - Asset freeze

--- a/meta/programs/EU-TUN.yml
+++ b/meta/programs/EU-TUN.yml
@@ -1,13 +1,22 @@
 id: 91
-title: EU Misappropriation of State Funds Of Tunisia (MSF)
+title: EU Restrictive measures in view of the situation in Tunisia
 key: EU-TUN
 url: https://sanctionsmap.eu/#/main/details/33/
-summary: These sanctions target individuals and entities involved in the misappropriation
-  of state funds in Tunisia. The measures include asset freezes and travel bans to
-  recover stolen assets and promote accountability and transparency in governance.
+summary: Targets persons identified as responsible for the misappropriation of
+  Tunisian state funds after the 2011 revolution, together with associated
+  persons and entities, with the aim of helping Tunisia recover the assets. The
+  legal basis is Council Decision 2011/72/CFSP and Council Regulation (EU)
+  No 101/2011. Designated persons are subject to an asset freeze and a
+  prohibition on making funds or economic resources available to them; the
+  regime imposes no travel ban and no country-wide restrictions.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 101/2011
+  - Decision 2011/72/CFSP
+  - Misappropriation of state funds of Tunisia (MSF)
+  - TUN
 target_territories:
-- tn
+  - tn
 measures:
-- Asset freeze
+  - Asset freeze

--- a/meta/programs/EU-TUR.yml
+++ b/meta/programs/EU-TUR.yml
@@ -1,16 +1,27 @@
 id: 92
-title: EU Restrictive Measures In View Of Turkey's Unauthorized Drilling In The Eastern
-  Mediterranean
+title: EU Restrictive measures in view of Türkiye's unauthorised drilling
+  activities in the Eastern Mediterranean
 key: EU-TUR
 url: https://sanctionsmap.eu/#/main/details/49/
-summary: These sanctions target individuals and entities involved in Turkey's unauthorized
-  drilling activities in the Eastern Mediterranean. The measures include asset freezes
-  and travel bans to pressure Turkey to cease its illegal drilling operations and
-  respect the sovereignty and territorial integrity of neighboring countries.
+summary: Provides for restrictive measures against natural and legal persons
+  responsible for or involved in unauthorised drilling for hydrocarbons in the
+  Eastern Mediterranean, notably in the territorial sea or exclusive economic
+  zone of Cyprus, under Council Decision (CFSP) 2019/1894 and Council
+  Regulation (EU) 2019/1890. Designated persons are subject to an asset freeze
+  and a prohibition on making funds or economic resources available to them,
+  and natural persons to an entry ban. The framework remains in force, but the
+  two Turkish Petroleum Corporation officials designated in 2020 have since
+  been delisted and no persons are currently designated.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2019/1890
+  - Decision (CFSP) 2019/1894
+  - Restrictive measures in view of Türkiye's unauthorised drilling activities
+    in the Eastern Mediterranean
+  - TUR
 target_territories:
-- tr
+  - tr
 measures:
-- Asset freeze
-- Travel ban
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-UKR.yml
+++ b/meta/programs/EU-UKR.yml
@@ -27,6 +27,10 @@ aliases:
   - UKR
 target_territories:
   - ua
+  - ua-cri
+  - ua-dpr
+  - ua-lpr
+  - ru
 measures:
   - Asset freeze
   - Travel ban

--- a/meta/programs/EU-UKR.yml
+++ b/meta/programs/EU-UKR.yml
@@ -2,28 +2,29 @@ id: 268
 title: EU sanctions related to Ukraine
 key: EU-UKR
 url: https://sanctionsmap.eu/#/main/details/35,36/
-summary: 'Entities listed under these programs may be subject to only one of them.
-  This regime covers the European Union''s sanctions related to Ukraine under two
-  main frameworks:
-
-
-  * **Misappropriation of State Funds**: In response to the violence and political
-  instability in Ukraine, the EU adopted measures targeting individuals identified
-  as responsible for the misappropriation of Ukrainian state funds and human rights
-  violations. These measures aim to support the rule of law and respect for human
-  rights. Sanctions include asset freezes and prohibitions on making funds available.
-
-
-  * **Territorial Integrity of Ukraine**: The EU imposed asset freezes and travel
-  bans on individuals and entities responsible for actions undermining Ukraine''s
-  territorial integrity, sovereignty, and independence. This followed Russia’s illegal
-  annexation of Crimea and the invasion of Ukraine in 2022. Sanctions were progressively
-  expanded to target those supporting the Russian government, providing substantial
-  revenue, and benefitting from its actions. These measures also address the involvement
-  of Belarus in the aggression. Derogations allow for humanitarian aid delivery.'
+summary: Covers two designation-based EU regimes related to Ukraine. Under
+  Council Decision 2014/145/CFSP and Regulation (EU) No 269/2014, the EU
+  freezes the assets of, and bans travel by, persons and entities responsible
+  for actions undermining or threatening the territorial integrity,
+  sovereignty and independence of Ukraine, including those supporting,
+  benefitting from, or providing substantial revenue to the Government of
+  Russia. Under Decision 2014/119/CFSP and Regulation (EU) No 208/2014, it
+  freezes the assets of former Ukrainian officials identified as responsible
+  for the misappropriation of Ukrainian state funds; this regime was most
+  recently renewed until March 2027. Both regimes impose designation-level
+  measures only; the EU's sector-wide restrictions on Russia are imposed
+  under separate instruments.
 issuer: eu_council
 dataset: eu_fsf
 aliases:
-- Misappropriation of state funds of Ukraine
-- Restrictive measures in respect of actions undermining or threatening the territorial
-  integrity, sovereignty and independence of Ukraine
+  - Misappropriation of state funds of Ukraine
+  - Restrictive measures in respect of actions undermining or threatening the
+    territorial integrity, sovereignty and independence of Ukraine
+  - Regulation (EU) No 269/2014
+  - Decision 2014/145/CFSP
+  - Regulation (EU) No 208/2014
+  - Decision 2014/119/CFSP
+  - UKR
+measures:
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-UKR.yml
+++ b/meta/programs/EU-UKR.yml
@@ -25,6 +25,8 @@ aliases:
   - Regulation (EU) No 208/2014
   - Decision 2014/119/CFSP
   - UKR
+target_territories:
+  - ua
 measures:
   - Asset freeze
   - Travel ban

--- a/meta/programs/EU-UNLI.yml
+++ b/meta/programs/EU-UNLI.yml
@@ -2,20 +2,15 @@ id: 283
 title: New EU listings of designations by the United Nations (UN)
 key: EU-UNLI
 url: https://data.europa.eu/data/datasets/consolidated-list-of-persons-groups-and-entities-subject-to-eu-financial-sanctions?locale=en
-summary: 'New listings of entities or individuals by the United Nations (UN) Security
-  Council under Chapter VII of the Charter of the United Nations may be associatd
-  with a program code `UNLI` when listed in the EU Consolidated Sanctions list.
-
-
-  The European Union transposes all UN designations into the EU framework of restrictive
-  measures (sanctions). The "UNLI" designation serves as a provisional marker within
-  the [Consolidated list of persons, groups and entities subject to EU financial sanction](https://data.europa.eu/data/datasets/consolidated-list-of-persons-groups-and-entities-subject-to-eu-financial-sanctions?locale=en)s,
-  acting as a preliminary alert for operators during the interim period before the
-  adoption and publication of the relevant EU legal acts in the [Official Journal](https://eur-lex.europa.eu/oj/direct-access.html)
-  (OJ).
-
-
-  Once the legal acts are published on the OJ, the "UNLI" designation will be appropriately
-  reclassified under the relevant EU legal base within the Consolidated list.'
+summary: Flags persons, groups and entities newly designated by the UN Security
+  Council whose listings have not yet been transposed into an EU legal act
+  published in the Official Journal. The European Commission (DG FISMA) applies
+  the transitional UNLI code to such entries in the EU consolidated list of
+  financial sanctions, alerting operators to new UN designations during the
+  interim period before the corresponding EU acts are adopted. Once those acts
+  are published, the entries are reclassified under the relevant EU sanctions
+  regime within the consolidated list.
 issuer: eu_dg_fisma
 dataset: eu_fsf
+aliases:
+  - UNLI

--- a/meta/programs/EU-US-LEG.yml
+++ b/meta/programs/EU-US-LEG.yml
@@ -1,13 +1,25 @@
 id: 97
-title: EU Measures Protecting Against The Effects Of The Extra-Territorial Application
-  Of Certain US Legislation
+title: EU Measures protecting against the effects of the extra-territorial
+  application of certain US legislation
 key: EU-US-LEG
 url: https://sanctionsmap.eu/#/main/details/38/
-summary: These measures aim to protect EU individuals and entities from the effects
-  of the extra-territorial application of certain US laws. The measures include blocking
-  statutes and other regulations to shield EU businesses from penalties and restrictions
-  imposed by US legislation that affects international trade and investment.
+summary: The EU Blocking Statute, Regulation (EC) No 2271/96, protects EU
+  operators against the extra-territorial application of the third-country
+  laws listed in its annex, currently US sanctions legislation concerning
+  Cuba and Iran. It is not a restrictive-measures regime and designates no
+  persons or entities; instead it prohibits EU operators from complying with
+  the listed US laws unless authorised by the European Commission, bars the
+  recognition or enforcement in the EU of foreign judgments giving effect to
+  them, and allows EU operators to recover damages caused by their
+  application.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EC) No 2271/96
+  - EU Blocking Statute
+  - Blocking Statute
+  - Joint Action 96/668/CFSP
+  - Measures protecting against the effects of the extra-territorial
+    application of certain legislation adopted by the US
 target_territories:
-- us
+  - us

--- a/meta/programs/EU-VEN.yml
+++ b/meta/programs/EU-VEN.yml
@@ -1,17 +1,30 @@
 id: 98
-title: EU Restrictive Measures In View Of The Situation In Venezuela
+title: EU Restrictive measures in view of the situation in Venezuela
 key: EU-VEN
 url: https://sanctionsmap.eu/#/main/details/44/
-summary: These sanctions target individuals and entities in Venezuela involved in
-  corruption, human rights abuses, and undermining democratic processes. The measures
-  include asset freezes, travel bans, and restrictions on trade to pressure the Venezuelan
-  government to restore democracy and respect human rights.
+summary: Targets those responsible for serious human rights violations, the
+  repression of civil society and the democratic opposition, and actions
+  undermining democracy or the rule of law in Venezuela, under the
+  EU-autonomous framework of Decision (CFSP) 2017/2074 and Regulation (EU)
+  2017/2063. Designated persons are subject to an asset freeze and a
+  prohibition on making funds or economic resources available to them, and
+  designated natural persons are barred from entering or transiting EU
+  territory. These designation-level measures combine with a country-wide
+  embargo on arms and related materiel and with bans on exporting equipment
+  which might be used for internal repression and equipment, technology or
+  software for monitoring or intercepting internet and telephone
+  communications.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) 2017/2063
+  - Decision (CFSP) 2017/2074
+  - Restrictive measures in view of the situation in Venezuela
+  - VEN
 target_territories:
-- ve
+  - ve
 measures:
-- Arms restrictions
-- Asset freeze
-- Export control
-- Travel ban
+  - Arms embargo
+  - Asset freeze
+  - Export control
+  - Travel ban

--- a/meta/programs/EU-YEM.yml
+++ b/meta/programs/EU-YEM.yml
@@ -2,19 +2,26 @@ id: 265
 title: EU Restrictive measures in view of the situation in Yemen
 key: EU-YEM
 url: https://sanctionsmap.eu/#/main/details/39/
-summary: 'On 26 February 2014, in view of the ongoing violence, terrorist activities
-  and political, security, economic and humanitarian challenges in Yemen, the UN Security
-  Council adopted Resolution 2140 (2014), where it reaffirmed its commitment to the
-  unity, sovereignty, independence and territorial integrity of Yemen, and established
-  travel restrictions and asset freezes to designated persons and entities. On 14
-  April 2015, the UN Security Council adopted Resolution 2216 (2015) which imposed
-  an arms embargo in relation to persons who engaged in acts that threaten the peace,
-  security or stability of Yemen.
-
-
-  Derogations to the restrictive measures are possible as well as exemptions for humanitarian
-  purposes.'
+summary: Gives effect in the EU to the UN sanctions regime on Yemen established
+  by Security Council Resolution 2140 (2014), targeting persons and entities
+  designated by the UN Sanctions Committee as engaging in or providing support
+  for acts that threaten the peace, security or stability of Yemen. The legal
+  basis is Council Decision 2014/932/CFSP and Council Regulation (EU)
+  No 1352/2014. Designated persons and entities are subject to an asset freeze,
+  and natural persons to an entry ban; an arms-supply prohibition under
+  Resolution 2216 (2015) covers designated persons and those acting on their
+  behalf, backed by cargo-inspection provisions.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EU) No 1352/2014
+  - Decision 2014/932/CFSP
+  - UNSCR 2140
+  - UNSCR 2216
+  - YEM
 target_territories:
-- ye
+  - ye
+measures:
+  - Arms restrictions
+  - Asset freeze
+  - Travel ban

--- a/meta/programs/EU-ZWE.yml
+++ b/meta/programs/EU-ZWE.yml
@@ -1,37 +1,28 @@
 id: 266
-title: EU Restrictive measures in view of the situation in Zimbabwe
+title: EU Restrictive measures concerning an arms embargo in view of the
+  situation in Zimbabwe
 key: EU-ZWE
 url: https://sanctionsmap.eu/#/main/details/40/
-summary: 'Restrictive measures were first introduced on 18 February 2002 in relation
-  to the situation in Zimbabwe, in particular the escalation of violence and intimidation
-  of political opponents and the harassment of the independent press. The Council
-  of the EU expressed serious concern about legislation in Zimbabwe which seriously
-  infringed on the right to freedom of speech, assembly and association and the legislation
-  to regulate the media. The Government of Zimbabwe continued to engage in serious
-  violations of human rights and of the freedom of opinion, of association and of
-  peaceful assembly. Thus the Council of the EU imposed embargo on arms and equipment
-  which might be used for internal repression, travel restrictions and asset freeze.
-
-
-  In 2008, the Council of the EU strengthened the restrictive measures in relation
-  to the violence organised and committed by the Zimbabwean authorities during the
-  presidential election campaign in 2008, which turned the election into a denial
-  of democracy.
-
-
-  On 23 July 2012 and 18 February 2013, the Council of the EU concluded that a peaceful
-  and credible constitutional referendum in Zimbabwe would represent an important
-  milestone in the preparation of democratic elections justifying an immediate suspension
-  of the majority of all remaining Union targeted restrictive measures against individuals
-  and entities. In view of the outcome of the Zimbabwean constitutional referendum
-  of 16 March 2013, the Council of the EU decided to suspend the travel ban and asset
-  freeze applying to the majority of the individuals and entities on the list.
-
-
-  On 17 February 2022, the Council of the EU decided to delete three persons from
-  the list of persons and entities subject to restrictive measures. At the moment,
-  the measures remains in force for the listed entity.'
+summary: Since February 2026 this EU-autonomous regime consists solely of a
+  country-wide arms embargo. Council Decision 2011/101/CFSP and Regulation
+  (EC) No 314/2004 prohibit exporting arms, related materiel and equipment
+  which might be used for internal repression to Zimbabwe, together with
+  related technical and financial assistance. The regime originally
+  combined the embargo with an asset freeze and travel ban on persons and
+  entities responsible for violence against political opponents and human
+  rights violations; those listings were progressively removed, with the
+  last remaining entity (Zimbabwe Defence Industries) delisted in February
+  2025 and the asset-freeze and travel-ban provisions repealed in February
+  2026. No persons or entities are currently designated under the regime.
 issuer: eu_council
 dataset: eu_fsf
+aliases:
+  - Regulation (EC) No 314/2004
+  - Decision 2011/101/CFSP
+  - Restrictive measures in view of the situation in Zimbabwe
+  - ZWE
 target_territories:
-- zw
+  - zw
+measures:
+  - Arms embargo
+  - Export control


### PR DESCRIPTION
Systematic review of all 43 `EU-*` program files in `meta/programs/` plus the four EU issuer files, continuing the per-jurisdiction series (#4978 US, #4987 GB, #4988 AU). Done with parallel research agents verifying every file against the EU Sanctions Map JSON API, Council press releases, and EUR-Lex, plus a read-only coverage audit against the full Sanctions Map regime universe.

Three commits, split by risk: the metadata review; the program-field fixes (EU-MARE dataset, target territories); and the eu_fsf lookup cleanup (crawl-verified no-op on emitted data).

## Metadata review

- **URLs**: all 43 verified. The `sanctionsmap.eu/#/main/details/N/` SPA fragments were validated by resolving regime id N against the map's JSON API (`/api/v1/regime`) rather than trusting HTTP 200. EU-ESMA's URL replaced (pointed at the MiFID II directive text, not the register; now the SARIS register itself, verified rendering in a live browser). One agent-proposed EUR-Lex "consolidated" URL turned out to be a fake-200 ("document does not exist" behind a 200) and was reverted to the working ELI form — worth knowing: undated consolidated CELEX URIs (`CELEX:02014R0833`) do not resolve.
- **Summaries** rewritten from legacy chronology prose to the targeting-basis-and-consequences policy, with 2025–2026 regime changes verified rather than assumed: EU-IRN reflects the post-snapback re-imposition of the pre-JCPOA nuclear measures (Regulation (EU) 2025/1975, 29 Sep 2025); EU-SYR the 28 May 2025 lifting of economic sanctions with retained Assad-regime/CW/captagon listings renewed to June 2027; EU-ZWE the February 2026 repeal of its asset-freeze/travel-ban framework (arms embargo only now); EU-MLI the fully autonomous post-UN-veto state. Never-used frameworks (EU-BOSNIA, EU-LEBANON, EU-NIGER) and emptied lists (EU-BDI, EU-TUR) are stated honestly. False claims removed (EU-TUN travel ban, EU-NIC/EU-GTM "trade restrictions", EU-CYB/EU-MDA trade claims).
- **Measures** (previously empty on most files) populated from the operative consolidated regulations and the Sanctions Map per-regime measure lists, using the controlled vocabulary boundaries: country-wide `Arms embargo` vs targeted `Arms restrictions` decided per regime (SDN/SSD/LBY/VEN/HTI embargo; SOM/CAF/COD/YEM/AFG targeted — incl. Somalia's 2023 lifting of the government embargo and Haiti's 2024 territory-wide SALW embargo, which the Sanctions Map still shows pre-amendment); EU-TERR corrected from `Financial restrictions` to `Asset freeze` (and its summary no longer claims an EU-level travel ban — CP 931 has none).
- **Aliases** now carry the operative Council Regulation + CFSP Decision citations, the Sanctions Map regime names, UNSCR numbers for UN-derived regimes, and the FSF programme codes matched by the dataset lookups (`RUS`, `TAQA`, `EUAQ`, …), mirroring the OFAC-code precedent from #4978.
- **Titles**: machine Title Case normalized to the official act names in sentence case; EU-PRK's title (identical to Iran's WMD regime name on the map) now names the DPRK; EU-ZWE retitled to the Council's February 2026 arms-embargo-only regime name.
- **Issuer fix**: eu_eeas claimed the EEAS is part of the European Commission — it is an autonomous EU body (Council Decision 2010/427/EU); `organisation` now reads European Union.

## Field and lookup fixes (separate commits)

- **EU-MARE `dataset: null` → `eu_sanctions_map`** — that crawler emits EU-MARE vessel designations (`datasets/eu/sanctions_map/crawler.py:36`).
- **`target_territories` added**: `zz` on the thematic EU-CHEM, EU-HR, EU-TERR, EU-TAQA-EUAQ per the README pseudo-territory policy; `iq` on EU-IRQ, `ua` on EU-UKR (the Sanctions Map's own country attribution for both sub-regimes), `ru` on EU-MARE.
- **EU-UKR `target_territories`** extended with the occupied territories (`ua-cri`, `ua-dpr`, `ua-lpr`) and `ru`, matching the AU-UKRAINE precedent for territorial-integrity regimes; `ua` stays for the misappropriation half.
- **eu_eeas issuer file removed** — referenced by zero programs or code anywhere in the repository.
- **eu_journal_sanctions forward-looking routes**: OJ acts keyed to the autonomous ISIL/Al-Qaida instruments (Reg (EU) 2016/1686 / Decision (CFSP) 2016/1693) or Decision (CFSP) 2026/455 (the new operative terrorism-list decision) now route to EU-TAQA-EUAQ / EU-TERR. Crawl-verified dormant: none of the three numbers occurs in current output.
- **eu_fsf lookup cleanup**: the four null-match options (empty programme code → EU-BOSNIA / EU-LEBANON / EU-NIGER / EU-US-LEG) commented out with a note that these regimes are empty and the mapping can be reactivated on a first designation. They were unreachable dead code (`zavod/zavod/shed/fsf.py` only consults the lookup for truthy codes) and a four-way ambiguous null match besides. Verified with a fresh `eu_fsf` crawl: zero occurrences of the four keys before and after, all other program-key counts identical (EU-UKR +46 from new source records published since the previous crawl), no lookup warnings.

## Consistency assessment vs EU restrictive-measures policy

Coverage is complete: every designation-capable regime among the 55 on the EU Sanctions Map resolves to an `EU-*` key, and no key corresponds to a revoked regime. Regimes without keys are all designation-less instruments (China Tiananmen arms-embargo declaration, claims-prohibition regimes, Crimea/non-government-controlled-areas trade regimes, never-used UN committees) — consistent with a designation-centred program model. The conflations mirror the FSF source granularity: EU-IRN = 3 map regimes (nuclear, human rights, Russia support), EU-RUS = 2 (situation-in-Russia + sectoral 833/2014), EU-UKR = 2 (territorial-integrity 269/2014 + misappropriation 208/2014) — all documented in the files' summaries, aliases, and multi-id URLs.

## Flags for follow-up (not changed here)

- EU-RUS excludes the main Russia designation list — 269/2014 listings route to EU-UKR (matching the FSF `UKR` code), so "EU Sanctions against Russia" ≠ the 269/2014 list. A split/rename is a data-coordination decision.
- EU-MARE overlaps EU-RUS (Annex XLII of the same Reg 833/2014); defensible as a distinct designation list, now cross-referenced in the summaries.
- EU-ESMA is market regulation (MiFID II suspensions), not a sanctions regime; EU-US-LEG is the Blocking Statute and can never designate anyone. Both kept, accurately described; whether they belong in the programs namespace is a product decision.
- Empty-but-live regimes (EU-BOSNIA, EU-LEBANON, EU-NIGER never used; EU-BDI, EU-TUR emptied; EU-GNB autonomous track emptied) — the eu_fsf dataset will emit nothing for them; presentation convention worth deciding once.
- EU-LEBANON's renewal horizon is 31 July 2026 — the file will need a touch-up when the expected renewal act lands.
- "EU Magnitsky Act" deliberately omitted from EU-HR aliases (Council rejected the name); add if vendor-reconciliation value outweighs that.
- The scope rule "program keys only for designation-capable regimes" is implicit; worth a line in `meta/README.md`.

## Verification

- `get_all_programs_by_key()` loads all 250 programs (keys, measures vocabulary, territory codes validated); yamllint/pre-commit hooks pass.
- Regime status through 2026-07-20 verified via Consilium press releases (Zimbabwe Feb 2026, EU-TERR/IRGC Feb 2026, Hamas May 2026, Guinea Oct 2025, Burundi Sep 2025 delisting, Tunisia Jan 2026 renewal), the Commission's Nov 2025 Syria FAQ, and the Sanctions Map API. EUR-Lex blocks non-browser clients; where needed, consolidated acts were checked via Wayback or a live browser session.
- The eu_fsf lookup change verified with a full crawl and before/after program-key diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

