### PR TITLE
Rename TranslationResult.get_english to get_preferred_language

### DIFF
--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -94,7 +94,7 @@ def make_position(
         from zavod.shed.trans import translate_position_name
 
         result = translate_position_name(context, LangText(text=name, lang=source_lang))
-        translated = result.get_english()
+        translated = result.get_preferred_language()
         if translated is not None:
             position.add(
                 "name",

--- a/zavod/zavod/shed/trans.py
+++ b/zavod/zavod/shed/trans.py
@@ -89,8 +89,9 @@ class TranslationResult:
     """The model that produced the translation. Suitable for passing as the
     ``origin`` when applying the resulting values to an entity."""
 
-    def get_english(self) -> Optional[LangText]:
-        """Return the English ``LangText`` from ``texts``, or None if absent."""
+    def get_preferred_language(self) -> Optional[LangText]:
+        """Return the ``LangText`` for the preferred output language, or None
+        if absent. The preferred language is currently English."""
         for text in self.texts:
             if text.lang == "eng":
                 return text
@@ -168,7 +169,7 @@ def translate_position_name(
 
     ``label`` carries the source text and its language in ``label.lang``,
     which must be set. Builds the position-translation prompt for that
-    language and runs it. Use ``result.get_english()`` to read the English
+    language and runs it. Use ``result.get_preferred_language()`` to read the
     ``LangText`` (None if none was produced) and ``result.origin`` as the
     ``origin`` when applying it to an entity.
     """

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -233,7 +233,7 @@ def wikidata_position(
                     context,
                     LangText(text=item.label.text, lang=item.label.lang),
                 )
-                translated = result.get_english()
+                translated = result.get_preferred_language()
                 # if for some reason the translation fails, fall back to the original
                 if translated is None:
                     item.label.apply(position, "name", clean=clean_wikidata_name)


### PR DESCRIPTION
Small rename: `TranslationResult.get_english()` → `get_preferred_language()`.

The preferred output language is currently English, but callers shouldn't
bake that assumption into the call site — this way "preferred" can change
in one place later. All callers moved over, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)