### PR TITLE
Add Algeria Council of the Nation PEP crawler

### DIFF
--- a/datasets/dz/council_nation/crawler.py
+++ b/datasets/dz/council_nation/crawler.py
@@ -1,0 +1,132 @@
+import re
+from itertools import count
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+MEMBER_HREF_RE = re.compile(r"/members/([0-9a-f]+)$")
+
+# Mandate lines read e.g. "العهدة التشريعية العاشرة 2025-2031 (19 مايو 2025 => ...)";
+# the "YYYY-YYYY" span gives the term's start and end years.
+MANDATE_YEARS_RE = re.compile(r"(\d{4})-(\d{4})")
+
+# Safety cap on pagination — the directory is ~11 pages of 15 members.
+MAX_PAGES = 40
+
+
+def collect_member_ids(context: Context) -> list[str]:
+    ids: list[str] = []
+    seen: set[str] = set()
+    for page in count(1):
+        if page > MAX_PAGES:
+            raise ValueError("Council members directory exceeded the page cap")
+        doc = context.fetch_html(context.data_url, params={"page": page}, cache_days=1)
+        page_ids: list[str] = []
+        for href in h.xpath_strings(doc, '//a[contains(@href, "/members/")]/@href'):
+            match = MEMBER_HREF_RE.search(href)
+            if match is not None:
+                page_ids.append(match.group(1))
+        # A page with no member links marks the end of the directory.
+        if not page_ids:
+            break
+        for member_id in page_ids:
+            if member_id not in seen:
+                seen.add(member_id)
+                ids.append(member_id)
+    return ids
+
+
+def latest_mandate(mandate_texts: list[str]) -> tuple[str, str] | None:
+    terms: list[tuple[int, int]] = []
+    for text in mandate_texts:
+        match = MANDATE_YEARS_RE.search(text)
+        if match is not None:
+            terms.append((int(match.group(1)), int(match.group(2))))
+    if not terms:
+        return None
+    start, end = max(terms, key=lambda t: t[1])
+    return str(start), str(end)
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    member_id: str,
+) -> None:
+    url = f"https://www.majliselouma.dz/ara/members/{member_id}"
+    doc = context.fetch_html(url, cache_days=30)
+
+    name = h.element_text(h.xpath_element(doc, '//h1[@class="title"]'))
+    assert name, f"Missing name for member {member_id}"
+
+    # The affiliation line is "<party> | <wilaya> (<dates>)".
+    affiliation_items = h.xpath_strings(
+        doc, '//*[contains(@class, "mbr-party")]//li//text()'
+    )
+    affiliation = " ".join(" ".join(affiliation_items).split())
+    party: str | None = None
+    wilaya: str | None = None
+    if "|" in affiliation:
+        party_part, _, rest = affiliation.partition("|")
+        party = party_part.strip() or None
+        wilaya = rest.split("(")[0].strip() or None
+
+    mandate_texts = [
+        " ".join(t.split())
+        for t in h.xpath_strings(
+            doc, '//*[contains(@class, "mbr-mandate")]//li//text()'
+        )
+        if t.strip()
+    ]
+    mandate = latest_mandate(mandate_texts)
+
+    person = context.make("Person")
+    person.id = context.make_slug(member_id)
+    person.add("name", name, lang="ara")
+    person.add("political", party, lang="ara")
+    person.add("sourceUrl", url)
+    # Members must be of Algerian nationality: the elected two-thirds must be sitting
+    # local-assembly members (Organic Law 21-01 on the electoral regime, art. 221 -> 220
+    # -> art. 184 "être de nationalité algérienne"); 2020 Constitution art. 128 delegates
+    # the regime. https://amb-algerie.fr/wp-content/uploads/2021/03/loi-organique-relative-au-regime-electoral.pdf
+    person.add("citizenship", "dz")
+
+    start_date = mandate[0] if mandate is not None else None
+    end_date = mandate[1] if mandate is not None else None
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        start_date=start_date,
+        end_date=end_date,
+        categorisation=categorisation,
+    )
+    if occupancy is None:
+        return
+    if wilaya is not None:
+        occupancy.add("constituency", wilaya, lang="ara")
+
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Council of the Nation of Algeria",
+        country="dz",
+        wikidata_id="Q21290885",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    member_ids = collect_member_ids(context)
+    if not member_ids:
+        raise ValueError("No members found in the Council directory")
+    for member_id in member_ids:
+        crawl_member(context, position, categorisation, member_id)

--- a/datasets/dz/council_nation/crawler.py
+++ b/datasets/dz/council_nation/crawler.py
@@ -4,6 +4,7 @@ from itertools import count
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
+from zavod.shed.trans import apply_translit_full_name
 from zavod.stateful.positions import PositionCategorisation, categorise
 
 MEMBER_HREF_RE = re.compile(r"/members/([0-9a-f]+)$")
@@ -22,7 +23,7 @@ def collect_member_ids(context: Context) -> list[str]:
     for page in count(1):
         if page > MAX_PAGES:
             raise ValueError("Council members directory exceeded the page cap")
-        doc = context.fetch_html(context.data_url, params={"page": page}, cache_days=1)
+        doc = context.fetch_html(context.data_url, params={"page": page}, cache_days=14)
         page_ids: list[str] = []
         for href in h.xpath_strings(doc, '//a[contains(@href, "/members/")]/@href'):
             match = MEMBER_HREF_RE.search(href)
@@ -86,6 +87,7 @@ def crawl_member(
     person = context.make("Person")
     person.id = context.make_slug(member_id)
     person.add("name", name, lang="ara")
+    apply_translit_full_name(context, person, "ara", name)
     person.add("political", party, lang="ara")
     person.add("sourceUrl", url)
     # Members must be of Algerian nationality: the elected two-thirds must be sitting
@@ -119,8 +121,9 @@ def crawl(context: Context) -> None:
         name="Member of the Council of the Nation of Algeria",
         country="dz",
         wikidata_id="Q21290885",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)

--- a/datasets/dz/council_nation/crawler.py
+++ b/datasets/dz/council_nation/crawler.py
@@ -6,6 +6,7 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.shed.trans import apply_translit_full_name
 from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import LangText
 
 MEMBER_HREF_RE = re.compile(r"/members/([0-9a-f]+)$")
 
@@ -87,7 +88,7 @@ def crawl_member(
     person = context.make("Person")
     person.id = context.make_slug(member_id)
     person.add("name", name, lang="ara")
-    apply_translit_full_name(context, person, "ara", name)
+    apply_translit_full_name(context, person, LangText(name, "ara"))
     person.add("political", party, lang="ara")
     person.add("sourceUrl", url)
     # Members must be of Algerian nationality: the elected two-thirds must be sitting

--- a/datasets/dz/council_nation/crawler.py
+++ b/datasets/dz/council_nation/crawler.py
@@ -1,5 +1,4 @@
 import re
-from itertools import count
 
 from zavod import Context
 from zavod import helpers as h
@@ -7,8 +6,6 @@ from zavod.entity import Entity
 from zavod.shed.trans import apply_translit_full_name
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import LangText
-
-MEMBER_HREF_RE = re.compile(r"/members/([0-9a-f]+)$")
 
 # Mandate lines read e.g. "العهدة التشريعية العاشرة 2025-2031 (19 مايو 2025 => ...)";
 # the "YYYY-YYYY" span gives the term's start and end years.
@@ -18,48 +15,42 @@ MANDATE_YEARS_RE = re.compile(r"(\d{4})-(\d{4})")
 MAX_PAGES = 40
 
 
-def collect_member_ids(context: Context) -> list[str]:
-    ids: list[str] = []
-    seen: set[str] = set()
-    for page in count(1):
-        if page > MAX_PAGES:
-            raise ValueError("Council members directory exceeded the page cap")
-        doc = context.fetch_html(context.data_url, params={"page": page}, cache_days=14)
-        page_ids: list[str] = []
-        for href in h.xpath_strings(doc, '//a[contains(@href, "/members/")]/@href'):
-            match = MEMBER_HREF_RE.search(href)
-            if match is not None:
-                page_ids.append(match.group(1))
+def collect_member_urls(context: Context) -> list[str]:
+    # Every profile link on the listing is a member; paginate until an empty page,
+    # keeping insertion order and dropping any repeats across pages.
+    urls: dict[str, None] = {}
+    for page in range(1, MAX_PAGES + 1):
+        doc = context.fetch_html(
+            context.data_url,
+            params={"page": page},
+            cache_days=14,
+            absolute_links=True,
+        )
+        page_urls = h.xpath_strings(doc, '//a[contains(@href, "/members/")]/@href')
         # A page with no member links marks the end of the directory.
-        if not page_ids:
-            break
-        for member_id in page_ids:
-            if member_id not in seen:
-                seen.add(member_id)
-                ids.append(member_id)
-    return ids
+        if not page_urls:
+            return list(urls)
+        urls.update(dict.fromkeys(page_urls))
+    raise ValueError("Council members directory exceeded the page cap")
 
 
-def latest_mandate(mandate_texts: list[str]) -> tuple[str, str] | None:
-    terms: list[tuple[int, int]] = []
-    for text in mandate_texts:
-        match = MANDATE_YEARS_RE.search(text)
-        if match is not None:
-            terms.append((int(match.group(1)), int(match.group(2))))
-    if not terms:
+def latest_mandate(text: str) -> tuple[str, str] | None:
+    # A member may list several terms; keep the "YYYY-YYYY" span running latest.
+    spans: list[tuple[str, str]] = MANDATE_YEARS_RE.findall(text)
+    if not spans:
         return None
-    start, end = max(terms, key=lambda t: t[1])
-    return str(start), str(end)
+    return max(spans, key=lambda span: int(span[1]))
 
 
 def crawl_member(
     context: Context,
     position: Entity,
     categorisation: PositionCategorisation,
-    member_id: str,
+    url: str,
 ) -> None:
-    url = f"https://www.majliselouma.dz/ara/members/{member_id}"
-    doc = context.fetch_html(url, cache_days=30)
+    member_id = url.rsplit("/", 1)[-1]
+    assert member_id, url
+    doc = context.fetch_html(url, cache_days=14)
 
     name = h.element_text(h.xpath_element(doc, '//h1[@class="title"]'))
     assert name, f"Missing name for member {member_id}"
@@ -76,14 +67,10 @@ def crawl_member(
         party = party_part.strip() or None
         wilaya = rest.split("(")[0].strip() or None
 
-    mandate_texts = [
-        " ".join(t.split())
-        for t in h.xpath_strings(
-            doc, '//*[contains(@class, "mbr-mandate")]//li//text()'
-        )
-        if t.strip()
-    ]
-    mandate = latest_mandate(mandate_texts)
+    mandate_text = " ".join(
+        h.xpath_strings(doc, '//*[contains(@class, "mbr-mandate")]//li//text()')
+    )
+    mandate = latest_mandate(mandate_text)
 
     person = context.make("Person")
     person.id = context.make_slug(member_id)
@@ -129,8 +116,5 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    member_ids = collect_member_ids(context)
-    if not member_ids:
-        raise ValueError("No members found in the Council directory")
-    for member_id in member_ids:
-        crawl_member(context, position, categorisation, member_id)
+    for url in collect_member_urls(context):
+        crawl_member(context, position, categorisation, url)

--- a/datasets/dz/council_nation/dz_council_nation.yml
+++ b/datasets/dz/council_nation/dz_council_nation.yml
@@ -1,0 +1,50 @@
+title: Algeria Council of the Nation
+name: dz_council_nation
+prefix: dz-con
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Council of the Nation, the upper chamber of the Algerian
+  parliament.
+description: |
+  The Council of the Nation (Majlis al-Umma) is the upper chamber of Algeria's bicameral
+  parliament. It has 144 members: two-thirds indirectly elected by the provincial and
+  municipal assemblies and one-third appointed by the President. Members serve six-year
+  terms, with half the chamber renewed every three years.
+
+  This dataset records each member with their name, political affiliation, the province
+  (wilaya) they represent and their mandate period, as published in the Council's members
+  directory.
+url: https://www.majliselouma.dz/
+publisher:
+  name: Council of the Nation
+  acronym: Majlis al-Umma
+  description: >
+    The Council of the Nation is the upper chamber of the Algerian parliament, composed of
+    members elected by local assemblies and members appointed by the President.
+  url: https://www.majliselouma.dz/
+  country: dz
+  official: true
+data:
+  url: https://www.majliselouma.dz/ara/%D8%A7%D9%84%D8%A3%D8%B9%D8%B6%D8%A7%D8%A1/HNRWRhHG
+  format: HTML
+  lang: ara
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 120
+      Position: 1
+    country_entities:
+      dz: 120
+  max:
+    schema_entities:
+      Person: 200
+      Position: 1

--- a/datasets/dz/council_nation/dz_council_nation.yml
+++ b/datasets/dz/council_nation/dz_council_nation.yml
@@ -31,8 +31,6 @@ publisher:
   country: dz
   official: true
 data:
-  # Slug-free canonical listing; the site also exposes it under volatile per-page
-  # slugs (…/الأعضاء/HNRWRhHG) that we avoid depending on.
   url: https://www.majliselouma.dz/ara/members
   format: HTML
   lang: ara

--- a/datasets/dz/council_nation/dz_council_nation.yml
+++ b/datasets/dz/council_nation/dz_council_nation.yml
@@ -31,7 +31,9 @@ publisher:
   country: dz
   official: true
 data:
-  url: https://www.majliselouma.dz/ara/%D8%A7%D9%84%D8%A3%D8%B9%D8%B6%D8%A7%D8%A1/HNRWRhHG
+  # Slug-free canonical listing; the site also exposes it under volatile per-page
+  # slugs (…/الأعضاء/HNRWRhHG) that we avoid depending on.
+  url: https://www.majliselouma.dz/ara/members
   format: HTML
   lang: ara
 

--- a/datasets/dz/council_nation/dz_council_nation.yml
+++ b/datasets/dz/council_nation/dz_council_nation.yml
@@ -1,4 +1,4 @@
-title: Algeria Council of the Nation
+title: Algeria Members of the Council of the Nation
 name: dz_council_nation
 prefix: dz-con
 entry_point: crawler.py
@@ -11,14 +11,15 @@ summary: >-
   Members of the Council of the Nation, the upper chamber of the Algerian
   parliament.
 description: |
-  The Council of the Nation (Majlis al-Umma) is the upper chamber of Algeria's bicameral
-  parliament. It has 144 members: two-thirds indirectly elected by the provincial and
-  municipal assemblies and one-third appointed by the President. Members serve six-year
-  terms, with half the chamber renewed every three years.
+  Current members of the Council of the Nation (Majlis al-Umma), the upper chamber of
+  Algeria's bicameral parliament. Its 144 members — two-thirds indirectly elected by the
+  provincial and municipal assemblies and one-third appointed by the President — serve
+  six-year terms, with half the chamber renewed every three years, and share the country's
+  legislative power with the People's National Assembly, including passing laws and approving
+  the budget.
 
   This dataset records each member with their name, political affiliation, the province
-  (wilaya) they represent and their mandate period, as published in the Council's members
-  directory.
+  (wilaya) they represent, and their mandate period.
 url: https://www.majliselouma.dz/
 publisher:
   name: Council of the Nation


### PR DESCRIPTION
Adds a PEP crawler for the **Council of the Nation** (upper chamber of the Algerian parliament).

## Source
Official members directory on `majliselouma.dz` (Arabic), server-rendered HTML. The crawler walks the paginated listing (`?page=N`) to collect member ids, then reads each member's profile page for name, political affiliation, province (wilaya) and mandate period. Self-signed TLS handled by zavod's fetch layer.

## Output
- Position: *Member of the Council of the Nation of Algeria* (`Q21290885`)
- 153 members emitted as PEPs (87 on 2022–2028 terms, 66 on 2025–2031 — the staggered half-renewals), all currently in office. The mandate start/end years drive the occupancy, so any listed former member falls out via `make_occupancy` naturally.
- Citizenship `dz` per Organic Law 21-01 Art. 184 (via 220/221); 2020 Constitution Art. 128 (see code comment).

Closes opensanctions/crawler-planning#756

🤖 Generated with [Claude Code](https://claude.com/claude-code)