### PR TITLE
Refactor apply_translit_full_name to take a LangText

### DIFF
--- a/datasets/cn/peoples_congress_wikipedia/crawler.py
+++ b/datasets/cn/peoples_congress_wikipedia/crawler.py
@@ -7,7 +7,8 @@ import re
 
 from zavod import Context, helpers as h
 from zavod.stateful.positions import categorise
-from zavod.shed.trans import ENGLISH, apply_translit_full_name
+from zavod.shed.trans import apply_translit_full_name
+from zavod.util import LangText
 
 
 REGEX_DELEGATION_HEADING = re.compile(r"(\w+)（\d+名）$")
@@ -37,7 +38,6 @@ IGNORE_DUPES = {
     # https://zh.wikipedia.org/wiki/%E7%8E%8B%E6%B0%B8%E7%BA%A2
     "cn-npc-wik-86fc6c8c076a7e4ed86efaec46620d13ea327908",
 }
-TRANSLIT_OUTPUT = [ENGLISH]
 
 
 def clean_text(text: str) -> str:
@@ -92,7 +92,7 @@ def crawl_item(
     entity.add("citizenship", "cn")
 
     entity.add("name", name, lang="chi")
-    apply_translit_full_name(context, entity, "chi", name, TRANSLIT_OUTPUT)
+    apply_translit_full_name(context, entity, LangText(name, "chi"))
     entity.add("gender", gender)
     entity.add("ethnicity", ethnicity, lang="chi")
     h.apply_date(entity, "birthDate", birth_date)

--- a/datasets/ge/declarations/crawler.py
+++ b/datasets/ge/declarations/crawler.py
@@ -19,6 +19,7 @@ from zavod.shed.trans import (
     ARABIC,
 )
 from zavod.stateful.positions import categorise, OccupancyStatus
+from zavod.util import LangText
 
 from zavod import helpers as h
 
@@ -115,7 +116,7 @@ def crawl_enterprise(
     company.id = context.make_id(name)
     company.add("name", name, lang="kat")
     apply_translit_full_name(
-        context, entity=company, input_code="kat", name=name, output=TRANSLIT_OUTPUT
+        context, entity=company, name=LangText(name, "kat"), output=TRANSLIT_OUTPUT
     )
     company.add("address", item.pop("EnterpriseAddress"), lang="kat")
     h.apply_date(company, "incorporationDate", item.pop("RegisterDate"))
@@ -144,8 +145,7 @@ def crawl_enterprise(
         apply_translit_full_name(
             context,
             entity=partner,
-            input_code="kat",
-            name=partner_name,
+            name=LangText(partner_name, "kat"),
             output=TRANSLIT_OUTPUT,
         )
         partner.add("address", address, lang="kat")

--- a/datasets/ge/ot_list/crawler.py
+++ b/datasets/ge/ot_list/crawler.py
@@ -9,7 +9,8 @@ from lxml.html import HtmlElement
 
 from zavod import Context, Entity
 from zavod import helpers as h
-from zavod.shed.trans import ENGLISH, apply_translit_full_name
+from zavod.shed.trans import apply_translit_full_name
+from zavod.util import LangText
 
 NAME_FIELD = "ბრალდებული/ მსჯავრდებული"
 DEMOGRAPHICS = "დემოგრაფიული მონაცემები"
@@ -22,7 +23,6 @@ UNUSED_FIELDS = [
     "შენიშვნა",  # Note
 ]
 PATROYNMIC = re.compile(r"\b(\S+)\s+ძე\s+")
-TRANSLIT_OUTPUT = [ENGLISH]
 
 
 def apply_translit_name(context: Context, person: Entity, name: str) -> None:
@@ -34,7 +34,7 @@ def apply_translit_name(context: Context, person: Entity, name: str) -> None:
         name = name[: m.start()] + name[m.end() :]
         context.log.debug(f"Patroynmic: {m.group(1)}")
     h.apply_name(person, full=name, patronymic=patronym, lang="kat")
-    apply_translit_full_name(context, person, "kat", name, TRANSLIT_OUTPUT)
+    apply_translit_full_name(context, person, LangText(name, "kat"))
 
 
 def crawl_row(context: Context, row: Dict[str, str]) -> None:

--- a/datasets/iq/aml_list/crawler.py
+++ b/datasets/iq/aml_list/crawler.py
@@ -7,15 +7,14 @@ from rigour.mime.types import JSON
 
 from zavod import Context
 from zavod import helpers as h
-from zavod.shed.trans import apply_translit_full_name, ENGLISH
+from zavod.shed.trans import apply_translit_full_name
+from zavod.util import LangText
 
 # The local sanctions list is served by the platform's JSON API. Its paginated
 # ordering is unstable — successive pages overlap and drop records — so we fetch
 # the whole list in a single request with a page size well above the row count
 # and assert it wasn't truncated.
 PAGE_SIZE = 100_000
-
-TRANSLIT_OUTPUT = [ENGLISH]
 
 # Nicknames are appended to the primary name, either introduced by a
 # "nicknamed" marker or wrapped in parentheses/quotes. Splitting on these
@@ -55,7 +54,7 @@ def crawl_item(context: Context, item: dict[str, Any]) -> None:
         if sector is not None:
             entity.add("sector", sector.group().strip(), lang="ara")
         if name != latinize_text(name):
-            apply_translit_full_name(context, entity, "ara", name, TRANSLIT_OUTPUT)
+            apply_translit_full_name(context, entity, LangText(name, "ara"))
     elif entity_type == "Individuals":
         mother_name = item.pop("motherName")
         birth_year = item.pop("birthYear")
@@ -73,11 +72,11 @@ def crawl_item(context: Context, item: dict[str, Any]) -> None:
         if birth_year is not None:
             h.apply_date(entity, "birthDate", str(birth_year))
         if name != latinize_text(name):
-            apply_translit_full_name(context, entity, "ara", name, TRANSLIT_OUTPUT)
+            apply_translit_full_name(context, entity, LangText(name, "ara"))
         for alias in aliases:
             if alias != latinize_text(alias):
                 apply_translit_full_name(
-                    context, entity, "ara", alias, TRANSLIT_OUTPUT, alias=True
+                    context, entity, LangText(alias, "ara"), alias=True
                 )
     else:
         context.log.warning("Unknown entity type", type=entity_type, name=raw_name)

--- a/zavod/zavod/shed/trans.py
+++ b/zavod/zavod/shed/trans.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, NamedTuple, List
+from typing import Optional, NamedTuple, List, Sequence
 import orjson
 
 from zavod.context import Context
@@ -33,6 +33,9 @@ ARABIC = TransliterationLanguageSpec(
     language_code="ara", script="Arabic", language_name="Arabic"
 )
 
+PREFERRED_LANGUAGE = ENGLISH
+"""Default transliteration output language for OpenSanctions data."""
+
 
 NAME_TRANSLIT_PROMPT = """
 Transliterate the following name from the language denoted by the ISO 639-2 Code {code},
@@ -61,7 +64,7 @@ Keep place names (countries, cities, regions, administrative areas) intact rathe
 
 
 def make_name_translit_prompt(
-    input_code: str, output_specs: List[TransliterationLanguageSpec]
+    input_code: str, output_specs: Sequence[TransliterationLanguageSpec]
 ) -> str:
     output_items = []
     for spec in output_specs:
@@ -252,29 +255,35 @@ def apply_translit_names(
 def apply_translit_full_name(
     context: Context,
     entity: Entity,
-    input_code: str,
-    name: str,
-    output: List[TransliterationLanguageSpec] = [ENGLISH],
+    name: LangText,
+    *,
+    output: Sequence[TransliterationLanguageSpec] = (PREFERRED_LANGUAGE,),
     prompt: Optional[str] = None,
     alias: bool = False,
     model: str = DEFAULT_MODEL,
 ) -> None:
-    """
-    Apply transliterated name to an entity.
+    """Apply a transliterated name to an entity.
+
+    ``name`` carries the source text and its language in ``name.lang``, which
+    must be set. Each spec in ``output`` produces one transliterated name
+    applied to the entity; the default transliterates into the preferred
+    output language only.
 
     Args:
         context: The context for the operation.
         entity: The entity to which to apply the names.
-        input_code: The ISO 639-2 code for the language of the input names.
-        name: The name to transliterate.
-        output: A list of language specifications for the output names.
+        name: The name to transliterate, with its source language.
+        output: The language specifications for the output names.
+        prompt: An optional override for the transliteration prompt.
+        alias: Whether to apply the results as aliases rather than names.
         model: GPT model used to translate/transliterate the name.
     """
+    assert name.lang is not None, "Source language is required for transliteration"
     if prompt is None:
-        prompt = make_name_translit_prompt(input_code, output)
+        prompt = make_name_translit_prompt(name.lang, output)
     output_langs = [spec.language_code for spec in output]
     result = run_translation_prompt(
-        context, prompt=prompt, text=name, output_langs=output_langs, model=model
+        context, prompt=prompt, text=name.text, output_langs=output_langs, model=model
     )
     for lang_text in result.texts:
         h.apply_name(


### PR DESCRIPTION
Brings `apply_translit_full_name` in line with `translate_position_name`:

- Takes `name: LangText` instead of separate `input_code` + `name`; the source language comes from `name.lang`.
- Everything after `name` is now keyword-only.
- Adds a module-level `PREFERRED_LANGUAGE = ENGLISH`, used as the default `output` (now a frozen tuple, not a mutable `[ENGLISH]`).
- Callers that just want English drop their `TRANSLIT_OUTPUT`/`ENGLISH` boilerplate and rely on the default; `ge/declarations` keeps its custom eng/rus/ara output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)