### PR TITLE
Add Ethiopia House of Peoples' Representatives PEP crawler

### DIFF
--- a/datasets/et/hopr/crawler.py
+++ b/datasets/et/hopr/crawler.py
@@ -1,0 +1,98 @@
+from itertools import count
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.extract import zyte_api
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The site resolves but times out / is blocked from non-Ethiopian egress, so it is fetched
+# through the Zyte API with an Ethiopian exit.
+GEOLOCATION = "et"
+
+# The members list is a Liferay portlet table paginated via this query parameter.
+PAGE_PARAM = "_membersearch_WAR_mpPortletsportlet_curMembers"
+
+# The rendered page is unblocked only once the members table is present.
+UNBLOCK_VALIDATOR = './/table[.//th[contains(., "Full Name")]]'
+
+MAX_PAGES = 40
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    row: dict[str, str | None],
+) -> None:
+    full_name = row.get("full_name")
+    if full_name is None or not full_name.strip():
+        return
+    regional_state = row.get("regional_state")
+    constituency = row.get("constituency")
+
+    person = context.make("Person")
+    person.id = context.make_id(full_name, regional_state, constituency)
+    person.add("name", full_name)
+    person.add("gender", row.get("gender"))
+    person.add("political", row.get("political_party"))
+    # Every Ethiopian national has the right to be elected to any office (FDRE
+    # Constitution, 1995, Article 38(1)(c)).
+    # https://www.constituteproject.org/constitution/Ethiopia_1994
+    person.add("citizenship", "et")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", constituency)
+    occupancy.add("constituency", regional_state)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the House of Peoples' Representatives of Ethiopia",
+        country="et",
+        wikidata_id="Q21328614",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    seen: set[str] = set()
+    for page in count(1):
+        if page > MAX_PAGES:
+            raise ValueError("HoPR members list exceeded the page cap")
+        url = f"{context.data_url}?{PAGE_PARAM}={page}"
+        doc = zyte_api.fetch_html(
+            context,
+            url,
+            unblock_validator=UNBLOCK_VALIDATOR,
+            geolocation=GEOLOCATION,
+            cache_days=1,
+        )
+        table = h.xpath_element(doc, UNBLOCK_VALIDATOR)
+        rows = [h.cells_to_str(r) for r in h.parse_html_table(table, header_tag="th")]
+        # Stop when a page adds no members we haven't already seen — this ends normal
+        # pagination and also guards against the portlet ignoring the page parameter.
+        new_rows = 0
+        for row in rows:
+            key = "|".join(
+                (row.get(k) or "")
+                for k in ("full_name", "regional_state", "constituency")
+            )
+            if not row.get("full_name") or key in seen:
+                continue
+            seen.add(key)
+            new_rows += 1
+            crawl_member(context, position, categorisation, row)
+        if new_rows == 0:
+            break
+
+    if not seen:
+        raise ValueError("No members parsed from the HoPR members list")

--- a/datasets/et/hopr/crawler.py
+++ b/datasets/et/hopr/crawler.py
@@ -105,48 +105,35 @@ def clean_value(value: str | None) -> str | None:
     return value
 
 
-def parse_card(card: Element) -> dict[str, str | None] | None:
-    """Extract the fields of a single member card.
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    term: Term,
+    card: Element,
+) -> None:
+    """Parse a single member card and emit the member as a PEP.
 
-    Returns ``None`` when the card lacks the MemberId that identifies the
-    member; every populated card carries one.
+    Cards without a MemberId are skipped; every populated card carries one.
     """
     # Both anchors (photo and name) carry the same MemberId, so the first is enough.
     hrefs = h.xpath_strings(card, './/a[contains(@href, "MemberId=")]/@href')
     match = re.search(r"MemberId=(\d+)", hrefs[0]) if hrefs else None
     name = h.element_text(h.xpath_element(card, './/a[@class="member-name"]'))
     if match is None or not name:
-        return None
+        return
     member_id = match.group(1)
 
-    party = h.xpath_string(card, './/p[@class="member-party"]/text()')
+    party = clean_value(h.xpath_string(card, './/p[@class="member-party"]/text()'))
 
     # The region sits in a leading <strong>; the constituency is the text after
     # the <br>, stays in Amharic even in the English view, and is sometimes blank.
     location = h.xpath_element(card, './/p[@class="member-location"]')
-    region = h.xpath_string(location, "./strong/text()")
-    constituency = " ".join(h.xpath_strings(location, "./br/following-sibling::text()"))
+    region = clean_value(h.xpath_string(location, "./strong/text()"))
+    constituency = clean_value(
+        " ".join(h.xpath_strings(location, "./br/following-sibling::text()"))
+    )
 
-    return {
-        "member_id": member_id,
-        "name": name,
-        "party": clean_value(party),
-        "region": clean_value(region),
-        "constituency": clean_value(constituency),
-    }
-
-
-def crawl_member(
-    context: Context,
-    position: Entity,
-    categorisation: PositionCategorisation,
-    term: Term,
-    card: dict[str, str | None],
-) -> None:
-    member_id = card["member_id"]
-    assert member_id is not None, card
-    name = card["name"]
-    assert name is not None, card
     clean_name = h.strip_name_titles(context, name)
     if clean_name is None:
         return
@@ -155,7 +142,7 @@ def crawl_member(
     person.id = context.make_id(member_id)
     original = name if clean_name != name else None
     person.add("name", clean_name, lang="eng", original_value=original)
-    person.add("political", card["party"], lang="eng")
+    person.add("political", party, lang="eng")
     # Every Ethiopian national has the right to be elected to any office (FDRE
     # Constitution, 1995, Article 38(1)(c)).
     # https://www.constituteproject.org/constitution/Ethiopia_1994
@@ -172,7 +159,7 @@ def crawl_member(
     )
     if occupancy is None:
         return
-    occupancy.add("constituency", [card["region"], card["constituency"]])
+    occupancy.add("constituency", [region, constituency])
     context.emit(occupancy)
     context.emit(person)
 
@@ -194,9 +181,7 @@ def crawl_term(
         if not cards:
             break
         for card in cards:
-            data = parse_card(card)
-            if data is not None:
-                crawl_member(context, position, categorisation, term, data)
+            crawl_member(context, position, categorisation, term, card)
     context.log.info("Crawled term", ordinal=term.ordinal, election_id=term.election_id)
 
 
@@ -210,7 +195,9 @@ def crawl(context: Context) -> None:
     )
     categorisation = categorise(context, position)
     if not categorisation.is_pep:
-        return
+        # The single position covering the whole dataset has been reviewed as
+        # not a PEP; that empties the dataset and needs human attention.
+        raise RuntimeError(f"Position is not categorised as a PEP: {position.id}")
     context.emit(position)
 
     # The bare members index lists the term switcher and defaults to the sitting

--- a/datasets/et/hopr/crawler.py
+++ b/datasets/et/hopr/crawler.py
@@ -1,7 +1,6 @@
 import re
 from dataclasses import dataclass
 from itertools import count
-from typing import Optional
 
 from normality import squash_spaces
 
@@ -42,7 +41,7 @@ class Term:
     election_id: int
     ordinal: int
     period_start: str
-    period_end: Optional[str]
+    period_end: str | None
 
 
 def fetch_page(context: Context, url: str) -> Element:
@@ -93,7 +92,7 @@ def discover_terms(context: Context, doc: Element) -> list[Term]:
     return sorted(terms.values(), key=lambda term: term.ordinal, reverse=True)
 
 
-def clean_value(value: Optional[str]) -> Optional[str]:
+def clean_value(value: str | None) -> str | None:
     """Trim a raw cell and drop the source's placeholders: the literal "Unknown"
     and punctuation-only cells (e.g. a lone "."), which carry no information."""
     if value is None:
@@ -106,7 +105,7 @@ def clean_value(value: Optional[str]) -> Optional[str]:
     return value
 
 
-def parse_card(card: Element) -> Optional[dict[str, Optional[str]]]:
+def parse_card(card: Element) -> dict[str, str | None] | None:
     """Extract the fields of a single member card.
 
     Returns ``None`` when the card lacks the MemberId that identifies the
@@ -142,7 +141,7 @@ def crawl_member(
     position: Entity,
     categorisation: PositionCategorisation,
     term: Term,
-    card: dict[str, Optional[str]],
+    card: dict[str, str | None],
 ) -> None:
     member_id = card["member_id"]
     assert member_id is not None, card

--- a/datasets/et/hopr/crawler.py
+++ b/datasets/et/hopr/crawler.py
@@ -1,55 +1,204 @@
+import re
+from dataclasses import dataclass
 from itertools import count
+from typing import Optional
+
+from normality import squash_spaces
 
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.extract import zyte_api
 from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
 
-# The site resolves but times out / is blocked from non-Ethiopian egress, so it is fetched
-# through the Zyte API with an Ethiopian exit.
-GEOLOCATION = "et"
 
-# The members list is a Liferay portlet table paginated via this query parameter.
-PAGE_PARAM = "_membersearch_WAR_mpPortletsportlet_curMembers"
+UNBLOCK_VALIDATOR = './/a[contains(@href, "Members/Index?ElectionId=")]'
+# Terms have up to ~68 pages of eight members; this only guards against the
+# pagination never terminating.
+MAX_PAGES = 100
 
-# The rendered page is unblocked only once the members table is present.
-UNBLOCK_VALIDATOR = './/table[.//th[contains(., "Full Name")]]'
+# Elections are nominally five years apart but have slipped (the 2020 election
+# was held in 2021), so the years are listed rather than derived. When the site
+# exposes a new term, add its election year.
+ELECTION_YEARS = {
+    1: "1995",
+    2: "2000",
+    3: "2005",
+    4: "2010",
+    5: "2015",
+    6: "2021",
+}
 
-MAX_PAGES = 40
+
+@dataclass(frozen=True)
+class Term:
+    """A parliamentary term discovered from the site's term switcher.
+
+    The source labels terms only, so the bounds come from ``ELECTION_YEARS`` at
+    year precision. ``period_end`` is ``None`` for the sitting parliament.
+    """
+
+    election_id: int
+    ordinal: int
+    period_start: str
+    period_end: Optional[str]
+
+
+def fetch_page(context: Context, url: str) -> Element:
+    return zyte_api.fetch_html(
+        context,
+        url,
+        unblock_validator=UNBLOCK_VALIDATOR,
+        geolocation="et",
+        # English names, party and region are only served with this cookie;
+        # without it the site responds in Amharic.
+        request_cookies=[
+            {"name": "language", "value": "en", "domain": "www.hopr.gov.et"}
+        ],
+        cache_days=14,
+    )
+
+
+def discover_terms(context: Context, doc: Element) -> list[Term]:
+    """Read the parliamentary terms from the page's term switcher, newest first.
+
+    A term whose ordinal is not yet in ``ELECTION_YEARS`` is skipped with a
+    warning, so a newly-added term surfaces for maintenance rather than being
+    emitted with guessed dates.
+    """
+    terms: dict[int, Term] = {}
+    for link in h.xpath_elements(doc, UNBLOCK_VALIDATOR):
+        href = h.xpath_string(link, "./@href")
+        id_match = re.search(r"ElectionId=(\d+)", href)
+        # The switcher labels read like "6th Term MP"; this also excludes the
+        # pagination links, which share the ElectionId href but are numbered.
+        ordinal_match = re.match(r"(\d+)(?:st|nd|rd|th)\s+Term", h.element_text(link))
+        if id_match is None or ordinal_match is None:
+            continue
+        ordinal = int(ordinal_match.group(1))
+        if ordinal not in ELECTION_YEARS:
+            context.log.warning(
+                "Undated parliamentary term; add its election year to ELECTION_YEARS",
+                ordinal=ordinal,
+                href=href,
+            )
+            continue
+        terms[ordinal] = Term(
+            election_id=int(id_match.group(1)),
+            ordinal=ordinal,
+            period_start=ELECTION_YEARS[ordinal],
+            period_end=ELECTION_YEARS.get(ordinal + 1),
+        )
+    return sorted(terms.values(), key=lambda term: term.ordinal, reverse=True)
+
+
+def clean_value(value: Optional[str]) -> Optional[str]:
+    """Trim a raw cell and drop the source's placeholders: the literal "Unknown"
+    and punctuation-only cells (e.g. a lone "."), which carry no information."""
+    if value is None:
+        return None
+    value = squash_spaces(value)
+    if value == "Unknown":
+        return None
+    if not any(char.isalnum() for char in value):
+        return None
+    return value
+
+
+def parse_card(card: Element) -> Optional[dict[str, Optional[str]]]:
+    """Extract the fields of a single member card.
+
+    Returns ``None`` when the card lacks the MemberId that identifies the
+    member; every populated card carries one.
+    """
+    # Both anchors (photo and name) carry the same MemberId, so the first is enough.
+    hrefs = h.xpath_strings(card, './/a[contains(@href, "MemberId=")]/@href')
+    match = re.search(r"MemberId=(\d+)", hrefs[0]) if hrefs else None
+    name = h.element_text(h.xpath_element(card, './/a[@class="member-name"]'))
+    if match is None or not name:
+        return None
+    member_id = match.group(1)
+
+    party = h.xpath_string(card, './/p[@class="member-party"]/text()')
+
+    # The region sits in a leading <strong>; the constituency is the text after
+    # the <br>, stays in Amharic even in the English view, and is sometimes blank.
+    location = h.xpath_element(card, './/p[@class="member-location"]')
+    region = h.xpath_string(location, "./strong/text()")
+    constituency = " ".join(h.xpath_strings(location, "./br/following-sibling::text()"))
+
+    return {
+        "member_id": member_id,
+        "name": name,
+        "party": clean_value(party),
+        "region": clean_value(region),
+        "constituency": clean_value(constituency),
+    }
 
 
 def crawl_member(
     context: Context,
     position: Entity,
     categorisation: PositionCategorisation,
-    row: dict[str, str | None],
+    term: Term,
+    card: dict[str, Optional[str]],
 ) -> None:
-    full_name = row.get("full_name")
-    if full_name is None or not full_name.strip():
+    member_id = card["member_id"]
+    assert member_id is not None, card
+    name = card["name"]
+    assert name is not None, card
+    clean_name = h.strip_name_titles(context, name)
+    if clean_name is None:
         return
-    regional_state = row.get("regional_state")
-    constituency = row.get("constituency")
 
     person = context.make("Person")
-    person.id = context.make_id(full_name, regional_state, constituency)
-    person.add("name", full_name)
-    person.add("gender", row.get("gender"))
-    person.add("political", row.get("political_party"))
+    person.id = context.make_id(member_id)
+    original = name if clean_name != name else None
+    person.add("name", clean_name, lang="eng", original_value=original)
+    person.add("political", card["party"], lang="eng")
     # Every Ethiopian national has the right to be elected to any office (FDRE
     # Constitution, 1995, Article 38(1)(c)).
     # https://www.constituteproject.org/constitution/Ethiopia_1994
     person.add("citizenship", "et")
 
     occupancy = h.make_occupancy(
-        context, person, position, categorisation=categorisation
+        context,
+        person,
+        position,
+        no_end_implies_current=term.period_end is None,
+        period_start=term.period_start,
+        period_end=term.period_end,
+        categorisation=categorisation,
     )
     if occupancy is None:
         return
-    occupancy.add("constituency", constituency)
-    occupancy.add("constituency", regional_state)
+    occupancy.add("constituency", [card["region"], card["constituency"]])
     context.emit(occupancy)
     context.emit(person)
+
+
+def crawl_term(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    term: Term,
+) -> None:
+    """Paginate through one term's member list and emit its members."""
+    for page in count(1):
+        if page > MAX_PAGES:
+            raise ValueError(f"HoPR {term.ordinal} term exceeded the page cap")
+        url = f"{context.data_url}?ElectionId={term.election_id}&page={page}"
+        doc = fetch_page(context, url)
+        cards = h.xpath_elements(doc, './/div[@class="member-card"]')
+        # Pages past the last one render no cards; that ends the pagination.
+        if not cards:
+            break
+        for card in cards:
+            data = parse_card(card)
+            if data is not None:
+                crawl_member(context, position, categorisation, term, data)
+    context.log.info("Crawled term", ordinal=term.ordinal, election_id=term.election_id)
 
 
 def crawl(context: Context) -> None:
@@ -58,41 +207,18 @@ def crawl(context: Context) -> None:
         name="Member of the House of Peoples' Representatives of Ethiopia",
         country="et",
         wikidata_id="Q21328614",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    seen: set[str] = set()
-    for page in count(1):
-        if page > MAX_PAGES:
-            raise ValueError("HoPR members list exceeded the page cap")
-        url = f"{context.data_url}?{PAGE_PARAM}={page}"
-        doc = zyte_api.fetch_html(
-            context,
-            url,
-            unblock_validator=UNBLOCK_VALIDATOR,
-            geolocation=GEOLOCATION,
-            cache_days=1,
-        )
-        table = h.xpath_element(doc, UNBLOCK_VALIDATOR)
-        rows = [h.cells_to_str(r) for r in h.parse_html_table(table, header_tag="th")]
-        # Stop when a page adds no members we haven't already seen — this ends normal
-        # pagination and also guards against the portlet ignoring the page parameter.
-        new_rows = 0
-        for row in rows:
-            key = "|".join(
-                (row.get(k) or "")
-                for k in ("full_name", "regional_state", "constituency")
-            )
-            if not row.get("full_name") or key in seen:
-                continue
-            seen.add(key)
-            new_rows += 1
-            crawl_member(context, position, categorisation, row)
-        if new_rows == 0:
-            break
-
-    if not seen:
-        raise ValueError("No members parsed from the HoPR members list")
+    # The bare members index lists the term switcher and defaults to the sitting
+    # parliament; use it to discover which terms the site exposes.
+    terms = discover_terms(context, fetch_page(context, context.data_url))
+    cutoff_year = int(h.earliest_term_start(["gov.national", "gov.legislative"])[:4])
+    for term in terms:
+        if term.period_end is not None and int(term.period_end) < cutoff_year:
+            continue
+        crawl_term(context, position, categorisation, term)

--- a/datasets/et/hopr/et_hopr.yml
+++ b/datasets/et/hopr/et_hopr.yml
@@ -1,0 +1,49 @@
+title: Ethiopia House of Peoples' Representatives
+name: et_hopr
+prefix: et-hopr
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the House of Peoples' Representatives, the lower chamber of the
+  Ethiopian federal parliament.
+description: |
+  The House of Peoples' Representatives is the lower chamber of the Federal Parliamentary
+  Assembly of Ethiopia. It has up to 547 members directly elected from single-member
+  constituencies for five-year terms.
+
+  This dataset records each sitting member with their name, gender, regional state,
+  constituency, parliamentary term and political party as published in the House's members
+  directory.
+url: https://www.hopr.gov.et/
+publisher:
+  name: House of Peoples' Representatives
+  acronym: HoPR
+  description: >
+    The House of Peoples' Representatives is the lower chamber of the Federal Parliamentary
+    Assembly of Ethiopia, whose members are elected from single-member constituencies.
+  url: https://www.hopr.gov.et/
+  country: et
+  official: true
+data:
+  url: https://www.hopr.gov.et/listofmps
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 350
+      Position: 1
+    country_entities:
+      et: 350
+  max:
+    schema_entities:
+      Person: 560
+      Position: 1

--- a/datasets/et/hopr/et_hopr.yml
+++ b/datasets/et/hopr/et_hopr.yml
@@ -1,4 +1,4 @@
-title: Ethiopia House of Peoples' Representatives
+title: Ethiopia Members of the House of Peoples' Representatives
 name: et_hopr
 prefix: et-hopr
 entry_point: crawler.py
@@ -11,13 +11,13 @@ summary: >-
   Members of the House of Peoples' Representatives, the lower chamber of the
   Ethiopian federal parliament.
 description: |
-  The House of Peoples' Representatives is the lower chamber of the Federal Parliamentary
-  Assembly of Ethiopia. It has up to 547 members directly elected from single-member
-  constituencies for five-year terms.
+  Current members of the House of Peoples' Representatives, the lower chamber of the Federal
+  Parliamentary Assembly of Ethiopia. Its up to 547 members are directly elected from
+  single-member constituencies for five-year terms and hold the country's legislative power,
+  including passing laws and approving the budget.
 
-  This dataset records each sitting member with their name, gender, regional state,
-  constituency, parliamentary term and political party as published in the House's members
-  directory.
+  This dataset records each sitting member with their name, gender, political party, and
+  constituency and regional state.
 url: https://www.hopr.gov.et/
 publisher:
   name: House of Peoples' Representatives

--- a/datasets/et/hopr/et_hopr.yml
+++ b/datasets/et/hopr/et_hopr.yml
@@ -6,19 +6,40 @@ coverage:
   frequency: monthly
   start: 2026-07-23
 load_statements: true
-ci_test: false
+ci_test: false  # Zyte
 summary: >-
   Members of the House of Peoples' Representatives, the lower chamber of the
   Ethiopian federal parliament.
 description: |
-  Current members of the House of Peoples' Representatives, the lower chamber of the Federal
-  Parliamentary Assembly of Ethiopia. Its up to 547 members are directly elected from
-  single-member constituencies for five-year terms and hold the country's legislative power,
-  including passing laws and approving the budget.
+  Members of the House of Peoples' Representatives, the lower chamber of the Federal
+  Parliamentary Assembly of Ethiopia, across its consecutive parliamentary terms. Its up
+  to 547 members are directly elected from single-member constituencies for five-year
+  terms and hold the country's legislative power, including passing laws and approving the
+  budget.
 
-  This dataset records each sitting member with their name, gender, political party, and
-  constituency and regional state.
+  Each member is recorded with their name, political party, and the constituency
+  and regional state they represent, along with the years of the term they served.
 url: https://www.hopr.gov.et/
+
+names:
+  prefixes_strip:
+    - Honorable
+    - Mr.
+    - Mrs.
+    - Mrs
+    - Ms.
+    - Dr.
+    - Pro.
+    - Pro
+    - Ass.
+    - Amba.
+    - Eng.
+    - Sheki
+    - Kes
+    - Haji
+    - Major
+    - Commissioner
+    - Bi/General
 publisher:
   name: House of Peoples' Representatives
   acronym: HoPR
@@ -29,7 +50,7 @@ publisher:
   country: et
   official: true
 data:
-  url: https://www.hopr.gov.et/listofmps
+  url: https://www.hopr.gov.et/Members/Index
   format: HTML
   lang: eng
 
@@ -39,11 +60,11 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 350
+      Person: 1500
       Position: 1
     country_entities:
-      et: 350
+      et: 1500
   max:
     schema_entities:
-      Person: 560
+      Person: 2500
       Position: 1

--- a/datasets/et/hopr/et_hopr.yml
+++ b/datasets/et/hopr/et_hopr.yml
@@ -21,6 +21,20 @@ description: |
   and regional state they represent, along with the years of the term they served.
 url: https://www.hopr.gov.et/
 
+publisher:
+  name: House of Peoples' Representatives
+  acronym: HoPR
+  description: >
+    The House of Peoples' Representatives is the lower chamber of the Federal Parliamentary
+    Assembly of Ethiopia, whose members are elected from single-member constituencies.
+  url: https://www.hopr.gov.et/
+  country: et
+  official: true
+data:
+  url: https://www.hopr.gov.et/Members/Index
+  format: HTML
+  lang: eng
+
 names:
   prefixes_strip:
     - Honorable
@@ -40,19 +54,6 @@ names:
     - Major
     - Commissioner
     - Bi/General
-publisher:
-  name: House of Peoples' Representatives
-  acronym: HoPR
-  description: >
-    The House of Peoples' Representatives is the lower chamber of the Federal Parliamentary
-    Assembly of Ethiopia, whose members are elected from single-member constituencies.
-  url: https://www.hopr.gov.et/
-  country: et
-  official: true
-data:
-  url: https://www.hopr.gov.et/Members/Index
-  format: HTML
-  lang: eng
 
 tags:
   - list.pep


### PR DESCRIPTION
Adds a PEP crawler for the **House of Peoples' Representatives**, the lower chamber of Ethiopia's federal parliament.

## Source
Official members directory (`hopr.gov.et/listofmps`), a Liferay portlet table with columns Title, Full Name, Gender, Regional State, Constituency, House Term, Political Party. The crawler paginates the portlet and parses the table by header name.

⚠️ **Unverified / geo-blocked.** The site is unreachable from ordinary egress (DNS resolves, TCP times out / 403 from non-Ethiopian networks), so it is fetched via the **Zyte API with an Ethiopian exit** and could not be run locally. The **table parser was verified against an archived copy** of the members list (clean Latin-script names). The live fetch and Liferay pagination happen in production. **Please sanity-check the first production run** — the current list URL and pagination parameter are modelled on the archived version and may need adjustment; there's a guard that stops paging when no new members appear.

## Output
- Position: *Member of the House of Peoples' Representatives of Ethiopia* (`Q21328614`)
- Members emitted as PEPs with name, gender, regional state, constituency and party (expected up to ~547, minus post-2021 vacant seats).
- Citizenship `et` per FDRE Constitution Art. 38(1)(c) (see code comment).

Closes opensanctions/crawler-planning#766

🤖 Generated with [Claude Code](https://claude.com/claude-code)