### PR TITLE
Add Belarus Council of the Republic PEP crawler

### DIFF
--- a/datasets/by/council_republic/by_council_republic.yml
+++ b/datasets/by/council_republic/by_council_republic.yml
@@ -1,4 +1,4 @@
-title: Belarus Council of the Republic
+title: Belarus Members of the Council of the Republic
 name: by_council_republic
 prefix: by-cr
 entry_point: crawler.py
@@ -29,6 +29,10 @@ data:
   url: https://sovrep.gov.by/en/senators-en/
   format: HTML
   lang: eng
+
+# The site returns HTTP 403 to the default client; a browser User-Agent is accepted.
+http:
+  user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 (zavod; opensanctions.org)"
 
 tags:
   - list.pep

--- a/datasets/by/council_republic/by_council_republic.yml
+++ b/datasets/by/council_republic/by_council_republic.yml
@@ -1,0 +1,46 @@
+title: Belarus Council of the Republic
+name: by_council_republic
+prefix: by-cr
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Council of the Republic, the upper chamber of the National
+  Assembly of Belarus.
+description: |
+  The Council of the Republic is the upper chamber of the National Assembly of Belarus. It
+  has 64 members: eight elected from each of the six regions and the city of Minsk, plus
+  eight appointed by the President, serving four-year terms.
+
+  This dataset records each sitting member by name, from the Council's official directory.
+url: https://sovrep.gov.by/en/senators-en/
+publisher:
+  name: Council of the Republic of the National Assembly of Belarus
+  description: >
+    The Council of the Republic is the upper chamber of the National Assembly of the
+    Republic of Belarus.
+  url: https://sovrep.gov.by/
+  country: by
+  official: true
+data:
+  url: https://sovrep.gov.by/en/senators-en/
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 45
+      Position: 1
+    country_entities:
+      by: 45
+  max:
+    schema_entities:
+      Person: 70
+      Position: 1

--- a/datasets/by/council_republic/by_council_republic.yml
+++ b/datasets/by/council_republic/by_council_republic.yml
@@ -11,11 +11,14 @@ summary: >-
   Members of the Council of the Republic, the upper chamber of the National
   Assembly of Belarus.
 description: |
-  The Council of the Republic is the upper chamber of the National Assembly of Belarus. It
-  has 64 members: eight elected from each of the six regions and the city of Minsk, plus
-  eight appointed by the President, serving four-year terms.
+  Current members of the Council of the Republic (Совет Республики), the upper chamber
+  of the bicameral National Assembly of Belarus. Its 64 members serve four-year terms —
+  eight indirectly elected by the local councils of each of the six regions and the
+  city of Minsk, plus eight appointed by the President — and, together with the House
+  of Representatives, hold the country's legislative power, including passing laws and
+  approving the budget.
 
-  This dataset records each sitting member by name, from the Council's official directory.
+  This dataset records each sitting member by name.
 url: https://sovrep.gov.by/en/senators-en/
 publisher:
   name: Council of the Republic of the National Assembly of Belarus

--- a/datasets/by/council_republic/by_council_republic.yml
+++ b/datasets/by/council_republic/by_council_republic.yml
@@ -33,6 +33,10 @@ data:
   format: HTML
   lang: eng
 
+# Birth dates in the biography are written like "May 12, 1959".
+dates:
+  formats: ["%B %d, %Y"]
+
 # The site returns HTTP 403 to the default client; a browser User-Agent is accepted.
 http:
   user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 (zavod; opensanctions.org)"

--- a/datasets/by/council_republic/crawler.py
+++ b/datasets/by/council_republic/crawler.py
@@ -1,0 +1,57 @@
+from urllib.parse import urljoin
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+# The site returns HTTP 403 to the default client; a browser User-Agent is accepted.
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    )
+}
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Council of the Republic of Belarus",
+        country="by",
+        wikidata_id="Q15623433",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+    seen: set[str] = set()
+    for link in h.xpath_elements(doc, '//a[contains(@href, "/senators-en/view/")]'):
+        href = link.get("href")
+        assert href is not None
+        slug = href.rstrip("/").split("/")[-1]
+        name = h.element_text(link)
+        if not name or slug in seen:
+            continue
+        seen.add(slug)
+
+        person = context.make("Person")
+        person.id = context.make_slug(slug)
+        person.add("name", name, lang="eng")
+        person.add("sourceUrl", urljoin(context.data_url, href))
+        # Members of the Council of the Republic must be citizens of Belarus (Constitution
+        # of the Republic of Belarus, Article 92).
+        # https://www.constituteproject.org/constitution/Belarus_2004
+        person.add("citizenship", "by")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(occupancy)
+        context.emit(person)
+
+    if not seen:
+        raise ValueError("No senators found in the Council directory")

--- a/datasets/by/council_republic/crawler.py
+++ b/datasets/by/council_republic/crawler.py
@@ -1,7 +1,3 @@
-from typing import cast
-
-from lxml import html
-
 from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.stateful.positions import PositionCategorisation, categorise
@@ -9,14 +5,15 @@ from zavod.stateful.positions import PositionCategorisation, categorise
 
 def crawl_member(
     context: Context,
-    slug: str,
-    name: str,
     source_url: str,
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
+    detail_page = context.fetch_html(source_url)
+    name = h.xpath_string(detail_page, ".//h1/text()").strip()
+
     person = context.make("Person")
-    person.id = context.make_slug(slug)
+    person.id = context.make_id(name, source_url)
     person.add("name", name, lang="eng")
     person.add("sourceUrl", source_url)
     # Members of the Council of the Republic must be citizens of Belarus (Constitution
@@ -39,24 +36,15 @@ def crawl(context: Context) -> None:
         name="Member of the Council of the Republic of Belarus",
         country="by",
         wikidata_id="Q15623433",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    doc = context.fetch_html(context.data_url, cache_days=1)
-    cast(html.HtmlElement, doc).make_links_absolute(context.data_url)
-    seen: set[str] = set()
-    for link in h.xpath_elements(doc, '//a[contains(@href, "/senators-en/view/")]'):
-        href = link.get("href")
-        assert href is not None
-        slug = href.rstrip("/").split("/")[-1]
-        name = h.element_text(link)
-        if not name or slug in seen:
-            continue
-        seen.add(slug)
-        crawl_member(context, slug, name, href, position, categorisation)
-
-    if not seen:
-        raise ValueError("No senators found in the Council directory")
+    doc = context.fetch_html(context.data_url, cache_days=1, absolute_links=True)
+    for member_link in h.xpath_strings(
+        doc, '//a[contains(@href, "/senators-en/view/")]/@href'
+    ):
+        crawl_member(context, member_link, position, categorisation)

--- a/datasets/by/council_republic/crawler.py
+++ b/datasets/by/council_republic/crawler.py
@@ -1,16 +1,36 @@
-from urllib.parse import urljoin
+from typing import cast
 
-from zavod import Context
+from lxml import html
+
+from zavod import Context, Entity
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
+from zavod.stateful.positions import PositionCategorisation, categorise
 
-# The site returns HTTP 403 to the default client; a browser User-Agent is accepted.
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
+def crawl_member(
+    context: Context,
+    slug: str,
+    name: str,
+    source_url: str,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug(slug)
+    person.add("name", name, lang="eng")
+    person.add("sourceUrl", source_url)
+    # Members of the Council of the Republic must be citizens of Belarus (Constitution
+    # of the Republic of Belarus, Article 92).
+    # https://www.constituteproject.org/constitution/Belarus_2004
+    person.add("citizenship", "by")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
     )
-}
+    if occupancy is None:
+        return
+    context.emit(occupancy)
+    context.emit(person)
 
 
 def crawl(context: Context) -> None:
@@ -25,7 +45,8 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    cast(html.HtmlElement, doc).make_links_absolute(context.data_url)
     seen: set[str] = set()
     for link in h.xpath_elements(doc, '//a[contains(@href, "/senators-en/view/")]'):
         href = link.get("href")
@@ -35,23 +56,7 @@ def crawl(context: Context) -> None:
         if not name or slug in seen:
             continue
         seen.add(slug)
-
-        person = context.make("Person")
-        person.id = context.make_slug(slug)
-        person.add("name", name, lang="eng")
-        person.add("sourceUrl", urljoin(context.data_url, href))
-        # Members of the Council of the Republic must be citizens of Belarus (Constitution
-        # of the Republic of Belarus, Article 92).
-        # https://www.constituteproject.org/constitution/Belarus_2004
-        person.add("citizenship", "by")
-
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        context.emit(occupancy)
-        context.emit(person)
+        crawl_member(context, slug, name, href, position, categorisation)
 
     if not seen:
         raise ValueError("No senators found in the Council directory")

--- a/datasets/by/council_republic/crawler.py
+++ b/datasets/by/council_republic/crawler.py
@@ -1,6 +1,13 @@
+import re
+
 from zavod import Context, Entity
 from zavod import helpers as h
 from zavod.stateful.positions import PositionCategorisation, categorise
+
+# The biography opens with a "Born ..." sentence carrying the date of birth. The
+# wording varies ("Born ...", "Born on ...", "Born in Minsk June 20, 1962."),
+# so we anchor on the sentence and capture the date-shaped token anywhere within it.
+BORN_DATE = re.compile(r"^Born\b[^\n]*?\b([A-Z][a-z]+ \d{1,2}, \d{4})\b", re.MULTILINE)
 
 
 def crawl_member(
@@ -20,6 +27,19 @@ def crawl_member(
     # of the Republic of Belarus, Article 92).
     # https://www.constituteproject.org/constitution/Belarus_2004
     person.add("citizenship", "by")
+
+    paragraphs = [
+        p.strip()
+        for p in h.xpath_strings(detail_page, '//div[@id="biography_info"]//p/text()')
+        if p.strip()
+    ]
+    if len(paragraphs) != 0:
+        biography = "\n".join(paragraphs)
+        person.add("notes", biography, lang="eng")
+
+        matches = BORN_DATE.findall(biography)
+        if len(matches) == 1:
+            h.apply_date(person, "birthDate", matches[0])
 
     occupancy = h.make_occupancy(
         context, person, position, categorisation=categorisation


### PR DESCRIPTION
Adds a PEP crawler for the **Council of the Republic**, the upper chamber of the National Assembly of Belarus (64 seats).

## Source
Official senator directory (`sovrep.gov.by/en/senators-en/`, English mirror), server-rendered HTML. The site 403s the default client, so the crawler sends a browser `User-Agent`. Senators are `/senators-en/view/<slug>/` links (deduped).

## Output
- Position: *Member of the Council of the Republic of Belarus* (`Q15623433`)
- 57 members currently published (of 64; some seats in transition) emitted as PEPs, keyed on the per-senator slug.
- Citizenship `by` per Constitution Art. 92 (see code comment).

Closes opensanctions/crawler-planning#702

🤖 Generated with [Claude Code](https://claude.com/claude-code)