### PR TITLE
Add Morocco House of Councillors PEP crawler

### DIFF
--- a/datasets/ma/house_councillors/crawler.py
+++ b/datasets/ma/house_councillors/crawler.py
@@ -1,0 +1,106 @@
+import re
+
+import pdfplumber
+from rigour.mime.types import PDF
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    )
+}
+
+# The members list is a dated PDF linked from the homepage as
+# docs/docs/conseillers<DDMMYYYY>.pdf; the filename date changes on each update.
+PDF_LINK_RE = re.compile(r"/docs/docs/conseillers(\d{8})\.pdf$", re.IGNORECASE)
+
+# Names are Arabic-only. The name column sits at table index 3 in the source layout.
+NAME_COLUMN = 3
+ARABIC_NAME_RE = re.compile(r"^[ء-ي ]+$")
+# Non-name rows carried in the same column (section headers, table header).
+SKIP_TOKENS = ("الشخصي", "المستشار", "الجهة", "الانتماء", "هيئة", "اللائحة")
+
+
+def normalize_name(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    # pdfplumber yields RTL glyphs in reversed visual order; reverse to logical order,
+    # drop the tatweel elongation character and collapse whitespace.
+    text = raw.replace("\n", " ").strip()[::-1].replace("ـ", "")
+    text = " ".join(text.split())
+    # A long name wraps so its final letter is split off as a trailing token; rejoin it.
+    text = re.sub(r" ([ء-ي])$", r"\1", text)
+    return text or None
+
+
+def find_pdf_url(context: Context) -> str:
+    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+    candidates: list[tuple[str, str]] = []
+    for href in h.xpath_strings(doc, "//a/@href"):
+        match = PDF_LINK_RE.search(href)
+        if match is not None:
+            candidates.append((match.group(1), href))
+    if not candidates:
+        raise ValueError("Could not find the councillors list PDF on the homepage")
+    # Pick the most recent by the DDMMYYYY date embedded in the filename.
+    _, url = max(candidates, key=lambda c: (c[0][4:], c[0][2:4], c[0][:2]))
+    if url.startswith("/"):
+        url = "https://www.chambredesconseillers.ma" + url
+    return url
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the House of Councillors of Morocco",
+        country="ma",
+        wikidata_id="Q21328580",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    pdf_url = find_pdf_url(context)
+    path = context.fetch_resource("councillors.pdf", pdf_url, headers=HEADERS)
+    context.export_resource(path, PDF, title=context.SOURCE_TITLE)
+
+    names: set[str] = set()
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            for table in page.extract_tables():
+                for row in table:
+                    if len(row) <= NAME_COLUMN:
+                        continue
+                    name = normalize_name(row[NAME_COLUMN])
+                    if name is None or not ARABIC_NAME_RE.match(name):
+                        continue
+                    if not 2 <= len(name.split()) <= 5:
+                        continue
+                    if any(token in name for token in SKIP_TOKENS):
+                        continue
+                    names.add(name)
+
+    if not names:
+        raise ValueError("No councillor names parsed from the members PDF")
+
+    for name in names:
+        person = context.make("Person")
+        person.id = context.make_id(name)
+        person.add("name", name, lang="ara")
+        # Eligibility to the House of Councillors requires Moroccan citizenship: only
+        # citizens are electors and eligible (2011 Constitution, Article 30).
+        # https://mjp.univ-perp.fr/constit/ma2011.htm
+        person.add("citizenship", "ma")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(occupancy)
+        context.emit(person)

--- a/datasets/ma/house_councillors/crawler.py
+++ b/datasets/ma/house_councillors/crawler.py
@@ -7,38 +7,114 @@ from zavod import Context
 from zavod import helpers as h
 from zavod.stateful.positions import categorise
 
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-    )
-}
-
 # The members list is a dated PDF linked from the homepage as
 # docs/docs/conseillers<DDMMYYYY>.pdf; the filename date changes on each update.
 PDF_LINK_RE = re.compile(r"/docs/docs/conseillers(\d{8})\.pdf$", re.IGNORECASE)
 
-# Names are Arabic-only. The name column sits at table index 3 in the source layout.
-NAME_COLUMN = 3
+TATWEEL = "ـ"
+# A person name is Arabic letters and spaces only, 2-5 words.
 ARABIC_NAME_RE = re.compile(r"^[ء-ي ]+$")
-# Non-name rows carried in the same column (section headers, table header).
-SKIP_TOKENS = ("الشخصي", "المستشار", "الجهة", "الانتماء", "هيئة", "اللائحة")
+# Party names are prefixed with "party of" in the affiliation column.
+PARTY_PREFIX = "حزب"
+# Some names carry a trailing footnote reference number (e.g. two members share a
+# name); it is not part of the name.
+FOOTNOTE_RE = re.compile(r"\s*\d+$")
+# A long value wraps so its final letter is split off as a trailing token.
+TRAILING_LETTER_RE = re.compile(r" ([ء-ي])$")
+# Non-name tokens carried in the name column (table/section header labels).
+SKIP_TOKENS = ("الشخصي", "المستشار", "الجهة", "الدائرة", "الانتماء", "هيئة", "اللائحة")
+
+# The PDF is split into one section per electoral college. Each section is
+# identified by a stable substring of its title and has its own column layout,
+# mapping (name column, party column, region column) by table index; None where
+# the column is absent for that college. pdfplumber's column boundaries shift
+# between the header and body rows, so the layout is keyed off the section rather
+# than the header labels.
+SECTIONS: list[tuple[str, tuple[int, int | None, int | None]]] = [
+    # 1 - Representatives of regional councils
+    ("المجالس الجهو", (3, 0, 4)),
+    # 2 - Representatives of communal and prefectural/provincial councils
+    ("المجالس الجماع", (3, 0, 4)),
+    # 3 - Representatives of professional chambers
+    ("الغرف المهن", (3, 0, 4)),
+    # 4 - Representatives of employers' organisations (no party affiliation)
+    ("المنظمات المهنية للمشغل", (0, None, 3)),
+    # 5 - Representatives of employees / trade unions (union affiliation, skipped)
+    ("المأجور", (3, None, None)),
+]
 
 
-def normalize_name(raw: str | None) -> str | None:
+def reverse_arabic(raw: str | None) -> str | None:
+    """Turn pdfplumber's reversed visual glyph order into logical order.
+
+    Each line is reversed independently and lines are kept in their original
+    top-to-bottom order, so multi-line cells (compound electoral districts)
+    reconstruct correctly. The tatweel elongation character is dropped and
+    whitespace collapsed.
+    """
     if raw is None:
         return None
-    # pdfplumber yields RTL glyphs in reversed visual order; reverse to logical order,
-    # drop the tatweel elongation character and collapse whitespace.
-    text = raw.replace("\n", " ").strip()[::-1].replace("ـ", "")
+    lines = [line.strip()[::-1].replace(TATWEEL, "") for line in raw.split("\n")]
+    text = " ".join(line for line in lines if line)
     text = " ".join(text.split())
-    # A long name wraps so its final letter is split off as a trailing token; rejoin it.
-    text = re.sub(r" ([ء-ي])$", r"\1", text)
     return text or None
 
 
+def dewrap(text: str) -> str:
+    """Rejoin a final letter that wrapped onto its own trailing token."""
+    return TRAILING_LETTER_RE.sub(r"\1", text)
+
+
+def clean_region(text: str) -> str:
+    """Normalise a region / electoral district string.
+
+    The source renders the separators between region parts inconsistently (plain
+    hyphen vs en-dash, with varying spacing); unify them so the same region reads
+    identically everywhere.
+    """
+    text = dewrap(text).replace("–", "-").replace("—", "-")
+    text = re.sub(r"\s*([/-])\s*", r" \1 ", text)
+    return " ".join(text.split())
+
+
+def normalize_name(raw: str | None) -> str | None:
+    text = reverse_arabic(raw)
+    if text is None:
+        return None
+    text = FOOTNOTE_RE.sub("", text).strip()
+    return dewrap(text) or None
+
+
+def is_person_name(name: str | None) -> bool:
+    if name is None:
+        return False
+    if not ARABIC_NAME_RE.match(name):
+        return False
+    if name.startswith(PARTY_PREFIX):
+        return False
+    if not 2 <= len(name.split()) <= 5:
+        return False
+    return not any(token in name for token in SKIP_TOKENS)
+
+
+def detect_section(
+    table: list[list[str | None]],
+) -> tuple[int, int | None, int | None]:
+    """Determine the column layout from the section title in the leading rows."""
+    header = " ".join(
+        text
+        for row in table[:3]
+        for cell in row
+        if (text := reverse_arabic(cell)) is not None
+    )
+    for keyword, layout in SECTIONS:
+        if keyword in header:
+            return layout
+    raise ValueError(f"Unrecognised section header: {header!r}")
+
+
 def find_pdf_url(context: Context) -> str:
-    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+    doc = context.fetch_html(context.data_url, cache_days=14)
     candidates: list[tuple[str, str]] = []
     for href in h.xpath_strings(doc, "//a/@href"):
         match = PDF_LINK_RE.search(href)
@@ -59,39 +135,68 @@ def crawl(context: Context) -> None:
         name="Member of the House of Councillors of Morocco",
         country="ma",
         wikidata_id="Q21328580",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
     pdf_url = find_pdf_url(context)
-    path = context.fetch_resource("councillors.pdf", pdf_url, headers=HEADERS)
+    path = context.fetch_resource("councillors.pdf", pdf_url)
     context.export_resource(path, PDF, title=context.SOURCE_TITLE)
 
-    names: set[str] = set()
+    # (name, party, constituency) per councillor.
+    records: list[tuple[str, str | None, str | None]] = []
+    current_layout: tuple[int, int | None, int | None] | None = None
+    # Region cells are vertically merged: the value appears on the first member
+    # of each group and is carried down. Reset when the section changes.
+    current_region: str | None = None
+
     with pdfplumber.open(path) as pdf:
         for page in pdf.pages:
-            for table in page.extract_tables():
-                for row in table:
-                    if len(row) <= NAME_COLUMN:
-                        continue
-                    name = normalize_name(row[NAME_COLUMN])
-                    if name is None or not ARABIC_NAME_RE.match(name):
-                        continue
-                    if not 2 <= len(name.split()) <= 5:
-                        continue
-                    if any(token in name for token in SKIP_TOKENS):
-                        continue
-                    names.add(name)
+            tables = page.extract_tables()
+            if not tables:
+                continue
+            table = max(tables, key=len)
+            layout = detect_section(table)
+            if layout != current_layout:
+                current_layout = layout
+                current_region = None
+            name_col, party_col, region_col = layout
 
-    if not names:
+            for row in table:
+                if len(row) <= name_col:
+                    continue
+                name = normalize_name(row[name_col])
+                if not is_person_name(name):
+                    continue
+                assert name is not None
+
+                party = None
+                if party_col is not None and len(row) > party_col:
+                    affiliation = reverse_arabic(row[party_col])
+                    if affiliation is not None and affiliation.startswith(PARTY_PREFIX):
+                        party = dewrap(affiliation)
+
+                if region_col is not None and len(row) > region_col:
+                    region = reverse_arabic(row[region_col])
+                    if region is not None:
+                        current_region = clean_region(region)
+                constituency = current_region if region_col is not None else None
+
+                records.append((name, party, constituency))
+
+    if not records:
         raise ValueError("No councillor names parsed from the members PDF")
 
-    for name in names:
+    for name, party, constituency in records:
         person = context.make("Person")
-        person.id = context.make_id(name)
+        person.id = context.make_id(name, party, constituency)
         person.add("name", name, lang="ara")
+        # The party the member ran for; trade-union affiliation (employees'
+        # college) is not a political association and is not recorded.
+        person.add("political", party, lang="ara")
         # Eligibility to the House of Councillors requires Moroccan citizenship: only
         # citizens are electors and eligible (2011 Constitution, Article 30).
         # https://mjp.univ-perp.fr/constit/ma2011.htm
@@ -102,5 +207,7 @@ def crawl(context: Context) -> None:
         )
         if occupancy is None:
             continue
+        # The region or electoral district the member represents.
+        occupancy.add("constituency", constituency, lang="ara")
         context.emit(occupancy)
         context.emit(person)

--- a/datasets/ma/house_councillors/crawler.py
+++ b/datasets/ma/house_councillors/crawler.py
@@ -5,7 +5,9 @@ from rigour.mime.types import PDF
 
 from zavod import Context
 from zavod import helpers as h
+from zavod.shed.trans import apply_translit_full_name
 from zavod.stateful.positions import categorise
+from zavod.util import LangText
 
 # The members list is a dated PDF linked from the homepage as
 # docs/docs/conseillers<DDMMYYYY>.pdf; the filename date changes on each update.
@@ -194,6 +196,7 @@ def crawl(context: Context) -> None:
         person = context.make("Person")
         person.id = context.make_id(name, party, constituency)
         person.add("name", name, lang="ara")
+        apply_translit_full_name(context, person, LangText(name, "ara"))
         # The party the member ran for; trade-union affiliation (employees'
         # college) is not a political association and is not recorded.
         person.add("political", party, lang="ara")

--- a/datasets/ma/house_councillors/ma_house_councillors.yml
+++ b/datasets/ma/house_councillors/ma_house_councillors.yml
@@ -1,0 +1,49 @@
+title: Morocco House of Councillors
+name: ma_house_councillors
+prefix: ma-hoc
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the House of Councillors, the upper chamber of the Moroccan
+  parliament.
+description: |
+  The House of Councillors (Majlis al-Mustasharin) is the upper chamber of Morocco's
+  bicameral parliament. Its 120 members are indirectly elected for six-year terms by five
+  electoral colleges: regional councils, local and prefectural councils, professional
+  chambers, employers' organisations and employee (trade-union) representatives.
+
+  This dataset records each councillor by name, as published in the official members list.
+url: https://www.chambredesconseillers.ma/
+publisher:
+  name: Chambre des Conseillers
+  acronym: HoC
+  description: >
+    The House of Councillors is the upper chamber of the Parliament of Morocco, whose
+    members are indirectly elected by regional, local, professional and employee
+    electoral colleges.
+  url: https://www.chambredesconseillers.ma/
+  country: ma
+  official: true
+data:
+  url: https://www.chambredesconseillers.ma/
+  format: PDF
+  lang: ara
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 80
+      Position: 1
+    country_entities:
+      ma: 80
+  max:
+    schema_entities:
+      Person: 140
+      Position: 1

--- a/datasets/ma/house_councillors/ma_house_councillors.yml
+++ b/datasets/ma/house_councillors/ma_house_councillors.yml
@@ -1,4 +1,4 @@
-title: Morocco House of Councillors
+title: Morocco Members of the House of Councillors
 name: ma_house_councillors
 prefix: ma-hoc
 entry_point: crawler.py
@@ -11,12 +11,14 @@ summary: >-
   Members of the House of Councillors, the upper chamber of the Moroccan
   parliament.
 description: |
-  The House of Councillors (Majlis al-Mustasharin) is the upper chamber of Morocco's
-  bicameral parliament. Its 120 members are indirectly elected for six-year terms by five
-  electoral colleges: regional councils, local and prefectural councils, professional
-  chambers, employers' organisations and employee (trade-union) representatives.
+  Current members of the House of Councillors (Majlis al-Mustasharin), the upper chamber of
+  Morocco's bicameral parliament. Its 120 members are indirectly elected for six-year terms
+  by five electoral colleges — regional councils, local and prefectural councils, professional
+  chambers, employers' organisations and employee (trade-union) representatives — and share
+  the country's legislative power with the House of Representatives, including passing laws
+  and approving the budget.
 
-  This dataset records each councillor by name, as published in the official members list.
+  This dataset records each councillor with their name.
 url: https://www.chambredesconseillers.ma/
 publisher:
   name: Chambre des Conseillers

--- a/datasets/ma/house_councillors/ma_house_councillors.yml
+++ b/datasets/ma/house_councillors/ma_house_councillors.yml
@@ -18,7 +18,8 @@ description: |
   the country's legislative power with the House of Representatives, including passing laws
   and approving the budget.
 
-  This dataset records each councillor with their name.
+  This dataset records each councillor with their name, the political party they ran
+  for (where applicable) and the region or electoral district they represent.
 url: https://www.chambredesconseillers.ma/
 publisher:
   name: Chambre des Conseillers
@@ -34,6 +35,11 @@ data:
   url: https://www.chambredesconseillers.ma/
   format: PDF
   lang: ara
+http:
+  # The site can reject non-browser clients, so present a browser User-Agent.
+  user_agent: >-
+    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
+    Chrome/124.0.0.0 Safari/537.36
 
 tags:
   - list.pep


### PR DESCRIPTION
Adds a PEP crawler for the **House of Councillors** (upper chamber of the Moroccan parliament).

## Source
Official members-list PDF, discovered from the homepage (`docs/docs/conseillers<DDMMYYYY>.pdf` — the filename date changes on each update, so the crawler scrapes the link rather than hardcoding it).

⚠️ **Approximate roster.** The PDF is Arabic **right-to-left**: pdfplumber returns glyphs in reversed visual order, so the crawler reverses cell text to logical order, strips the tatweel elongation character, and rejoins wrapped trailing letters. This recovers **~106 of the 120** councillors as clean names; a handful of rows fall outside the regular column layout (mixed party/name columns on the employee-college page, footnote annotations) and are not captured. The name matcher normalises spacing, so the recovered names match reliably.

## Output
- Position: *Member of the House of Councillors of Morocco* (`Q21328580`)
- ~~approx 106 councillors emitted as PEPs (Arabic names).~~ **119 councillors**
- Citizenship `ma` per 2011 Constitution Art. 30 (see code comment).

Closes opensanctions/crawler-planning#755

🤖 Generated with [Claude Code](https://claude.com/claude-code)