### PR TITLE
Add Thailand House of Representatives PEP crawler

### DIFF
--- a/datasets/th/house_representatives/crawler.py
+++ b/datasets/th/house_representatives/crawler.py
@@ -1,0 +1,105 @@
+from itertools import count
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+REFERER = "https://www.parliament.go.th/view/1/mpconnect/TH-TH"
+
+# Civilian honorifics prefixed (without a space) to the given name. Military, police and
+# academic titles are left in place as they are part of how the member is known.
+HONORIFICS = ("นางสาว", "นาย", "นาง")
+
+# partyType values: single-member constituency vs national party list.
+CONSTITUENCY = "แบบแบ่งเขต"
+PARTY_LIST = "แบบบัญชีรายชื่อ"
+
+
+def clean_name(raw: str) -> str:
+    name = " ".join(raw.split())
+    for honorific in HONORIFICS:
+        if name.startswith(honorific):
+            return name[len(honorific) :].strip()
+    return name
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    member: dict[str, Any],
+) -> None:
+    member_id = member.pop("ID_member")
+    name = clean_name(member.pop("name"))
+    assert name, f"Empty name for member {member_id}"
+    party_type = member.pop("partyType")
+    if party_type not in (CONSTITUENCY, PARTY_LIST):
+        context.log.warning("Unknown party type", value=party_type, member=member_id)
+
+    person = context.make("Person")
+    person.id = context.make_slug(member_id)
+    person.add("name", name, lang="tha")
+    person.add("political", member.pop("category_party"), lang="tha")
+    # A candidate for the House of Representatives must be of Thai nationality by birth
+    # (Constitution of Thailand 2017, Section 97(1)).
+    # https://www.constituteproject.org/constitution/Thailand_2017
+    person.add("citizenship", "th")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    # Constituency members represent a numbered district within a province; party-list
+    # members have no district.
+    province = member.pop("province", None)
+    district = member.pop("district", None)
+    if party_type == CONSTITUENCY and province and district:
+        occupancy.add("constituency", f"{province} {district}", lang="tha")
+    elif province:
+        occupancy.add("constituency", province, lang="tha")
+
+    context.audit_data(member, ignore=["category", "NO_member", "profileImage"])
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the House of Representatives of Thailand",
+        country="th",
+        wikidata_id="Q21290865",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    seen: set[str] = set()
+    total: int | None = None
+    for page in count(1):
+        data = context.fetch_json(
+            context.data_url,
+            method="POST",
+            params={"page": page},
+            headers={"Referer": REFERER},
+            cache_days=1,
+        )
+        if total is None:
+            total = data["total"]
+        members = data["arrdata"]
+        if not members:
+            break
+        for member in members:
+            if member["ID_member"] in seen:
+                continue
+            seen.add(member["ID_member"])
+            crawl_member(context, position, categorisation, member)
+        if len(seen) >= total:
+            break
+
+    if not seen:
+        raise ValueError("No members returned by the HoR endpoint")

--- a/datasets/th/house_representatives/crawler.py
+++ b/datasets/th/house_representatives/crawler.py
@@ -21,11 +21,17 @@ def crawl_member(
 ) -> None:
     member_id = member.pop("ID_member")
     raw_name = member.pop("name")
+    # The roster spans all 500 seats. A seat awaiting a by-election or a party-list
+    # replacement is published with its party set but no holder name, so skip it
+    # rather than emitting a nameless Person. The dataset's min-Person assertion
+    # catches a source regression that blanks names wholesale.
+    if not raw_name.strip():
+        context.log.info("Seat has no named holder", member=member_id)
+        return
     clean_name = h.strip_name_titles(context, raw_name)
-    assert clean_name is not None
-    party_type = member.pop("partyType")
-    if party_type not in (CONSTITUENCY, PARTY_LIST):
-        context.log.warning("Unknown party type", value=party_type, member=member_id)
+    if clean_name is None:
+        # strip_name_titles has already warned that the name was only titles.
+        return
 
     person = context.make("Person")
     person.id = context.make_slug(member_id)
@@ -43,15 +49,26 @@ def crawl_member(
     )
     if occupancy is None:
         return
-    # Constituency members represent a numbered district within a province; party-list
-    # members have no district.
-    province = member.pop("province", None)
-    district = member.pop("district", None)
-    if party_type == CONSTITUENCY and province and district:
-        occupancy.add("constituency", f"{province} {district}", lang="tha")
-    elif province:
-        occupancy.add("constituency", province, lang="tha")
 
+    party_type = member.pop("partyType")
+    province = member.pop("province")
+    district = member.pop("district")
+    if party_type == CONSTITUENCY:
+        # Constituency members represent a numbered district within a province.
+        assert province and district, (member_id, province, district)
+        occupancy.add("constituency", f"{province} {district}", lang="tha")
+    elif party_type == PARTY_LIST:
+        # Party-list members are elected nationally, so they have no district.
+        assert not province and district is None, (member_id, province, district)
+    else:
+        # Don't guess at a constituency for a member whose route into the House we
+        # don't recognise. The rest of their record is still valid.
+        context.log.warning(
+            "Unknown party type", party_type=party_type, member=member_id
+        )
+
+    # category is an internal classification code, NO_member a seat number, and
+    # profileImage a photo URL, which Person:images cannot hold (it links entities).
     context.audit_data(member, ignore=["category", "NO_member", "profileImage"])
     context.emit(occupancy)
     context.emit(person)
@@ -70,17 +87,20 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    # Fetch pages until the API returns an empty batch; the expected roster size is
-    # enforced by the dataset assertions.
+    # Each response reports the full roster size, so page until we've seen that many
+    # members rather than trusting an empty batch to mean the roster is exhausted.
+    seen = 0
     for page in count(1):
         data = context.fetch_json(
-            context.data_url,
-            method="POST",
-            params={"page": page},
-            cache_days=14,
+            context.data_url, method="POST", params={"page": page}
         )
+        total = data["total"]
         members = data["arrdata"]
-        if not members:
-            break
+        # A page running dry before the roster is complete would silently under-collect.
+        assert len(members) > 0, (page, seen, total)
         for member in members:
             crawl_member(context, position, categorisation, member)
+        seen += len(members)
+        if seen >= total:
+            break
+    assert seen == total, (seen, total)

--- a/datasets/th/house_representatives/crawler.py
+++ b/datasets/th/house_representatives/crawler.py
@@ -4,25 +4,13 @@ from typing import Any
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
+from zavod.shed.trans import apply_translit_full_name
 from zavod.stateful.positions import PositionCategorisation, categorise
-
-REFERER = "https://www.parliament.go.th/view/1/mpconnect/TH-TH"
-
-# Civilian honorifics prefixed (without a space) to the given name. Military, police and
-# academic titles are left in place as they are part of how the member is known.
-HONORIFICS = ("นางสาว", "นาย", "นาง")
+from zavod.util import LangText
 
 # partyType values: single-member constituency vs national party list.
 CONSTITUENCY = "แบบแบ่งเขต"
 PARTY_LIST = "แบบบัญชีรายชื่อ"
-
-
-def clean_name(raw: str) -> str:
-    name = " ".join(raw.split())
-    for honorific in HONORIFICS:
-        if name.startswith(honorific):
-            return name[len(honorific) :].strip()
-    return name
 
 
 def crawl_member(
@@ -32,15 +20,18 @@ def crawl_member(
     member: dict[str, Any],
 ) -> None:
     member_id = member.pop("ID_member")
-    name = clean_name(member.pop("name"))
-    assert name, f"Empty name for member {member_id}"
+    raw_name = member.pop("name")
+    clean_name = h.strip_name_titles(context, raw_name)
+    assert clean_name is not None
     party_type = member.pop("partyType")
     if party_type not in (CONSTITUENCY, PARTY_LIST):
         context.log.warning("Unknown party type", value=party_type, member=member_id)
 
     person = context.make("Person")
     person.id = context.make_slug(member_id)
-    person.add("name", name, lang="tha")
+    original_name = raw_name if clean_name != raw_name else None
+    person.add("name", clean_name, lang="tha", original_value=original_name)
+    apply_translit_full_name(context, person, LangText(clean_name, "tha"))
     person.add("political", member.pop("category_party"), lang="tha")
     # A candidate for the House of Representatives must be of Thai nationality by birth
     # (Constitution of Thailand 2017, Section 97(1)).
@@ -72,34 +63,24 @@ def crawl(context: Context) -> None:
         name="Member of the House of Representatives of Thailand",
         country="th",
         wikidata_id="Q21290865",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    seen: set[str] = set()
-    total: int | None = None
+    # Fetch pages until the API returns an empty batch; the expected roster size is
+    # enforced by the dataset assertions.
     for page in count(1):
         data = context.fetch_json(
             context.data_url,
             method="POST",
             params={"page": page},
-            headers={"Referer": REFERER},
-            cache_days=1,
+            cache_days=14,
         )
-        if total is None:
-            total = data["total"]
         members = data["arrdata"]
         if not members:
             break
         for member in members:
-            if member["ID_member"] in seen:
-                continue
-            seen.add(member["ID_member"])
             crawl_member(context, position, categorisation, member)
-        if len(seen) >= total:
-            break
-
-    if not seen:
-        raise ValueError("No members returned by the HoR endpoint")

--- a/datasets/th/house_representatives/crawler.py
+++ b/datasets/th/house_representatives/crawler.py
@@ -8,10 +8,6 @@ from zavod.shed.trans import apply_translit_full_name
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import LangText
 
-# partyType values: single-member constituency vs national party list.
-CONSTITUENCY = "แบบแบ่งเขต"
-PARTY_LIST = "แบบบัญชีรายชื่อ"
-
 
 def crawl_member(
     context: Context,
@@ -53,11 +49,11 @@ def crawl_member(
     party_type = member.pop("partyType")
     province = member.pop("province")
     district = member.pop("district")
-    if party_type == CONSTITUENCY:
+    if party_type == "แบบแบ่งเขต":
         # Constituency members represent a numbered district within a province.
         assert province and district, (member_id, province, district)
         occupancy.add("constituency", f"{province} {district}", lang="tha")
-    elif party_type == PARTY_LIST:
+    elif party_type == "แบบบัญชีรายชื่อ":
         # Party-list members are elected nationally, so they have no district.
         assert not province and district is None, (member_id, province, district)
     else:

--- a/datasets/th/house_representatives/th_house_representatives.yml
+++ b/datasets/th/house_representatives/th_house_representatives.yml
@@ -1,0 +1,48 @@
+title: Thailand House of Representatives
+name: th_house_representatives
+prefix: th-hor
+entry_point: crawler.py
+coverage:
+  frequency: weekly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the House of Representatives of Thailand, the lower chamber of the
+  National Assembly.
+description: |
+  The House of Representatives is the lower chamber of the National Assembly of Thailand.
+  It has 500 members: 400 elected from single-member constituencies and 100 from national
+  party lists, for a four-year term.
+
+  This dataset records each sitting member with their name, political party, province and
+  (for constituency members) electoral district, as published in the House's MP directory.
+url: https://www.parliament.go.th/view/1/mpconnect/TH-TH
+publisher:
+  name: House of Representatives of Thailand
+  acronym: HoR
+  description: >
+    The House of Representatives is the lower chamber of the National Assembly of Thailand,
+    whose members are elected from constituencies and national party lists.
+  url: https://www.parliament.go.th/
+  country: th
+  official: true
+data:
+  url: https://www.parliament.go.th/member/loaddata
+  format: JSON
+  lang: tha
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 400
+      Position: 1
+    country_entities:
+      th: 400
+  max:
+    schema_entities:
+      Person: 550
+      Position: 1

--- a/datasets/th/house_representatives/th_house_representatives.yml
+++ b/datasets/th/house_representatives/th_house_representatives.yml
@@ -1,9 +1,9 @@
-title: Thailand House of Representatives
+title: Thailand Members of the House of Representatives
 name: th_house_representatives
 prefix: th-hor
 entry_point: crawler.py
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-07-23
 load_statements: true
 ci_test: false
@@ -11,12 +11,14 @@ summary: >-
   Members of the House of Representatives of Thailand, the lower chamber of the
   National Assembly.
 description: |
-  The House of Representatives is the lower chamber of the National Assembly of Thailand.
-  It has 500 members: 400 elected from single-member constituencies and 100 from national
-  party lists, for a four-year term.
+  Current members of the House of Representatives, the lower chamber of the bicameral
+  National Assembly of Thailand. Its 500 members are directly elected for a four-year
+  term — 400 from single-member constituencies and 100 from national party lists — and,
+  together with the Senate, hold the country's legislative power, including passing laws
+  and approving the budget.
 
-  This dataset records each sitting member with their name, political party, province and
-  (for constituency members) electoral district, as published in the House's MP directory.
+  This dataset records each sitting member with their name, political party, province,
+  and (for constituency members) electoral district.
 url: https://www.parliament.go.th/view/1/mpconnect/TH-TH
 publisher:
   name: House of Representatives of Thailand
@@ -31,6 +33,12 @@ data:
   url: https://www.parliament.go.th/member/loaddata
   format: JSON
   lang: tha
+
+names:
+  prefixes_strip:
+    - นางสาว
+    - นาย
+    - นาง
 
 tags:
   - list.pep

--- a/datasets/th/house_representatives/th_house_representatives.yml
+++ b/datasets/th/house_representatives/th_house_representatives.yml
@@ -36,9 +36,30 @@ data:
 
 names:
   prefixes_strip:
+    # Civil honorifics. Thai attaches these directly to the given name with no
+    # space (นางกนกพร), and strip_name_titles only strips a bare-word prefix that
+    # is followed by whitespace, so these do not currently match. The same holds
+    # for the academic titles ศาสตราจารย์ and รองศาสตราจารย์, which is why five
+    # members keep them. Listed so they take effect once the helper can express a
+    # prefix in a script that does not separate words.
     - นางสาว
     - นาย
     - นาง
+    # Military and police ranks, which the source does separate with a space.
+    - จ่าอากาศเอก  # Flight Sergeant 1st Class
+    - จ่าเอก  # Chief Petty Officer 1st Class
+    - นาวาอากาศเอก  # Group Captain
+    - นาวาโท  # Commander
+    - พลตำรวจตรี  # Police Major General
+    - พลตำรวจเอก  # Police General
+    - พลตำรวจโท  # Police Lieutenant General
+    - พันตำรวจเอก  # Police Colonel
+    - พันเอก  # Colonel
+    - พันโท  # Lieutenant Colonel
+    - ร้อยตำรวจเอก  # Police Captain
+    - ร้อยเอก  # Captain
+    - ว่าที่ร้อยตรี  # Acting Sub-Lieutenant
+    - เรืออากาศโท  # Flight Lieutenant
 
 tags:
   - list.pep

--- a/datasets/th/house_representatives/th_house_representatives.yml
+++ b/datasets/th/house_representatives/th_house_representatives.yml
@@ -1,3 +1,6 @@
+# ci_test is off because the crawler transliterates every member name with an LLM
+# call — around 500 of them, ~9 minutes on a cold cache, and API credentials are
+# needed to make them at all.
 title: Thailand Members of the House of Representatives
 name: th_house_representatives
 prefix: th-hor
@@ -8,24 +11,26 @@ coverage:
 load_statements: true
 ci_test: false
 summary: >-
-  Members of the House of Representatives of Thailand, the lower chamber of the
-  National Assembly.
+  The 500-seat lower chamber of Thailand's bicameral National Assembly
 description: |
-  Current members of the House of Representatives, the lower chamber of the bicameral
-  National Assembly of Thailand. Its 500 members are directly elected for a four-year
-  term — 400 from single-member constituencies and 100 from national party lists — and,
-  together with the Senate, hold the country's legislative power, including passing laws
-  and approving the budget.
+  Current members of the House of Representatives (สภาผู้แทนราษฎร), the lower chamber of
+  the bicameral National Assembly of Thailand. Its 500 members are directly elected for a
+  four-year term — 400 from single-member constituencies and 100 from national party
+  lists — and, together with the Senate, hold the country's legislative power, including
+  passing laws and approving the budget.
 
-  This dataset records each sitting member with their name, political party, province,
-  and (for constituency members) electoral district.
+  This dataset records each sitting member with their name in Thai and Latin script and
+  their political party, and, for constituency members, the province and numbered
+  district they represent. Seats standing vacant pending a by-election or a party-list
+  replacement are not included.
 url: https://www.parliament.go.th/view/1/mpconnect/TH-TH
 publisher:
-  name: House of Representatives of Thailand
-  acronym: HoR
+  name: สภาผู้แทนราษฎร
+  name_en: House of Representatives of Thailand
   description: >
-    The House of Representatives is the lower chamber of the National Assembly of Thailand,
-    whose members are elected from constituencies and national party lists.
+    The House of Representatives is the elected lower chamber of Thailand's National
+    Assembly. Its Secretariat runs the parliamentary web portal, publishing the roster
+    of sitting members alongside the chamber's agendas and proceedings.
   url: https://www.parliament.go.th/
   country: th
   official: true


### PR DESCRIPTION
Adds a PEP crawler for the **House of Representatives of Thailand** (lower chamber, 26th HoR, 500 seats).

## Source
Official MP Connect JSON backend (`parliament.go.th/member/loaddata`, paginated, ~12/page, requires the site as `Referer`). No cookies/CSRF.

## Output
- Position: *Member of the House of Representatives of Thailand* (`Q21290865`)
- 498 members emitted as PEPs (2 vacancies) with party and — for constituency members — province + district.
- Civilian honorific prefixes stripped from Thai names; constituency vs party-list distinguished by `partyType`.
- Citizenship `th` per 2017 Constitution s.97(1) (see code comment).

Closes opensanctions/crawler-planning#719

🤖 Generated with [Claude Code](https://claude.com/claude-code)