### PR TITLE
[cz_business_register] Skip placeholder address values

### DIFF
--- a/datasets/cz/business_register/crawler.py
+++ b/datasets/cz/business_register/crawler.py
@@ -4,6 +4,7 @@ from typing import Optional, IO
 
 from followthemoney.util import make_entity_id
 from lxml import etree
+from rigour.text import is_nullword
 from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.util import ElementOrTree
@@ -30,7 +31,7 @@ def make_address(tree: Optional[ElementOrTree] = None) -> Optional[str]:
         return None
 
     full = tree.findtext("text")
-    if full is not None:
+    if full is not None and not is_nullword(full.strip()) and full.strip() != ".":
         return full
 
     components = {


### PR DESCRIPTION
Some records in the CZ business register use a placeholder like "-" or "." in the address `text` field instead of a real address. These emit as address values and trip the "too short for an address" warning (~950/run, dominated by "." at 874×).

`is_nullword` (post opensanctions/rigour#173) catches the dash variants; "." isn't in the nullword list, so it's special-cased. Placeholder values now fall through to the structured address components, which are empty for these records. Real short place names (Aš, Lom, USA, ...) are untouched.

Entity IDs are unaffected: person_id already ran slugify(address) and fell back to the company-based slug for these placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)