### PR TITLE
expand on configured topic match or supporting schemata

### DIFF
--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -149,6 +149,7 @@ def emit_patch(
     topic: str,
     existing_topics: set[str],
 ) -> None:
+    """Emit a minimal patch entity to add ``topic`` to ``related_entity``."""
     context.log.info(
         f"Adding topic: {topic}",
         risk_source=risk_source.caption,

--- a/datasets/_externals/ext_us_ofac_press_releases.yml
+++ b/datasets/_externals/ext_us_ofac_press_releases.yml
@@ -47,6 +47,7 @@ inputs:
   # - maritime
 
 config:
+  topic_gated: true
   index_options:
     memory: 2000
     max_bucket_size: 300

--- a/zavod/zavod/runner/README.md
+++ b/zavod/zavod/runner/README.md
@@ -1,0 +1,16 @@
+## Enrichment
+
+https://nomenklatura.followthemoney.tech/reference/enrich/
+
+https://www.opensanctions.org/docs/enrichment/
+
+Enrichment can add entities related to entities with one of the enricher's filter topics, e.g. a company they own, the board of directors, etc. This is only done for related entities that have also been tagged with a filter topic. It can also add "supporting" schemata, e.g. linked Article entities.
+
+Topic-based expansion works as follows:
+
+1. First an enricher emits the adjacent entities (one hop over edge entities) as external.
+2. ann_graph_topics loads both internal and external entities, and emits the patch with the topic as external for adjacent entities that are still only external.
+3. Next the enricher sees the (external) risk topic, and now emits the adjacent entity as internal.
+4. Finally ann_graph_topics emits the patch as internal because it now sees the adjacent entity has become internal.
+
+Edges (Ownership, Family, Documentation) etc are emitted when both vertices are "publishable" (have a filter topic or is supporting).

--- a/zavod/zavod/runner/enrich.py
+++ b/zavod/zavod/runner/enrich.py
@@ -35,7 +35,7 @@ def save_match(
 
         # The first expansion result is the confirmed match itself. Keep it
         # visible; gate the graph context that follows it on risk topics assigned
-        # by the subject datasets and analyzers.
+        # by the subject datasets and analyzers or being supporting schemata.
         context.emit(expanded[0])
         adjacent = [e for e in expanded[1:] if not check_person_cutoff(e)]
         publishable = check_publishability(

--- a/zavod/zavod/runner/enrich.py
+++ b/zavod/zavod/runner/enrich.py
@@ -6,7 +6,7 @@ from nomenklatura.enrich import Enricher, EnrichmentException, make_enricher
 from zavod.meta import Dataset, get_multi_dataset
 from zavod.entity import Entity
 from zavod.context import Context
-from zavod.runner.util import check_enrich_topics, is_analyzer_stub, should_promote
+from zavod.runner.util import check_publishability, is_analyzer_stub, should_promote
 from zavod.store import get_store, View
 
 
@@ -38,13 +38,13 @@ def save_match(
         # by the subject datasets and analyzers.
         context.emit(expanded[0])
         adjacent = [e for e in expanded[1:] if not check_person_cutoff(e)]
-        topic_matches = check_enrich_topics(
+        publishable = check_publishability(
             adjacent, subject_view, frozenset(registry.topic.RISKS)
         )
         for adjacent_entity in adjacent:
             context.emit(
                 adjacent_entity,
-                external=not should_promote(adjacent_entity, topic_matches),
+                external=not should_promote(adjacent_entity, publishable),
             )
 
 

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -223,8 +223,8 @@ def enrich(context: Context) -> None:
     enricher = LocalEnricher(context.dataset, context.cache, config)
     # The same resolved set gates expansion context (check_publishability) and
     # filters which subject entities are matched and expanded at all
-    # (_filter_entity). That coupling guarantees the confirmed match always
-    # passes the gate, so supporting entities never publish disconnected.
+    # (BaseEnricher._filter_entity). That coupling guarantees the confirmed match
+    # always passes the gate, so supporting entities never publish disconnected.
     enrich_topics: frozenset[str] = frozenset(enricher.filter_topics)
     if topic_gated and not enrich_topics:
         raise ValueError(

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -197,6 +197,9 @@ def save_match(
         expanded = [adj for adj in expanded if not check_person_cutoff(adj)]
 
         if topic_gated:
+            # The first expansion result is the confirmed match itself. Keep it
+            # visible; gate the graph context that follows it on risk topics assigned
+            # by the subject datasets and analyzers.
             publishable = check_publishability(expanded, subject_view, enrich_topics)
             for adj in expanded:
                 context.emit(adj, external=not should_promote(adj, publishable))

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -18,7 +18,7 @@ from zavod.context import Context
 from zavod.integration.dedupe import get_dataset_linker
 from zavod.entity import Entity
 from zavod.meta import Dataset, get_multi_dataset, get_catalog
-from zavod.runner.util import check_enrich_topics, is_analyzer_stub, should_promote
+from zavod.runner.util import check_publishability, is_analyzer_stub, should_promote
 from zavod.store import get_store, View
 from zavod.reset import reset_caches
 
@@ -197,9 +197,9 @@ def save_match(
         expanded = [adj for adj in expanded if not check_person_cutoff(adj)]
 
         if topic_gated:
-            topic_matches = check_enrich_topics(expanded, subject_view, enrich_topics)
+            publishable = check_publishability(expanded, subject_view, enrich_topics)
             for adj in expanded:
-                context.emit(adj, external=not should_promote(adj, topic_matches))
+                context.emit(adj, external=not should_promote(adj, publishable))
         else:
             for adj in expanded:
                 context.emit(adj, external=False)
@@ -216,8 +216,10 @@ def enrich(context: Context) -> None:
     enricher = LocalEnricher(context.dataset, context.cache, config)
     enrich_topics: frozenset[str] = frozenset(enricher.filter_topics)
     if topic_gated and not enrich_topics:
-        context.log.warning(
-            "topic_gated=True but no topics configured; all expanded entities will be external"
+        enrich_topics = frozenset(registry.topic.RISKS)
+        context.log.info(
+            "topic_gated=True but no `topics` configured; gating expansion on "
+            "FollowTheMoney's risk topics (registry.topic.RISKS)."
         )
 
     subject_store = get_store(scope, context.resolver)
@@ -226,6 +228,9 @@ def enrich(context: Context) -> None:
     # resolver is in-memory after the load.
     context.flush()
     subject_store.sync()
+    # When topic-gated, read the subject store including external statements so
+    # the analyzer's topic patches on ingested-but-untagged neighbours are
+    # visible.
     subject_view = subject_store.view(scope, external=topic_gated)
 
     reset_caches()

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -166,6 +166,10 @@ class LocalEnricher(BaseEnricher[Dataset]):
     def expand_wrapped(
         self, entity: Entity, match: Entity
     ) -> Generator[Entity, None, None]:
+        """Yield the confirmed match itself, followed by entities related to
+        it in the external source (e.g. officers, owners, family members).
+
+        Only yields if ``entity`` passes the filter."""
         if not self._filter_entity(entity):
             return
         yield from self.expand(match)
@@ -199,7 +203,7 @@ def save_match(
         if topic_gated:
             # The first expansion result is the confirmed match itself. Keep it
             # visible; gate the graph context that follows it on risk topics assigned
-            # by the subject datasets and analyzers.
+            # by the subject datasets and analyzers or being supporting schemata.
             publishable = check_publishability(expanded, subject_view, enrich_topics)
             for adj in expanded:
                 context.emit(adj, external=not should_promote(adj, publishable))
@@ -217,12 +221,16 @@ def enrich(context: Context) -> None:
     config = dict(context.dataset.config)
     topic_gated: bool = bool(config.get("topic_gated", False))
     enricher = LocalEnricher(context.dataset, context.cache, config)
+    # The same resolved set gates expansion context (check_publishability) and
+    # filters which subject entities are matched and expanded at all
+    # (_filter_entity). That coupling guarantees the confirmed match always
+    # passes the gate, so supporting entities never publish disconnected.
     enrich_topics: frozenset[str] = frozenset(enricher.filter_topics)
     if topic_gated and not enrich_topics:
-        enrich_topics = frozenset(registry.topic.RISKS)
-        context.log.info(
-            "topic_gated=True but no `topics` configured; gating expansion on "
-            "FollowTheMoney's risk topics (registry.topic.RISKS)."
+        raise ValueError(
+            "topic_gated=True requires `topics` to be configured: without a "
+            "subject topic filter, expansion of untagged matches would emit "
+            "disconnected supporting entities."
         )
 
     subject_store = get_store(scope, context.resolver)

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -30,9 +30,7 @@ def is_supporting_schema(schema: Schema) -> bool:
     """Schemata that don't carry risk topics themselves but appear in expansion
     as attachments or context around risk targets — Addresses, Documents (Article,
     Image, PlainText, ...), Notes and other Analyzables, and non-edge Intervals
-    like Sanction, Passport, Identification. Under topic gating these are always
-    published when expansion reaches them; only risk targets (LegalEntity/Asset
-    descendants, Position, CryptoWallet) require a topic.
+    like Sanction, Passport, Identification.
     """
     return any(schema.is_a(schema_name) for schema_name in SUPPORTING_SCHEMATA)
 

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -58,19 +58,20 @@ def _is_publishable(entity_id: str, view: View, enrich_topics: frozenset[str]) -
 
 
 def check_publishability(
-    expanded: Iterable[Entity], view: View, enrich_topics: frozenset[str]
+    expanded: Iterable[Entity], subject_view: View, enrich_topics: frozenset[str]
 ) -> dict[str, bool]:
     """Look up publishability once per entity ID that will need it.
 
     Non-edge supporting entities in the expansion are publishable by virtue of
-    their schema, so they are seeded into the map without a lookup. Supporting
-    entities usually come from the target dataset and are absent from the
-    subject view, so this seeding is also what lets an edge to them (e.g. a
-    Documentation edge to an Article) publish.
+    their schema, not due to risk topics, so they are seeded into the returned
+    map without a lookup in the subject view.
 
     Non-supporting entities (the more common case - entities related via e.g.
     Ownership, Family) are looked up in the subject view where graph analyzer
     could have added topics.
+
+    Edges (supporting and risk-connecting) are publishable if all their endpoints
+    are publishable.
     """
     publishable: dict[str, bool] = {}
     ids_to_check: set[str] = set()
@@ -85,7 +86,7 @@ def check_publishability(
                 ids_to_check.add(entity.id)
     for eid in ids_to_check:
         if eid not in publishable:
-            publishable[eid] = _is_publishable(eid, view, enrich_topics)
+            publishable[eid] = _is_publishable(eid, subject_view, enrich_topics)
     return publishable
 
 

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -53,7 +53,7 @@ def _is_publishable(entity_id: str, view: View, enrich_topics: frozenset[str]) -
         return False
     if is_supporting_schema(entity.schema):
         return True
-    # Match _filter_entity's topic extraction (any topic-typed property).
+    # Match BaseEnricher._filter_entity's topic extraction (any topic-typed property).
     return bool(enrich_topics.intersection(entity.get_type_values(registry.topic)))
 
 

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from collections.abc import Iterable, Mapping
 
+from followthemoney import registry
 from followthemoney.schema import Schema
 
 from zavod.constants import ANALYZER_DATASETS
@@ -52,7 +53,8 @@ def _is_publishable(entity_id: str, view: View, enrich_topics: frozenset[str]) -
         return False
     if is_supporting_schema(entity.schema):
         return True
-    return bool(enrich_topics.intersection(entity.get("topics", quiet=True)))
+    # Match _filter_entity's topic extraction (any topic-typed property).
+    return bool(enrich_topics.intersection(entity.get_type_values(registry.topic)))
 
 
 def check_publishability(

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -62,23 +62,37 @@ def check_publishability(
 ) -> dict[str, bool]:
     """Look up publishability once per entity ID that will need it.
 
-    We need a lookup for every edge endpoint (to gate the edge) and for every
-    non-edge risk target (to gate the node). Non-edge supporting schemata are
-    always publishable, so we skip the lookup for them.
+    Non-edge supporting entities in the expansion are publishable by virtue of
+    their schema, so they are seeded into the map without a lookup. Supporting
+    entities usually come from the target dataset and are absent from the
+    subject view, so this seeding is also what lets an edge to them (e.g. a
+    Documentation edge to an Article) publish.
+
+    Non-supporting entities (the more common case - entities related via e.g.
+    Ownership, Family) are looked up in the subject view where graph analyzer
+    could have added topics.
     """
+    publishable: dict[str, bool] = {}
     ids_to_check: set[str] = set()
     for entity in expanded:
         if entity.schema.edge:
             ids_to_check.update(endpoint_ids(entity))
         else:
             assert entity.id is not None
-            ids_to_check.add(entity.id)
-    return {eid: _is_publishable(eid, view, enrich_topics) for eid in ids_to_check}
+            if is_supporting_schema(entity.schema):
+                publishable[entity.id] = True
+            else:
+                ids_to_check.add(entity.id)
+    for eid in ids_to_check:
+        if eid not in publishable:
+            publishable[eid] = _is_publishable(eid, view, enrich_topics)
+    return publishable
 
 
 def should_promote(entity: Entity, publishable: Mapping[str, bool]) -> bool:
-    """Publish supporting non-edges always, risk-target non-edges iff they carry a
-    topic, and edges iff every endpoint is itself publishable."""
+    """Publish non-edges iff the map says so (supporting schemata were seeded
+    True, risk targets need a topic) and edges iff every endpoint is itself
+    publishable."""
     if entity.schema.edge:
         endpoints = endpoint_ids(entity)
         if not endpoints:

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -1,4 +1,7 @@
+from functools import lru_cache
 from collections.abc import Iterable, Mapping
+
+from followthemoney.schema import Schema
 
 from zavod.constants import ANALYZER_DATASETS
 from zavod.entity import Entity
@@ -15,6 +18,20 @@ def is_analyzer_stub(entity: Entity) -> bool:
     return entity.datasets.issubset(ANALYZER_DATASETS)
 
 
+@lru_cache(maxsize=None)
+def is_supporting_schema(schema: Schema) -> bool:
+    """Schemata that don't carry risk topics themselves but appear in expansion
+    as attachments or context around risk targets — Addresses, Documents (Article,
+    Image, PlainText, ...), Notes and other Analyzables, and non-edge Intervals
+    like Sanction, Passport, Identification. Under topic gating these are always
+    published when expansion reaches them; only risk targets (LegalEntity/Asset
+    descendants, Position, CryptoWallet) require a topic.
+    """
+    return (
+        schema.is_a("Address") or schema.is_a("Analyzable") or schema.is_a("Interval")
+    )
+
+
 def endpoint_ids(entity: Entity) -> set[str]:
     """Get the entity IDs joined by an edge."""
     endpoint_ids: set[str] = set()
@@ -25,35 +42,44 @@ def endpoint_ids(entity: Entity) -> set[str]:
     return endpoint_ids
 
 
-def has_enrich_topic(entity_id: str, view: View, enrich_topics: frozenset[str]) -> bool:
-    """Check whether an entity carries a topic that justifies publication."""
+def _is_publishable(entity_id: str, view: View, enrich_topics: frozenset[str]) -> bool:
     canonical_id = view.store.linker.get_canonical(entity_id)
     entity = view.get_entity(canonical_id)
     if entity is None:
         return False
+    if is_supporting_schema(entity.schema):
+        return True
     return bool(enrich_topics.intersection(entity.get("topics")))
 
 
-def check_enrich_topics(
+def check_publishability(
     expanded: Iterable[Entity], view: View, enrich_topics: frozenset[str]
 ) -> dict[str, bool]:
-    """Look up publication topics once per entity ID in an expansion."""
+    """Look up publishability once per entity ID that will need it.
+
+    We need a lookup for every edge endpoint (to gate the edge) and for every
+    non-edge risk target (to gate the node). Non-edge supporting schemata are
+    always publishable, so we skip the lookup for them.
+    """
     ids_to_check: set[str] = set()
     for entity in expanded:
         if entity.schema.edge:
             ids_to_check.update(endpoint_ids(entity))
-        else:
+        elif not is_supporting_schema(entity.schema):
             assert entity.id is not None
             ids_to_check.add(entity.id)
-    return {eid: has_enrich_topic(eid, view, enrich_topics) for eid in ids_to_check}
+    return {eid: _is_publishable(eid, view, enrich_topics) for eid in ids_to_check}
 
 
-def should_promote(entity: Entity, topic_matches: Mapping[str, bool]) -> bool:
-    """Publish nodes with a topic and edges whose endpoints all have topics."""
+def should_promote(entity: Entity, publishable: Mapping[str, bool]) -> bool:
+    """Publish supporting non-edges always, risk-target non-edges iff they carry a
+    topic, and edges iff every endpoint is itself publishable."""
     if entity.schema.edge:
         endpoints = endpoint_ids(entity)
         if not endpoints:
             return False
-        return all(topic_matches.get(entity_id, False) for entity_id in endpoints)
+        return all(publishable.get(eid, False) for eid in endpoints)
+    if is_supporting_schema(entity.schema):
+        return True
     assert entity.id is not None
-    return topic_matches.get(entity.id, False)
+    return publishable.get(entity.id, False)

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -7,6 +7,13 @@ from zavod.constants import ANALYZER_DATASETS
 from zavod.entity import Entity
 from zavod.store import View
 
+SUPPORTING_SCHEMATA = {
+    "Address",
+    "Analyzable",
+    "Identification",
+    "Sanction",
+}
+
 
 def is_analyzer_stub(entity: Entity) -> bool:
     """Return whether the entity consists only of analyzer-emitted statements.
@@ -27,9 +34,7 @@ def is_supporting_schema(schema: Schema) -> bool:
     published when expansion reaches them; only risk targets (LegalEntity/Asset
     descendants, Position, CryptoWallet) require a topic.
     """
-    return (
-        schema.is_a("Address") or schema.is_a("Analyzable") or schema.is_a("Interval")
-    )
+    return any(schema.is_a(schema_name) for schema_name in SUPPORTING_SCHEMATA)
 
 
 def endpoint_ids(entity: Entity) -> set[str]:
@@ -49,7 +54,7 @@ def _is_publishable(entity_id: str, view: View, enrich_topics: frozenset[str]) -
         return False
     if is_supporting_schema(entity.schema):
         return True
-    return bool(enrich_topics.intersection(entity.get("topics")))
+    return bool(enrich_topics.intersection(entity.get("topics", quiet=True)))
 
 
 def check_publishability(
@@ -65,7 +70,7 @@ def check_publishability(
     for entity in expanded:
         if entity.schema.edge:
             ids_to_check.update(endpoint_ids(entity))
-        elif not is_supporting_schema(entity.schema):
+        else:
             assert entity.id is not None
             ids_to_check.add(entity.id)
     return {eid: _is_publishable(eid, view, enrich_topics) for eid in ids_to_check}
@@ -79,7 +84,5 @@ def should_promote(entity: Entity, publishable: Mapping[str, bool]) -> bool:
         if not endpoints:
             return False
         return all(publishable.get(eid, False) for eid in endpoints)
-    if is_supporting_schema(entity.schema):
-        return True
     assert entity.id is not None
     return publishable.get(entity.id, False)

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -1,4 +1,4 @@
-from functools import lru_cache
+from functools import cache
 from collections.abc import Iterable, Mapping
 
 from followthemoney import registry
@@ -26,7 +26,7 @@ def is_analyzer_stub(entity: Entity) -> bool:
     return entity.datasets.issubset(ANALYZER_DATASETS)
 
 
-@lru_cache(maxsize=None)
+@cache
 def is_supporting_schema(schema: Schema) -> bool:
     """Schemata that don't carry risk topics themselves but appear in expansion
     as attachments or context around risk targets — Addresses, Documents (Article,

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -1,6 +1,7 @@
 import shutil
 from copy import deepcopy
 
+import pytest
 from nomenklatura.judgement import Judgement
 
 from zavod import settings
@@ -9,6 +10,7 @@ from zavod.archive import clear_data_path, dataset_state_path
 from zavod.context import Context
 from nomenklatura.db import make_session
 from zavod.crawl import crawl_dataset
+from zavod.exc import RunFailedException
 from zavod.integration.dedupe import get_resolver
 from zavod.meta import Dataset
 from zavod.runner.local_enricher import LocalEnricher
@@ -211,6 +213,19 @@ def test_limit(vcontext: Context):
     results = list(enricher.match_candidates(entity, candidates[entity.id]))
     assert len(results) == 0, results
 
+    shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
+
+
+def test_topic_gated_requires_topics(testdataset1: Dataset):
+    """topic_gated without `topics` is a config error: subjects wouldn't be
+    topic-filtered, so untagged matches could emit disconnected supporting
+    entities."""
+    crawl_dataset(testdataset1)
+    dataset_data = deepcopy(DATASET_DATA)
+    dataset_data["config"]["topic_gated"] = True
+    enricher_ds = make_enricher_dataset(dataset_data, testdataset1.name)
+    with pytest.raises(RunFailedException):
+        crawl_dataset(enricher_ds)
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
 
 

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -216,7 +216,9 @@ def test_limit(vcontext: Context):
 
 def test_enrich_topic_gated(testdataset1: Dataset, testdataset_enrich_subject: Dataset):
     """With topic_gated=True, the matched entity (which has a topic) is emitted
-    internal; adjacent entities not in the subject store are emitted external."""
+    internal; an adjacent untagged risk-target entity is emitted external. Once
+    that neighbour is tagged in the subject store, a subsequent run promotes
+    both the node and the connecting edge to internal."""
     clear_data_path(testdataset_enrich_subject.name)
     crawl_dataset(testdataset_enrich_subject)  # enriching this
     crawl_dataset(testdataset1)  # enriching against this

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -127,6 +127,28 @@ def test_check_publishability(testdataset1: Dataset) -> None:
     assert not should_promote(ownership, publishable)
 
 
+def test_check_publishability_supporting_absent_from_view(
+    testdataset1: Dataset,
+) -> None:
+    """Supporting entities come from the target dataset via expansion and are
+    typically absent from the subject view; they and the edges reaching them
+    must still publish (e.g. ext_us_ofac_press_releases Articles)."""
+    tagged = make(testdataset1, "Person", "tagged", topics=["crime.boss"])
+    article = make(testdataset1, "Article", "article", title=["Scoop"])
+    documentation = make(
+        testdataset1, "Documentation", "doc", entity=["tagged"], document=["article"]
+    )
+
+    # The subject view knows nothing about the article.
+    view = FakeView([tagged])
+    expanded = [tagged, article, documentation]
+    publishable = check_publishability(expanded, view, ENRICH_TOPICS)
+    assert publishable == {"tagged": True, "article": True}
+
+    assert should_promote(article, publishable)
+    assert should_promote(documentation, publishable)
+
+
 def test_check_publishability_missing_endpoint(testdataset1: Dataset) -> None:
     tagged = make(testdataset1, "Person", "tagged", topics=["crime.boss"])
     edge = make(

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -111,28 +111,18 @@ def test_should_promote_edges(testdataset1: Dataset) -> None:
 def test_check_publishability(testdataset1: Dataset) -> None:
     tagged = make(testdataset1, "Person", "tagged", topics=["crime.boss"])
     untagged = make(testdataset1, "Person", "untagged", name=["Jane"])
-    article = make(testdataset1, "Article", "article", title=["Scoop"])
     ownership = make(
         testdataset1, "Ownership", "own", owner=["tagged"], asset=["untagged"]
     )
-    documentation = make(
-        testdataset1, "Documentation", "doc", entity=["tagged"], document=["article"]
-    )
 
-    view = FakeView([tagged, untagged, article])
-    expanded = [tagged, untagged, article, ownership, documentation]
+    view = FakeView([tagged, untagged])
+    expanded = [tagged, untagged, ownership]
     publishable = check_publishability(expanded, view, ENRICH_TOPICS)
-
-    # The article is looked up as a Documentation endpoint and is publishable
-    # as a supporting schema despite carrying no topic.
-    assert publishable == {"tagged": True, "untagged": False, "article": True}
+    assert publishable == {"tagged": True, "untagged": False}
 
     assert should_promote(tagged, publishable)
     assert not should_promote(untagged, publishable)
-    assert should_promote(article, publishable)
-    # The edge to the supporting article follows the article ...
-    assert should_promote(documentation, publishable)
-    # ... but the edge to the lateral untagged person still drops.
+    # The edge to the lateral untagged person drops.
     assert not should_promote(ownership, publishable)
 
 

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -1,0 +1,135 @@
+from followthemoney import model
+
+from zavod.entity import Entity
+from zavod.meta import Dataset
+from zavod.runner.util import (
+    check_publishability,
+    endpoint_ids,
+    is_supporting_schema,
+    should_promote,
+)
+
+ENRICH_TOPICS = frozenset({"reg.warn", "crime.boss"})
+
+
+class FakeLinker:
+    def get_canonical(self, entity_id: str) -> str:
+        return entity_id
+
+
+class FakeStore:
+    linker = FakeLinker()
+
+
+class FakeView:
+    """Stands in for zavod.store.View in check_publishability lookups."""
+
+    def __init__(self, entities: list[Entity]):
+        self.store = FakeStore()
+        self._entities = {e.id: e for e in entities}
+
+    def get_entity(self, entity_id: str) -> Entity | None:
+        return self._entities.get(entity_id)
+
+
+def make(dataset: Dataset, schema: str, id: str, **props: list[str]) -> Entity:
+    return Entity.from_data(dataset, {"schema": schema, "id": id, "properties": props})
+
+
+def test_is_supporting_schema():
+    supporting = [
+        "Address",
+        "Article",
+        "Image",
+        "PlainText",
+        "Note",
+        "Sanction",
+        "Passport",
+        "Identification",
+    ]
+    for name in supporting:
+        assert is_supporting_schema(model.get(name)), name
+    risk_targets = [
+        "Person",
+        "Company",
+        "Organization",
+        "LegalEntity",
+        "Security",
+        "Position",
+        "CryptoWallet",
+    ]
+    for name in risk_targets:
+        assert not is_supporting_schema(model.get(name)), name
+
+
+def test_endpoint_ids(testdataset1: Dataset):
+    ownership = make(testdataset1, "Ownership", "own", owner=["per"], asset=["com"])
+    assert endpoint_ids(ownership) == {"per", "com"}
+    person = make(testdataset1, "Person", "per", name=["Jane"])
+    assert endpoint_ids(person) == set()
+
+
+def test_should_promote_non_edges(testdataset1: Dataset):
+    # Supporting schemata publish without any lookup entry.
+    address = make(testdataset1, "Address", "addr", full=["1 Main St"])
+    assert should_promote(address, {})
+    article = make(testdataset1, "Article", "article", title=["Scoop"])
+    assert should_promote(article, {})
+    sanction = make(testdataset1, "Sanction", "sanc", reason=["bad"])
+    assert should_promote(sanction, {})
+
+    # Risk targets publish iff their lookup found a matching topic.
+    person = make(testdataset1, "Person", "per", name=["Jane"])
+    assert should_promote(person, {"per": True})
+    assert not should_promote(person, {"per": False})
+    assert not should_promote(person, {})
+
+
+def test_should_promote_edges(testdataset1: Dataset):
+    ownership = make(testdataset1, "Ownership", "own", owner=["per"], asset=["com"])
+    assert should_promote(ownership, {"per": True, "com": True})
+    assert not should_promote(ownership, {"per": True, "com": False})
+    assert not should_promote(ownership, {"per": True})
+
+    # An edge with no endpoint values never publishes.
+    dangling = make(testdataset1, "Ownership", "own2", role=["shareholder"])
+    assert not should_promote(dangling, {})
+
+
+def test_check_publishability(testdataset1: Dataset):
+    tagged = make(testdataset1, "Person", "tagged", topics=["crime.boss"])
+    untagged = make(testdataset1, "Person", "untagged", name=["Jane"])
+    article = make(testdataset1, "Article", "article", title=["Scoop"])
+    ownership = make(
+        testdataset1, "Ownership", "own", owner=["tagged"], asset=["untagged"]
+    )
+    documentation = make(
+        testdataset1, "Documentation", "doc", entity=["tagged"], document=["article"]
+    )
+
+    view = FakeView([tagged, untagged, article])
+    expanded = [tagged, untagged, article, ownership, documentation]
+    publishable = check_publishability(expanded, view, ENRICH_TOPICS)
+
+    # The article is looked up as a Documentation endpoint and is publishable
+    # as a supporting schema despite carrying no topic.
+    assert publishable == {"tagged": True, "untagged": False, "article": True}
+
+    assert should_promote(tagged, publishable)
+    assert not should_promote(untagged, publishable)
+    assert should_promote(article, publishable)
+    # The edge to the supporting article follows the article ...
+    assert should_promote(documentation, publishable)
+    # ... but the edge to the lateral untagged person still drops.
+    assert not should_promote(ownership, publishable)
+
+
+def test_check_publishability_missing_endpoint(testdataset1: Dataset):
+    tagged = make(testdataset1, "Person", "tagged", topics=["crime.boss"])
+    edge = make(
+        testdataset1, "Documentation", "doc", entity=["tagged"], document=["ghost"]
+    )
+    view = FakeView([tagged])
+    publishable = check_publishability([edge], view, ENRICH_TOPICS)
+    assert publishable == {"tagged": True, "ghost": False}
+    assert not should_promote(edge, publishable)

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -72,13 +72,13 @@ def test_endpoint_ids(testdataset1: Dataset) -> None:
 def test_should_promote_non_edges(testdataset1: Dataset) -> None:
     # Supporting schemata publish without any lookup entry.
     address = make(testdataset1, "Address", "addr", full=["1 Main St"])
-    publishability = check_publishability([address], FakeView([address]), frozenset())
+    publishability = check_publishability([address], FakeView([]), frozenset())
     assert should_promote(address, publishability)
     article = make(testdataset1, "Article", "article", title=["Scoop"])
-    publishability = check_publishability([article], FakeView([article]), frozenset())
+    publishability = check_publishability([article], FakeView([]), frozenset())
     assert should_promote(article, publishability)
     sanction = make(testdataset1, "Sanction", "sanc", reason=["bad"])
-    publishability = check_publishability([sanction], FakeView([sanction]), frozenset())
+    publishability = check_publishability([sanction], FakeView([]), frozenset())
     assert should_promote(sanction, publishability)
 
     # Risk targets publish iff their lookup found a matching topic.
@@ -97,6 +97,15 @@ def test_should_promote_edges(testdataset1: Dataset) -> None:
     # An edge with no endpoint values never publishes.
     dangling = make(testdataset1, "Ownership", "own2", role=["shareholder"])
     assert not should_promote(dangling, {})
+
+    # Documentation is an edge like any other: publishable iff its endpoints are,
+    # regardless of it being an Interval subclass.
+    documentation = make(
+        testdataset1, "Documentation", "doc", entity=["per"], document=["art"]
+    )
+    assert should_promote(documentation, {"per": True, "art": True})
+    assert not should_promote(documentation, {"per": True, "art": False})
+    assert not should_promote(documentation, {"per": True})
 
 
 def test_check_publishability(testdataset1: Dataset) -> None:

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -36,7 +36,7 @@ def make(dataset: Dataset, schema: str, id: str, **props: list[str]) -> Entity:
     return Entity.from_data(dataset, {"schema": schema, "id": id, "properties": props})
 
 
-def test_is_supporting_schema():
+def test_is_supporting_schema() -> None:
     supporting = [
         "Address",
         "Article",
@@ -62,21 +62,24 @@ def test_is_supporting_schema():
         assert not is_supporting_schema(model.get(name)), name
 
 
-def test_endpoint_ids(testdataset1: Dataset):
+def test_endpoint_ids(testdataset1: Dataset) -> None:
     ownership = make(testdataset1, "Ownership", "own", owner=["per"], asset=["com"])
     assert endpoint_ids(ownership) == {"per", "com"}
     person = make(testdataset1, "Person", "per", name=["Jane"])
     assert endpoint_ids(person) == set()
 
 
-def test_should_promote_non_edges(testdataset1: Dataset):
+def test_should_promote_non_edges(testdataset1: Dataset) -> None:
     # Supporting schemata publish without any lookup entry.
     address = make(testdataset1, "Address", "addr", full=["1 Main St"])
-    assert should_promote(address, {})
+    publishability = check_publishability([address], FakeView([address]), frozenset())
+    assert should_promote(address, publishability)
     article = make(testdataset1, "Article", "article", title=["Scoop"])
-    assert should_promote(article, {})
+    publishability = check_publishability([article], FakeView([article]), frozenset())
+    assert should_promote(article, publishability)
     sanction = make(testdataset1, "Sanction", "sanc", reason=["bad"])
-    assert should_promote(sanction, {})
+    publishability = check_publishability([sanction], FakeView([sanction]), frozenset())
+    assert should_promote(sanction, publishability)
 
     # Risk targets publish iff their lookup found a matching topic.
     person = make(testdataset1, "Person", "per", name=["Jane"])
@@ -85,7 +88,7 @@ def test_should_promote_non_edges(testdataset1: Dataset):
     assert not should_promote(person, {})
 
 
-def test_should_promote_edges(testdataset1: Dataset):
+def test_should_promote_edges(testdataset1: Dataset) -> None:
     ownership = make(testdataset1, "Ownership", "own", owner=["per"], asset=["com"])
     assert should_promote(ownership, {"per": True, "com": True})
     assert not should_promote(ownership, {"per": True, "com": False})
@@ -96,7 +99,7 @@ def test_should_promote_edges(testdataset1: Dataset):
     assert not should_promote(dangling, {})
 
 
-def test_check_publishability(testdataset1: Dataset):
+def test_check_publishability(testdataset1: Dataset) -> None:
     tagged = make(testdataset1, "Person", "tagged", topics=["crime.boss"])
     untagged = make(testdataset1, "Person", "untagged", name=["Jane"])
     article = make(testdataset1, "Article", "article", title=["Scoop"])
@@ -124,7 +127,7 @@ def test_check_publishability(testdataset1: Dataset):
     assert not should_promote(ownership, publishable)
 
 
-def test_check_publishability_missing_endpoint(testdataset1: Dataset):
+def test_check_publishability_missing_endpoint(testdataset1: Dataset) -> None:
     tagged = make(testdataset1, "Person", "tagged", topics=["crime.boss"])
     edge = make(
         testdataset1, "Documentation", "doc", entity=["tagged"], document=["ghost"]


### PR DESCRIPTION
Closes https://github.com/opensanctions/opensanctions/issues/4566

"supporting" schemata like Article, Identification, etc, never get risk topics. This defines a relevant set of superclasses which are always emitted when expanding related entities. Supporting edges (e.g. Documentation) are emitted if both vertices are "publishable" (topic and supporting)

@leonhandreke maybe good to get a sense whether this code is understandable. the intro in zavod/runner/README.md should help.