### PR TITLE
Add Cambodia Senate PEP crawler

### DIFF
--- a/datasets/kh/senate/crawler.py
+++ b/datasets/kh/senate/crawler.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+# The senator directory is populated by this AJAX endpoint; session 5 is the current
+# (5th) legislature.
+SESSION = "5"
+HEADERS = {
+    "X-Requested-With": "XMLHttpRequest",
+    "Referer": "https://senate.gov.kh/search-senator-all/",
+}
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Senate of Cambodia",
+        country="kh",
+        wikidata_id="Q21295127",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    records: list[dict[str, Any]] = context.fetch_json(
+        context.data_url,
+        method="POST",
+        headers=HEADERS,
+        data={"session": SESSION, "keyword": "", "chck_status": "1"},
+        cache_days=1,
+    )
+    if not records:
+        raise ValueError("Senate AJAX endpoint returned no senators")
+
+    for record in records:
+        str_id = record.pop("str_id")
+        name = record.pop("name")
+        assert name, f"Empty name for senator {str_id}"
+
+        person = context.make("Person")
+        person.id = context.make_slug(str_id)
+        person.add("name", name, lang="khm")
+        person.add("gender", record.pop("gender", None))
+        h.apply_date(person, "birthDate", record.pop("dob", None))
+        person.add("political", record.pop("party", None), lang="khm")
+        person.add("sourceUrl", record.pop("biography", None))
+        # Senators must be Khmer citizens (Constitution of Cambodia, Article 34 (New)).
+        # https://constitutionnet.org/sites/default/files/Cambodia%20Constitution.pdf
+        person.add("citizenship", "kh")
+
+        # Some records carry a data-entry error where the start date is the senator's
+        # birth year (e.g. "1950-07-06"); ignore any start before the modern Senate.
+        start_date = record.pop("start", None)
+        if (
+            start_date is not None
+            and start_date[:4].isdigit()
+            and int(start_date[:4]) < 2000
+        ):
+            start_date = None
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            start_date=start_date,
+            end_date=record.pop("end", None),
+            categorisation=categorisation,
+        )
+        if occupancy is None:
+            continue
+
+        context.audit_data(
+            record,
+            ignore=[
+                "photo",
+                "phone",
+                "status",
+                "replaceby",
+                "session",
+                "session_id",
+            ],
+        )
+        context.emit(occupancy)
+        context.emit(person)

--- a/datasets/kh/senate/crawler.py
+++ b/datasets/kh/senate/crawler.py
@@ -1,23 +1,196 @@
+from dataclasses import dataclass
 from typing import Any
 
 from zavod import Context
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The senator directory is populated by this AJAX endpoint; session 5 is the current
-# (5th) legislature. A new session lands under a new number, so an empty response is the
-# structural signal that this constant needs bumping.
-SESSION = "5"
+TOPICS = ["gov.national", "gov.legislative"]
+
+# The senator directory is populated by an AJAX endpoint keyed on the legislature
+# ("session") number. The search form on this page lists the legislatures on offer.
+SEARCH_URL = "https://senate.gov.kh/search-senator-all/"
 
 # The endpoint only answers to an in-page XHR: neither header has an `http` metadata
 # field, so both stay on the fetch call.
 HEADERS = {
     "X-Requested-With": "XMLHttpRequest",
-    "Referer": "https://senate.gov.kh/search-senator-all/",
+    "Referer": SEARCH_URL,
 }
 
-# The source uses an all-zero date as its "no date of birth" placeholder.
-DOB_PLACEHOLDER = "0000-00-00"
+# The source uses an all-zero date as its placeholder for an unknown date of birth,
+# mandate start or mandate end.
+DATE_PLACEHOLDER = "0000-00-00"
+
+# The Senate was established by the constitutional amendment that entered into force on
+# this date, so no mandate can have started earlier.
+INCEPTION_DATE = "1999-03-08"
+
+
+@dataclass(frozen=True)
+class Term:
+    """A legislature of the Senate. `period_end` is None for the sitting legislature."""
+
+    id: str
+    period_start: str
+    period_end: str | None
+
+
+# The date each legislature first convened — and with it the date on which the preceding
+# legislature's mandate lapsed — as published in the Senate's own history:
+# https://senate.gov.kh/about-senate/senate-history/
+TERMS = {
+    term.id: term
+    for term in [
+        Term("1", "1999-03-25", "2006-03-20"),
+        Term("2", "2006-03-20", "2012-03-20"),
+        Term("3", "2012-03-20", "2018-04-23"),
+        Term("4", "2018-04-23", "2024-04-03"),
+        Term("5", "2024-04-03", None),
+    ]
+}
+
+
+def discover_terms(context: Context) -> list[Term]:
+    """Return the legislatures the search form offers, newest first."""
+    doc = context.fetch_html(SEARCH_URL, cache_days=1)
+    options = h.xpath_elements(doc, '//select[@id="keysession"]/option')
+    if len(options) == 0:
+        raise ValueError("The senator search form lists no legislatures")
+    terms: list[Term] = []
+    for option in options:
+        session_id = option.get("value")
+        term = None if session_id is None else TERMS.get(session_id)
+        if term is None:
+            raise ValueError(
+                f"No dates known for legislature {session_id!r}. Add them from "
+                "https://senate.gov.kh/about-senate/senate-history/"
+            )
+        terms.append(term)
+    return sorted(terms, key=lambda t: t.period_start, reverse=True)
+
+
+def mandate_date(
+    context: Context, value: str | None, term: Term, senator: str
+) -> str | None:
+    """Return a senator's own mandate date, or None where the source's value is
+    impossible for the legislature in question.
+
+    Some records hold the senator's date of birth in the mandate `start` field, and one
+    holds the date the *following* legislature convened, so a date that falls outside
+    the window in which a mandate of this legislature could run is dropped and the term
+    bounds are left to date the occupancy on their own.
+    """
+    if value is None or value == DATE_PLACEHOLDER:
+        return None
+    if value < INCEPTION_DATE or (
+        term.period_end is not None and value >= term.period_end
+    ):
+        context.log.info(
+            "Ignoring mandate date from outside the legislature",
+            session=term.id,
+            senator=senator,
+            date=value,
+        )
+        return None
+    return value
+
+
+def crawl_senator(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    term: Term,
+    record: dict[str, Any],
+) -> None:
+    raw_name = record.pop("name")
+    name = h.strip_name_titles(context, raw_name)
+    if name is None:
+        return
+    dob = record.pop("dob")
+    if dob == DATE_PLACEHOLDER:
+        dob = None
+
+    person = context.make("Person")
+    # The source's row ids are per-legislature: a senator who served several
+    # legislatures gets a fresh `str_id` in each, so keying the person on it would
+    # split them into one entity per term. Their name and date of birth identify them
+    # across legislatures instead.
+    person.id = context.make_id(name, dob)
+    person.add(
+        "name",
+        name,
+        lang="khm",
+        original_value=raw_name if name != raw_name else None,
+    )
+    person.add("gender", record.pop("gender"))
+    h.apply_date(person, "birthDate", dob)
+    person.add("political", record.pop("party"), lang="khm")
+    # A senator's profile document, where they have one. Records without one point at
+    # the bare directory that holds the documents, which is not about the senator.
+    biography = record.pop("biography")
+    if biography.lower().endswith(".pdf"):
+        person.add("sourceUrl", biography)
+    # Senators must be Khmer citizens (Constitution of Cambodia, Article 34 (New)).
+    # https://constitutionnet.org/sites/default/files/Cambodia%20Constitution.pdf
+    person.add("citizenship", "kh")
+
+    status = record.pop("status")
+    if status not in ("0", "1"):
+        raise ValueError(f"Unexpected senator status {status!r} for {name}")
+
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+        period_start=term.period_start,
+        period_end=term.period_end,
+        start_date=mandate_date(context, record.pop("start"), term, name),
+        end_date=mandate_date(context, record.pop("end"), term, name),
+        # Per occupancy, not per dataset: only the sitting legislature is still open,
+        # and a senator it marks as no longer serving isn't current either.
+        no_end_implies_current=term.period_end is None and status == "1",
+    )
+    context.audit_data(
+        record,
+        ignore=[
+            # A per-legislature row id, not a stable identifier for the senator.
+            "str_id",
+            "photo",
+            "phone",
+            # The row id of the senator who took over the seat, or vice versa.
+            "replaceby",
+            "session",
+            "session_id",
+        ],
+    )
+    if occupancy is None:
+        return
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl_term(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    term: Term,
+) -> None:
+    records: list[dict[str, Any]] = context.fetch_json(
+        context.data_url,
+        method="POST",
+        headers=HEADERS,
+        # The form's two status checkboxes combine into `chck_status`: 1 returns the
+        # senators still serving in the legislature, 2 those who left it early, 3 both.
+        data={"session": term.id, "keyword": "", "chck_status": "3"},
+        cache_days=1,
+    )
+    if len(records) == 0:
+        raise ValueError(f"No senators returned for legislature {term.id}")
+    for record in records:
+        crawl_senator(context, position, categorisation, term, record)
 
 
 def crawl(context: Context) -> None:
@@ -25,8 +198,9 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Senate of Cambodia",
         country="kh",
-        topics=["gov.national", "gov.legislative"],
+        topics=TOPICS,
         wikidata_id="Q21295127",
+        inception_date=[INCEPTION_DATE],
         lang="eng",
     )
     categorisation = categorise(context, position)
@@ -34,65 +208,14 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    records: list[dict[str, Any]] = context.fetch_json(
-        context.data_url,
-        method="POST",
-        headers=HEADERS,
-        data={"session": SESSION, "keyword": "", "chck_status": "1"},
-        cache_days=1,
-    )
-    if not records:
-        raise ValueError(
-            f"No senators for session {SESSION} — a new session may have started"
-        )
-
-    for record in records:
-        str_id = record.pop("str_id")
-        name = record.pop("name")
-        assert name, f"Empty name for senator {str_id}"
-
-        person = context.make("Person")
-        person.id = context.make_slug(str_id)
-        person.add("name", name, lang="khm")
-        person.add("gender", record.pop("gender", None))
-        dob = record.pop("dob", None)
-        h.apply_date(person, "birthDate", None if dob == DOB_PLACEHOLDER else dob)
-        person.add("political", record.pop("party", None), lang="khm")
-        person.add("sourceUrl", record.pop("biography", None))
-        # Senators must be Khmer citizens (Constitution of Cambodia, Article 34 (New)).
-        # https://constitutionnet.org/sites/default/files/Cambodia%20Constitution.pdf
-        person.add("citizenship", "kh")
-
-        # Some records carry a data-entry error where the start date is the senator's
-        # birth year (e.g. "1950-07-06"); ignore any start before the modern Senate.
-        start_date = record.pop("start", None)
-        if (
-            start_date is not None
-            and start_date[:4].isdigit()
-            and int(start_date[:4]) < 2000
-        ):
-            start_date = None
-        occupancy = h.make_occupancy(
-            context,
-            person,
-            position,
-            start_date=start_date,
-            end_date=record.pop("end", None),
-            categorisation=categorisation,
-        )
-        if occupancy is None:
-            continue
-
-        context.audit_data(
-            record,
-            ignore=[
-                "photo",
-                "phone",
-                "status",
-                "replaceby",
-                "session",
-                "session_id",
-            ],
-        )
-        context.emit(occupancy)
-        context.emit(person)
+    cutoff = h.earliest_term_start(TOPICS)
+    for term in discover_terms(context):
+        # ISO date strings compare correctly here.
+        if term.period_end is not None and term.period_end < cutoff:
+            context.log.info(
+                "Legislature predates the PEP relevance window; skipping",
+                session=term.id,
+                period_end=term.period_end,
+            )
+            break
+        crawl_term(context, position, categorisation, term)

--- a/datasets/kh/senate/crawler.py
+++ b/datasets/kh/senate/crawler.py
@@ -1,9 +1,8 @@
 from typing import Any
 
-from zavod.stateful.positions import categorise
-
 from zavod import Context
 from zavod import helpers as h
+from zavod.stateful.positions import categorise
 
 # The senator directory is populated by this AJAX endpoint; session 5 is the current
 # (5th) legislature.

--- a/datasets/kh/senate/crawler.py
+++ b/datasets/kh/senate/crawler.py
@@ -115,9 +115,13 @@ def crawl_senator(
     person = context.make("Person")
     # The source's row ids are per-legislature: a senator who served several
     # legislatures gets a fresh `str_id` in each, so keying the person on it would
-    # split them into one entity per term. Their name and date of birth identify them
-    # across legislatures instead.
-    person.id = context.make_id(name, dob)
+    # split them into one entity per term. The published name and date of birth
+    # identify them across legislatures instead — raw, as `entity_id.md` requires, so
+    # that revising the honorifics in `names.prefixes_strip` cannot mutate an ID that
+    # has already been published. The source writes a senator's honorifics
+    # inconsistently between legislatures, so a returning senator whose title or
+    # spacing changed splits into one entity per spelling, which deduplication merges.
+    person.id = context.make_id(raw_name, dob)
     person.add(
         "name",
         name,

--- a/datasets/kh/senate/crawler.py
+++ b/datasets/kh/senate/crawler.py
@@ -1,30 +1,15 @@
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urljoin
+
+from zavod.entity import Entity
+from zavod.shed.trans import apply_translit_full_name
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import LangText
 
 from zavod import Context
 from zavod import helpers as h
-from zavod.entity import Entity
-from zavod.stateful.positions import PositionCategorisation, categorise
 
-TOPICS = ["gov.national", "gov.legislative"]
-
-# The senator directory is populated by an AJAX endpoint keyed on the legislature
-# ("session") number. The search form on this page lists the legislatures on offer.
-SEARCH_URL = "https://senate.gov.kh/search-senator-all/"
-
-# The endpoint only answers to an in-page XHR: neither header has an `http` metadata
-# field, so both stay on the fetch call.
-HEADERS = {
-    "X-Requested-With": "XMLHttpRequest",
-    "Referer": SEARCH_URL,
-}
-
-# The source uses an all-zero date as its placeholder for an unknown date of birth,
-# mandate start or mandate end.
-DATE_PLACEHOLDER = "0000-00-00"
-
-# The Senate was established by the constitutional amendment that entered into force on
-# this date, so no mandate can have started earlier.
 INCEPTION_DATE = "1999-03-08"
 
 
@@ -37,24 +22,37 @@ class Term:
     period_end: str | None
 
 
-# The date each legislature first convened — and with it the date on which the preceding
-# legislature's mandate lapsed — as published in the Senate's own history:
+# The date each legislature first convened, keyed on its session id. The Senate's own
+# history publishes these only in Khmer prose, so they are curated here:
 # https://senate.gov.kh/about-senate/senate-history/
-TERMS = {
-    term.id: term
-    for term in [
-        Term("1", "1999-03-25", "2006-03-20"),
-        Term("2", "2006-03-20", "2012-03-20"),
-        Term("3", "2012-03-20", "2018-04-23"),
-        Term("4", "2018-04-23", "2024-04-03"),
-        Term("5", "2024-04-03", None),
-    ]
+# When a new legislature appears in the search form, appending its convening date both
+# opens its term and closes its predecessor's.
+CONVENING_DATES = {
+    "1": "1999-03-25",
+    "2": "2006-03-20",
+    "3": "2012-03-20",
+    "4": "2018-04-23",
+    "5": "2024-04-03",
 }
 
 
+def build_terms(convening_dates: dict[str, str]) -> dict[str, Term]:
+    """Derive the term of each legislature: a legislature's mandate lapses when its
+    successor convenes, and the latest legislature's term is still open."""
+    sessions = sorted(convening_dates.items(), key=lambda item: item[1])
+    ends = [start for _, start in sessions[1:]]
+    return {
+        session_id: Term(session_id, start, end)
+        for (session_id, start), end in zip(sessions, ends + [None])
+    }
+
+
+TERMS = build_terms(CONVENING_DATES)
+
+
 def discover_terms(context: Context) -> list[Term]:
-    """Return the legislatures the search form offers, newest first."""
-    doc = context.fetch_html(SEARCH_URL, cache_days=1)
+    """Return the legislatures the search form offers."""
+    doc = context.fetch_html(context.data_url, cache_days=1)
     options = h.xpath_elements(doc, '//select[@id="keysession"]/option')
     if len(options) == 0:
         raise ValueError("The senator search form lists no legislatures")
@@ -64,11 +62,11 @@ def discover_terms(context: Context) -> list[Term]:
         term = None if session_id is None else TERMS.get(session_id)
         if term is None:
             raise ValueError(
-                f"No dates known for legislature {session_id!r}. Add them from "
-                "https://senate.gov.kh/about-senate/senate-history/"
+                f"No convening date known for legislature {session_id!r}. Add it to "
+                "CONVENING_DATES from https://senate.gov.kh/about-senate/senate-history/"
             )
         terms.append(term)
-    return sorted(terms, key=lambda t: t.period_start, reverse=True)
+    return terms
 
 
 def mandate_date(
@@ -82,8 +80,13 @@ def mandate_date(
     the window in which a mandate of this legislature could run is dropped and the term
     bounds are left to date the occupancy on their own.
     """
-    if value is None or value == DATE_PLACEHOLDER:
+    if (result := context.lookup("type.date", value)) is not None:
+        value = result.value
+    if value is None:
         return None
+    # The lower bound is the Senate's inception, not `term.period_start`: mandates
+    # legitimately begin before a legislature first convenes (all of legislature 1
+    # was appointed a week before convening, one senator of legislature 5 a month).
     if value < INCEPTION_DATE or (
         term.period_end is not None and value >= term.period_end
     ):
@@ -106,33 +109,22 @@ def crawl_senator(
 ) -> None:
     raw_name = record.pop("name")
     name = h.strip_name_titles(context, raw_name)
-    if name is None:
-        return
+    assert name is not None
     dob = record.pop("dob")
-    if dob == DATE_PLACEHOLDER:
-        dob = None
+    party = record.pop("party")
 
     person = context.make("Person")
-    # The source's row ids are per-legislature: a senator who served several
-    # legislatures gets a fresh `str_id` in each, so keying the person on it would
-    # split them into one entity per term. The published name and date of birth
-    # identify them across legislatures instead — raw, as `entity_id.md` requires, so
-    # that revising the honorifics in `names.prefixes_strip` cannot mutate an ID that
-    # has already been published. The source writes a senator's honorifics
-    # inconsistently between legislatures, so a returning senator whose title or
-    # spacing changed splits into one entity per spelling, which deduplication merges.
-    person.id = context.make_id(raw_name, dob)
+    person.id = context.make_id(raw_name, dob, party)
     person.add(
         "name",
         name,
         lang="khm",
         original_value=raw_name if name != raw_name else None,
     )
+    apply_translit_full_name(context, person, LangText(name, "khm"))
     person.add("gender", record.pop("gender"))
     h.apply_date(person, "birthDate", dob)
-    person.add("political", record.pop("party"), lang="khm")
-    # A senator's profile document, where they have one. Records without one point at
-    # the bare directory that holds the documents, which is not about the senator.
+    person.add("political", party, lang="khm")
     biography = record.pop("biography")
     if biography.lower().endswith(".pdf"):
         person.add("sourceUrl", biography)
@@ -141,8 +133,7 @@ def crawl_senator(
     person.add("citizenship", "kh")
 
     status = record.pop("status")
-    if status not in ("0", "1"):
-        raise ValueError(f"Unexpected senator status {status!r} for {name}")
+    assert status in ("0", "1")
 
     occupancy = h.make_occupancy(
         context,
@@ -183,9 +174,15 @@ def crawl_term(
     term: Term,
 ) -> None:
     records: list[dict[str, Any]] = context.fetch_json(
-        context.data_url,
+        # The AJAX endpoint that populates the search page's senator directory.
+        urljoin(context.data_url, "/wp-content/themes/senate/ajax/generalsearch.php"),
         method="POST",
-        headers=HEADERS,
+        # The endpoint only answers to an in-page XHR: neither header has an `http`
+        # metadata field, so both stay on the fetch call.
+        headers={
+            "X-Requested-With": "XMLHttpRequest",
+            "Referer": context.data_url,
+        },
         # The form's two status checkboxes combine into `chck_status`: 1 returns the
         # senators still serving in the legislature, 2 those who left it early, 3 both.
         data={"session": term.id, "keyword": "", "chck_status": "3"},
@@ -202,7 +199,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Senate of Cambodia",
         country="kh",
-        topics=TOPICS,
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21295127",
         inception_date=[INCEPTION_DATE],
         lang="eng",
@@ -212,14 +209,5 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    cutoff = h.earliest_term_start(TOPICS)
     for term in discover_terms(context):
-        # ISO date strings compare correctly here.
-        if term.period_end is not None and term.period_end < cutoff:
-            context.log.info(
-                "Legislature predates the PEP relevance window; skipping",
-                session=term.id,
-                period_end=term.period_end,
-            )
-            break
         crawl_term(context, position, categorisation, term)

--- a/datasets/kh/senate/crawler.py
+++ b/datasets/kh/senate/crawler.py
@@ -1,8 +1,9 @@
 from typing import Any
 
+from zavod.stateful.positions import categorise
+
 from zavod import Context
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
 
 # The senator directory is populated by this AJAX endpoint; session 5 is the current
 # (5th) legislature.

--- a/datasets/kh/senate/crawler.py
+++ b/datasets/kh/senate/crawler.py
@@ -5,12 +5,19 @@ from zavod import helpers as h
 from zavod.stateful.positions import categorise
 
 # The senator directory is populated by this AJAX endpoint; session 5 is the current
-# (5th) legislature.
+# (5th) legislature. A new session lands under a new number, so an empty response is the
+# structural signal that this constant needs bumping.
 SESSION = "5"
+
+# The endpoint only answers to an in-page XHR: neither header has an `http` metadata
+# field, so both stay on the fetch call.
 HEADERS = {
     "X-Requested-With": "XMLHttpRequest",
     "Referer": "https://senate.gov.kh/search-senator-all/",
 }
+
+# The source uses an all-zero date as its "no date of birth" placeholder.
+DOB_PLACEHOLDER = "0000-00-00"
 
 
 def crawl(context: Context) -> None:
@@ -22,7 +29,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q21295127",
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
@@ -35,7 +42,9 @@ def crawl(context: Context) -> None:
         cache_days=1,
     )
     if not records:
-        raise ValueError("Senate AJAX endpoint returned no senators")
+        raise ValueError(
+            f"No senators for session {SESSION} — a new session may have started"
+        )
 
     for record in records:
         str_id = record.pop("str_id")
@@ -46,7 +55,8 @@ def crawl(context: Context) -> None:
         person.id = context.make_slug(str_id)
         person.add("name", name, lang="khm")
         person.add("gender", record.pop("gender", None))
-        h.apply_date(person, "birthDate", record.pop("dob", None))
+        dob = record.pop("dob", None)
+        h.apply_date(person, "birthDate", None if dob == DOB_PLACEHOLDER else dob)
         person.add("political", record.pop("party", None), lang="khm")
         person.add("sourceUrl", record.pop("biography", None))
         # Senators must be Khmer citizens (Constitution of Cambodia, Article 34 (New)).

--- a/datasets/kh/senate/crawler.py
+++ b/datasets/kh/senate/crawler.py
@@ -18,7 +18,9 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Senate of Cambodia",
         country="kh",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21295127",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/kh/senate/kh_senate.yml
+++ b/datasets/kh/senate/kh_senate.yml
@@ -1,0 +1,47 @@
+title: Cambodia Senate
+name: kh_senate
+prefix: kh-sen
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Senate of Cambodia, the upper chamber of the Parliament.
+description: |
+  The Senate is the upper chamber of the Parliament of Cambodia. It has 62 members: most
+  indirectly elected by commune councillors and the National Assembly across eight regions,
+  plus royal and National Assembly appointees, serving six-year terms. The current Senate is
+  the 5th legislature, inaugurated on 3 April 2024.
+
+  This dataset records each senator with their name, gender, date of birth, political party
+  and term dates, from the Senate's official directory.
+url: https://senate.gov.kh/search-senator-all/
+publisher:
+  name: Senate of Cambodia
+  description: >
+    The Senate is the upper chamber of the Parliament of Cambodia, whose members are
+    indirectly elected and appointed for six-year terms.
+  url: https://senate.gov.kh/
+  country: kh
+  official: true
+data:
+  url: https://senate.gov.kh/wp-content/themes/senate/ajax/generalsearch.php
+  format: JSON
+  lang: khm
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 50
+      Position: 1
+    country_entities:
+      kh: 50
+  max:
+    schema_entities:
+      Person: 80
+      Position: 1

--- a/datasets/kh/senate/kh_senate.yml
+++ b/datasets/kh/senate/kh_senate.yml
@@ -6,7 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-23
 load_statements: true
-ci_test: false
+ci_test: true
 summary: >-
   Upper chamber of Parliament, indirectly elected and appointed for six years
 description: |

--- a/datasets/kh/senate/kh_senate.yml
+++ b/datasets/kh/senate/kh_senate.yml
@@ -54,11 +54,11 @@ names:
 assertions:
   min:
     schema_entities:
-      Person: 150
+      Person: 155
       Position: 1
     country_entities:
-      kh: 150
+      kh: 155
   max:
     schema_entities:
-      Person: 340
+      Person: 345
       Position: 1

--- a/datasets/kh/senate/kh_senate.yml
+++ b/datasets/kh/senate/kh_senate.yml
@@ -1,4 +1,4 @@
-title: Cambodia Senate
+title: Cambodia Members of the Senate
 name: kh_senate
 prefix: kh-sen
 entry_point: crawler.py
@@ -8,15 +8,13 @@ coverage:
 load_statements: true
 ci_test: false
 summary: >-
-  Members of the Senate of Cambodia, the upper chamber of the Parliament.
+  Upper chamber of Parliament, indirectly elected and appointed for six years
 description: |
-  The Senate is the upper chamber of the Parliament of Cambodia. It has 62 members: most
-  indirectly elected by commune councillors and the National Assembly across eight regions,
-  plus royal and National Assembly appointees, serving six-year terms. The current Senate is
-  the 5th legislature, inaugurated on 3 April 2024.
-
-  This dataset records each senator with their name, gender, date of birth, political party
-  and term dates, from the Senate's official directory.
+  Current members of the Senate, the upper chamber of the Parliament of Cambodia. Its 62
+  members serve six-year terms — most indirectly elected by commune councillors and the
+  National Assembly across eight regions, the rest appointed by the King and the National
+  Assembly — and share the country's legislative power with the National Assembly,
+  including passing laws and approving the budget.
 url: https://senate.gov.kh/search-senator-all/
 publisher:
   name: Senate of Cambodia

--- a/datasets/kh/senate/kh_senate.yml
+++ b/datasets/kh/senate/kh_senate.yml
@@ -10,11 +10,12 @@ ci_test: true
 summary: >-
   Upper chamber of Parliament, indirectly elected and appointed for six years
 description: |
-  Current members of the Senate, the upper chamber of the Parliament of Cambodia. Its 62
-  members serve six-year terms — most indirectly elected by commune councillors and the
-  National Assembly across eight regions, the rest appointed by the King and the National
-  Assembly — and share the country's legislative power with the National Assembly,
-  including passing laws and approving the budget.
+  Current and historical members of the Senate, the upper chamber of the Parliament of
+  Cambodia, from its first legislature in 1999 onwards. Its 62 members serve six-year
+  terms — most indirectly elected by commune councillors and the National Assembly
+  across eight regions, the rest appointed by the King and the National Assembly — and
+  share the country's legislative power with the National Assembly, including passing
+  laws and approving the budget.
 url: https://senate.gov.kh/search-senator-all/
 publisher:
   name: Senate of Cambodia
@@ -32,14 +33,32 @@ data:
 tags:
   - list.pep
 
+names:
+  # Khmer honorifics and honorary titles the source stores as part of the name. Both
+  # spellings of ឯកឧត្តម (His Excellency) occur.
+  prefixes_strip:
+    - សម្តេចអគ្គមហាធម្មពោធិសាល
+    - សម្តេចអគ្គមហាសេនាបតីតេជោ
+    - សម្តេចវិបុលសេនាភក្តី
+    - សម្តេចរាជបុត្រីព្រះរៀម
+    - សម្តេចរាជបុត្រីព្រះអនុជ
+    - សម្តេច
+    - ព្រះអង្គម្ចាស់
+    - អ្នកម្នាង
+    - ឯកឧត្តម
+    - ឯកឧត្ដម
+    - លោកជំទាវ
+    - កិត្តិសង្គហបណ្ឌិត
+    - កិត្តិនីតិកោសលបណ្ឌិត
+
 assertions:
   min:
     schema_entities:
-      Person: 50
+      Person: 150
       Position: 1
     country_entities:
-      kh: 50
+      kh: 150
   max:
     schema_entities:
-      Person: 80
+      Person: 340
       Position: 1

--- a/datasets/kh/senate/kh_senate.yml
+++ b/datasets/kh/senate/kh_senate.yml
@@ -6,7 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-23
 load_statements: true
-ci_test: true
+ci_test: false  # openAI API for name translit
 summary: >-
   Upper chamber of Parliament, indirectly elected and appointed for six years
 description: |
@@ -26,16 +26,20 @@ publisher:
   country: kh
   official: true
 data:
-  url: https://senate.gov.kh/wp-content/themes/senate/ajax/generalsearch.php
+  url: https://senate.gov.kh/search-senator-all/
   format: JSON
   lang: khm
 
 tags:
   - list.pep
 
+lookups:
+  type.date:
+    options:
+      - match: "0000-00-00"
+        value: null
+
 names:
-  # Khmer honorifics and honorary titles the source stores as part of the name. Both
-  # spellings of ឯកឧត្តម (His Excellency) occur.
   prefixes_strip:
     - សម្តេចអគ្គមហាធម្មពោធិសាល
     - សម្តេចអគ្គមហាសេនាបតីតេជោ
@@ -54,11 +58,11 @@ names:
 assertions:
   min:
     schema_entities:
-      Person: 155
+      Person: 80
       Position: 1
     country_entities:
-      kh: 155
+      kh: 80
   max:
     schema_entities:
-      Person: 345
+      Person: 160
       Position: 1


### PR DESCRIPTION
Adds a PEP crawler for the **Senate of Cambodia** (upper chamber, 5th legislature, 62 seats).

## Source
Official senator directory AJAX endpoint (`senate.gov.kh/.../generalsearch.php`, `session=5`), returning all 62 senators as JSON.

## Output
- Position: *Member of the Senate of Cambodia* (`Q21295127`)
- 62 senators emitted as PEPs with Khmer name, gender, date of birth, party and term start; biography PDF as sourceUrl.
- Guards against a source data-entry error where a few records' start date is the birth year (ignored so the senator stays current).
- Citizenship `kh` per Constitution Art. 34 (New) (see code comment).

Closes opensanctions/crawler-planning#709

🤖 Generated with [Claude Code](https://claude.com/claude-code)