### PR TITLE
Add Algeria People's National Assembly (APN) PEP crawler

### DIFF
--- a/datasets/dz/apn/crawler.py
+++ b/datasets/dz/apn/crawler.py
@@ -1,0 +1,76 @@
+import re
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.extract import zyte_api
+from zavod.stateful.positions import categorise
+
+# The APN site is a React single-page app behind a WAF; the deputies list only appears
+# after client-side rendering, so it is fetched through the Zyte API (browser rendering)
+# with an Algerian exit.
+GEOLOCATION = "dz"
+
+# Each deputy links to a detail page "/<id>-<slug>", e.g. "/1302-guend-nabil". This is
+# the stable anchor we key on; the slug carries the transliterated name.
+DEPUTY_HREF_RE = re.compile(r"^/?(\d+)-([a-z][a-z0-9-]+)$")
+
+# Validator: the rendered page must contain at least one deputy-style link.
+UNBLOCK_VALIDATOR = './/a[contains(@href, "-")]'
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the People's National Assembly of Algeria",
+        country="dz",
+        wikidata_id="Q21290886",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    doc = zyte_api.fetch_html(
+        context,
+        context.data_url,
+        unblock_validator=UNBLOCK_VALIDATOR,
+        geolocation=GEOLOCATION,
+        cache_days=1,
+    )
+
+    seen: set[str] = set()
+    for link in h.xpath_elements(doc, "//a[@href]"):
+        href = link.get("href")
+        if href is None:
+            continue
+        match = DEPUTY_HREF_RE.match(href)
+        if match is None:
+            continue
+        deputy_id, slug = match.group(1), match.group(2)
+        if deputy_id in seen:
+            continue
+        seen.add(deputy_id)
+
+        # Prefer the rendered link text (native spelling); fall back to the slug.
+        link_text = h.element_text(link)
+        name = link_text if link_text else slug.replace("-", " ").title()
+
+        person = context.make("Person")
+        person.id = context.make_slug(deputy_id)
+        person.add("name", name)
+        person.add("sourceUrl", f"https://www.apn.dz/{deputy_id}-{slug}")
+        # A candidate for the APN must be of Algerian nationality (Organic Law 21-01 on
+        # the electoral regime, Article 200; 2020 Constitution Article 128).
+        # https://cour-constitutionnelle.dz/wp-content/uploads/2023/02/loi%20-electFR.pdf
+        person.add("citizenship", "dz")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(occupancy)
+        context.emit(person)
+
+    if not seen:
+        raise ValueError("No deputy links found on the APN deputies page")

--- a/datasets/dz/apn/crawler.py
+++ b/datasets/dz/apn/crawler.py
@@ -1,47 +1,64 @@
-import re
+import json
+from itertools import count
+from typing import Any
 
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
-from zavod.extract import zyte_api
-from zavod.stateful.positions import PositionCategorisation, categorise
-from zavod.util import Element
+from zavod.stateful.positions import (
+    OccupancyStatus,
+    PositionCategorisation,
+    categorise,
+)
 
+# The public /nuwab page is a JavaScript single-page app; the deputy roster is
+# loaded from this paginated JSON POST endpoint, PAGE_SIZE records per page.
+PAGE_SIZE = 100
 
-# Each deputy links to a detail page "/<id>-<slug>", e.g. "/1302-guend-nabil". This is
-# the stable anchor we key on; the slug carries the transliterated name.
-DEPUTY_HREF_RE = re.compile(r"^/?(\d+)-([a-z][a-z0-9-]+)$")
+# The API rejects the POST unless it carries a JSON Content-Type (415 otherwise) and
+# a French Accept-Language (400 otherwise); the browser User-Agent it also requires
+# (500 otherwise) is set via http.user_agent in the dataset metadata.
+HEADERS = {
+    "Accept-Language": "fr",
+    "Content-Type": "application/json",
+}
 
 
 def crawl_member(
     context: Context,
     position: Entity,
     categorisation: PositionCategorisation,
-    link: Element,
+    record: dict[str, Any],
 ) -> None:
-    match = DEPUTY_HREF_RE.match(h.xpath_string(link, "./@href"))
-    if match is None:
-        return
-    deputy_id, slug = match.group(1), match.group(2)
-
-    # Prefer the rendered link text (native spelling); fall back to the slug.
-    name = h.element_text(link) or slug.replace("-", " ").title()
+    full_name = record["fullName"]
+    district = record["wilaya"]
+    assert full_name is not None and district is not None
 
     person = context.make("Person")
-    # Deputies linked more than once on the page merge on this deterministic ID.
-    person.id = context.make_slug(deputy_id)
-    person.add("name", name)
-    person.add("sourceUrl", f"https://www.apn.dz/{deputy_id}-{slug}")
+    person.id = context.make_id(full_name, district)
+    person.add("name", full_name)
+    h.apply_name(
+        person,
+        first_name=record["prenom"],
+        last_name=record["nom"],
+        lang="eng",
+    )
+    if record["parti"]:
+        person.add("political", record["parti"])
     # A candidate for the APN must be of Algerian nationality (Organic Law 21-01 on
     # the electoral regime, Article 200; 2020 Constitution Article 128).
     # https://cour-constitutionnelle.dz/wp-content/uploads/2023/02/loi%20-electFR.pdf
     person.add("citizenship", "dz")
 
+    # A recorded seat vacancy (death, resignation or a declared incompatibility)
+    # means the deputy no longer sits; their occupancy has ended.
+    status = OccupancyStatus.ENDED if record["vacancesiege"] is not None else None
     occupancy = h.make_occupancy(
-        context, person, position, categorisation=categorisation
+        context, person, position, categorisation=categorisation, status=status
     )
     if occupancy is None:
         return
+    occupancy.add("constituency", district)
     context.emit(occupancy)
     context.emit(person)
 
@@ -59,13 +76,19 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    doc = zyte_api.fetch_html(
-        context,
-        context.data_url,
-        unblock_validator="//a[@href]",
-        geolocation="dz",
-        cache_days=14,
-    )
-
-    for link in h.xpath_elements(doc, "//a[@href]"):
-        crawl_member(context, position, categorisation, link)
+    # Fetch pages until the API returns an empty batch; the expected roster size is
+    # enforced by the dataset assertions.
+    for page in count():
+        payload = json.dumps({"size": PAGE_SIZE, "page": page})
+        data = context.fetch_json(
+            context.data_url,
+            method="POST",
+            data=payload,
+            headers=HEADERS,
+            cache_days=7,
+        )
+        rows = data["data"]
+        if len(rows) == 0:
+            break
+        for record in rows:
+            crawl_member(context, position, categorisation, record)

--- a/datasets/dz/apn/crawler.py
+++ b/datasets/dz/apn/crawler.py
@@ -2,20 +2,48 @@ import re
 
 from zavod import Context
 from zavod import helpers as h
+from zavod.entity import Entity
 from zavod.extract import zyte_api
-from zavod.stateful.positions import categorise
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
 
-# The APN site is a React single-page app behind a WAF; the deputies list only appears
-# after client-side rendering, so it is fetched through the Zyte API (browser rendering)
-# with an Algerian exit.
-GEOLOCATION = "dz"
 
 # Each deputy links to a detail page "/<id>-<slug>", e.g. "/1302-guend-nabil". This is
 # the stable anchor we key on; the slug carries the transliterated name.
 DEPUTY_HREF_RE = re.compile(r"^/?(\d+)-([a-z][a-z0-9-]+)$")
 
-# Validator: the rendered page must contain at least one deputy-style link.
-UNBLOCK_VALIDATOR = './/a[contains(@href, "-")]'
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    link: Element,
+) -> None:
+    match = DEPUTY_HREF_RE.match(h.xpath_string(link, "./@href"))
+    if match is None:
+        return
+    deputy_id, slug = match.group(1), match.group(2)
+
+    # Prefer the rendered link text (native spelling); fall back to the slug.
+    name = h.element_text(link) or slug.replace("-", " ").title()
+
+    person = context.make("Person")
+    # Deputies linked more than once on the page merge on this deterministic ID.
+    person.id = context.make_slug(deputy_id)
+    person.add("name", name)
+    person.add("sourceUrl", f"https://www.apn.dz/{deputy_id}-{slug}")
+    # A candidate for the APN must be of Algerian nationality (Organic Law 21-01 on
+    # the electoral regime, Article 200; 2020 Constitution Article 128).
+    # https://cour-constitutionnelle.dz/wp-content/uploads/2023/02/loi%20-electFR.pdf
+    person.add("citizenship", "dz")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    context.emit(occupancy)
+    context.emit(person)
 
 
 def crawl(context: Context) -> None:
@@ -24,8 +52,9 @@ def crawl(context: Context) -> None:
         name="Member of the People's National Assembly of Algeria",
         country="dz",
         wikidata_id="Q21290886",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
@@ -33,44 +62,10 @@ def crawl(context: Context) -> None:
     doc = zyte_api.fetch_html(
         context,
         context.data_url,
-        unblock_validator=UNBLOCK_VALIDATOR,
-        geolocation=GEOLOCATION,
-        cache_days=1,
+        unblock_validator="//a[@href]",
+        geolocation="dz",
+        cache_days=14,
     )
 
-    seen: set[str] = set()
     for link in h.xpath_elements(doc, "//a[@href]"):
-        href = link.get("href")
-        if href is None:
-            continue
-        match = DEPUTY_HREF_RE.match(href)
-        if match is None:
-            continue
-        deputy_id, slug = match.group(1), match.group(2)
-        if deputy_id in seen:
-            continue
-        seen.add(deputy_id)
-
-        # Prefer the rendered link text (native spelling); fall back to the slug.
-        link_text = h.element_text(link)
-        name = link_text if link_text else slug.replace("-", " ").title()
-
-        person = context.make("Person")
-        person.id = context.make_slug(deputy_id)
-        person.add("name", name)
-        person.add("sourceUrl", f"https://www.apn.dz/{deputy_id}-{slug}")
-        # A candidate for the APN must be of Algerian nationality (Organic Law 21-01 on
-        # the electoral regime, Article 200; 2020 Constitution Article 128).
-        # https://cour-constitutionnelle.dz/wp-content/uploads/2023/02/loi%20-electFR.pdf
-        person.add("citizenship", "dz")
-
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        context.emit(occupancy)
-        context.emit(person)
-
-    if not seen:
-        raise ValueError("No deputy links found on the APN deputies page")
+        crawl_member(context, position, categorisation, link)

--- a/datasets/dz/apn/dz_apn.yml
+++ b/datasets/dz/apn/dz_apn.yml
@@ -1,0 +1,48 @@
+title: Algeria People's National Assembly
+name: dz_apn
+prefix: dz-apn
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Deputies of the People's National Assembly (APN), the lower chamber of the
+  Algerian parliament.
+description: |
+  The People's National Assembly (Assemblée populaire nationale, APN) is the lower chamber
+  of Algeria's bicameral parliament. Its deputies are directly elected from the wilayas and
+  from constituencies for Algerians abroad for a five-year term.
+
+  This dataset records each sitting deputy by name, as published in the Assembly's members
+  directory.
+url: https://www.apn.dz/
+publisher:
+  name: People's National Assembly
+  acronym: APN
+  description: >
+    The People's National Assembly is the lower chamber of the Algerian parliament, whose
+    deputies are directly elected from the wilayas and overseas constituencies.
+  url: https://www.apn.dz/
+  country: dz
+  official: true
+data:
+  url: https://www.apn.dz/deputes-liste
+  format: HTML
+  lang: fra
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 300
+      Position: 1
+    country_entities:
+      dz: 300
+  max:
+    schema_entities:
+      Person: 500
+      Position: 1

--- a/datasets/dz/apn/dz_apn.yml
+++ b/datasets/dz/apn/dz_apn.yml
@@ -16,8 +16,10 @@ description: |
   the wilayas and from constituencies for Algerians abroad for a five-year term and hold the
   country's legislative power, including passing laws and approving the budget.
 
-  This dataset records each sitting deputy with their name.
-url: https://www.apn.dz/
+  This dataset records each sitting deputy with their name, political party and
+  the electoral district (wilaya, or an overseas voting zone for the diaspora)
+  they represent.
+url: https://www.apn.dz/API/serachInDepute
 publisher:
   name: People's National Assembly
   acronym: APN
@@ -28,9 +30,14 @@ publisher:
   country: dz
   official: true
 data:
-  url: https://www.apn.dz/deputes-liste
-  format: HTML
+  url: https://www.apn.dz/API/serachInDepute
+  format: JSON
   lang: fra
+http:
+  # The API returns 500 for a non-browser User-Agent.
+  user_agent: >-
+    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+    like Gecko) Chrome/120.0 Safari/537.36
 
 tags:
   - list.pep

--- a/datasets/dz/apn/dz_apn.yml
+++ b/datasets/dz/apn/dz_apn.yml
@@ -1,4 +1,4 @@
-title: Algeria People's National Assembly
+title: Algeria Members of the People's National Assembly
 name: dz_apn
 prefix: dz-apn
 entry_point: crawler.py
@@ -11,12 +11,12 @@ summary: >-
   Deputies of the People's National Assembly (APN), the lower chamber of the
   Algerian parliament.
 description: |
-  The People's National Assembly (Assemblée populaire nationale, APN) is the lower chamber
-  of Algeria's bicameral parliament. Its deputies are directly elected from the wilayas and
-  from constituencies for Algerians abroad for a five-year term.
+  Current members of the People's National Assembly (Assemblée populaire nationale, APN), the
+  lower chamber of Algeria's bicameral parliament. Its 407 deputies are directly elected from
+  the wilayas and from constituencies for Algerians abroad for a five-year term and hold the
+  country's legislative power, including passing laws and approving the budget.
 
-  This dataset records each sitting deputy by name, as published in the Assembly's members
-  directory.
+  This dataset records each sitting deputy with their name.
 url: https://www.apn.dz/
 publisher:
   name: People's National Assembly


### PR DESCRIPTION
Adds a PEP crawler for the **People's National Assembly (APN)**, the lower chamber of the Algerian parliament.

## Source
`apn.dz` is a **React SPA behind a WAF**; the deputies list only appears after client-side rendering, so it is fetched via the **Zyte API** (browser rendering, Algerian exit). Each deputy links to a `/<id>-<slug>` detail page — the crawler keys on that id and uses the rendered link text (falling back to the transliterated slug) as the name.

^ kicked Zyte and switched to API. The deputy IDs aren't stable, so we rely on `h.make_id()` instead to key

## Output
- Position: *Member of the People's National Assembly of Algeria* (`Q21290886`)
- Citizenship `dz` per Organic Law 21-01 Art. 200 (see code comment).

Closes opensanctions/crawler-planning#757

🤖 Generated with [Claude Code](https://claude.com/claude-code)