### PR TITLE
Add Côte d'Ivoire National Assembly PEP crawler

### DIFF
--- a/datasets/ci/national_assembly/ci_national_assembly.yml
+++ b/datasets/ci/national_assembly/ci_national_assembly.yml
@@ -1,0 +1,51 @@
+title: Côte d'Ivoire National Assembly
+name: ci_national_assembly
+prefix: ci-an
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Deputies of the National Assembly of Côte d'Ivoire, the lower chamber of the
+  bicameral parliament.
+description: |
+  The National Assembly (Assemblée nationale) is the lower chamber of the Parliament of
+  Côte d'Ivoire. It has 255 deputies (titulaires) elected from single- and multi-member
+  constituencies for a five-year term.
+
+  This dataset records each titular deputy with their name, political group or party,
+  date of birth and place of birth as published in the official list of deputies.
+url: https://www.assnat.ci/
+publisher:
+  name: Assemblée nationale de Côte d'Ivoire
+  acronym: AN
+  description: >
+    The National Assembly is the lower chamber of the Parliament of Côte d'Ivoire, whose
+    deputies are elected from constituencies across the country.
+  url: https://www.assnat.ci/
+  country: ci
+  official: true
+data:
+  url: https://www.assnat.ci/liste_des_depute_anci.pdf
+  format: PDF
+  lang: fra
+
+dates:
+  formats: ["%d/%m/%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 200
+      Position: 1
+    country_entities:
+      ci: 200
+  max:
+    schema_entities:
+      Person: 300
+      Position: 1

--- a/datasets/ci/national_assembly/ci_national_assembly.yml
+++ b/datasets/ci/national_assembly/ci_national_assembly.yml
@@ -32,6 +32,11 @@ data:
   url: https://www.assnat.ci/liste_des_depute_anci.pdf
   format: PDF
   lang: fra
+http:
+  # The Apache server returns 403 without a browser User-Agent.
+  user_agent: >-
+    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+    like Gecko) Chrome/124.0.0.0 Safari/537.36
 
 dates:
   formats: ["%d/%m/%Y"]

--- a/datasets/ci/national_assembly/ci_national_assembly.yml
+++ b/datasets/ci/national_assembly/ci_national_assembly.yml
@@ -16,8 +16,8 @@ description: |
   from single- and multi-member constituencies for a five-year term and hold the country's
   legislative power, including passing laws and approving the budget.
 
-  This dataset records each titular deputy with their name, date and place of birth, and
-  political party.
+  This dataset records each titular deputy with their name, date and place of birth,
+  political party, and the constituency they represent.
 url: https://www.assnat.ci/
 publisher:
   name: Assemblée nationale de Côte d'Ivoire
@@ -40,6 +40,15 @@ http:
 
 dates:
   formats: ["%d/%m/%Y"]
+
+config:
+  header_labels:
+    constituency: CIRCONSCRIPTION
+    party: GRP/PARTI
+    last_name: NOM
+    first_name: PRENOMS
+    dob: DATE DE NAISSANCE
+    birth_place: LIEU DE NAISSANCE
 
 tags:
   - list.pep

--- a/datasets/ci/national_assembly/ci_national_assembly.yml
+++ b/datasets/ci/national_assembly/ci_national_assembly.yml
@@ -1,4 +1,4 @@
-title: Côte d'Ivoire National Assembly
+title: Côte d'Ivoire Members of the National Assembly
 name: ci_national_assembly
 prefix: ci-an
 entry_point: crawler.py
@@ -11,12 +11,13 @@ summary: >-
   Deputies of the National Assembly of Côte d'Ivoire, the lower chamber of the
   bicameral parliament.
 description: |
-  The National Assembly (Assemblée nationale) is the lower chamber of the Parliament of
-  Côte d'Ivoire. It has 255 deputies (titulaires) elected from single- and multi-member
-  constituencies for a five-year term.
+  Current members of the National Assembly (Assemblée nationale), the lower chamber of the
+  bicameral Parliament of Côte d'Ivoire. Its 255 titular deputies (titulaires) are elected
+  from single- and multi-member constituencies for a five-year term and hold the country's
+  legislative power, including passing laws and approving the budget.
 
-  This dataset records each titular deputy with their name, political group or party,
-  date of birth and place of birth as published in the official list of deputies.
+  This dataset records each titular deputy with their name, date and place of birth, and
+  political party.
 url: https://www.assnat.ci/
 publisher:
   name: Assemblée nationale de Côte d'Ivoire

--- a/datasets/ci/national_assembly/crawler.py
+++ b/datasets/ci/national_assembly/crawler.py
@@ -1,0 +1,91 @@
+import re
+
+import pdfplumber
+from rigour.mime.types import PDF
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+# The Apache server returns 403 without a browser User-Agent and a same-site Referer.
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Referer": "https://www.assnat.ci/",
+}
+
+DATE_RE = re.compile(r"^\d{2}/\d{2}/\d{4}$")
+
+# The list is a fixed-column PDF. Each titular deputy row is anchored on a date-of-birth
+# cell; the surrounding columns sit at stable horizontal positions (measured in points
+# from the left edge). The vertical "région" label on the far left (x < 160) is ignored.
+PARTY_X = (360, 440)  # GRP/PARTI abbreviation
+NAME_X = (440, 656)  # NOM + PRÉNOMS, between the party and the date of birth
+BIRTHPLACE_X = 690  # LIEU DE NAISSANCE, to the right of the date of birth
+ROW_TOLERANCE = 6  # points; words within this vertical distance are one row
+
+# Known political groups / parties, used to flag unexpected values loudly.
+KNOWN_PARTIES = {"RHDP", "PDCI-RDA", "INDEPENDANT", "UNPR", "FPI", "LE BUFFLE"}
+
+
+def cell(words: list[dict[str, float]], lo: float, hi: float) -> str:
+    return " ".join(str(w["text"]) for w in words if lo <= float(w["x0"]) < hi).strip()
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of Côte d'Ivoire",
+        country="ci",
+        wikidata_id="Q21295981",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    path = context.fetch_resource("deputies.pdf", context.data_url, headers=HEADERS)
+    context.export_resource(path, PDF, title=context.SOURCE_TITLE)
+
+    count = 0
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            words = page.extract_words()
+            dob_words = [w for w in words if DATE_RE.match(str(w["text"]))]
+            for dob in dob_words:
+                top = float(dob["top"])
+                band = sorted(
+                    (w for w in words if abs(float(w["top"]) - top) < ROW_TOLERANCE),
+                    key=lambda w: float(w["x0"]),
+                )
+                name = cell(band, *NAME_X)
+                party = cell(band, *PARTY_X)
+                birth_place = cell(band, BIRTHPLACE_X, 100000)
+                assert name, f"Empty deputy name near DOB {dob['text']!r}"
+                if party and party not in KNOWN_PARTIES:
+                    context.log.warning("Unknown party/group", party=party, name=name)
+
+                person = context.make("Person")
+                person.id = context.make_id(name, str(dob["text"]))
+                person.add("name", name, lang="fra")
+                h.apply_date(person, "birthDate", str(dob["text"]))
+                person.add("birthPlace", birth_place or None, lang="fra")
+                person.add("political", party or None, lang="fra")
+                # A candidate for the National Assembly must be Ivorian by birth and never
+                # have renounced Ivorian nationality (Electoral Code, Loi 2000-514,
+                # Article 71). https://aceproject.org/ero-en/regions/africa/CI/cote-divoire-electoral-law-nb0-2000-514-of-1/at_download/file
+                person.add("citizenship", "ci")
+
+                occupancy = h.make_occupancy(
+                    context, person, position, categorisation=categorisation
+                )
+                if occupancy is None:
+                    continue
+                context.emit(occupancy)
+                context.emit(person)
+                count += 1
+
+    if count == 0:
+        raise ValueError("No deputies parsed from the National Assembly PDF")

--- a/datasets/ci/national_assembly/crawler.py
+++ b/datasets/ci/national_assembly/crawler.py
@@ -7,15 +7,6 @@ from zavod import Context
 from zavod import helpers as h
 from zavod.stateful.positions import categorise
 
-# The Apache server returns 403 without a browser User-Agent and a same-site Referer.
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-    ),
-    "Referer": "https://www.assnat.ci/",
-}
-
 DATE_RE = re.compile(r"^\d{2}/\d{2}/\d{4}$")
 
 # The list is a fixed-column PDF. Each titular deputy row is anchored on a date-of-birth
@@ -40,16 +31,16 @@ def crawl(context: Context) -> None:
         name="Member of the National Assembly of Côte d'Ivoire",
         country="ci",
         wikidata_id="Q21295981",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    path = context.fetch_resource("deputies.pdf", context.data_url, headers=HEADERS)
+    path = context.fetch_resource("deputies.pdf", context.data_url)
     context.export_resource(path, PDF, title=context.SOURCE_TITLE)
 
-    count = 0
     with pdfplumber.open(path) as pdf:
         for page in pdf.pages:
             words = page.extract_words()
@@ -85,7 +76,3 @@ def crawl(context: Context) -> None:
                     continue
                 context.emit(occupancy)
                 context.emit(person)
-                count += 1
-
-    if count == 0:
-        raise ValueError("No deputies parsed from the National Assembly PDF")

--- a/datasets/ci/national_assembly/crawler.py
+++ b/datasets/ci/national_assembly/crawler.py
@@ -1,28 +1,122 @@
 import re
+from collections import defaultdict
 
 import pdfplumber
+from pdfplumber.page import Page
 from rigour.mime.types import PDF
 
 from zavod import Context
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
 
 DATE_RE = re.compile(r"^\d{2}/\d{2}/\d{4}$")
 
-# The list is a fixed-column PDF. Each titular deputy row is anchored on a date-of-birth
-# cell; the surrounding columns sit at stable horizontal positions (measured in points
-# from the left edge). The vertical "région" label on the far left (x < 160) is ignored.
-PARTY_X = (360, 440)  # GRP/PARTI abbreviation
-NAME_X = (440, 656)  # NOM + PRÉNOMS, between the party and the date of birth
-BIRTHPLACE_X = 690  # LIEU DE NAISSANCE, to the right of the date of birth
-ROW_TOLERANCE = 6  # points; words within this vertical distance are one row
+# The deputy list is a PDF laid out as a ruled table. Rather than hard-coding pixel
+# offsets, we derive the column boundaries from the table's own vertical ruling lines,
+# which sit at stable positions on every page. The far-left "région" label is set in
+# rotated text that produces spurious vertical edges, so we only consider ruling lines
+# at x >= COLUMN_XMIN, i.e. from the CIRCONSCRIPTION column rightwards.
+COLUMN_XMIN = 155.0
+EDGE_CLUSTER = 8.0  # points; vertical ruling lines closer than this are one boundary
+# Columns left-to-right once the "région" label is dropped.
+COLUMNS = ("constituency", "party", "last_name", "first_name", "dob", "birth_place")
 
-# Known political groups / parties, used to flag unexpected values loudly.
-KNOWN_PARTIES = {"RHDP", "PDCI-RDA", "INDEPENDANT", "UNPR", "FPI", "LE BUFFLE"}
+
+def column_separators(page: Page) -> list[float]:
+    """Cluster the page's vertical ruling lines into column boundary x-positions."""
+    xs = sorted(
+        float(edge["x0"])
+        for edge in page.edges
+        if edge["orientation"] == "v" and float(edge["x0"]) >= COLUMN_XMIN
+    )
+    separators: list[float] = []
+    cluster: list[float] = []
+    for x in xs:
+        if cluster and x - cluster[-1] > EDGE_CLUSTER:
+            separators.append(sum(cluster) / len(cluster))
+            cluster = []
+        cluster.append(x)
+    if cluster:
+        separators.append(sum(cluster) / len(cluster))
+    return separators
 
 
-def cell(words: list[dict[str, float]], lo: float, hi: float) -> str:
-    return " ".join(str(w["text"]) for w in words if lo <= float(w["x0"]) < hi).strip()
+def extract_rows(page: Page) -> list[list[str]]:
+    """Extract the deputy table as rows of trimmed, single-line cells.
+
+    Each cell's wrapped lines are collapsed to a single whitespace-separated string.
+    """
+    settings = {
+        "vertical_strategy": "explicit",
+        "explicit_vertical_lines": column_separators(page),
+        "horizontal_strategy": "lines",
+    }
+    tables = page.extract_tables(settings)
+    if len(tables) == 0:
+        return []
+    table = max(tables, key=len)
+    return [[re.sub(r"\s+", " ", cell or "").strip() for cell in row] for row in table]
+
+
+def validate_header(rows: list[list[str]], header_labels: dict[str, str]) -> None:
+    """Assert every column carries its expected header label, else crash.
+
+    The header spans several rows and its labels sit above the first data row (the
+    first row bearing a date of birth), so accumulate the text per column until then.
+    """
+    header: dict[int, list[str]] = defaultdict(list)
+    for row in rows:
+        if any(DATE_RE.match(cell) for cell in row):
+            break
+        for index, cell in enumerate(row):
+            if cell:
+                header[index].append(cell.upper())
+    for index, key in enumerate(COLUMNS):
+        label = header_labels[key]
+        joined = " ".join(header.get(index, []))
+        if label not in joined:
+            raise ValueError(
+                f"Unexpected column {index}: want {label!r}, found {joined!r}"
+            )
+
+
+def crawl_deputy(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    row: dict[str, str],
+    constituency: str | None,
+) -> None:
+    name = f"{row['last_name']} {row['first_name']}".strip()
+    if not name:
+        raise ValueError(f"Empty deputy name near DOB {row['dob']!r}")
+    party = row["party"]
+
+    person = context.make("Person")
+    person.id = context.make_id(name, row["dob"])
+    h.apply_name(
+        person,
+        first_name=row["first_name"] or None,
+        last_name=row["last_name"] or None,
+        lang="fra",
+    )
+    h.apply_date(person, "birthDate", row["dob"])
+    person.add("birthPlace", row["birth_place"] or None, lang="fra")
+    person.add("political", party or None, lang="fra")
+    # A candidate for the National Assembly must be Ivorian by birth and never have
+    # renounced Ivorian nationality (Electoral Code, Loi 2000-514, Article 71).
+    # https://aceproject.org/ero-en/regions/africa/CI/cote-divoire-electoral-law-nb0-2000-514-of-1/at_download/file
+    person.add("citizenship", "ci")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", constituency, lang="fra")
+    context.emit(occupancy)
+    context.emit(person)
 
 
 def crawl(context: Context) -> None:
@@ -41,38 +135,21 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("deputies.pdf", context.data_url)
     context.export_resource(path, PDF, title=context.SOURCE_TITLE)
 
+    header_labels: dict[str, str] = context.dataset.config["header_labels"]
     with pdfplumber.open(path) as pdf:
+        # The header only appears on the first page; validate it there, then apply the
+        # same column model to every page.
+        validate_header(extract_rows(pdf.pages[0]), header_labels)
+        constituency: str | None = None
         for page in pdf.pages:
-            words = page.extract_words()
-            dob_words = [w for w in words if DATE_RE.match(str(w["text"]))]
-            for dob in dob_words:
-                top = float(dob["top"])
-                band = sorted(
-                    (w for w in words if abs(float(w["top"]) - top) < ROW_TOLERANCE),
-                    key=lambda w: float(w["x0"]),
-                )
-                name = cell(band, *NAME_X)
-                party = cell(band, *PARTY_X)
-                birth_place = cell(band, BIRTHPLACE_X, 100000)
-                assert name, f"Empty deputy name near DOB {dob['text']!r}"
-                if party and party not in KNOWN_PARTIES:
-                    context.log.warning("Unknown party/group", party=party, name=name)
-
-                person = context.make("Person")
-                person.id = context.make_id(name, str(dob["text"]))
-                person.add("name", name, lang="fra")
-                h.apply_date(person, "birthDate", str(dob["text"]))
-                person.add("birthPlace", birth_place or None, lang="fra")
-                person.add("political", party or None, lang="fra")
-                # A candidate for the National Assembly must be Ivorian by birth and never
-                # have renounced Ivorian nationality (Electoral Code, Loi 2000-514,
-                # Article 71). https://aceproject.org/ero-en/regions/africa/CI/cote-divoire-electoral-law-nb0-2000-514-of-1/at_download/file
-                person.add("citizenship", "ci")
-
-                occupancy = h.make_occupancy(
-                    context, person, position, categorisation=categorisation
-                )
-                if occupancy is None:
-                    continue
-                context.emit(occupancy)
-                context.emit(person)
+            for cells in extract_rows(page):
+                if len(cells) != len(COLUMNS):
+                    raise ValueError(f"Unexpected column count in row: {cells!r}")
+                row: dict[str, str] = dict(zip(COLUMNS, cells))
+                if not DATE_RE.match(row["dob"]):
+                    continue  # header or spacer row, not a titular deputy
+                # Multi-seat constituencies list their localities once, on the first
+                # deputy's row; carry that forward to the co-elected deputies below.
+                if row["constituency"]:
+                    constituency = row["constituency"]
+                crawl_deputy(context, position, categorisation, row, constituency)


### PR DESCRIPTION
Adds a PEP crawler for the **National Assembly of Côte d'Ivoire** (lower chamber, 255 deputies).

## Source
Official list-of-deputies PDF (`assnat.ci/liste_des_depute_anci.pdf`). The Apache server 403s without a browser `User-Agent` + same-site `Referer`.

The PDF is a fixed-column table with a **vertically-rendered région label** that breaks naive text/table extraction. The crawler parses it **positionally**: it anchors each titular row on its date-of-birth cell (x0≈661, consistent across all pages) and reads the party, name and birthplace columns by their stable horizontal positions. This yields exactly 255 records with the correct party tally (RHDP 197 / PDCI-RDA 32 / INDEPENDANT 23 / …).

## Output
- Position: *Member of the National Assembly of Côte d'Ivoire* (`Q21295981`)
- 255 deputies emitted as PEPs with name, party, date of birth and place of birth.
- Citizenship `ci` per Electoral Code (Loi 2000-514) Art. 71 (see code comment).

Closes opensanctions/crawler-planning#762

🤖 Generated with [Claude Code](https://claude.com/claude-code)