### PR TITLE
Add Georgia Parliament PEP crawler

### DIFF
--- a/datasets/ge/parliament/crawler.py
+++ b/datasets/ge/parliament/crawler.py
@@ -12,8 +12,8 @@ def crawl_member(
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
-    first_name = member.pop("firstName").strip().title()
-    family_name = member.pop("familyName").strip().title()
+    first_name = member.pop("firstName").strip()
+    family_name = member.pop("familyName").strip()
 
     person = context.make("Person")
     person.id = context.make_slug(str(member.pop("id")))

--- a/datasets/ge/parliament/crawler.py
+++ b/datasets/ge/parliament/crawler.py
@@ -1,15 +1,15 @@
 from typing import Any
 
-from zavod import Context
+from zavod import Context, Entity
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
+from zavod.stateful.positions import PositionCategorisation, categorise
 
 # The API needs a browser User-Agent (else 403) and both an Accept and Accept-Language
 # header (else HTTP 500); Accept-Language "en" yields Latin-script (transliterated) names.
 HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 (zavod; opensanctions.org)"
     ),
     "Accept": "application/json",
     "Accept-Language": "en",
@@ -17,6 +17,73 @@ HEADERS = {
 
 # gender.id in the API payload.
 GENDERS = {1: "male", 2: "female"}
+
+
+def crawl_member(
+    context: Context,
+    member: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    source_id = member.pop("id")
+    # The endpoint serves parliamentary "colleagues"; every row today is a sitting deputy
+    # (mp=True). Fail loudly if a non-MP ever appears rather than emitting it as one.
+    if member.pop("mp") is not True:
+        raise ValueError(f"Non-MP colleague in deputies feed: {source_id}")
+
+    first_name = (member.pop("firstName") or "").strip().title()
+    family_name = (member.pop("familyName") or "").strip().title()
+    if not (first_name or family_name):
+        raise ValueError(f"Member without a name: {source_id}")
+
+    person = context.make("Person")
+    person.id = context.make_slug(str(source_id))
+    h.apply_name(person, first_name=first_name, last_name=family_name, lang="eng")
+
+    gender = member.pop("gender", None)
+    if gender is not None:
+        label = GENDERS.get(gender.get("id"))
+        if label is None:
+            raise ValueError(f"Unknown gender {gender!r} for member {source_id}")
+        person.add("gender", label)
+
+    h.apply_date(person, "birthDate", member.pop("dob"))
+    person.add("birthPlace", member.pop("birthPlace"), lang="eng")
+    # Candidates for Parliament must be citizens of Georgia (Constitution of Georgia,
+    # Article 37(4)). https://www.constituteproject.org/constitution/Georgia_2018
+    person.add("citizenship", "ge")
+
+    # contactInfo carries phone numbers, which we deliberately never extract.
+    context.audit_data(
+        member,
+        ignore=[
+            "avatar",
+            "biography",
+            "bureau",
+            "colleagueStatus",
+            "contactInfo",
+            "declaration",
+            "fatherName",
+            "fullName",
+            "image",
+            "local_avatar",
+            "node",
+            "position",
+            "positionIndex",
+            "supervisorId",
+            "supervisorName",
+            "supervisorNameEn",
+            "voteCount",
+        ],
+    )
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    context.emit(occupancy)
+    context.emit(person)
 
 
 def crawl(context: Context) -> None:
@@ -37,27 +104,4 @@ def crawl(context: Context) -> None:
         raise ValueError("Georgia deputies API returned no members")
 
     for member in members:
-        first_name = (member.get("firstName") or "").strip().title()
-        family_name = (member.get("familyName") or "").strip().title()
-        assert first_name or family_name, f"Member without a name: {member.get('id')}"
-
-        person = context.make("Person")
-        person.id = context.make_slug(str(member["id"]))
-        h.apply_name(person, first_name=first_name, last_name=family_name, lang="eng")
-        gender = member.get("gender") or {}
-        gender_id = gender.get("id")
-        if isinstance(gender_id, int):
-            person.add("gender", GENDERS.get(gender_id))
-        h.apply_date(person, "birthDate", member.get("dob"))
-        person.add("birthPlace", member.get("birthPlace"), lang="eng")
-        # Candidates for Parliament must be citizens of Georgia (Constitution of Georgia,
-        # Article 37(4)). https://www.constituteproject.org/constitution/Georgia_2018
-        person.add("citizenship", "ge")
-
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        context.emit(occupancy)
-        context.emit(person)
+        crawl_member(context, member, position, categorisation)

--- a/datasets/ge/parliament/crawler.py
+++ b/datasets/ge/parliament/crawler.py
@@ -1,22 +1,9 @@
 from typing import Any
+from lxml import html
 
 from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.stateful.positions import PositionCategorisation, categorise
-
-# The API needs a browser User-Agent (else 403) and both an Accept and Accept-Language
-# header (else HTTP 500); Accept-Language "en" yields Latin-script (transliterated) names.
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 (zavod; opensanctions.org)"
-    ),
-    "Accept": "application/json",
-    "Accept-Language": "en",
-}
-
-# gender.id in the API payload.
-GENDERS = {1: "male", 2: "female"}
 
 
 def crawl_member(
@@ -25,48 +12,49 @@ def crawl_member(
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
-    source_id = member.pop("id")
-    # The endpoint serves parliamentary "colleagues"; every row today is a sitting deputy
-    # (mp=True). Fail loudly if a non-MP ever appears rather than emitting it as one.
-    if member.pop("mp") is not True:
-        raise ValueError(f"Non-MP colleague in deputies feed: {source_id}")
-
-    first_name = (member.pop("firstName") or "").strip().title()
-    family_name = (member.pop("familyName") or "").strip().title()
-    if not (first_name or family_name):
-        raise ValueError(f"Member without a name: {source_id}")
+    first_name = member.pop("firstName").strip().title()
+    family_name = member.pop("familyName").strip().title()
 
     person = context.make("Person")
-    person.id = context.make_slug(str(source_id))
+    person.id = context.make_slug(str(member.pop("id")))
     h.apply_name(person, first_name=first_name, last_name=family_name, lang="eng")
-
-    gender = member.pop("gender", None)
-    if gender is not None:
-        label = GENDERS.get(gender.get("id"))
-        if label is None:
-            raise ValueError(f"Unknown gender {gender!r} for member {source_id}")
-        person.add("gender", label)
+    person.add("gender", str(member.pop("gender")["id"]))
 
     h.apply_date(person, "birthDate", member.pop("dob"))
     person.add("birthPlace", member.pop("birthPlace"), lang="eng")
+    person.add("notes", member.pop("declaration"))  # link to declaration pdf
+
+    # biography is an HTML fragment; extract the text of each paragraph and list
+    # item (decoding entities and stripping tags) into clean plain text.
+    biography = member.pop("biography")
+    if biography:
+        doc = html.fromstring(f"<div>{biography}</div>")
+        paragraphs = [
+            h.element_text(el) for el in h.xpath_elements(doc, ".//p | .//li")
+        ]
+        person.add("biography", "\n".join(p for p in paragraphs if p))
+
+    contact_info = member.pop("contactInfo")
+    for email in contact_info["emails"]:
+        person.add("email", email)
+    for phone in contact_info["phones"]:
+        person.add("phone", phone)
+
     # Candidates for Parliament must be citizens of Georgia (Constitution of Georgia,
     # Article 37(4)). https://www.constituteproject.org/constitution/Georgia_2018
     person.add("citizenship", "ge")
 
-    # contactInfo carries phone numbers, which we deliberately never extract.
     context.audit_data(
         member,
         ignore=[
             "avatar",
-            "biography",
             "bureau",
             "colleagueStatus",
-            "contactInfo",
-            "declaration",
             "fatherName",
-            "fullName",
+            "fullName",  # often None
             "image",
             "local_avatar",
+            "mp",
             "node",
             "position",
             "positionIndex",
@@ -93,15 +81,18 @@ def crawl(context: Context) -> None:
         country="ge",
         wikidata_id="Q21290878",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    payload = context.fetch_json(context.data_url, headers=HEADERS, cache_days=1)
-    members: list[dict[str, Any]] = payload["data"]
-    if not members:
-        raise ValueError("Georgia deputies API returned no members")
-
-    for member in members:
+    # Accept-Language "en" yields Latin-script (transliterated) names; without an
+    # Accept header the API returns HTTP 500. The browser User-Agent that avoids a
+    # 403 is configured via http.user_agent in the dataset metadata.
+    payload = context.fetch_json(
+        context.data_url,
+        headers={"Accept": "application/json", "Accept-Language": "en"},
+        cache_days=1,
+    )
+    for member in payload["data"]:
         crawl_member(context, member, position, categorisation)

--- a/datasets/ge/parliament/crawler.py
+++ b/datasets/ge/parliament/crawler.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+# The API needs a browser User-Agent (else 403) and both an Accept and Accept-Language
+# header (else HTTP 500); Accept-Language "en" yields Latin-script (transliterated) names.
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json",
+    "Accept-Language": "en",
+}
+
+# gender.id in the API payload.
+GENDERS = {1: "male", 2: "female"}
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Parliament of Georgia",
+        country="ge",
+        wikidata_id="Q21290878",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    payload = context.fetch_json(context.data_url, headers=HEADERS, cache_days=1)
+    members: list[dict[str, Any]] = payload["data"]
+    if not members:
+        raise ValueError("Georgia deputies API returned no members")
+
+    for member in members:
+        first_name = (member.get("firstName") or "").strip().title()
+        family_name = (member.get("familyName") or "").strip().title()
+        assert first_name or family_name, f"Member without a name: {member.get('id')}"
+
+        person = context.make("Person")
+        person.id = context.make_slug(str(member["id"]))
+        h.apply_name(person, first_name=first_name, last_name=family_name, lang="eng")
+        gender = member.get("gender") or {}
+        gender_id = gender.get("id")
+        if isinstance(gender_id, int):
+            person.add("gender", GENDERS.get(gender_id))
+        h.apply_date(person, "birthDate", member.get("dob"))
+        person.add("birthPlace", member.get("birthPlace"), lang="eng")
+        # Candidates for Parliament must be citizens of Georgia (Constitution of Georgia,
+        # Article 37(4)). https://www.constituteproject.org/constitution/Georgia_2018
+        person.add("citizenship", "ge")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(occupancy)
+        context.emit(person)

--- a/datasets/ge/parliament/crawler.py
+++ b/datasets/ge/parliament/crawler.py
@@ -82,6 +82,7 @@ def crawl(context: Context) -> None:
         name="Member of the Parliament of Georgia",
         country="ge",
         wikidata_id="Q21290878",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     if not categorisation.is_pep:

--- a/datasets/ge/parliament/crawler.py
+++ b/datasets/ge/parliament/crawler.py
@@ -14,10 +14,13 @@ def crawl_member(
 ) -> None:
     first_name = member.pop("firstName").strip()
     family_name = member.pop("familyName").strip()
+    father_name = member.pop("fatherName")
 
     person = context.make("Person")
     person.id = context.make_slug(str(member.pop("id")))
     h.apply_name(person, first_name=first_name, last_name=family_name, lang="eng")
+    if father_name is not None:
+        person.add("fatherName", father_name.strip(), lang="eng")
     person.add("gender", str(member.pop("gender")["id"]))
 
     h.apply_date(person, "birthDate", member.pop("dob"))
@@ -50,7 +53,6 @@ def crawl_member(
             "avatar",
             "bureau",
             "colleagueStatus",
-            "fatherName",
             "fullName",  # often None
             "image",
             "local_avatar",

--- a/datasets/ge/parliament/crawler.py
+++ b/datasets/ge/parliament/crawler.py
@@ -14,13 +14,10 @@ def crawl_member(
 ) -> None:
     first_name = member.pop("firstName").strip()
     family_name = member.pop("familyName").strip()
-    father_name = member.pop("fatherName")
 
     person = context.make("Person")
     person.id = context.make_slug(str(member.pop("id")))
     h.apply_name(person, first_name=first_name, last_name=family_name, lang="eng")
-    if father_name is not None:
-        person.add("fatherName", father_name.strip(), lang="eng")
     person.add("gender", str(member.pop("gender")["id"]))
 
     h.apply_date(person, "birthDate", member.pop("dob"))

--- a/datasets/ge/parliament/ge_parliament.yml
+++ b/datasets/ge/parliament/ge_parliament.yml
@@ -1,9 +1,9 @@
-title: Georgia Parliament
+title: Georgia Members of Parliament
 name: ge_parliament
 prefix: ge-parl
 entry_point: crawler.py
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-07-23
 load_statements: true
 ci_test: false

--- a/datasets/ge/parliament/ge_parliament.yml
+++ b/datasets/ge/parliament/ge_parliament.yml
@@ -1,0 +1,47 @@
+title: Georgia Parliament
+name: ge_parliament
+prefix: ge-parl
+entry_point: crawler.py
+coverage:
+  frequency: weekly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Parliament of Georgia, the unicameral national legislature.
+description: |
+  The Parliament of Georgia is the country's unicameral national legislature, with 150
+  members elected under proportional representation for a four-year term.
+
+  This dataset records each seated member with their name, gender and date of birth, from
+  the Parliament's official member API.
+url: https://parliament.ge/en/parliament-members
+publisher:
+  name: Parliament of Georgia
+  description: >
+    The Parliament of Georgia is the unicameral national legislature of Georgia.
+  url: https://parliament.ge/
+  country: ge
+  official: true
+data:
+  url: https://web-api.parliament.ge/api/colleagues/deputies
+  format: JSON
+  lang: eng
+
+dates:
+  formats: ["%d-%m-%Y"]
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 90
+      Position: 1
+    country_entities:
+      ge: 90
+  max:
+    schema_entities:
+      Person: 170
+      Position: 1

--- a/datasets/ge/parliament/ge_parliament.yml
+++ b/datasets/ge/parliament/ge_parliament.yml
@@ -10,11 +10,13 @@ ci_test: false
 summary: >-
   Members of the Parliament of Georgia, the unicameral national legislature.
 description: |
-  The Parliament of Georgia is the country's unicameral national legislature, with 150
-  members elected under proportional representation for a four-year term.
+  Current members of the Parliament of Georgia, the country's unicameral national
+  legislature. Its 150 members are elected under proportional representation for a
+  four-year term and hold the country's legislative power, including passing laws,
+  approving the budget, and overseeing the government.
 
-  This dataset records each seated member with their name, gender and date of birth, from
-  the Parliament's official member API.
+  This dataset records each seated member with their name, gender, and date and place
+  of birth.
 url: https://parliament.ge/en/parliament-members
 publisher:
   name: Parliament of Georgia
@@ -27,12 +29,25 @@ data:
   url: https://web-api.parliament.ge/api/colleagues/deputies
   format: JSON
   lang: eng
+http:
+  # A default zavod User-Agent gets a 403 from this API; a browser one works.
+  user_agent: >-
+    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
+    Chrome/124.0.0.0 Safari/537.36 (zavod; opensanctions.org)
 
 dates:
   formats: ["%d-%m-%Y"]
 
 tags:
   - list.pep
+
+lookups:
+  type.gender:
+    options:
+      - match: "1"
+        value: male
+      - match: "2"
+        value: female
 
 assertions:
   min:


### PR DESCRIPTION
Adds a PEP crawler for the **Parliament of Georgia** (unicameral).

## Source
Official member backend JSON API (`web-api.parliament.ge/api/colleagues/deputies`). Requires a browser `User-Agent` (else 403) and both `Accept` + `Accept-Language` headers (else HTTP 500); `Accept-Language: en` returns Latin-transliterated names.

## Output
- Position: *Member of the Parliament of Georgia* (`Q21290878`)
- 101 seated members emitted as PEPs (of 150 statutory; ~49 vacant after the post-2024 opposition boycott) with name, gender and date of birth.
- Citizenship `ge` per Constitution Art. 37(4) (see code comment).

Closes opensanctions/crawler-planning#695

🤖 Generated with [Claude Code](https://claude.com/claude-code)