### PR TITLE
[us_cms_npi] Disable LegalEntity.name fill-rate assertion

### DIFF
--- a/datasets/us/cms_npi/us_cms_npi.yml
+++ b/datasets/us/cms_npi/us_cms_npi.yml
@@ -53,6 +53,14 @@ assertions:
   min:
     schema_entities:
       LegalEntity: 100000
+    property_fill_rate:
+      # Providers materialise as Person or Organization (from the primary
+      # npidata file). Bare LegalEntity entities only exist as a side effect:
+      # the othername file contributes secondary/DBA names keyed by NPI, which
+      # we attach as `alias` (not `name`) so they merge into the primary entity
+      # by shared id.
+      LegalEntity:
+        name: 0
 
 lookups:
   type.name:


### PR DESCRIPTION
Bare `LegalEntity` entities in this dataset only arise from othername stubs — secondary/DBA names attached to a provider by NPI as `alias`. When such a stub's NPI has no primary record this run, it aggregates into a name-less `LegalEntity`, tanking the `LegalEntity.name` fill-rate to 0. The name legitimately lives on the merged Person/Organization, not the stub, so setting the threshold to 0 is the right call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)