### PR TITLE
[us_cms_npi] Filter non-name values from name fields with is_name

### DIFF
--- a/datasets/us/cms_npi/crawler.py
+++ b/datasets/us/cms_npi/crawler.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, TextIO
 from urllib.parse import urljoin
 import zipfile
 from rigour.mime.types import ZIP
+from rigour.names import is_name
 from rigour.text.stopwords import is_nullword
 
 from zavod import Context
@@ -16,6 +17,20 @@ def unescape_row(row: dict[str, Any]) -> dict[str, Any]:
     source CSV embeds in name and address fields. Leaving them undecoded trips
     zavod's HTML/XSS smell check; decoding recovers the intended characters."""
     return {k: html.unescape(v) if isinstance(v, str) else v for k, v in row.items()}
+
+
+def clean_name(value: Optional[str]) -> Optional[str]:
+    """Return ``value`` only if it plausibly contains a name.
+
+    The source frequently misuses name fields for placeholders (``-----``,
+    ``0``), phone numbers, postal codes, dates and bare digits. ``is_name``
+    rejects anything without at least one letter, keeping such junk out of the
+    name properties and out of zavod's "not a valid name" warnings."""
+    if value is None:
+        return None
+    if is_nullword(value) or not is_name(value):
+        return None
+    return value
 
 
 def npi_id(npi: Any) -> Optional[str]:
@@ -58,18 +73,15 @@ def crawl_npidata(context: Context, fh: TextIO) -> None:
             continue
 
         entity.add("npiCode", npi)
-        entity.add("name", row.pop("Provider Organization Name (Legal Business Name)"))
-        # The source uses placeholders like "-" or a bare "0" for missing middle names
-        middle_name = row.pop("Provider Middle Name")
-        if middle_name is not None and (
-            is_nullword(middle_name) or middle_name.strip() == "0"
-        ):
-            middle_name = None
+        entity.add(
+            "name",
+            clean_name(row.pop("Provider Organization Name (Legal Business Name)")),
+        )
         h.apply_name(
             entity,
-            first_name=row.pop("Provider First Name"),
-            last_name=row.pop("Provider Last Name (Legal Name)"),
-            middle_name=middle_name,
+            first_name=clean_name(row.pop("Provider First Name")),
+            last_name=clean_name(row.pop("Provider Last Name (Legal Name)")),
+            middle_name=clean_name(row.pop("Provider Middle Name")),
             quiet=True,
         )
         entity.add("title", row.pop("Provider Name Prefix Text"), quiet=True)
@@ -116,18 +128,11 @@ def crawl_othernames(context: Context, fh: TextIO) -> None:
         if not entity.id:
             context.log.warning(f"Invalid NPI in othername record: {row!r}")
             continue
-        name = row.get("Provider Other Organization Name")
-        if name is None or is_nullword(name):
+        name = clean_name(row.get("Provider Other Organization Name"))
+        if name is None:
             continue
-        # if name is None or len(name.strip()) == 0:
-        #     context.log.warning(f"Missing other organization name in record: {row!r}")
-        #     continue
         entity.add("alias", name)
-        if not entity.has("alias"):
-            # context.log.warning(f"Empty other organization name in record: {name!r}")
-            pass
-        else:
-            context.emit(entity)
+        context.emit(entity)
 
 
 def crawl(context: Context) -> None:


### PR DESCRIPTION
The source misuses name fields for placeholders, phone numbers, postal codes, dates and bare digits, tripping zavod's "not a valid name" warnings. Add a clean_name() helper using rigour.names.is_name and apply it to organization name, first/last/middle name and other-name alias.