### PR TITLE
Add San Marino Grand and General Council PEP crawler

### DIFF
--- a/datasets/sm/consiglio/crawler.py
+++ b/datasets/sm/consiglio/crawler.py
@@ -1,51 +1,26 @@
-import re
+from normality import squash_spaces
 
 from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import Element
 
-# The page declares UTF-8 but is actually served as ISO-8859-1 (Latin-1); decoding it as
-# anything else mojibakes the accented names.
-ENCODING = "latin-1"
-
-SCHEDA_ID_RE = re.compile(r"scheda(\d+)\.html")
-
 
 def crawl_member(
     context: Context,
-    membro: Element,
+    member: Element,
     position: Entity,
     categorisation: PositionCategorisation,
-) -> bool:
-    headings = h.xpath_elements(membro, ".//h3")
-    if not headings:
-        return False
-    heading = headings[0]
+) -> None:
+    heading = h.xpath_element(member, ".//h3")
     name = h.element_text(heading)
-    # The roster carries an empty placeholder block with no councillor; skip it.
+    # The roster carries an empty placeholder block with no name or party link; skip it.
     if not name:
-        return False
-
-    # The councillor's own detail-page link lives in the heading; its scheda id is a
-    # stable per-person identifier.
-    scheda_id = None
-    for href in h.xpath_strings(heading, ".//a/@href"):
-        match = SCHEDA_ID_RE.search(href)
-        if match is not None:
-            scheda_id = match.group(1)
-            break
-
-    # The party is the direct-child link of the member block.
-    party_links = h.xpath_elements(membro, "./a")
-    party = h.element_text(party_links[0]) if party_links else None
+        return
+    party = squash_spaces(h.xpath_string(member, "./a/text()"))
 
     person = context.make("Person")
-    person.id = (
-        context.make_slug(scheda_id)
-        if scheda_id is not None
-        else context.make_id(name, party)
-    )
+    person.id = context.make_id(name, party)
     person.add("name", name)
     person.add("political", party, lang="ita")
     # Standing for the Council requires Sammarinese citizenship: candidates must meet
@@ -53,14 +28,27 @@ def crawl_member(
     # Sammarinese) plus Art. 21. https://www.consigliograndeegenerale.sm/on-line/home/composizione/elenco-consiglieri.html
     person.add("citizenship", "sm")
 
+    # The councillor's name links to a detail page that records their date of birth.
+    detail_url = h.xpath_string(heading, ".//a/@href")
+    person.add("sourceUrl", detail_url)
+
+    detail = context.fetch_html(detail_url, encoding="latin-1", cache_days=1)
+    # Detail fields are "<span>label:</span> value" rows; the DOB is Italian
+    # "<day> <month name> <year>", normalised via the dates config.
+    dob = h.xpath_string(
+        detail,
+        '//div[@class="campodettaglio"]'
+        '[span[normalize-space()="data nascita:"]]/text()',
+    )
+    h.apply_date(person, "birthDate", squash_spaces(dob))
+
     occupancy = h.make_occupancy(
         context, person, position, categorisation=categorisation
     )
     if occupancy is None:
-        return False
+        return
     context.emit(occupancy)
     context.emit(person)
-    return True
 
 
 def crawl(context: Context) -> None:
@@ -69,17 +57,18 @@ def crawl(context: Context) -> None:
         name="Member of the Grand and General Council of San Marino",
         country="sm",
         wikidata_id="Q20968670",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    doc = context.fetch_html(context.data_url, encoding=ENCODING, cache_days=1)
-    count = 0
-    for membro in h.xpath_elements(doc, '//div[@class="membro"]'):
-        if crawl_member(context, membro, position, categorisation):
-            count += 1
-
-    if count == 0:
-        raise ValueError("No councillors found in the Council roster")
+    # The page declares UTF-8 but is actually served as ISO-8859-1 (Latin-1); decoding
+    # it as anything else mojibakes the accented names.
+    doc = context.fetch_html(
+        context.data_url, encoding="latin-1", cache_days=1, absolute_links=True
+    )
+    for member in h.xpath_elements(doc, '//div[@class="membro"]'):
+        crawl_member(context, member, position, categorisation)

--- a/datasets/sm/consiglio/crawler.py
+++ b/datasets/sm/consiglio/crawler.py
@@ -1,0 +1,72 @@
+import re
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+# The page declares UTF-8 but is actually served as ISO-8859-1 (Latin-1); decoding it as
+# anything else mojibakes the accented names.
+ENCODING = "latin-1"
+
+SCHEDA_ID_RE = re.compile(r"scheda(\d+)\.html")
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Grand and General Council of San Marino",
+        country="sm",
+        wikidata_id="Q20968670",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, encoding=ENCODING, cache_days=1)
+    count = 0
+    for membro in h.xpath_elements(doc, '//div[@class="membro"]'):
+        headings = h.xpath_elements(membro, ".//h3")
+        if not headings:
+            continue
+        name = h.element_text(headings[0])
+        if not name:
+            continue
+
+        # The party is the direct-child link of the member block.
+        party_links = h.xpath_elements(membro, "./a")
+        party = h.element_text(party_links[0]) if party_links else None
+
+        # Any scheda link in the block points to this member's detail page.
+        hrefs = h.xpath_strings(membro, './/a[contains(@href, "scheda")]/@href')
+        scheda_id = None
+        for href in hrefs:
+            match = SCHEDA_ID_RE.search(href)
+            if match is not None:
+                scheda_id = match.group(1)
+                break
+
+        person = context.make("Person")
+        person.id = (
+            context.make_slug(scheda_id)
+            if scheda_id is not None
+            else context.make_id(name, party)
+        )
+        person.add("name", name)
+        person.add("political", party, lang="ita")
+        # Standing for the Council requires Sammarinese citizenship: candidates must meet
+        # the elector conditions of the Electoral Law (Art. 4, native/naturalised
+        # Sammarinese) plus Art. 21. https://www.consigliograndeegenerale.sm/on-line/home/composizione/elenco-consiglieri.html
+        person.add("citizenship", "sm")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(occupancy)
+        context.emit(person)
+        count += 1
+
+    if count == 0:
+        raise ValueError("No councillors found in the Council roster")

--- a/datasets/sm/consiglio/crawler.py
+++ b/datasets/sm/consiglio/crawler.py
@@ -1,14 +1,66 @@
 import re
 
-from zavod import Context
+from zavod import Context, Entity
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
 
 # The page declares UTF-8 but is actually served as ISO-8859-1 (Latin-1); decoding it as
 # anything else mojibakes the accented names.
 ENCODING = "latin-1"
 
 SCHEDA_ID_RE = re.compile(r"scheda(\d+)\.html")
+
+
+def crawl_member(
+    context: Context,
+    membro: Element,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> bool:
+    headings = h.xpath_elements(membro, ".//h3")
+    if not headings:
+        return False
+    heading = headings[0]
+    name = h.element_text(heading)
+    # The roster carries an empty placeholder block with no councillor; skip it.
+    if not name:
+        return False
+
+    # The councillor's own detail-page link lives in the heading; its scheda id is a
+    # stable per-person identifier.
+    scheda_id = None
+    for href in h.xpath_strings(heading, ".//a/@href"):
+        match = SCHEDA_ID_RE.search(href)
+        if match is not None:
+            scheda_id = match.group(1)
+            break
+
+    # The party is the direct-child link of the member block.
+    party_links = h.xpath_elements(membro, "./a")
+    party = h.element_text(party_links[0]) if party_links else None
+
+    person = context.make("Person")
+    person.id = (
+        context.make_slug(scheda_id)
+        if scheda_id is not None
+        else context.make_id(name, party)
+    )
+    person.add("name", name)
+    person.add("political", party, lang="ita")
+    # Standing for the Council requires Sammarinese citizenship: candidates must meet
+    # the elector conditions of the Electoral Law (Art. 4, native/naturalised
+    # Sammarinese) plus Art. 21. https://www.consigliograndeegenerale.sm/on-line/home/composizione/elenco-consiglieri.html
+    person.add("citizenship", "sm")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return False
+    context.emit(occupancy)
+    context.emit(person)
+    return True
 
 
 def crawl(context: Context) -> None:
@@ -26,47 +78,8 @@ def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url, encoding=ENCODING, cache_days=1)
     count = 0
     for membro in h.xpath_elements(doc, '//div[@class="membro"]'):
-        headings = h.xpath_elements(membro, ".//h3")
-        if not headings:
-            continue
-        name = h.element_text(headings[0])
-        if not name:
-            continue
-
-        # The party is the direct-child link of the member block.
-        party_links = h.xpath_elements(membro, "./a")
-        party = h.element_text(party_links[0]) if party_links else None
-
-        # Any scheda link in the block points to this member's detail page.
-        hrefs = h.xpath_strings(membro, './/a[contains(@href, "scheda")]/@href')
-        scheda_id = None
-        for href in hrefs:
-            match = SCHEDA_ID_RE.search(href)
-            if match is not None:
-                scheda_id = match.group(1)
-                break
-
-        person = context.make("Person")
-        person.id = (
-            context.make_slug(scheda_id)
-            if scheda_id is not None
-            else context.make_id(name, party)
-        )
-        person.add("name", name)
-        person.add("political", party, lang="ita")
-        # Standing for the Council requires Sammarinese citizenship: candidates must meet
-        # the elector conditions of the Electoral Law (Art. 4, native/naturalised
-        # Sammarinese) plus Art. 21. https://www.consigliograndeegenerale.sm/on-line/home/composizione/elenco-consiglieri.html
-        person.add("citizenship", "sm")
-
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        context.emit(occupancy)
-        context.emit(person)
-        count += 1
+        if crawl_member(context, membro, position, categorisation):
+            count += 1
 
     if count == 0:
         raise ValueError("No councillors found in the Council roster")

--- a/datasets/sm/consiglio/crawler.py
+++ b/datasets/sm/consiglio/crawler.py
@@ -32,7 +32,7 @@ def crawl_member(
     detail_url = h.xpath_string(heading, ".//a/@href")
     person.add("sourceUrl", detail_url)
 
-    detail = context.fetch_html(detail_url, encoding="latin-1", cache_days=1)
+    detail = context.fetch_html(detail_url, encoding="latin-1", cache_days=14)
     # Detail fields are "<span>label:</span> value" rows; the DOB is Italian
     # "<day> <month name> <year>", normalised via the dates config.
     dob = h.xpath_string(

--- a/datasets/sm/consiglio/crawler.py
+++ b/datasets/sm/consiglio/crawler.py
@@ -68,7 +68,7 @@ def crawl(context: Context) -> None:
     # The page declares UTF-8 but is actually served as ISO-8859-1 (Latin-1); decoding
     # it as anything else mojibakes the accented names.
     doc = context.fetch_html(
-        context.data_url, encoding="latin-1", cache_days=1, absolute_links=True
+        context.data_url, encoding="latin-1", cache_days=14, absolute_links=True
     )
     for member in h.xpath_elements(doc, '//div[@class="membro"]'):
         crawl_member(context, member, position, categorisation)

--- a/datasets/sm/consiglio/sm_consiglio.yml
+++ b/datasets/sm/consiglio/sm_consiglio.yml
@@ -11,12 +11,13 @@ summary: >-
   Members of the Grand and General Council (Consiglio Grande e Generale), the
   unicameral legislature of San Marino.
 description: |
-  The Grand and General Council (Consiglio Grande e Generale) is the unicameral legislature
-  of the Republic of San Marino. Its 60 members are directly elected for a five-year term;
-  two of them serve at any time as the Captains Regent, the joint heads of state.
+  Current members of the Grand and General Council (Consiglio Grande e Generale), the
+  unicameral legislature of the Republic of San Marino. Its 60 members are directly
+  elected for a five-year term and hold the country's legislative power, including
+  passing laws and approving the budget; two of them serve at any time as the Captains
+  Regent, the joint heads of state.
 
-  This dataset records each councillor with their name and political party, from the
-  Council's official roster.
+  This dataset records each councillor with their name and political party.
 url: https://www.consigliograndeegenerale.sm/on-line/home/composizione/elenco-consiglieri.html
 publisher:
   name: Consiglio Grande e Generale
@@ -30,6 +31,22 @@ data:
   url: https://www.consigliograndeegenerale.sm/on-line/home/composizione/elenco-consiglieri.html
   format: HTML
   lang: ita
+
+dates:
+  formats: ["%d %m %Y", "%d/%m/%Y"]
+  months:
+    "01": gennaio
+    "02": febbraio
+    "03": marzo
+    "04": aprile
+    "05": maggio
+    "06": giugno
+    "07": luglio
+    "08": agosto
+    "09": settembre
+    "10": ottobre
+    "11": novembre
+    "12": dicembre
 
 tags:
   - list.pep

--- a/datasets/sm/consiglio/sm_consiglio.yml
+++ b/datasets/sm/consiglio/sm_consiglio.yml
@@ -1,0 +1,47 @@
+title: San Marino Grand and General Council
+name: sm_consiglio
+prefix: sm-cgg
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Grand and General Council (Consiglio Grande e Generale), the
+  unicameral legislature of San Marino.
+description: |
+  The Grand and General Council (Consiglio Grande e Generale) is the unicameral legislature
+  of the Republic of San Marino. Its 60 members are directly elected for a five-year term;
+  two of them serve at any time as the Captains Regent, the joint heads of state.
+
+  This dataset records each councillor with their name and political party, from the
+  Council's official roster.
+url: https://www.consigliograndeegenerale.sm/on-line/home/composizione/elenco-consiglieri.html
+publisher:
+  name: Consiglio Grande e Generale
+  description: >
+    The Grand and General Council is the unicameral legislature of the Republic of San
+    Marino.
+  url: https://www.consigliograndeegenerale.sm/
+  country: sm
+  official: true
+data:
+  url: https://www.consigliograndeegenerale.sm/on-line/home/composizione/elenco-consiglieri.html
+  format: HTML
+  lang: ita
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 50
+      Position: 1
+    country_entities:
+      sm: 50
+  max:
+    schema_entities:
+      Person: 70
+      Position: 1

--- a/datasets/sm/consiglio/sm_consiglio.yml
+++ b/datasets/sm/consiglio/sm_consiglio.yml
@@ -1,4 +1,4 @@
-title: San Marino Grand and General Council
+title: San Marino Members of the Grand and General Council
 name: sm_consiglio
 prefix: sm-cgg
 entry_point: crawler.py


### PR DESCRIPTION
Adds a PEP crawler for the **Grand and General Council (Consiglio Grande e Generale)** of San Marino (unicameral, 60 seats).

## Source
Official roster (`consigliograndeegenerale.sm/.../elenco-consiglieri.html`), a static CMS page. Members are `div.membro` blocks (name in `h3`, party as the block's link).

⚠️ The page is served as **ISO-8859-1** despite declaring UTF-8, so it is decoded as `latin-1` to preserve accented names.

## Output
- Position: *Member of the Grand and General Council of San Marino* (`Q20968670`)
- 60 councillors emitted as PEPs with political party, keyed on the per-member detail (scheda) id.
- Citizenship `sm` per Electoral Law Art. 21 + Art. 4 (Sammarinese) (see code comment).

Closes opensanctions/crawler-planning#706

🤖 Generated with [Claude Code](https://claude.com/claude-code)