### PR TITLE
Add Monaco National Council PEP crawler

### DIFF
--- a/datasets/mc/conseil_national/crawler.py
+++ b/datasets/mc/conseil_national/crawler.py
@@ -1,12 +1,43 @@
 from typing import Any
 
-from zavod import Context
+from zavod import Context, Entity
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
+from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The current legislature's member pages are children of this WordPress page; the set also
-# contains the "Législature 2023-2028" section page itself, which is not a member.
+# The current legislature's member pages are children of this WordPress page. The children
+# also include the "Législature 2023-2028" section page itself, which is not a member.
 CURRENT_LEGISLATURE_PARENT = 13076
+
+
+def crawl_member(
+    context: Context,
+    page: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> bool:
+    name = page["title"]["rendered"].strip()
+    # Skip the section/index page; only individual councillors are members. The prefix
+    # match still holds when the year in the title changes with each new legislature.
+    if not name or name.lower().startswith("législature"):
+        return False
+
+    person = context.make("Person")
+    person.id = context.make_slug(page["slug"])
+    person.add("name", name)
+    person.add("sourceUrl", page.get("link"))
+    # National Council members must have held Monegasque nationality for at least five
+    # years (Constitution of Monaco, Article 54).
+    # https://www.constituteproject.org/constitution/Monaco_2002
+    person.add("citizenship", "mc")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return False
+    context.emit(occupancy)
+    context.emit(person)
+    return True
 
 
 def crawl(context: Context) -> None:
@@ -28,28 +59,8 @@ def crawl(context: Context) -> None:
     )
     count = 0
     for page in pages:
-        name = page["title"]["rendered"].strip()
-        # Skip the section/index page; only individual councillors are members.
-        if not name or name.lower().startswith("législature"):
-            continue
-
-        person = context.make("Person")
-        person.id = context.make_slug(page["slug"])
-        person.add("name", name)
-        person.add("sourceUrl", page.get("link"))
-        # National Council members must have held Monegasque nationality for at least five
-        # years (Constitution of Monaco, Article 54).
-        # https://www.constituteproject.org/constitution/Monaco_2002
-        person.add("citizenship", "mc")
-
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        context.emit(occupancy)
-        context.emit(person)
-        count += 1
+        if crawl_member(context, page, position, categorisation):
+            count += 1
 
     if count == 0:
         raise ValueError("No National Council members found")

--- a/datasets/mc/conseil_national/crawler.py
+++ b/datasets/mc/conseil_national/crawler.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+# The current legislature's member pages are children of this WordPress page; the set also
+# contains the "Législature 2023-2028" section page itself, which is not a member.
+CURRENT_LEGISLATURE_PARENT = 13076
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the National Council of Monaco",
+        country="mc",
+        wikidata_id="Q21328626",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    pages: list[dict[str, Any]] = context.fetch_json(
+        context.data_url,
+        params={"parent": CURRENT_LEGISLATURE_PARENT, "per_page": "100"},
+        cache_days=1,
+    )
+    count = 0
+    for page in pages:
+        name = page["title"]["rendered"].strip()
+        # Skip the section/index page; only individual councillors are members.
+        if not name or name.lower().startswith("législature"):
+            continue
+
+        person = context.make("Person")
+        person.id = context.make_slug(page["slug"])
+        person.add("name", name)
+        person.add("sourceUrl", page.get("link"))
+        # National Council members must have held Monegasque nationality for at least five
+        # years (Constitution of Monaco, Article 54).
+        # https://www.constituteproject.org/constitution/Monaco_2002
+        person.add("citizenship", "mc")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(occupancy)
+        context.emit(person)
+        count += 1
+
+    if count == 0:
+        raise ValueError("No National Council members found")

--- a/datasets/mc/conseil_national/crawler.py
+++ b/datasets/mc/conseil_national/crawler.py
@@ -4,22 +4,18 @@ from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The current legislature's member pages are children of this WordPress page. The children
-# also include the "Législature 2023-2028" section page itself, which is not a member.
-CURRENT_LEGISLATURE_PARENT = 13076
-
 
 def crawl_member(
     context: Context,
     page: dict[str, Any],
     position: Entity,
     categorisation: PositionCategorisation,
-) -> bool:
+) -> None:
     name = page["title"]["rendered"].strip()
     # Skip the section/index page; only individual councillors are members. The prefix
     # match still holds when the year in the title changes with each new legislature.
     if not name or name.lower().startswith("législature"):
-        return False
+        return
 
     person = context.make("Person")
     person.id = context.make_slug(page["slug"])
@@ -34,10 +30,9 @@ def crawl_member(
         context, person, position, categorisation=categorisation
     )
     if occupancy is None:
-        return False
+        return
     context.emit(occupancy)
     context.emit(person)
-    return True
 
 
 def crawl(context: Context) -> None:
@@ -46,21 +41,25 @@ def crawl(context: Context) -> None:
         name="Member of the National Council of Monaco",
         country="mc",
         wikidata_id="Q21328626",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
+    # Sitting councillors are the child pages of the stable "Les conseillers nationaux" page
+    slug = "les-conseillers-nationaux"
+    parents = context.fetch_json(context.data_url, params={"slug": slug}, cache_days=1)
+    if len(parents) != 1:
+        raise ValueError(
+            f"Expected exactly one page for slug {slug!r}, got {len(parents)}"
+        )
+
     pages: list[dict[str, Any]] = context.fetch_json(
         context.data_url,
-        params={"parent": CURRENT_LEGISLATURE_PARENT, "per_page": "100"},
+        params={"parent": parents[0]["id"], "per_page": "100"},
         cache_days=1,
     )
-    count = 0
     for page in pages:
-        if crawl_member(context, page, position, categorisation):
-            count += 1
-
-    if count == 0:
-        raise ValueError("No National Council members found")
+        crawl_member(context, page, position, categorisation)

--- a/datasets/mc/conseil_national/mc_conseil_national.yml
+++ b/datasets/mc/conseil_national/mc_conseil_national.yml
@@ -8,15 +8,15 @@ coverage:
 load_statements: true
 ci_test: false
 summary: >-
-  Members of the National Council (Conseil National) of Monaco, the unicameral
+  Members of the National Council of Monaco, the unicameral
   legislature.
 description: |
-  The National Council (Conseil National) is the unicameral legislature of the Principality
-  of Monaco. Its 24 members are directly elected for a five-year term. The current
-  legislature covers 2023–2028.
+  Current members of the National Council (Conseil National), the unicameral
+  legislature of the Principality of Monaco. Its 24 members are directly elected for a
+  five-year term and hold the principality's legislative power, including passing laws
+  and approving the budget.
 
-  This dataset records each member of the current National Council by name, from the
-  Council's official website.
+  This dataset records each sitting member by name.
 url: https://www.conseil-national.mc/vos-elus/
 publisher:
   name: Conseil National de Monaco

--- a/datasets/mc/conseil_national/mc_conseil_national.yml
+++ b/datasets/mc/conseil_national/mc_conseil_national.yml
@@ -1,4 +1,4 @@
-title: Monaco Conseil National
+title: Monaco Members of the National Council
 name: mc_conseil_national
 prefix: mc-cn
 entry_point: crawler.py

--- a/datasets/mc/conseil_national/mc_conseil_national.yml
+++ b/datasets/mc/conseil_national/mc_conseil_national.yml
@@ -1,0 +1,46 @@
+title: Monaco Conseil National
+name: mc_conseil_national
+prefix: mc-cn
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the National Council (Conseil National) of Monaco, the unicameral
+  legislature.
+description: |
+  The National Council (Conseil National) is the unicameral legislature of the Principality
+  of Monaco. Its 24 members are directly elected for a five-year term. The current
+  legislature covers 2023–2028.
+
+  This dataset records each member of the current National Council by name, from the
+  Council's official website.
+url: https://www.conseil-national.mc/vos-elus/
+publisher:
+  name: Conseil National de Monaco
+  description: >
+    The National Council is the unicameral legislature of the Principality of Monaco.
+  url: https://www.conseil-national.mc/
+  country: mc
+  official: true
+data:
+  url: https://www.conseil-national.mc/wp-json/wp/v2/pages
+  format: JSON
+  lang: fra
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 18
+      Position: 1
+    country_entities:
+      mc: 18
+  max:
+    schema_entities:
+      Person: 30
+      Position: 1


### PR DESCRIPTION
Adds a PEP crawler for the **National Council (Conseil National)** of Monaco (unicameral, 24 seats).

## Source
Official site WordPress REST API (`conseil-national.mc/wp-json/wp/v2/pages`). The current legislature's member pages are children of the "Législature 2023-2028" page (`parent=13076`); the section page itself is skipped. Self-signed TLS is handled by zavod's fetch layer.

## Output
- Position: *Member of the National Council of Monaco* (`Q21328626`)
- 24 members emitted as PEPs, keyed on the WordPress slug.
- Citizenship `mc` per Constitution Art. 54 (Monegasque ≥5 years) (see code comment).

Closes opensanctions/crawler-planning#705

🤖 Generated with [Claude Code](https://claude.com/claude-code)