### PR TITLE
Document deterministic name-title stripping

### DIFF
--- a/.claude/docs/crawler-guide.md
+++ b/.claude/docs/crawler-guide.md
@@ -176,6 +176,8 @@ full = h.make_name(full=row.get("fullname"), first_name=first, last_name=last)
 
 Use `h.apply_name()` for Person entities. For name-only: `entity.add("name", ...)`.
 
+When source names carry a fixed set of honorifics or post-nominals (`Hon.`, `Dr.`, `, MP`), strip them deterministically via dataset config rather than the review system — see `zavod/docs/best_practices/name_titles.md`.
+
 ### Dates
 
 ```python

--- a/zavod/docs/best_practices/name_titles.md
+++ b/zavod/docs/best_practices/name_titles.md
@@ -1,0 +1,83 @@
+# Stripping name prefixes and suffixes
+
+Remove a known set of honorific prefixes and post-nominal suffixes from source names with per-dataset configuration, without a human review.
+
+Many official sources publish names with titles attached: `Hon. Jane Doe, MP`, `Dr. John Smith`, `Sen. (Rtd) Amina Yusuf`. These titles are not part of the name and reduce match quality. When a source uses a fixed, predictable set of titles, strip them deterministically with [`h.strip_name_titles`][zavod.helpers.strip_name_titles] instead of routing the names through the [name review system](../extract/names.md).
+
+## Prefer deterministic stripping when the affix set is known
+
+If the honorifics and post-nominals a source uses are a closed, enumerable list (`Hon.`, `Dr.`, `Prof.`, `, MP`, `, CS`), declare them in the dataset metadata and call `h.strip_name_titles`. Do not send predictable titles through the review system: that adds LLM cost and human-review latency to a problem the crawler can solve on its own, and every new member waits on a review before their name is clean.
+
+Reach for the name review system only when the name is genuinely ambiguous: multiple names packed into one string, alias or previous-name categorization, or transliteration variants. Those cases are covered under [when to use the review system instead](#when-to-use-the-review-system-instead).
+
+## The pattern
+
+Declare the titles under a `names` block in the dataset YAML, listing prefixes and suffixes separately:
+
+```yaml
+names:
+  prefixes_strip:
+    - Hon.
+    - "Hon "
+    - Dr.
+    - (Dr.)
+    - Prof.
+    - Sen.
+    - (Rtd)
+  suffixes_strip:
+    - ", MP"
+    - ", CS"
+```
+
+In the crawler, pass each raw name through `h.strip_name_titles`. It reads the configured affixes from the dataset metadata, so the call takes only the context and the name:
+
+```python
+clean_name = h.strip_name_titles(context, raw_name)
+original_name = raw_name if clean_name != raw_name else None
+person.add("name", clean_name, lang="eng", original_value=original_name)
+```
+
+`datasets/ke/national_assembly/crawler.py` and `datasets/ke/senate/crawler.py` follow this idiom directly. `datasets/ug/parliament/crawler.py` shows the variant that feeds the cleaned string into [`h.apply_name`][zavod.helpers.apply_name]:
+
+```python
+clean_name = h.strip_name_titles(context, name)
+h.apply_name(person, full=clean_name, lang="eng")
+```
+
+## Configure the exact strings the source uses
+
+`strip_name_titles` matches configured affixes as exact strings, case-insensitively. It does no punctuation folding, so every surface form the source uses is its own list entry:
+
+- **Punctuation variants are separate.** `Dr.` does not match `(Dr.)`. List both if the source uses both.
+- **Trailing-space variants are separate.** A prefix that appears both as `Hon.` and as `Hon ` (no dot, space before the name) needs both `Hon.` and `"Hon "`. Quote entries with leading or trailing spaces so YAML preserves them.
+- **Suffix entries include the separator.** A post-nominal published as `Jane Doe, MP` is configured as `", MP"`, with the comma and space, because that whole run is what gets removed.
+
+Affixes are tried **longest first**, so a longer form is stripped before any shorter string it contains. This is why `(Prof.)` must be listed explicitly: relying on `Prof.` alone would strip the letters and leave a stray `)`.
+
+Stripping is **iterative**: the helper peels one matching affix per pass and repeats until nothing matches. Stacked titles are handled without extra configuration:
+
+```text
+"Hon. Dr. Jane Doe, MP"  ->  "Jane Doe"
+```
+
+## Preserve the original value
+
+When the cleaned name differs from the source string, keep the original on the statement with `original_value` so the source form stays traceable:
+
+```python
+original_name = raw_name if clean_name != raw_name else None
+person.add("name", clean_name, lang="eng", original_value=original_name)
+```
+
+Set `original_value` only when the strings differ. Passing the raw value when nothing was stripped records a redundant provenance entry.
+
+## When to use the review system instead
+
+Deterministic stripping handles a fixed affix list and nothing else. Use [the name review system](../extract/names.md) when a name needs judgment rather than a lookup:
+
+- **Multiple names in one string**, such as `John Smith; Jonny Smith` or a name plus its former name.
+- **Categorization** into `alias`, `weakAlias`, or `previousName`.
+- **Splitting** or handling transliteration variants like `Aleksandr(Oleksandr) KALYUSSKY`.
+- **Open-ended dirt** that isn't a predictable, enumerable set of titles.
+
+The two approaches compose. Strip the known titles deterministically, and the irregularity checks in [`h.is_name_irregular`][zavod.helpers.is_name_irregular] and the `apply_reviewed_*` helpers still apply to whatever remains.

--- a/zavod/docs/extract/names.md
+++ b/zavod/docs/extract/names.md
@@ -10,6 +10,8 @@ Clean, correctly categorised names are important to maximise recall (finding all
 
 While we've done this using simple, explainable logic for the most part, this leaves some noise or incorrectly-categorised names for a number of sources.
 
+When a source attaches a fixed, predictable set of honorific titles to names (`Hon.`, `Dr.`, `, MP`), strip them deterministically rather than through review. See [stripping name prefixes and suffixes](../best_practices/name_titles.md).
+
 In most cases, the end goal is to use the [zavod.helpers.apply_reviewed_name_string][] or [zavod.helpers.apply_reviewed_names][] to
 
 - determine whether names need cleaning

--- a/zavod/mkdocs.yml
+++ b/zavod/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - best_practices/caching.md
       - best_practices/patterns.md
       - best_practices/addresses.md
+      - best_practices/name_titles.md
       - best_practices/datapatch_lookups.md
       - best_practices/dates_meta.md
       - best_practices/entity_id.md


### PR DESCRIPTION
Adds documentation for `h.strip_name_titles` and the `names.prefixes_strip` / `names.suffixes_strip` dataset-metadata config, which strips a known, closed set of honorific prefixes and post-nominal suffixes (`Hon.`, `Dr.`, `, MP`) deterministically — without the review system. This mechanism (used by the Kenya and Uganda parliamentary crawlers) previously had no documentation anywhere in `zavod/docs/`.

## Changes

- **New:** `zavod/docs/best_practices/name_titles.md` — "Stripping name prefixes and suffixes". Leads with the recommendation (prefer deterministic stripping when the affix set is known), shows the crawler + YAML pattern with `original_value` provenance, documents the exact-string / longest-first / iterative matching behavior, and points to the review system for genuinely ambiguous names.
- **Nav:** registered the page in `zavod/mkdocs.yml` under Best practices.
- **Cross-references:** a See-also line in `.claude/docs/crawler-guide.md` (Names section) and a back-link from `zavod/docs/extract/names.md`.

## Verification

- `mkdocs build --strict` passes with no new warnings; all mkdocstrings autoref links resolve.
- Prose follows the FollowTheMoney documentation styleguide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)