### PR TITLE
Add Indonesia Regional Representative Council (DPD) PEP crawler

### DIFF
--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.extract import zyte_api
+from zavod.stateful.positions import categorise
+
+# The API host sits behind a WAF that rejects ordinary egress, so it is fetched through the
+# Zyte API with an Indonesian exit.
+GEOLOCATION = "id"
+
+
+def member_list(payload: Any) -> list[dict[str, Any]]:
+    """Return the member array from the API envelope.
+
+    The service wraps the rows in a `data` object; be tolerant of a bare list or one extra
+    level of nesting so a minor envelope change fails loudly rather than silently.
+    """
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict) and isinstance(data.get("data"), list):
+            return list(data["data"])
+    raise ValueError("Unexpected DPD API response shape")
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Regional Representative Council of Indonesia",
+        country="id",
+        wikidata_id="Q21328635",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    payload = zyte_api.fetch_json(
+        context, context.data_url, geolocation=GEOLOCATION, cache_days=1
+    )
+    members = member_list(payload)
+    if not members:
+        raise ValueError("DPD API returned no members")
+
+    for member in members:
+        name = member.get("fullName")
+        assert name, f"Member without a name: {member!r}"
+
+        person = context.make("Person")
+        person.id = context.make_id(name, member.get("dateOfBirth"))
+        person.add("name", name)
+        person.add("gender", member.get("gender"))
+        person.add("birthPlace", member.get("placeOfBirth"))
+        h.apply_date(person, "birthDate", member.get("dateOfBirth"))
+        person.add("email", member.get("email"))
+        # DPD candidates must be Indonesian citizens (Law No. 7 of 2017 on General
+        # Elections, Article 182 letter a). https://peraturan.bpk.go.id/Details/37644
+        person.add("citizenship", "id")
+
+        # The most recent member period gives the province and inauguration date.
+        periods = member.get("memberPeriods") or []
+        province = None
+        start_date = None
+        if periods:
+            latest = periods[-1]
+            region = latest.get("region") or {}
+            province = region.get("name")
+            start_date = latest.get("inaugurationDate")
+
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            start_date=start_date,
+            categorisation=categorisation,
+        )
+        if occupancy is None:
+            continue
+        if province is not None:
+            occupancy.add("constituency", province)
+        context.emit(occupancy)
+        context.emit(person)

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -1,10 +1,9 @@
 from typing import Any
 
-from zavod.extract import zyte_api
-from zavod.stateful.positions import categorise
-
 from zavod import Context
 from zavod import helpers as h
+from zavod.extract import zyte_api
+from zavod.stateful.positions import categorise
 
 # The API host sits behind a WAF that rejects ordinary egress, so it is fetched through the
 # Zyte API with an Indonesian exit.

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any
 
 from zavod import Context, settings
@@ -14,42 +13,23 @@ from zavod.stateful.positions import (
 TOPICS = ["gov.national", "gov.legislative"]
 # Sibling of the member endpoint in `data.url`, listing every term the API knows.
 PERIOD_URL = "https://service.dpd.go.id/anggota/api/v1/period"
+# The chamber seats 152, so one page takes a whole term.
 PER_PAGE = 300
 STATUS_SERVING = 0
 STATUS_LEFT = 1
-
-
-@dataclass(frozen=True)
-class Term:
-    period_id: int
-    start_year: int
-    end_year: int
-
-
-def fetch_terms(context: Context) -> list[Term]:
-    """Return every term the source lists, newest first.
-
-    The period table is shared across chambers, so some of them serve no DPD members.
-    """
-    periods = zyte_api.fetch_json(context, PERIOD_URL, geolocation="id", cache_days=7)
-    if not isinstance(periods, list):
-        raise ValueError("Period endpoint did not return a list")
-    terms = [Term(p["id"], p["startYear"], p["endYear"]) for p in periods]
-    if len(terms) == 0:
-        raise ValueError("Period endpoint returned no terms")
-    terms.sort(key=lambda t: (t.end_year, t.start_year, t.period_id), reverse=True)
-    return terms
-
-
-def fetch_members(context: Context, term: Term) -> list[dict[str, Any]]:
-    url = f"{context.data_url}?periodId={term.period_id}&page=1&perPage={PER_PAGE}"
-    # The API host sits behind a WAF that rejects ordinary egress.
-    members = zyte_api.fetch_json(context, url, geolocation="id", cache_days=7)
-    if not isinstance(members, list):
-        raise ValueError(f"Period {term.period_id} did not return a list of members")
-    if len(members) == PER_PAGE:
-        raise ValueError(f"Period {term.period_id} filled page 1; rows may be missing")
-    return members
+IGNORE = [
+    "photoUrl",
+    "photoThumbnailUrl",
+    "religionName",
+    "maritalStatus",
+    "organStructures",
+    "facebook",
+    "instagram",
+    "tiktok",
+    "youtube",
+    "twitter",
+    "website",
+]
 
 
 def crawl_member(
@@ -57,12 +37,11 @@ def crawl_member(
     position: Entity,
     categorisation: PositionCategorisation,
     member: dict[str, Any],
-    term: Term,
-    is_current: bool,
+    period: dict[str, Any],
 ) -> None:
     person = context.make("Person")
     person.id = context.make_slug(str(member.pop("id")))
-    # Names carry honorifics and post-nominals; the affixes to strip are in the metadata.
+    # Names carry honorifics and post-nominals; the affixes are in the metadata.
     raw_name = member.pop("fullName")
     clean_name = h.strip_name_titles(context, raw_name)
     person.add(
@@ -78,53 +57,40 @@ def crawl_member(
     person.add("email", member.pop("email"))
     # DPD members must be Indonesian citizens (Law No. 7 of 2017, Article 182a).
     person.add("citizenship", "id")
-    mandates = member.pop("memberPeriods")
-    context.audit_data(
-        member,
-        [
-            "photoUrl",
-            "photoThumbnailUrl",
-            "religionName",
-            "maritalStatus",
-            "organStructures",
-            "facebook",
-            "instagram",
-            "tiktok",
-            "youtube",
-            "twitter",
-            "website",
-        ],
-    )
+    # memberPeriods spans a member's whole career, so pick out this term's mandate.
+    mandates = [
+        m for m in member.pop("memberPeriods") if m["period"]["id"] == period["id"]
+    ]
+    context.audit_data(member, IGNORE)
 
-    occupancies: list[Entity] = []
-    for mandate in mandates:
-        if mandate["period"]["id"] != term.period_id:
-            raise ValueError(
-                f"Period {mandate['period']['id']} returned for {term.period_id}"
-            )
-        status = mandate["memberStatus"]
-        if status not in (STATUS_SERVING, STATUS_LEFT):
-            raise ValueError(f"Unknown memberStatus: {status!r}")
-        occupancy = h.make_occupancy(
-            context,
-            person,
-            position,
-            start_date=mandate["inaugurationDate"],
-            period_start=str(term.start_year),
-            period_end=str(term.end_year),
-            status=(
-                OccupancyStatus.ENDED if is_current and status == STATUS_LEFT else None
-            ),
-            categorisation=categorisation,
+    if len(mandates) != 1:
+        context.log.warning(
+            f"{person.id} has {len(mandates)} mandates in {period['id']}"
         )
-        if occupancy is not None:
-            occupancy.add("constituency", mandate["region"]["name"])
-            occupancies.append(occupancy)
-    # No occupancy means every mandate fell outside the PEP window.
-    if len(occupancies) == 0:
+    mandate = mandates[0]
+    if mandate["memberStatus"] not in (STATUS_SERVING, STATUS_LEFT):
+        raise ValueError(f"Unknown memberStatus: {mandate['memberStatus']!r}")
+    # A term that is still running implies everyone in it is still serving, so
+    # someone who left it early needs saying so explicitly.
+    left_early = (
+        mandate["memberStatus"] == STATUS_LEFT
+        and period["endYear"] >= settings.RUN_TIME.year
+    )
+    occupancy = h.make_occupancy(
+        context,
+        person,
+        position,
+        start_date=mandate["inaugurationDate"],
+        period_start=str(period["startYear"]),
+        period_end=str(period["endYear"]),
+        status=OccupancyStatus.ENDED if left_early else None,
+        categorisation=categorisation,
+    )
+    # No occupancy means the term has aged out of the PEP window.
+    if occupancy is None:
         return
-    for occupancy in occupancies:
-        context.emit(occupancy)
+    occupancy.add("constituency", mandate["region"]["name"])
+    context.emit(occupancy)
     context.emit(person)
 
 
@@ -142,30 +108,22 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    window_start_year = int(h.earliest_term_start(TOPICS)[:4])
-    current_term: Term | None = None
-    for term in fetch_terms(context):
-        if term.end_year < window_start_year:
-            continue
-        members = fetch_members(context, term)
-        if len(members) == 0:
-            continue  # A term of one of the other chambers.
-        if current_term is None:
-            current_term = term
-            if term.end_year < settings.RUN_TIME.year:
-                raise ValueError(
-                    f"Newest period {term.period_id} ended in {term.end_year}; "
-                    "refusing to emit its members as current."
-                )
-        for member in members:
-            crawl_member(
-                context, position, categorisation, member, term, term is current_term
-            )
+    # The API host sits behind a WAF that rejects ordinary egress.
+    periods = zyte_api.fetch_json(context, PERIOD_URL, geolocation="id", cache_days=7)
+    earliest_year = int(h.earliest_term_start(TOPICS)[:4])
+    # The period table is shared across chambers, so those of the others serve
+    # no members here.
+    for period in sorted(periods, key=lambda p: p["endYear"], reverse=True):
+        if period["endYear"] < earliest_year:
+            break
+        url = f"{context.data_url}?periodId={period['id']}&perPage={PER_PAGE}"
+        members = zyte_api.fetch_json(context, url, geolocation="id", cache_days=7)
+        assert len(members) < PER_PAGE, (period["id"], len(members))
         context.log.info(
-            "Crawled term",
-            id=term.period_id,
-            years=f"{term.start_year}-{term.end_year}",
+            "Crawling term",
+            id=period["id"],
+            years=f"{period['startYear']}-{period['endYear']}",
             members=len(members),
         )
-    if current_term is None:
-        raise ValueError("No term in the PEP window serves DPD members")
+        for member in members:
+            crawl_member(context, position, categorisation, member, period)

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -1,9 +1,10 @@
 from typing import Any
 
-from zavod import Context
-from zavod import helpers as h
 from zavod.extract import zyte_api
 from zavod.stateful.positions import categorise
+
+from zavod import Context
+from zavod import helpers as h
 
 # The API host sits behind a WAF that rejects ordinary egress, so it is fetched through the
 # Zyte API with an Indonesian exit.

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -11,12 +11,11 @@ from zavod.stateful.positions import (
 )
 
 TOPICS = ["gov.national", "gov.legislative"]
-# Sibling of the member endpoint in `data.url`, listing every term the API knows.
 PERIOD_URL = "https://service.dpd.go.id/anggota/api/v1/period"
-# The chamber seats 152, so one page takes a whole term.
 PER_PAGE = 300
 STATUS_SERVING = 0
 STATUS_LEFT = 1
+UNSET_DATE = "0001-01-01T00:00:00Z"
 IGNORE = [
     "photoUrl",
     "photoThumbnailUrl",
@@ -41,7 +40,6 @@ def crawl_member(
 ) -> None:
     person = context.make("Person")
     person.id = context.make_slug(str(member.pop("id")))
-    # Names carry honorifics and post-nominals; the affixes are in the metadata.
     raw_name = member.pop("fullName")
     clean_name = h.strip_name_titles(context, raw_name)
     person.add(
@@ -61,21 +59,16 @@ def crawl_member(
     mandates = [
         m for m in member.pop("memberPeriods") if m["period"]["id"] == period["id"]
     ]
-    context.audit_data(member, IGNORE)
-
-    if len(mandates) != 1:
-        context.log.warning(
-            f"{person.id} has {len(mandates)} mandates in {period['id']}"
-        )
+    if len(mandates) > 1:
+        # Many sole mandates are dateless too, so only drop a stub when one is dated.
+        mandates = [m for m in mandates if m["inaugurationDate"] != UNSET_DATE]
+    assert len(mandates) == 1, (person.id, len(mandates))
     mandate = mandates[0]
-    if mandate["memberStatus"] not in (STATUS_SERVING, STATUS_LEFT):
-        raise ValueError(f"Unknown memberStatus: {mandate['memberStatus']!r}")
-    # A term that is still running implies everyone in it is still serving, so
-    # someone who left it early needs saying so explicitly.
-    left_early = (
-        mandate["memberStatus"] == STATUS_LEFT
-        and period["endYear"] >= settings.RUN_TIME.year
-    )
+    status = mandate["memberStatus"]
+    if status not in (STATUS_SERVING, STATUS_LEFT):
+        context.log.warning(f"{person.id} has unknown memberStatus {status!r}")
+    # In a running term, no end date implies still serving, so say when they left.
+    left_early = status == STATUS_LEFT and period["endYear"] >= settings.RUN_TIME.year
     occupancy = h.make_occupancy(
         context,
         person,
@@ -86,12 +79,14 @@ def crawl_member(
         status=OccupancyStatus.ENDED if left_early else None,
         categorisation=categorisation,
     )
-    # No occupancy means the term has aged out of the PEP window.
     if occupancy is None:
         return
     occupancy.add("constituency", mandate["region"]["name"])
+
     context.emit(occupancy)
     context.emit(person)
+
+    context.audit_data(member, IGNORE)
 
 
 def crawl(context: Context) -> None:
@@ -111,19 +106,13 @@ def crawl(context: Context) -> None:
     # The API host sits behind a WAF that rejects ordinary egress.
     periods = zyte_api.fetch_json(context, PERIOD_URL, geolocation="id", cache_days=7)
     earliest_year = int(h.earliest_term_start(TOPICS)[:4])
-    # The period table is shared across chambers, so those of the others serve
-    # no members here.
     for period in sorted(periods, key=lambda p: p["endYear"], reverse=True):
         if period["endYear"] < earliest_year:
             break
         url = f"{context.data_url}?periodId={period['id']}&perPage={PER_PAGE}"
         members = zyte_api.fetch_json(context, url, geolocation="id", cache_days=7)
         assert len(members) < PER_PAGE, (period["id"], len(members))
-        context.log.info(
-            "Crawling term",
-            id=period["id"],
-            years=f"{period['startYear']}-{period['endYear']}",
-            members=len(members),
-        )
+        term = f"{period['startYear']}-{period['endYear']}"
+        context.log.info("Crawling term", term=term, members=len(members))
         for member in members:
             crawl_member(context, position, categorisation, member, period)

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -36,7 +36,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q21328635",
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
@@ -45,9 +45,6 @@ def crawl(context: Context) -> None:
         context, context.data_url, geolocation=GEOLOCATION, cache_days=1
     )
     members = member_list(payload)
-    if not members:
-        raise ValueError("DPD API returned no members")
-
     for member in members:
         name = member.get("fullName")
         assert name, f"Member without a name: {member!r}"

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -12,11 +12,9 @@ from zavod.stateful.positions import (
 )
 
 TOPICS = ["gov.national", "gov.legislative"]
-
+# Sibling of the member endpoint in `data.url`, listing every term the API knows.
+PERIOD_URL = "https://service.dpd.go.id/anggota/api/v1/period"
 PER_PAGE = 300
-
-EMPTY_PERIODS_BEFORE_STOP = 3
-MAX_PERIODS_PROBED = 40
 STATUS_SERVING = 0
 STATUS_LEFT = 1
 
@@ -26,56 +24,32 @@ class Term:
     period_id: int
     start_year: int
     end_year: int
-    members: list[dict[str, Any]]
 
 
 def fetch_terms(context: Context) -> list[Term]:
-    """Return every term the source serves DPD members for, newest first.
+    """Return every term the source lists, newest first.
 
-    The period table is shared across chambers, so the DPD's terms sit in a window of
-    ids inside it, not starting at 1. Nothing here pins a term: the window and each
-    term's years are read off the source, so an election needs no change to this code.
+    The period table is shared across chambers, so some of them serve no DPD members.
     """
-    terms: list[Term] = []
-    empty_run = 0
-    for period_id in range(1, MAX_PERIODS_PROBED + 1):
-        url = f"{context.data_url}?periodId={period_id}&page=1&perPage={PER_PAGE}"
-        # The API host sits behind a WAF that rejects ordinary egress.
-        members = zyte_api.fetch_json(context, url, geolocation="id", cache_days=7)
-        # Also narrows `fetch_json`'s untyped return for the strict type check.
-        if not isinstance(members, list):
-            raise ValueError(f"Period {period_id} did not return a list of members")
-
-        if len(members) == 0:
-            if len(terms) == 0:
-                continue  # Still below the window the DPD's terms occupy.
-            empty_run += 1
-            if empty_run >= EMPTY_PERIODS_BEFORE_STOP:
-                break
-            continue
-
-        if len(members) == PER_PAGE:
-            raise ValueError(f"Period {period_id} filled page 1; rows may be missing")
-        empty_run = 0
-
-        spans = {
-            (mandate["period"]["startYear"], mandate["period"]["endYear"])
-            for member in members
-            for mandate in member["memberPeriods"]
-            if mandate["period"]["id"] == period_id
-        }
-        if len(spans) != 1:
-            raise ValueError(f"Period {period_id} has ambiguous years: {spans}")
-        start_year, end_year = spans.pop()
-        terms.append(Term(period_id, start_year, end_year, members))
-
+    periods = zyte_api.fetch_json(context, PERIOD_URL, geolocation="id", cache_days=7)
+    if not isinstance(periods, list):
+        raise ValueError("Period endpoint did not return a list")
+    terms = [Term(p["id"], p["startYear"], p["endYear"]) for p in periods]
     if len(terms) == 0:
-        raise ValueError(f"No period up to {MAX_PERIODS_PROBED} serves DPD members")
-    context.log.info(
-        "Found terms",
-        terms={t.period_id: f"{t.start_year}-{t.end_year}" for t in terms},
-    )
-    return sorted(terms, key=lambda t: t.period_id, reverse=True)
+        raise ValueError("Period endpoint returned no terms")
+    terms.sort(key=lambda t: (t.end_year, t.start_year, t.period_id), reverse=True)
+    return terms
+
+
+def fetch_members(context: Context, term: Term) -> list[dict[str, Any]]:
+    url = f"{context.data_url}?periodId={term.period_id}&page=1&perPage={PER_PAGE}"
+    # The API host sits behind a WAF that rejects ordinary egress.
+    members = zyte_api.fetch_json(context, url, geolocation="id", cache_days=7)
+    if not isinstance(members, list):
+        raise ValueError(f"Period {term.period_id} did not return a list of members")
+    if len(members) == PER_PAGE:
+        raise ValueError(f"Period {term.period_id} filled page 1; rows may be missing")
+    return members
 
 
 def crawl_member(
@@ -84,12 +58,11 @@ def crawl_member(
     categorisation: PositionCategorisation,
     member: dict[str, Any],
     term: Term,
-    sitting: bool,
+    is_current: bool,
 ) -> None:
     person = context.make("Person")
     person.id = context.make_slug(str(member.pop("id")))
-    # Source names carry honorifics and academic post-nominals as part of the
-    # name; strip the affixes declared in the dataset metadata.
+    # Names carry honorifics and post-nominals; the affixes to strip are in the metadata.
     raw_name = member.pop("fullName")
     clean_name = h.strip_name_titles(context, raw_name)
     person.add(
@@ -101,13 +74,27 @@ def crawl_member(
     person.add("gender", member.pop("gender"))
     person.add("birthPlace", member.pop("placeOfBirth"))
     h.apply_date(person, "birthDate", member.pop("dateOfBirth"))
-    person.add("biography", member.pop("profile"))  # local lang
+    person.add("biography", member.pop("profile"))
     person.add("email", member.pop("email"))
-    # DPD candidates must be Indonesian citizens (Law No. 7 of 2017 on General
-    # Elections, Article 182 letter a). https://peraturan.bpk.go.id/Details/37644
+    # DPD members must be Indonesian citizens (Law No. 7 of 2017, Article 182a).
     person.add("citizenship", "id")
-
     mandates = member.pop("memberPeriods")
+    context.audit_data(
+        member,
+        [
+            "photoUrl",
+            "photoThumbnailUrl",
+            "religionName",
+            "maritalStatus",
+            "organStructures",
+            "facebook",
+            "instagram",
+            "tiktok",
+            "youtube",
+            "twitter",
+            "website",
+        ],
+    )
 
     occupancies: list[Entity] = []
     for mandate in mandates:
@@ -126,14 +113,14 @@ def crawl_member(
             period_start=str(term.start_year),
             period_end=str(term.end_year),
             status=(
-                OccupancyStatus.ENDED if sitting and status == STATUS_LEFT else None
+                OccupancyStatus.ENDED if is_current and status == STATUS_LEFT else None
             ),
             categorisation=categorisation,
         )
         if occupancy is not None:
             occupancy.add("constituency", mandate["region"]["name"])
             occupancies.append(occupancy)
-    # A member whose only mandate falls outside the PEP window gets no occupancy.
+    # No occupancy means every mandate fell outside the PEP window.
     if len(occupancies) == 0:
         return
     for occupancy in occupancies:
@@ -155,30 +142,30 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    terms = fetch_terms(context)
-    sitting = terms[0]
-    if sitting.end_year < settings.RUN_TIME.year:
-        raise ValueError(
-            f"Newest period {sitting.period_id} ended in {sitting.end_year}: the "
-            "source has no term in progress. Aborting as not to emit its members as "
-            "current."
-        )
-
-    for term in terms:
-        if term.end_year < int(h.earliest_term_start(TOPICS)[:4]):
-            context.log.info(
-                "Term ended before the PEP window; stopping",
-                id=term.period_id,
-                years=f"{term.start_year}-{term.end_year}",
-            )
-            break
-        for member in term.members:
+    window_start_year = int(h.earliest_term_start(TOPICS)[:4])
+    current_term: Term | None = None
+    for term in fetch_terms(context):
+        if term.end_year < window_start_year:
+            continue
+        members = fetch_members(context, term)
+        if len(members) == 0:
+            continue  # A term of one of the other chambers.
+        if current_term is None:
+            current_term = term
+            if term.end_year < settings.RUN_TIME.year:
+                raise ValueError(
+                    f"Newest period {term.period_id} ended in {term.end_year}; "
+                    "refusing to emit its members as current."
+                )
+        for member in members:
             crawl_member(
-                context, position, categorisation, member, term, term is sitting
+                context, position, categorisation, member, term, term is current_term
             )
         context.log.info(
             "Crawled term",
             id=term.period_id,
             years=f"{term.start_year}-{term.end_year}",
-            members=len(term.members),
+            members=len(members),
         )
+    if current_term is None:
+        raise ValueError("No term in the PEP window serves DPD members")

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -32,7 +32,9 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Regional Representative Council of Indonesia",
         country="id",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21328635",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -1,9 +1,144 @@
-from datetime import datetime
+from dataclasses import dataclass
+from typing import Any
 
-from zavod import Context
+from zavod import Context, settings
 from zavod import helpers as h
+from zavod.entity import Entity
 from zavod.extract import zyte_api
-from zavod.stateful.positions import categorise
+from zavod.stateful.positions import (
+    OccupancyStatus,
+    PositionCategorisation,
+    categorise,
+)
+
+TOPICS = ["gov.national", "gov.legislative"]
+
+PER_PAGE = 300
+
+EMPTY_PERIODS_BEFORE_STOP = 3
+MAX_PERIODS_PROBED = 40
+STATUS_SERVING = 0
+STATUS_LEFT = 1
+
+
+@dataclass(frozen=True)
+class Term:
+    period_id: int
+    start_year: int
+    end_year: int
+    members: list[dict[str, Any]]
+
+
+def fetch_terms(context: Context) -> list[Term]:
+    """Return every term the source serves DPD members for, newest first.
+
+    The period table is shared across chambers, so the DPD's terms sit in a window of
+    ids inside it, not starting at 1. Nothing here pins a term: the window and each
+    term's years are read off the source, so an election needs no change to this code.
+    """
+    terms: list[Term] = []
+    empty_run = 0
+    for period_id in range(1, MAX_PERIODS_PROBED + 1):
+        url = f"{context.data_url}?periodId={period_id}&page=1&perPage={PER_PAGE}"
+        # The API host sits behind a WAF that rejects ordinary egress.
+        members = zyte_api.fetch_json(context, url, geolocation="id", cache_days=7)
+        # Also narrows `fetch_json`'s untyped return for the strict type check.
+        if not isinstance(members, list):
+            raise ValueError(f"Period {period_id} did not return a list of members")
+
+        if len(members) == 0:
+            if len(terms) == 0:
+                continue  # Still below the window the DPD's terms occupy.
+            empty_run += 1
+            if empty_run >= EMPTY_PERIODS_BEFORE_STOP:
+                break
+            continue
+
+        if len(members) == PER_PAGE:
+            raise ValueError(f"Period {period_id} filled page 1; rows may be missing")
+        empty_run = 0
+
+        spans = {
+            (mandate["period"]["startYear"], mandate["period"]["endYear"])
+            for member in members
+            for mandate in member["memberPeriods"]
+            if mandate["period"]["id"] == period_id
+        }
+        if len(spans) != 1:
+            raise ValueError(f"Period {period_id} has ambiguous years: {spans}")
+        start_year, end_year = spans.pop()
+        terms.append(Term(period_id, start_year, end_year, members))
+
+    if len(terms) == 0:
+        raise ValueError(f"No period up to {MAX_PERIODS_PROBED} serves DPD members")
+    context.log.info(
+        "Found terms",
+        terms={t.period_id: f"{t.start_year}-{t.end_year}" for t in terms},
+    )
+    return sorted(terms, key=lambda t: t.period_id, reverse=True)
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    member: dict[str, Any],
+    term: Term,
+    sitting: bool,
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug(str(member.pop("id")))
+    # Source names carry honorifics and academic post-nominals as part of the
+    # name; strip the affixes declared in the dataset metadata.
+    raw_name = member.pop("fullName")
+    clean_name = h.strip_name_titles(context, raw_name)
+    person.add(
+        "name",
+        clean_name,
+        lang="ind",
+        original_value=raw_name if clean_name != raw_name else None,
+    )
+    person.add("gender", member.pop("gender"))
+    person.add("birthPlace", member.pop("placeOfBirth"))
+    h.apply_date(person, "birthDate", member.pop("dateOfBirth"))
+    person.add("biography", member.pop("profile"))  # local lang
+    person.add("email", member.pop("email"))
+    # DPD candidates must be Indonesian citizens (Law No. 7 of 2017 on General
+    # Elections, Article 182 letter a). https://peraturan.bpk.go.id/Details/37644
+    person.add("citizenship", "id")
+
+    mandates = member.pop("memberPeriods")
+
+    occupancies: list[Entity] = []
+    for mandate in mandates:
+        if mandate["period"]["id"] != term.period_id:
+            raise ValueError(
+                f"Period {mandate['period']['id']} returned for {term.period_id}"
+            )
+        status = mandate["memberStatus"]
+        if status not in (STATUS_SERVING, STATUS_LEFT):
+            raise ValueError(f"Unknown memberStatus: {status!r}")
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            start_date=mandate["inaugurationDate"],
+            period_start=str(term.start_year),
+            period_end=str(term.end_year),
+            status=(
+                OccupancyStatus.ENDED if sitting and status == STATUS_LEFT else None
+            ),
+            categorisation=categorisation,
+        )
+        if occupancy is not None:
+            occupancy.add("constituency", mandate["region"]["name"])
+            occupancies.append(occupancy)
+    # A member whose only mandate falls outside the PEP window gets no occupancy.
+    if len(occupancies) == 0:
+        return
+    for occupancy in occupancies:
+        context.emit(occupancy)
+    context.emit(person)
 
 
 def crawl(context: Context) -> None:
@@ -11,7 +146,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Regional Representative Council of Indonesia",
         country="id",
-        topics=["gov.national", "gov.legislative"],
+        topics=TOPICS,
         wikidata_id="Q21328635",
         lang="eng",
     )
@@ -20,53 +155,30 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    members = zyte_api.fetch_json(
-        # The API host sits behind a WAF that rejects ordinary egress
-        context,
-        context.data_url,
-        geolocation="id",
-        cache_days=7,
-    )
-    for member in members:
-        name = member.pop("fullName")
-        dob = member.pop("dateOfBirth")
-
-        person = context.make("Person")
-        person.id = context.make_id(name, dob)
-        person.add("name", name)
-        person.add("gender", member.pop("gender"))
-        person.add("birthPlace", member.pop("placeOfBirth"))
-        h.apply_date(person, "birthDate", dob)
-        person.add("biography", member.pop("profile"))  # local lang
-        person.add("email", member.pop("email"))
-        # DPD candidates must be Indonesian citizens (Law No. 7 of 2017 on General
-        # Elections, Article 182 letter a). https://peraturan.bpk.go.id/Details/37644
-        person.add("citizenship", "id")
-
-        periods = member.pop("memberPeriods") or []
-        province = None
-        start_date = None
-
-        if periods:
-            if len(periods) == 1:
-                latest = periods[0]
-            else:
-                latest = max(
-                    periods, key=lambda p: datetime.fromisoformat(p["inaugurationDate"])
-                )
-            province = latest["region"]["name"]
-            start_date = latest.get("inaugurationDate")
-
-        occupancy = h.make_occupancy(
-            context,
-            person,
-            position,
-            start_date=start_date,
-            categorisation=categorisation,
+    terms = fetch_terms(context)
+    sitting = terms[0]
+    if sitting.end_year < settings.RUN_TIME.year:
+        raise ValueError(
+            f"Newest period {sitting.period_id} ended in {sitting.end_year}: the "
+            "source has no term in progress. Aborting as not to emit its members as "
+            "current."
         )
-        if occupancy is None:
-            continue
-        if province is not None:
-            occupancy.add("constituency", province)
-        context.emit(occupancy)
-        context.emit(person)
+
+    for term in terms:
+        if term.end_year < int(h.earliest_term_start(TOPICS)[:4]):
+            context.log.info(
+                "Term ended before the PEP window; stopping",
+                id=term.period_id,
+                years=f"{term.start_year}-{term.end_year}",
+            )
+            break
+        for member in term.members:
+            crawl_member(
+                context, position, categorisation, member, term, term is sitting
+            )
+        context.log.info(
+            "Crawled term",
+            id=term.period_id,
+            years=f"{term.start_year}-{term.end_year}",
+            members=len(term.members),
+        )

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -1,30 +1,9 @@
-from typing import Any
+from datetime import datetime
 
 from zavod import Context
 from zavod import helpers as h
 from zavod.extract import zyte_api
 from zavod.stateful.positions import categorise
-
-# The API host sits behind a WAF that rejects ordinary egress, so it is fetched through the
-# Zyte API with an Indonesian exit.
-GEOLOCATION = "id"
-
-
-def member_list(payload: Any) -> list[dict[str, Any]]:
-    """Return the member array from the API envelope.
-
-    The service wraps the rows in a `data` object; be tolerant of a bare list or one extra
-    level of nesting so a minor envelope change fails loudly rather than silently.
-    """
-    if isinstance(payload, list):
-        return payload
-    if isinstance(payload, dict):
-        data = payload.get("data")
-        if isinstance(data, list):
-            return data
-        if isinstance(data, dict) and isinstance(data.get("data"), list):
-            return list(data["data"])
-    raise ValueError("Unexpected DPD API response shape")
 
 
 def crawl(context: Context) -> None:
@@ -41,33 +20,41 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    payload = zyte_api.fetch_json(
-        context, context.data_url, geolocation=GEOLOCATION, cache_days=1
+    members = zyte_api.fetch_json(
+        # The API host sits behind a WAF that rejects ordinary egress
+        context,
+        context.data_url,
+        geolocation="id",
+        cache_days=7,
     )
-    members = member_list(payload)
     for member in members:
-        name = member.get("fullName")
-        assert name, f"Member without a name: {member!r}"
+        name = member.pop("fullName")
+        dob = member.pop("dateOfBirth")
 
         person = context.make("Person")
-        person.id = context.make_id(name, member.get("dateOfBirth"))
+        person.id = context.make_id(name, dob)
         person.add("name", name)
-        person.add("gender", member.get("gender"))
-        person.add("birthPlace", member.get("placeOfBirth"))
-        h.apply_date(person, "birthDate", member.get("dateOfBirth"))
-        person.add("email", member.get("email"))
+        person.add("gender", member.pop("gender"))
+        person.add("birthPlace", member.pop("placeOfBirth"))
+        h.apply_date(person, "birthDate", dob)
+        person.add("biography", member.pop("profile"))  # local lang
+        person.add("email", member.pop("email"))
         # DPD candidates must be Indonesian citizens (Law No. 7 of 2017 on General
         # Elections, Article 182 letter a). https://peraturan.bpk.go.id/Details/37644
         person.add("citizenship", "id")
 
-        # The most recent member period gives the province and inauguration date.
-        periods = member.get("memberPeriods") or []
+        periods = member.pop("memberPeriods") or []
         province = None
         start_date = None
+
         if periods:
-            latest = periods[-1]
-            region = latest.get("region") or {}
-            province = region.get("name")
+            if len(periods) == 1:
+                latest = periods[0]
+            else:
+                latest = max(
+                    periods, key=lambda p: datetime.fromisoformat(p["inaugurationDate"])
+                )
+            province = latest["region"]["name"]
             start_date = latest.get("inaugurationDate")
 
         occupancy = h.make_occupancy(

--- a/datasets/id/dpd/crawler.py
+++ b/datasets/id/dpd/crawler.py
@@ -11,7 +11,6 @@ from zavod.stateful.positions import (
 )
 
 TOPICS = ["gov.national", "gov.legislative"]
-PERIOD_URL = "https://service.dpd.go.id/anggota/api/v1/period"
 PER_PAGE = 300
 STATUS_SERVING = 0
 STATUS_LEFT = 1
@@ -104,7 +103,12 @@ def crawl(context: Context) -> None:
     context.emit(position)
 
     # The API host sits behind a WAF that rejects ordinary egress.
-    periods = zyte_api.fetch_json(context, PERIOD_URL, geolocation="id", cache_days=7)
+    periods = zyte_api.fetch_json(
+        context,
+        context.data_url.replace("member/public/profile", "period"),
+        geolocation="id",
+        cache_days=7,
+    )
     earliest_year = int(h.earliest_term_start(TOPICS)[:4])
     for period in sorted(periods, key=lambda p: p["endYear"], reverse=True):
         if period["endYear"] < earliest_year:

--- a/datasets/id/dpd/id_dpd.yml
+++ b/datasets/id/dpd/id_dpd.yml
@@ -1,0 +1,48 @@
+title: Indonesia Regional Representative Council (DPD)
+name: id_dpd
+prefix: id-dpd
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Regional Representative Council (DPD), the upper chamber of the
+  Indonesian parliament.
+description: |
+  The Regional Representative Council (Dewan Perwakilan Daerah, DPD) is the upper chamber of
+  Indonesia's parliament. It has 152 members: four non-partisan senators directly elected
+  from each of the 38 provinces, serving five-year terms. The current term is 2024–2029.
+
+  This dataset records each member with their name, province, gender, place and date of
+  birth from the Council's official member API.
+url: https://www.dpd.go.id/anggota/anggota
+publisher:
+  name: Dewan Perwakilan Daerah Republik Indonesia
+  acronym: DPD
+  description: >
+    The Regional Representative Council is the upper chamber of the Indonesian parliament,
+    composed of directly elected provincial senators.
+  url: https://www.dpd.go.id/
+  country: id
+  official: true
+data:
+  url: https://service.dpd.go.id/anggota/api/v1/member/public/profile?periodId=13&page=1&perPage=200
+  format: JSON
+  lang: ind
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 120
+      Position: 1
+    country_entities:
+      id: 120
+  max:
+    schema_entities:
+      Person: 180
+      Position: 1

--- a/datasets/id/dpd/id_dpd.yml
+++ b/datasets/id/dpd/id_dpd.yml
@@ -33,6 +33,25 @@ data:
 tags:
   - list.pep
 
+lookups:
+  type.gender:
+    options:
+      - match: 0
+        value: male
+      - match: 1
+        value: female
+  type.email:
+    options:
+      # Placeholder for a missing address.
+      - match: "--"
+        value: null
+      # Trailing separator left over from data entry.
+      - match: marthin.billa@dpd.go.id;
+        value: marthin.billa@dpd.go.id
+      # Space where the source's dot convention (firstname.lastname) belongs.
+      - match: siti aseanti@dpd.go.id
+        value: siti.aseanti@dpd.go.id
+
 assertions:
   min:
     schema_entities:

--- a/datasets/id/dpd/id_dpd.yml
+++ b/datasets/id/dpd/id_dpd.yml
@@ -6,7 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-23
 load_statements: true
-ci_test: false
+ci_test: false  # The API is only reachable through the Zyte API.
 summary: >-
   Upper chamber seating four non-partisan senators from each of 38 provinces
 description: |

--- a/datasets/id/dpd/id_dpd.yml
+++ b/datasets/id/dpd/id_dpd.yml
@@ -1,4 +1,4 @@
-title: Indonesia Regional Representative Council (DPD)
+title: Indonesia Members of the Regional Representative Council (DPD)
 name: id_dpd
 prefix: id-dpd
 entry_point: crawler.py
@@ -8,15 +8,13 @@ coverage:
 load_statements: true
 ci_test: false
 summary: >-
-  Members of the Regional Representative Council (DPD), the upper chamber of the
-  Indonesian parliament.
+  Upper chamber seating four non-partisan senators from each of 38 provinces
 description: |
-  The Regional Representative Council (Dewan Perwakilan Daerah, DPD) is the upper chamber of
-  Indonesia's parliament. It has 152 members: four non-partisan senators directly elected
-  from each of the 38 provinces, serving five-year terms. The current term is 2024–2029.
-
-  This dataset records each member with their name, province, gender, place and date of
-  birth from the Council's official member API.
+  Current members of the Regional Representative Council (Dewan Perwakilan Daerah, DPD),
+  the upper chamber of Indonesia's bicameral parliament. Four non-partisan senators are
+  directly elected from each of the 38 provinces for a five-year term, giving the chamber
+  152 members, and share the country's legislative power with the People's Representative
+  Council.
 url: https://www.dpd.go.id/anggota/anggota
 publisher:
   name: Dewan Perwakilan Daerah Republik Indonesia

--- a/datasets/id/dpd/id_dpd.yml
+++ b/datasets/id/dpd/id_dpd.yml
@@ -6,15 +6,19 @@ coverage:
   frequency: monthly
   start: 2026-07-23
 load_statements: true
-ci_test: false  # The API is only reachable through the Zyte API.
+ci_test: false  # The API is only reachable through Zyte
 summary: >-
   Upper chamber seating four non-partisan senators from each of 38 provinces
 description: |
-  Current members of the Regional Representative Council (Dewan Perwakilan Daerah, DPD),
-  the upper chamber of Indonesia's bicameral parliament. Four non-partisan senators are
-  directly elected from each of the 38 provinces for a five-year term, giving the chamber
-  152 members, and share the country's legislative power with the People's Representative
-  Council.
+  Current and historical members of the Regional Representative Council (Dewan Perwakilan
+  Daerah, DPD), the upper chamber of Indonesia's bicameral parliament. Four non-partisan
+  senators are directly elected from each of the 38 provinces for a five-year term, giving
+  the chamber 152 members, and share the country's legislative power with the People's
+  Representative Council.
+
+  Coverage reaches back to the chamber's first term in 2004, with one occupancy per term
+  a member served. The source states no date on which a member left, so a mandate that
+  ended before its term expired is recorded without an end date.
 url: https://www.dpd.go.id/anggota/anggota
 publisher:
   name: Dewan Perwakilan Daerah Republik Indonesia
@@ -26,14 +30,159 @@ publisher:
   country: id
   official: true
 data:
-  url: https://service.dpd.go.id/anggota/api/v1/member/public/profile?periodId=13&page=1&perPage=200
+  url: https://service.dpd.go.id/anggota/api/v1/member/public/profile
   format: JSON
   lang: ind
 
 tags:
   - list.pep
 
+names:
+  prefixes_strip:
+    # Religious / customary honorifics
+    - "H."          # Haji
+    - "H "          # Haji, written without the dot
+    - "H,"          # Haji, comma typo for the dot
+    - "Hj."         # Hajjah
+    - "Hi."         # Haji (regional variant)
+    - "K.H."        # Kyai Haji
+    - "KH."
+    - "Tgk."        # Teungku (Acehnese)
+    - "TGH."        # Tuan Guru Haji
+    - "Ust."        # Ustaz
+    - "Pdt."        # Pendeta (Protestant minister)
+    - "Pendeta"
+    - "Dato'"       # Malay honorific
+    # Academic / professional titles
+    - "Prof."
+    - "Dr."         # doctorate; also matches lowercase "dr." (physician)
+    - "Drs."        # Doctorandus
+    - "Dra."        # Doctoranda
+    - "Ir."         # Insinyur (engineer)
+    - "Apt."        # Apoteker (pharmacist)
+    - "Dipl."       # Diplom-Ingenieur
+    - "Ing."
+    # Doctorate qualifiers that follow the title
+    - "(C)"         # candidate
+    - "(HC)"        # honoris causa
+    - "(H.C.)"
+    # Military rank
+    - "Laksma TNI (Purn)"   # retired rear admiral
+  suffixes_strip:
+    - ","           # trailing comma left after a dropped post-nominal
+    # Bachelor's / diploma
+    - ", B.A."
+    - ", B.A. (Hons.)"
+    - ", B.Bus."
+    - ", B.Bus.Com."
+    - ", B.Sc."
+    - ", A.Md."
+    - ", A.Md. Kep."
+    - ", A.Md.Par."
+    # Sarjana (bachelor) degrees
+    - ", S.AP."
+    - ", S.Ag."
+    - ", S.E."
+    - ", S.E"
+    - ", S.Farm."
+    - ", S.H."
+    - ", S.H.I."
+    - ", S.I.Kom."
+    - ", S.IP."
+    - ", S.IP"
+    - ", S.KG."
+    - ", S.Ked."
+    - ", S.Mn."
+    - ", S.P."
+    - ", S.PAK."
+    - ", S.Pd."
+    - ", S.Pd.I."
+    - ", S.Pi."
+    - ", S.Psi."
+    - ", S.S."
+    - ", S.Si."
+    - ", S.Si"
+    - ", S.Sos."
+    - ", S.Sos"
+    - ", S.Sos.I."
+    - ", S.ST."
+    - ", S.T."
+    - ", S.Th."
+    # Master's degrees
+    - ", M.A."
+    - ", M.A.C.Ed."
+    - ", M.A.P."
+    - ", M.A.R.S."
+    - ", M.AP."
+    - ", M.Ag."
+    - ", M.B.A."
+    - ", M.Biomed."
+    - ", M.Com."
+    - ", M.Div."
+    - ", M.E.I."
+    - ", M.Ed."
+    - ", M.Eng."
+    - ", M.Fin."
+    - ", M.H."
+    - ", M.HP."
+    - ", M.Hi."
+    - ", M.Hum."
+    - ", M.I.Kom."
+    - ", M.I.P."
+    - ", M.Keb."
+    - ", M.Kes."
+    - ", M.Kesos."
+    - ", M.Kn."
+    - ", M.M."
+    - ", M.M"
+    - ", M.,Si"    # typo for M.Si.
+    - ", M.MSip."
+    - ", M.Pd."
+    - ", M.Pd.I."
+    - ", MM. M.Pd.I."
+    - ", M.S."
+    - ", M.S.M."
+    - ", M.S.P."
+    - ", M.SP."
+    - ", M.Sc."
+    - ", M.Si."
+    - ", M.Sos."
+    - ", M.T."
+    - ", M.Th."
+    - ", MMSI."
+    - ", (MTRU)"
+    - ", M(Tru)"
+    # Doctorate / professional certifications
+    - ", D.Min."
+    - ", LL.M."
+    - ", Ph.d"
+    - ", Lc."      # Licence (Islamic studies)
+    - ", Akt."     # Akuntan
+    - ", Apt."     # Apoteker
+    - ", BD."
+    - ", Bc. Hk."
+    - ", C.L.A."
+    - ", CIRBC."
+    - ", CM.NNLP."
+    - ", CWC."
+    - ", SM.Th."
+    - ", Sp.N."    # medical specialist (neurology)
+    - ", Sp.OG"    # medical specialist (obstetrics/gynaecology)
+    - ", Teol."
+
 lookups:
+  type.name:
+    options:
+      # A second, informal name ("Habib Banua") was appended after this member's
+      # post-nominals in the source. Title stripping cannot reach the degrees
+      # buried mid-string, so drop them here while keeping both name parts.
+      - match: "PANGERAN SYARIF ABDURRAHMAN BAHASYIM, S.E., M.M. HABIB BANUA"
+        value: "PANGERAN SYARIF ABDURRAHMAN BAHASYIM HABIB BANUA"
+  type.date:
+    options:
+      # .NET's DateTime.MinValue: the API's sentinel for an unset date, not a real one.
+      - match: "0001-01-01T00:00:00Z"
+        value: null
   type.gender:
     options:
       - match: 0
@@ -42,24 +191,28 @@ lookups:
         value: female
   type.email:
     options:
-      # Placeholder for a missing address.
-      - match: "--"
+      - match:
+          - "--"
+          - "-"
+          - "."
+          - dpd.go.id
+          - "@dpd.go.id"
         value: null
-      # Trailing separator left over from data entry.
       - match: marthin.billa@dpd.go.id;
         value: marthin.billa@dpd.go.id
-      # Space where the source's dot convention (firstname.lastname) belongs.
+      - match: abdul.rachman@dpd.go.id;
+        value: abdul.rachman@dpd.go.id
       - match: siti aseanti@dpd.go.id
         value: siti.aseanti@dpd.go.id
 
 assertions:
   min:
     schema_entities:
-      Person: 120
+      Person: 450
       Position: 1
     country_entities:
-      id: 120
+      id: 450
   max:
     schema_entities:
-      Person: 180
+      Person: 1000
       Position: 1


### PR DESCRIPTION
Adds a PEP crawler for the **Regional Representative Council (DPD)**, the upper chamber of Indonesia's parliament (152 seats, 4 per province).

## Source
Public member JSON API (`service.dpd.go.id/.../member/public/profile?periodId=13`), returning all 152 members in one response.

⚠️ **Unverified.** The API host sits behind a WAF that rejects ordinary egress (returns "Request Rejected"), so it is fetched via the **Zyte API** with an Indonesian exit and could not be run locally. The field mapping follows the API structure documented in the issue (`fullName`, `dateOfBirth`, `placeOfBirth`, `gender`, `memberPeriods[].region.name`); the envelope handling is defensive. **Please sanity-check the first production run** (expected 152 members).

## Output
- Position: *Member of the Regional Representative Council of Indonesia* (`Q21328635`)
- Members with name, gender, place/date of birth, province and inauguration date.
- Citizenship `id` per Law No. 7/2017 Art. 182(a) (see code comment).

Closes opensanctions/crawler-planning#712

🤖 Generated with [Claude Code](https://claude.com/claude-code)