### PR TITLE
Validate dataset catalog metadata in zavod before writing

### DIFF
--- a/zavod/zavod/exporters/metadata/__init__.py
+++ b/zavod/zavod/exporters/metadata/__init__.py
@@ -2,9 +2,12 @@ from enum import StrEnum
 import json
 from typing import Any
 
+from pydantic import ValidationError
+
 from zavod import settings
 from zavod.logs import get_logger
 from zavod.meta import Dataset, get_catalog
+from zavod.exporters.metadata.model import CatalogDatasetModel
 from zavod.archive import INDEX_FILE, STATISTICS_FILE, ISSUES_FILE
 from zavod.archive import CATALOG_FILE, DELTA_INDEX_FILE, DELTA_EXPORT_FILE
 from zavod.archive import UNLISTED_RESOURCES
@@ -139,6 +142,21 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
                     dataset.name, version.id, DELTA_INDEX_FILE
                 )
                 break
+
+    # Validate against the published output contract before writing. The model
+    # knows a failed run legitimately lacks statistics, so a degraded failure
+    # index doesn't trip it.
+    # TODO: For now this only warns so we can gauge how often real runs violate
+    # the contract; tighten it to a hard failure once we're confident
+    # (https://github.com/opensanctions/opensanctions/issues/4643).
+    try:
+        CatalogDatasetModel.model_validate(meta)
+    except ValidationError as exc:
+        log.warning(
+            "Dataset metadata does not conform to the catalog model",
+            dataset=dataset.name,
+            errors=exc.errors(),
+        )
 
     with open(index_path, "wb") as fh:
         write_json(meta, fh)

--- a/zavod/zavod/exporters/metadata/model.py
+++ b/zavod/zavod/exporters/metadata/model.py
@@ -1,30 +1,24 @@
 """Typed model for the metadata zavod writes to a dataset's ``index.json``.
 
-This is the *output* contract for a single dataset entry in the catalog, and it
-is deliberately distinct from the two *input* models it sits downstream of:
+This is the *output* contract for a single dataset entry in the catalog. It
+extends :class:`followthemoney.dataset.dataset.DatasetModel` — the loose schema
+used to read any catalog, where nearly every field is optional — and tightens
+it into what a published export must actually contain: ``version``,
+``updated_at`` and ``last_export`` become required, ``resources`` use the
+stricter published :class:`ResourceModel`, and it adds the operational fields
+that only exist once a run has produced them (counts, ``last_change``, issue
+levels, artifact URLs, ``result``).
 
-- ``followthemoney.dataset.dataset.DatasetModel`` is the loose, general schema
-  used to parse any catalog. Nearly every field there is optional so it can read
-  many shapes, so it cannot guard our exports.
-- ``zavod.meta.model.ZavodDatasetModel`` reads a dataset's description from its
-  ``.yml`` metadata file. Beyond the descriptive fields it also carries knobs
-  that control how the crawler runs — e.g. scheduling and memory consumption —
-  which have no place on the output side. It carries none of the operational
-  run fields (counts, ``last_change``, artifact URLs, ``result``) that only
-  come into existence after an export.
+The statistics-derived fields are required only for a successful run — a failed
+run deliberately drops its statistics.
 
-``CatalogDatasetModel`` is a flat, standalone model rather than a subclass of
-either of the above, for two reasons: (a) it adds the operational fields that
-only exist once a run has produced them, and (b) it is more restrictive than the
-input models because it is public API surface, which we want to evolve
-deliberately.
+It is public API surface, so evolve it deliberately.
 """
 
 from datetime import datetime
 from typing import Annotated, Any, Literal, Optional, Self
 
-from followthemoney.dataset.coverage import DataCoverage
-from followthemoney.dataset.publisher import DataPublisher
+from followthemoney.dataset.dataset import DatasetModel as FTMDatasetModel
 from pydantic import (
     BaseModel,
     HttpUrl,
@@ -74,31 +68,22 @@ class ResourceModel(BaseModel):
         return self
 
 
-class CatalogDatasetModel(BaseModel):
-    """Typed representation of a dataset entry in the OpenSanctions catalog and
-    per-dataset ``index.json``.
+class CatalogDatasetModel(FTMDatasetModel):
+    """A dataset entry in the OpenSanctions catalog and per-dataset ``index.json``.
 
-    See the module docstring for how this output model relates to the
-    ``DatasetModel`` / ``ZavodDatasetModel`` input models.
+    See the module docstring for how this tightens the FtM ``DatasetModel`` base.
     """
 
-    name: str
-    title: str
-    summary: Optional[str] = None
-    description: Optional[str] = None
-    url: Optional[HttpUrl] = None
+    # ── Tightened from the FtM base ───────────────────────────────────────────
     version: str
-    tags: list[str] = []
-    publisher: Optional[DataPublisher] = None
-    """None for collections, which aggregate sources rather than having their own publisher."""
-    coverage: Optional[DataCoverage] = None
-    children: set[str] = set()
-    """Internal representation of the datasets included in this collection. Prefer `datasets` for external use."""
-    deprecation: Optional[str] = None
-    """Markdown explanation of why the dataset was deprecated and what happened to it.
-    Only present when `deprecated` is True, e.g. 'The source API was shut down in April 2025...'"""
-    deprecated: bool
-    """Whether this dataset is deprecated (i.e. no longer actively maintained or updated)."""
+    updated_at: IsoDatetime
+    last_export: IsoDatetime
+    # ResourceModel is the stricter published form of the base's DataResource;
+    # list invariance stops mypy from seeing this as a valid narrowing.
+    resources: list[ResourceModel] = []  # type: ignore[assignment]
+    """Downloadable data files for this dataset (excludes internal artifact files)."""
+
+    # ── Zavod configuration carried into the export ───────────────────────────
     entry_point: Optional[str] = None
     disabled: bool
     hidden: bool
@@ -106,7 +91,6 @@ class CatalogDatasetModel(BaseModel):
     """Whether to run entity resolution on this dataset. Implicit default is True;
     only serialized when False (currently only 'maritime')."""
     full_dataset: Optional[str] = None
-
     data: Optional[DataModel] = None
     """Crawler source metadata (URL, format, mode). None for collections and some externals."""
 
@@ -123,13 +107,10 @@ class CatalogDatasetModel(BaseModel):
     """The public-facing list of datasets included in this collection — always identical to `children`.
     This is the field documented and intended for external consumers; `children` is the internal representation."""
 
-    updated_at: IsoDatetime
-    last_export: IsoDatetime
+    # ── Operational fields, only present after a run ──────────────────────────
     last_change: Optional[IsoDatetime] = None
     """Timestamp of the most recent entity change in the dataset."""
 
-    entity_count: Optional[int] = None
-    thing_count: Optional[int] = None
     target_count: Optional[int] = None
     """Number of entities flagged as targets."""
 
@@ -139,9 +120,6 @@ class CatalogDatasetModel(BaseModel):
 
     issue_count: int
     """Total number of issues across all levels."""
-
-    resources: list[ResourceModel] = []
-    """Downloadable data files for this dataset (excludes internal artifact files)."""
 
     index_url: HttpUrl
     """Published URL of this dataset's index.json."""

--- a/zavod/zavod/exporters/metadata/model.py
+++ b/zavod/zavod/exporters/metadata/model.py
@@ -9,6 +9,11 @@ stricter published :class:`ResourceModel`, and it adds the operational fields
 that only exist once a run has produced them (counts, ``last_change``, issue
 levels, artifact URLs, ``result``).
 
+The input side, :class:`zavod.meta.model.ZavodDatasetModel`, also extends
+``DatasetModel``: it reads a dataset's description from its ``.yml`` metadata
+file and carries knobs controlling how the crawler runs (e.g. scheduling and
+memory consumption) that have no place on the output side.
+
 The statistics-derived fields are required only for a successful run — a failed
 run deliberately drops its statistics.
 

--- a/zavod/zavod/exporters/metadata/model.py
+++ b/zavod/zavod/exporters/metadata/model.py
@@ -89,13 +89,17 @@ class CatalogDatasetModel(FTMDatasetModel):
     """Downloadable data files for this dataset (excludes internal artifact files)."""
 
     # ── Zavod configuration carried into the export ───────────────────────────
+    # TODO: this default ideally belongs only on the input (ZavodDatasetModel) side and passes through; kept here while we still build the index JSON by hand.
     entry_point: Optional[str] = None
     disabled: bool
     hidden: bool
+    # TODO: this default ideally belongs only on the input (ZavodDatasetModel) side and passes through; kept here while we still build the index JSON by hand.
     resolve: bool = True
     """Whether to run entity resolution on this dataset. Implicit default is True;
     only serialized when False (currently only 'maritime')."""
+    # TODO: this default ideally belongs only on the input (ZavodDatasetModel) side and passes through; kept here while we still build the index JSON by hand.
     full_dataset: Optional[str] = None
+    # TODO: this default ideally belongs only on the input (ZavodDatasetModel) side and passes through; kept here while we still build the index JSON by hand.
     data: Optional[DataModel] = None
     """Crawler source metadata (URL, format, mode). None for collections and some externals."""
 

--- a/zavod/zavod/exporters/metadata/model.py
+++ b/zavod/zavod/exporters/metadata/model.py
@@ -21,7 +21,7 @@ It is public API surface, so evolve it deliberately.
 """
 
 from datetime import datetime
-from typing import Annotated, Any, Literal, Optional, Self
+from typing import Annotated, Any, Literal, Self
 
 from followthemoney.dataset.dataset import DatasetModel as FTMDatasetModel
 from pydantic import (
@@ -58,7 +58,7 @@ class ResourceModel(BaseModel):
     """MIME type, e.g. 'application/json+ftm' or 'text/plain'."""
     mime_type_label: str
     """Generic format label derived from the MIME type, e.g. 'FollowTheMoney Entities' or 'Plain text'."""
-    title: Optional[str] = None
+    title: str | None = None
     """Description of what this specific file contains, e.g. 'FollowTheMoney entities' or 'Target names text file'.
     Absent for raw source files published without a title (e.g. pass-through .xlsx files)."""
     size: int
@@ -90,7 +90,7 @@ class CatalogDatasetModel(FTMDatasetModel):
 
     # ── Zavod configuration carried into the export ───────────────────────────
     # TODO: this default ideally belongs only on the input (ZavodDatasetModel) side and passes through; kept here while we still build the index JSON by hand.
-    entry_point: Optional[str] = None
+    entry_point: str | None = None
     disabled: bool
     hidden: bool
     # TODO: this default ideally belongs only on the input (ZavodDatasetModel) side and passes through; kept here while we still build the index JSON by hand.
@@ -98,9 +98,9 @@ class CatalogDatasetModel(FTMDatasetModel):
     """Whether to run entity resolution on this dataset. Implicit default is True;
     only serialized when False (currently only 'maritime')."""
     # TODO: this default ideally belongs only on the input (ZavodDatasetModel) side and passes through; kept here while we still build the index JSON by hand.
-    full_dataset: Optional[str] = None
+    full_dataset: str | None = None
     # TODO: this default ideally belongs only on the input (ZavodDatasetModel) side and passes through; kept here while we still build the index JSON by hand.
-    data: Optional[DataModel] = None
+    data: DataModel | None = None
     """Crawler source metadata (URL, format, mode). None for collections and some externals."""
 
     # ── Fields computed for the catalog export ────────────────────────────────
@@ -117,10 +117,10 @@ class CatalogDatasetModel(FTMDatasetModel):
     This is the field documented and intended for external consumers; `children` is the internal representation."""
 
     # ── Operational fields, only present after a run ──────────────────────────
-    last_change: Optional[IsoDatetime] = None
+    last_change: IsoDatetime | None = None
     """Timestamp of the most recent entity change in the dataset."""
 
-    target_count: Optional[int] = None
+    target_count: int | None = None
     """Number of entities flagged as targets."""
 
     issue_levels: dict[str, int] = {}
@@ -139,11 +139,11 @@ class CatalogDatasetModel(FTMDatasetModel):
     statistics_url: HttpUrl
     """URL to the statistics JSON artifact for the last export."""
 
-    delta_url: Optional[HttpUrl] = None
+    delta_url: HttpUrl | None = None
     """URL to the delta index for the most recent export that produced one.
     Not all exports produce a delta; None when absent."""
 
-    result: Optional[Literal["success", "failure"]] = None
+    result: Literal["success", "failure"] | None = None
     """Outcome of the last export run."""
 
     @field_validator("tags")

--- a/zavod/zavod/exporters/metadata/model.py
+++ b/zavod/zavod/exporters/metadata/model.py
@@ -1,0 +1,205 @@
+"""Typed model for the metadata zavod writes to a dataset's ``index.json``.
+
+This is the *output* contract for a single dataset entry in the catalog, and it
+is deliberately distinct from the two *input* models it sits downstream of:
+
+- ``followthemoney.dataset.dataset.DatasetModel`` is the loose, general schema
+  used to parse any catalog. Nearly every field there is optional so it can read
+  many shapes, so it cannot guard our exports.
+- ``zavod.meta.model.ZavodDatasetModel`` reads a dataset's description from its
+  ``.yml`` metadata file. Beyond the descriptive fields it also carries knobs
+  that control how the crawler runs — e.g. scheduling and memory consumption —
+  which have no place on the output side. It carries none of the operational
+  run fields (counts, ``last_change``, artifact URLs, ``result``) that only
+  come into existence after an export.
+
+``CatalogDatasetModel`` is a flat, standalone model rather than a subclass of
+either of the above, for two reasons: (a) it adds the operational fields that
+only exist once a run has produced them, and (b) it is more restrictive than the
+input models because it is public API surface, which we want to evolve
+deliberately.
+"""
+
+from datetime import datetime
+from typing import Annotated, Any, Literal, Optional, Self
+
+from followthemoney.dataset.coverage import DataCoverage
+from followthemoney.dataset.publisher import DataPublisher
+from pydantic import (
+    BaseModel,
+    HttpUrl,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
+from pydantic.functional_serializers import PlainSerializer
+
+from zavod.meta.model import DataModel
+
+# Very explicitly enforce the datetime format we use in the catalog
+# (ISO 8601 without timezone).
+IsoDatetime = Annotated[
+    datetime,
+    PlainSerializer(lambda dt: dt.strftime("%Y-%m-%dT%H:%M:%S"), return_type=str),
+]
+
+
+class ResourceModel(BaseModel):
+    """A downloadable data file attached to a dataset."""
+
+    name: str
+    """Filename, e.g. 'entities.ftm.json' or 'targets.csv'."""
+    path: str
+    """Deprecated — always identical to `name`. Kept for backwards compatibility with older consumers."""
+    url: HttpUrl
+    """Full published URL, e.g. 'https://data.opensanctions.org/datasets/20260429/us_ofac_sdn/entities.ftm.json'."""
+    checksum: str
+    """SHA1 hex digest of the file content."""
+    mime_type: str
+    """MIME type, e.g. 'application/json+ftm' or 'text/plain'."""
+    mime_type_label: str
+    """Generic format label derived from the MIME type, e.g. 'FollowTheMoney Entities' or 'Plain text'."""
+    title: Optional[str] = None
+    """Description of what this specific file contains, e.g. 'FollowTheMoney entities' or 'Target names text file'.
+    Absent for raw source files published without a title (e.g. pass-through .xlsx files)."""
+    size: int
+    """File size in bytes."""
+
+    @model_validator(mode="after")
+    def validate_name_equals_path(self) -> Self:
+        if self.name != self.path:
+            raise ValueError(
+                f"resource name {self.name!r} does not match path {self.path!r}"
+            )
+        return self
+
+
+class CatalogDatasetModel(BaseModel):
+    """Typed representation of a dataset entry in the OpenSanctions catalog and
+    per-dataset ``index.json``.
+
+    See the module docstring for how this output model relates to the
+    ``DatasetModel`` / ``ZavodDatasetModel`` input models.
+    """
+
+    name: str
+    title: str
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    url: Optional[HttpUrl] = None
+    version: str
+    tags: list[str] = []
+    publisher: Optional[DataPublisher] = None
+    """None for collections, which aggregate sources rather than having their own publisher."""
+    coverage: Optional[DataCoverage] = None
+    children: set[str] = set()
+    """Internal representation of the datasets included in this collection. Prefer `datasets` for external use."""
+    deprecation: Optional[str] = None
+    """Markdown explanation of why the dataset was deprecated and what happened to it.
+    Only present when `deprecated` is True, e.g. 'The source API was shut down in April 2025...'"""
+    deprecated: bool
+    """Whether this dataset is deprecated (i.e. no longer actively maintained or updated)."""
+    entry_point: Optional[str] = None
+    disabled: bool
+    hidden: bool
+    resolve: bool = True
+    """Whether to run entity resolution on this dataset. Implicit default is True;
+    only serialized when False (currently only 'maritime')."""
+    full_dataset: Optional[str] = None
+
+    data: Optional[DataModel] = None
+    """Crawler source metadata (URL, format, mode). None for collections and some externals."""
+
+    # ── Fields computed for the catalog export ────────────────────────────────
+    type: Literal["collection", "source", "external"]
+    """Dataset kind: 'collection' groups sources; 'source' is a crawled dataset;
+    'external' is an externally-managed dataset."""
+
+    collections: list[str] = []
+    """For sources/externals: names of all collections that include this dataset,
+    populated by scanning the catalog. Empty for collections themselves."""
+
+    datasets: list[str] = []
+    """The public-facing list of datasets included in this collection — always identical to `children`.
+    This is the field documented and intended for external consumers; `children` is the internal representation."""
+
+    updated_at: IsoDatetime
+    last_export: IsoDatetime
+    last_change: Optional[IsoDatetime] = None
+    """Timestamp of the most recent entity change in the dataset."""
+
+    entity_count: Optional[int] = None
+    thing_count: Optional[int] = None
+    target_count: Optional[int] = None
+    """Number of entities flagged as targets."""
+
+    issue_levels: dict[str, int] = {}
+    """Count of issues per log level (e.g. {'warning': 3, 'error': 1}).
+    Zero-filled before the first export. Keys are lowercase structlog level names."""
+
+    issue_count: int
+    """Total number of issues across all levels."""
+
+    resources: list[ResourceModel] = []
+    """Downloadable data files for this dataset (excludes internal artifact files)."""
+
+    index_url: HttpUrl
+    """Published URL of this dataset's index.json."""
+
+    issues_url: HttpUrl
+    """URL to the issues log artifact for the last export."""
+
+    statistics_url: HttpUrl
+    """URL to the statistics JSON artifact for the last export."""
+
+    delta_url: Optional[HttpUrl] = None
+    """URL to the delta index for the most recent export that produced one.
+    Not all exports produce a delta; None when absent."""
+
+    result: Optional[Literal["success", "failure"]] = None
+    """Outcome of the last export run."""
+
+    @field_validator("tags")
+    @classmethod
+    def validate_tags(cls, v: list[str]) -> list[str]:
+        for tag in v:
+            if " " in tag:
+                raise ValueError(f"tag {tag!r} must not contain spaces")
+        return v
+
+    @model_validator(mode="after")
+    def validate_collection_has_children(self) -> Self:
+        if self.type == "collection" and not self.children:
+            raise ValueError(
+                f"collection {self.name!r} must have at least one child dataset"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_successful_run_has_statistics(self) -> Self:
+        # A failed run deliberately drops its statistics, so the derived fields
+        # are absent by design. A successful run must carry them.
+        if self.result == "success":
+            missing = [
+                name
+                for name in (
+                    "entity_count",
+                    "thing_count",
+                    "target_count",
+                    "last_change",
+                )
+                if getattr(self, name) is None
+            ]
+            if missing:
+                raise ValueError(
+                    f"successful run of {self.name!r} is missing statistics fields: {missing}"
+                )
+        return self
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: Any) -> dict[str, Any]:
+        d: dict[str, Any] = handler(self)
+        # Mirror zavod's serialization: resolve is omitted when True (currently only 'maritime' has False).
+        if self.resolve is True:
+            d.pop("resolve", None)
+        return d

--- a/zavod/zavod/tests/exporters/test_metadata.py
+++ b/zavod/zavod/tests/exporters/test_metadata.py
@@ -145,7 +145,7 @@ def test_metadata_failure_no_statistics_no_warning(collection: Dataset) -> None:
     ]
 
     index_path = settings.DATA_PATH / "datasets" / collection.name / "index.json"
-    with open(index_path, "r") as fh:
+    with open(index_path) as fh:
         index = json.load(fh)
     assert index["result"] == "failure"
     assert "entity_count" not in index

--- a/zavod/zavod/tests/exporters/test_metadata.py
+++ b/zavod/zavod/tests/exporters/test_metadata.py
@@ -2,14 +2,18 @@ import json
 import logging
 
 from nomenklatura import Resolver
+from pytest import MonkeyPatch
+from structlog.testing import capture_logs
 
 from zavod import settings
+from zavod.archive import STATISTICS_FILE, dataset_resource_path
 from zavod.context import Context
 from zavod.crawl import crawl_dataset
 from zavod.entity import Entity
-from zavod.exporters import export_dataset
+from zavod.exporters import export_dataset, metadata
 from zavod.exporters.metadata import DatasetVersionResult, write_dataset_index
 from zavod.meta import Dataset
+from zavod.exporters.metadata.model import CatalogDatasetModel
 from zavod.store import get_store
 
 
@@ -35,6 +39,8 @@ def test_metadata_collection_export(
         # When resolve is false, the resolve key is exported with correct value
         assert testdataset1.model.resolve is False
         assert index["resolve"] is False, index
+        # The written index conforms to the output contract zavod validates against.
+        CatalogDatasetModel.model_validate(index)
 
     collection_path = settings.DATA_PATH / "datasets" / collection.name
     export_dataset(collection, view)
@@ -78,3 +84,68 @@ def test_metadata_collection_issue_count(
         index = json.load(fh)
     assert index["issue_count"] == 2, index
     assert index["issue_levels"] == {"error": 1, "warning": 1}, index
+
+
+def test_metadata_validation_warns_on_missing_required_field(
+    collection: Dataset, monkeypatch: MonkeyPatch
+) -> None:
+    """A successful run whose metadata is missing a required field only warns;
+    the index is still written."""
+    context = Context(collection)
+    context.begin(clear=True)
+    context.close()
+
+    with open(dataset_resource_path(collection.name, STATISTICS_FILE), "w") as fh:
+        json.dump(
+            {
+                "entity_count": 5,
+                "things": {"total": 5},
+                "targets": {"total": 2},
+                "last_change": settings.RUN_TIME_ISO,
+            },
+            fh,
+        )
+
+    real_get_base = metadata.get_base_dataset_metadata
+
+    def drop_required_field(dataset: Dataset) -> dict:
+        meta = real_get_base(dataset)
+        del meta["entity_count"]
+        return meta
+
+    monkeypatch.setattr(metadata, "get_base_dataset_metadata", drop_required_field)
+
+    with capture_logs() as cap_logs:
+        write_dataset_index(collection, DatasetVersionResult.SUCCESS)
+
+    assert any(
+        entry.get("log_level") == "warning"
+        and "catalog model" in entry.get("event", "")
+        for entry in cap_logs
+    )
+    assert (settings.DATA_PATH / "datasets" / collection.name / "index.json").is_file()
+
+
+def test_metadata_failure_no_statistics_no_warning(collection: Dataset) -> None:
+    """A failed run legitimately lacks statistics, so the model tolerates the
+    missing fields and validation does not warn."""
+    context = Context(collection)
+    context.begin(clear=True)
+    context.close()
+
+    assert not dataset_resource_path(collection.name, STATISTICS_FILE).is_file()
+    with capture_logs() as cap_logs:
+        write_dataset_index(collection, DatasetVersionResult.FAILURE)
+
+    assert not [
+        entry
+        for entry in cap_logs
+        if entry.get("log_level") == "warning"
+        and "catalog model" in entry.get("event", "")
+    ]
+
+    index_path = settings.DATA_PATH / "datasets" / collection.name / "index.json"
+    with open(index_path, "r") as fh:
+        index = json.load(fh)
+    assert index["result"] == "failure"
+    assert "entity_count" not in index


### PR DESCRIPTION
Adds a `CatalogDatasetModel` (+ published-form `ResourceModel`) in the zavod `exporters.metadata` package and validates the assembled `index.json` against it in `write_dataset_index`.

The model **extends FtM `DatasetModel`** (the loose read schema) and tightens it into the published output contract: `version` / `updated_at` / `last_export` become required, `resources` use the stricter `ResourceModel`, and it adds the operational fields that only exist after a run (counts, `last_change`, issue levels, artifact URLs, `result`). The statistics-derived fields are required only for successful runs — a failed run legitimately drops its statistics.

For now this only **warns** on non-conformance so we can gauge how often runs actually violate the contract before making it fatal — https://github.com/opensanctions/opensanctions/issues/4643.

kombinat keeps its own catalog validation at assembly time for now; unifying the two (and eventually using this model to *build* the metadata rather than validating a hand-assembled dict) is follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)