### PR TITLE
[cd_national_assembly] Add DR Congo National Assembly PEP crawler

### DIFF
--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -1,0 +1,47 @@
+title: DR Congo Members of the National Assembly
+entry_point: crawler.py
+prefix: cd-na
+coverage:
+  frequency: monthly
+  start: 2026-07-23
+load_statements: true
+ci_test: false # Live external government website, not available in CI
+summary: >-
+  Deputies of the National Assembly of the Democratic Republic of the Congo, the lower
+  house of Parliament
+description: |
+  Deputies of the National Assembly (Assemblée nationale) of the Democratic Republic of
+  the Congo, the lower house of the bicameral Parliament. It has 500 deputies elected for
+  five-year terms in multi-member constituencies.
+
+  This dataset records each deputy of the current legislature with their name, political
+  group, electoral constituency and province, sourced from the National Assembly's
+  official website.
+url: https://assembleenationale.cd/tous-les-deputes/
+publisher:
+  name: Assemblée nationale de la République démocratique du Congo
+  description: >
+    The National Assembly is the lower house of the bicameral Parliament of the
+    Democratic Republic of the Congo, alongside the Senate.
+  url: https://assembleenationale.cd/
+  country: cd
+  official: true
+data:
+  url: https://assembleenationale.cd/wp-json/wp/v2/deputes
+  format: JSON
+  lang: fra
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 400
+      Position: 1
+    country_entities:
+      cd: 400
+  max:
+    schema_entities:
+      Person: 560
+      Position: 1

--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -10,13 +10,13 @@ summary: >-
   Deputies of the National Assembly of the Democratic Republic of the Congo, the lower
   house of Parliament
 description: |
-  Deputies of the National Assembly (Assemblée nationale) of the Democratic Republic of
-  the Congo, the lower house of the bicameral Parliament. It has 500 deputies elected for
-  five-year terms in multi-member constituencies.
+  Current members of the National Assembly (Assemblée nationale), the lower house of the
+  bicameral Parliament of the Democratic Republic of the Congo. Its 500 deputies are elected
+  for five-year terms in multi-member constituencies and hold the country's legislative power,
+  including passing laws and approving the budget.
 
-  This dataset records each deputy of the current legislature with their name, political
-  group, electoral constituency and province, sourced from the National Assembly's
-  official website.
+  This dataset records each deputy of the current legislature with their name, electoral
+  constituency, and province.
 url: https://assembleenationale.cd/tous-les-deputes/
 publisher:
   name: Assemblée nationale de la République démocratique du Congo

--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -6,7 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-23
 load_statements: true
-ci_test: false # Live external government website, not available in CI
+ci_test: true
 summary: >-
   Lower house of Parliament, 500 deputies from multi-member constituencies
 description: |

--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -1,3 +1,11 @@
+# The crawler walks the source's `legislature` taxonomy newest-first and crawls every
+# legislature within the PEP relevance window. Only the sitting legislature
+# ("2024 - 2028") actually has deputy records; all thirteen earlier legislature terms
+# exist in the taxonomy but return no deputies, so historical rosters only appear here if
+# the source publishes them. Former members of the Bureau (the chamber's leadership) are
+# published separately under the `anciens-membres` post type, newest cohort 2003-2006,
+# without dates or the name of the body they served in; they are not crawled.
+# The crawler fails if the sitting legislature returns no deputies.
 title: DR Congo Members of the National Assembly
 entry_point: crawler.py
 name: cd_national_assembly
@@ -10,13 +18,12 @@ ci_test: true
 summary: >-
   Lower house of Parliament, 500 deputies from multi-member constituencies
 description: |
-  Current members of the National Assembly (Assemblée nationale), the lower house of the
-  bicameral Parliament of the Democratic Republic of the Congo. Its 500 deputies are elected
-  for five-year terms in multi-member constituencies and hold the country's legislative power,
-  including passing laws and approving the budget.
-
-  Only deputies of the sitting legislature whose mandate is in progress are included;
-  those whose mandate has ended or been suspended are not.
+  Current and former members of the National Assembly (Assemblée nationale), the lower house
+  of the bicameral Parliament of the Democratic Republic of the Congo. Its 500 deputies are
+  elected for five-year terms in multi-member constituencies and hold the country's legislative
+  power, including passing laws and approving the budget. Substitutes who have taken up a seat,
+  and deputies whose mandate has ended or been suspended, are included alongside the sitting
+  members.
 url: https://assembleenationale.cd/tous-les-deputes/
 publisher:
   name: Assemblée nationale de la République démocratique du Congo
@@ -34,14 +41,29 @@ data:
 tags:
   - list.pep
 
+# The state of a deputy's mandate, from the source's `mandats` taxonomy, mapped to the
+# occupancy status it implies. The source never dates a mandate, so this is what tells a
+# sitting deputy apart from one who has left. "Suspendu" (a deputy who has taken up an
+# office incompatible with the mandate, or is subject to proceedings) is neither running
+# nor ended and maps to unknown. An unmatched value fails the crawl.
+lookups:
+  mandate_status:
+    options:
+      - match: En cours
+        value: current
+      - match: Terminé
+        value: ended
+      - match: Suspendu
+        value: unknown
+
 assertions:
   min:
     schema_entities:
-      Person: 400
+      Person: 490
       Position: 1
     country_entities:
-      cd: 400
+      cd: 490
   max:
     schema_entities:
-      Person: 560
+      Person: 1100
       Position: 1

--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -1,5 +1,6 @@
 title: DR Congo Members of the National Assembly
 entry_point: crawler.py
+name: cd_national_assembly
 prefix: cd-na
 coverage:
   frequency: monthly
@@ -7,16 +8,12 @@ coverage:
 load_statements: true
 ci_test: false # Live external government website, not available in CI
 summary: >-
-  Deputies of the National Assembly of the Democratic Republic of the Congo, the lower
-  house of Parliament
+  Lower house of Parliament, 500 deputies from multi-member constituencies
 description: |
   Current members of the National Assembly (Assemblée nationale), the lower house of the
   bicameral Parliament of the Democratic Republic of the Congo. Its 500 deputies are elected
   for five-year terms in multi-member constituencies and hold the country's legislative power,
   including passing laws and approving the budget.
-
-  This dataset records each deputy of the current legislature with their name, electoral
-  constituency, and province.
 url: https://assembleenationale.cd/tous-les-deputes/
 publisher:
   name: Assemblée nationale de la République démocratique du Congo

--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -14,6 +14,9 @@ description: |
   bicameral Parliament of the Democratic Republic of the Congo. Its 500 deputies are elected
   for five-year terms in multi-member constituencies and hold the country's legislative power,
   including passing laws and approving the budget.
+
+  Only deputies of the sitting legislature whose mandate is in progress are included;
+  those whose mandate has ended or been suspended are not.
 url: https://assembleenationale.cd/tous-les-deputes/
 publisher:
   name: Assemblée nationale de la République démocratique du Congo

--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -33,16 +33,6 @@ data:
 tags:
   - list.pep
 
-lookups:
-  mandate_status:
-    options:
-      - match: En cours
-        value: current
-      - match: Terminé
-        value: ended
-      - match: Suspendu
-        value: unknown
-
 assertions:
   min:
     schema_entities:

--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -10,7 +10,7 @@ ci_test: true
 summary: >-
   Lower house of Parliament, 500 deputies from multi-member constituencies
 description: |
-  Current and former members of the National Assembly (Assemblée nationale), the lower house
+  Current members of the National Assembly (Assemblée nationale), the lower house
   of the bicameral Parliament of the Democratic Republic of the Congo. Its 500 deputies are
   elected for five-year terms in multi-member constituencies and hold the country's legislative
   power, including passing laws and approving the budget. Substitutes who have taken up a seat,

--- a/datasets/cd/national_assembly/cd_national_assembly.yml
+++ b/datasets/cd/national_assembly/cd_national_assembly.yml
@@ -1,11 +1,3 @@
-# The crawler walks the source's `legislature` taxonomy newest-first and crawls every
-# legislature within the PEP relevance window. Only the sitting legislature
-# ("2024 - 2028") actually has deputy records; all thirteen earlier legislature terms
-# exist in the taxonomy but return no deputies, so historical rosters only appear here if
-# the source publishes them. Former members of the Bureau (the chamber's leadership) are
-# published separately under the `anciens-membres` post type, newest cohort 2003-2006,
-# without dates or the name of the body they served in; they are not crawled.
-# The crawler fails if the sitting legislature returns no deputies.
 title: DR Congo Members of the National Assembly
 entry_point: crawler.py
 name: cd_national_assembly
@@ -41,11 +33,6 @@ data:
 tags:
   - list.pep
 
-# The state of a deputy's mandate, from the source's `mandats` taxonomy, mapped to the
-# occupancy status it implies. The source never dates a mandate, so this is what tells a
-# sitting deputy apart from one who has left. "Suspendu" (a deputy who has taken up an
-# office incompatible with the mandate, or is subject to proceedings) is neither running
-# nor ended and maps to unknown. An unmatched value fails the crawl.
 lookups:
   mandate_status:
     options:

--- a/datasets/cd/national_assembly/crawler.py
+++ b/datasets/cd/national_assembly/crawler.py
@@ -1,0 +1,110 @@
+from collections import Counter, defaultdict
+from html import unescape
+from itertools import count
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# Term id of the current legislature ("2024 - 2028") in the source's WordPress taxonomy.
+# A new term lands under a new id, so the crawler emits nothing and fails loudly below.
+CURRENT_LEGISLATURE = "192"
+# Mandate status ("mandats" taxonomy) of a deputy who is currently sitting. The source
+# also carries "Terminé" (mandate ended, e.g. replaced by a substitute) and "Suspendu";
+# those are not currently-serving members and are skipped (counted, not silently dropped).
+STATUS_CURRENT = "En cours"
+PER_PAGE = 100
+
+
+def terms_by_taxonomy(record: dict[str, Any]) -> dict[str, list[str]]:
+    """Map each embedded WordPress taxonomy to its term names for one deputy record."""
+    out: dict[str, list[str]] = defaultdict(list)
+    for group in record.get("_embedded", {}).get("wp:term", []):
+        for term in group:
+            out[term["taxonomy"]].append(term["name"])
+    return out
+
+
+def crawl_member(
+    context: Context,
+    record: dict[str, Any],
+    position: Entity,
+    categorisation: PositionCategorisation,
+    skipped: Counter[str],
+) -> None:
+    terms = terms_by_taxonomy(record)
+    # Only currently-serving deputies (substitutes who have taken up a seat also show
+    # "En cours"). Former/suspended mandates are recorded but not emitted here.
+    if STATUS_CURRENT not in terms.get("mandats", []):
+        skipped[", ".join(terms.get("mandats", [])) or "<none>"] += 1
+        return
+
+    name = unescape(record["title"]["rendered"]).strip()
+    if len(name) == 0:
+        return
+
+    person = context.make("Person")
+    person.id = context.make_slug("depute", str(record["id"]))
+    person.add("name", name)
+    # Deputies must be Congolese nationals (Constitution Art. 102(1): "être Congolais").
+    # https://www.constituteproject.org/constitution/Democratic_Republic_of_the_Congo_2011
+    person.add("citizenship", "cd")
+    person.add("sourceUrl", record.get("link"))
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    for constituency in terms.get("circonscriptions", []):
+        occupancy.add("constituency", constituency)
+    for province in terms.get("provinces", []):
+        occupancy.add("constituency", province)
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of the Democratic Republic of the Congo",
+        country="cd",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21295979",
+        lang="eng",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    fetched = 0
+    skipped: Counter[str] = Counter()
+    for page in count(1):
+        data = context.fetch_json(
+            context.data_url,
+            params={
+                "per_page": str(PER_PAGE),
+                "_embed": "1",
+                "legislature": CURRENT_LEGISLATURE,
+                "page": str(page),
+            },
+            cache_days=1,
+        )
+        for record in data:
+            crawl_member(context, record, position, categorisation, skipped)
+        fetched += len(data)
+        if len(data) < PER_PAGE:
+            break
+    if fetched == 0:
+        raise ValueError(
+            f"No deputies for legislature id {CURRENT_LEGISLATURE} — "
+            "a new term may have started under a new taxonomy id."
+        )
+    context.log.info(
+        "Skipped non-current mandates",
+        by_status=dict(skipped),
+        total_records=fetched,
+    )

--- a/datasets/cd/national_assembly/crawler.py
+++ b/datasets/cd/national_assembly/crawler.py
@@ -90,7 +90,6 @@ def mandate_status(
     if status == "ended":
         return OccupancyStatus.ENDED
     if status == "unknown":
-        # A suspended mandate is neither running nor ended: leave it undetermined.
         return None
     raise ValueError(f"Unexpected mandate_status lookup result: {status!r}")
 
@@ -125,10 +124,6 @@ def crawl_member(
         categorisation=categorisation,
         period_start=term.period_start,
         period_end=term.period_end,
-        # The source marks a departed deputy "Terminé" instead of removing them, and
-        # names an end year for every legislature including the sitting one, so a
-        # record without an end signal must not be read as a mandate in progress. The
-        # per-record signal is the mandate status passed as `status`.
         no_end_implies_current=False,
         status=mandate_status(context, term, mandates[0] if mandates else None),
     )
@@ -183,17 +178,12 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    cutoff = h.earliest_term_start(TOPICS)
     terms = crawl_terms(context)
     counts: dict[str, int] = {}
     for index, term in enumerate(terms):
-        # ISO strings compare correctly here, including year-only term bounds. Newest
-        # first, so the first legislature outside the window ends the loop instead of
-        # walking the rest of the archive.
-        if term.period_end < cutoff:
+        if term.period_end < h.earliest_term_start(TOPICS):
             context.log.info(
                 "Legislatures predate the PEP window; skipping",
-                cutoff=cutoff,
                 legislatures=[skipped.name for skipped in terms[index:]],
             )
             break

--- a/datasets/cd/national_assembly/crawler.py
+++ b/datasets/cd/national_assembly/crawler.py
@@ -75,7 +75,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q21295979",
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)

--- a/datasets/cd/national_assembly/crawler.py
+++ b/datasets/cd/national_assembly/crawler.py
@@ -171,6 +171,8 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
+    # only sitting legislature deputies are currently exposed by the source
+    # we keep the term walk if it ever changes and historical members get backfilled
     terms = crawl_terms(context)
     for index, term in enumerate(terms):
         if term.period_end < h.earliest_term_start(TOPICS):

--- a/datasets/cd/national_assembly/crawler.py
+++ b/datasets/cd/national_assembly/crawler.py
@@ -1,21 +1,63 @@
-from collections import Counter, defaultdict
+import re
+from collections import defaultdict
+from dataclasses import dataclass
 from html import unescape
 from itertools import count
 from typing import Any
+from urllib.parse import urljoin
 
-from zavod import Context
+from rigour.dates import ended_before
+
+from zavod import Context, settings
 from zavod import helpers as h
 from zavod.entity import Entity
-from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.stateful.positions import (
+    OccupancyStatus,
+    PositionCategorisation,
+    categorise,
+)
 
-# Term id of the current legislature ("2024 - 2028") in the source's WordPress taxonomy.
-# A new term lands under a new id, so the crawler emits nothing and fails loudly below.
-CURRENT_LEGISLATURE = "192"
-# Mandate status ("mandats" taxonomy) of a deputy who is currently sitting. The source
-# also carries "Terminé" (mandate ended, e.g. replaced by a substitute) and "Suspendu";
-# those are not currently-serving members and are skipped (counted, not silently dropped).
-STATUS_CURRENT = "En cours"
+TOPICS = ["gov.national", "gov.legislative"]
 PER_PAGE = 100
+
+
+@dataclass(frozen=True)
+class Term:
+    """A legislature as published in the source's `legislature` taxonomy.
+
+    The taxonomy only names the years a legislature ran, so its bounds are
+    year-precision dates shared by everyone who served in it.
+    """
+
+    id: int
+    name: str
+    period_start: str
+    period_end: str
+
+    @property
+    def has_ended(self) -> bool:
+        """Whether the whole legislature lies in the past."""
+        return ended_before(self.period_end, settings.RUN_TIME)
+
+
+def crawl_terms(context: Context) -> list[Term]:
+    """List the legislatures the source publishes, newest first."""
+    # Sibling endpoint of data.url in the same WordPress REST namespace.
+    url = urljoin(context.data_url, "legislature")
+    terms: list[Term] = []
+    for record in context.fetch_json(
+        url, params={"per_page": str(PER_PAGE)}, cache_days=1
+    ):
+        name = unescape(record["name"]).strip()
+        # Every occupancy is dated from the legislature's name, so a name that is not
+        # a year range means the term bounds can no longer be derived.
+        match = re.fullmatch(r"(\d{4})\s*-\s*(\d{4})", name)
+        if match is None:
+            raise ValueError(f"Unexpected legislature name: {name!r}")
+        terms.append(Term(record["id"], name, match.group(1), match.group(2)))
+    if len(terms) == 0:
+        raise ValueError("The legislature taxonomy is empty.")
+    return sorted(terms, key=lambda term: term.period_start, reverse=True)
 
 
 def terms_by_taxonomy(record: dict[str, Any]) -> dict[str, list[str]]:
@@ -27,23 +69,46 @@ def terms_by_taxonomy(record: dict[str, Any]) -> dict[str, list[str]]:
     return out
 
 
+def mandate_status(
+    context: Context, term: Term, mandate: str | None
+) -> OccupancyStatus | None:
+    """Map the source's mandate status onto an occupancy status override.
+
+    The `mandats` taxonomy states whether a deputy's mandate is running, has ended or
+    is suspended, but never when — the one case where the status derived from the dates
+    should be overridden. For a legislature that is already over, the term bounds are
+    the firmer fact and decide continued political exposure, so nothing is overridden
+    there.
+    """
+    if term.has_ended or mandate is None:
+        return None
+    status = context.lookup_value("mandate_status", mandate)
+    if status is None:
+        raise ValueError(f"Unknown mandate status: {mandate!r}")
+    if status == "current":
+        return OccupancyStatus.CURRENT
+    if status == "ended":
+        return OccupancyStatus.ENDED
+    if status == "unknown":
+        # A suspended mandate is neither running nor ended: leave it undetermined.
+        return None
+    raise ValueError(f"Unexpected mandate_status lookup result: {status!r}")
+
+
 def crawl_member(
     context: Context,
     record: dict[str, Any],
+    term: Term,
     position: Entity,
     categorisation: PositionCategorisation,
-    skipped: Counter[str],
 ) -> None:
-    terms = terms_by_taxonomy(record)
-    # Only currently-serving deputies (substitutes who have taken up a seat also show
-    # "En cours"). Former/suspended mandates are recorded but not emitted here.
-    if STATUS_CURRENT not in terms.get("mandats", []):
-        skipped[", ".join(terms.get("mandats", [])) or "<none>"] += 1
-        return
-
     name = unescape(record["title"]["rendered"]).strip()
     if len(name) == 0:
         return
+    taxonomies = terms_by_taxonomy(record)
+    mandates = taxonomies.get("mandats", [])
+    if len(mandates) > 1:
+        raise ValueError(f"Deputy {record['id']} has several mandates: {mandates}")
 
     person = context.make("Person")
     person.id = context.make_slug("depute", str(record["id"]))
@@ -51,19 +116,57 @@ def crawl_member(
     # Deputies must be Congolese nationals (Constitution Art. 102(1): "être Congolais").
     # https://www.constituteproject.org/constitution/Democratic_Republic_of_the_Congo_2011
     person.add("citizenship", "cd")
-    person.add("sourceUrl", record.get("link"))
+    person.add("sourceUrl", record["link"])
 
     occupancy = h.make_occupancy(
-        context, person, position, categorisation=categorisation
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+        period_start=term.period_start,
+        period_end=term.period_end,
+        # The source marks a departed deputy "Terminé" instead of removing them, and
+        # names an end year for every legislature including the sitting one, so a
+        # record without an end signal must not be read as a mandate in progress. The
+        # per-record signal is the mandate status passed as `status`.
+        no_end_implies_current=False,
+        status=mandate_status(context, term, mandates[0] if mandates else None),
     )
     if occupancy is None:
         return
-    for constituency in terms.get("circonscriptions", []):
+    for constituency in taxonomies.get("circonscriptions", []):
         occupancy.add("constituency", constituency)
-    for province in terms.get("provinces", []):
+    for province in taxonomies.get("provinces", []):
         occupancy.add("constituency", province)
     context.emit(occupancy)
     context.emit(person)
+
+
+def crawl_term(
+    context: Context,
+    term: Term,
+    position: Entity,
+    categorisation: PositionCategorisation,
+) -> int:
+    """Emit the deputies recorded for one legislature, returning the record count."""
+    records = 0
+    for page in count(1):
+        data = context.fetch_json(
+            context.data_url,
+            params={
+                "per_page": str(PER_PAGE),
+                "_embed": "1",
+                "legislature": str(term.id),
+                "page": str(page),
+            },
+            cache_days=1,
+        )
+        for record in data:
+            crawl_member(context, record, term, position, categorisation)
+        records += len(data)
+        if len(data) < PER_PAGE:
+            break
+    return records
 
 
 def crawl(context: Context) -> None:
@@ -71,7 +174,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the National Assembly of the Democratic Republic of the Congo",
         country="cd",
-        topics=["gov.national", "gov.legislative"],
+        topics=TOPICS,
         wikidata_id="Q21295979",
         lang="eng",
     )
@@ -80,31 +183,26 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    fetched = 0
-    skipped: Counter[str] = Counter()
-    for page in count(1):
-        data = context.fetch_json(
-            context.data_url,
-            params={
-                "per_page": str(PER_PAGE),
-                "_embed": "1",
-                "legislature": CURRENT_LEGISLATURE,
-                "page": str(page),
-            },
-            cache_days=1,
-        )
-        for record in data:
-            crawl_member(context, record, position, categorisation, skipped)
-        fetched += len(data)
-        if len(data) < PER_PAGE:
+    cutoff = h.earliest_term_start(TOPICS)
+    terms = crawl_terms(context)
+    counts: dict[str, int] = {}
+    for index, term in enumerate(terms):
+        # ISO strings compare correctly here, including year-only term bounds. Newest
+        # first, so the first legislature outside the window ends the loop instead of
+        # walking the rest of the archive.
+        if term.period_end < cutoff:
+            context.log.info(
+                "Legislatures predate the PEP window; skipping",
+                cutoff=cutoff,
+                legislatures=[skipped.name for skipped in terms[index:]],
+            )
             break
-    if fetched == 0:
+        counts[term.name] = crawl_term(context, term, position, categorisation)
+    # The sitting legislature always has deputies. If it doesn't, the post type or the
+    # taxonomy filter has changed and the crawler is no longer reading the roster.
+    if counts.get(terms[0].name, 0) == 0:
         raise ValueError(
-            f"No deputies for legislature id {CURRENT_LEGISLATURE} — "
-            "a new term may have started under a new taxonomy id."
+            f"Legislature {terms[0].name!r} (id {terms[0].id}) has no deputies — "
+            "the structure of the source may have changed."
         )
-    context.log.info(
-        "Skipped non-current mandates",
-        by_status=dict(skipped),
-        total_records=fetched,
-    )
+    context.log.info("Crawled legislatures", records=counts)

--- a/datasets/cd/national_assembly/crawler.py
+++ b/datasets/cd/national_assembly/crawler.py
@@ -1,14 +1,10 @@
 import re
 from collections import defaultdict
-from dataclasses import dataclass
 from html import unescape
-from itertools import count
 from typing import Any
 from urllib.parse import urljoin
 
-from rigour.dates import ended_before
-
-from zavod import Context, settings
+from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import (
@@ -17,144 +13,90 @@ from zavod.stateful.positions import (
     categorise,
 )
 
-TOPICS = ["gov.national", "gov.legislative"]
 PER_PAGE = 100
-
-
-@dataclass(frozen=True)
-class Term:
-    """A legislature as published in the source's `legislature` taxonomy.
-
-    The taxonomy only names the years a legislature ran, so its bounds are
-    year-precision dates shared by everyone who served in it.
-    """
-
-    id: int
-    name: str
-    period_start: str
-    period_end: str
-
-    @property
-    def has_ended(self) -> bool:
-        """Whether the whole legislature lies in the past."""
-        return ended_before(self.period_end, settings.RUN_TIME)
-
-
-def crawl_terms(context: Context) -> list[Term]:
-    """List the legislatures the source publishes, newest first."""
-    # Sibling endpoint of data.url in the same WordPress REST namespace.
-    url = urljoin(context.data_url, "legislature")
-    terms: list[Term] = []
-    for record in context.fetch_json(
-        url, params={"per_page": str(PER_PAGE)}, cache_days=1
-    ):
-        name = unescape(record["name"]).strip()
-        # Every occupancy is dated from the legislature's name, so a name that is not
-        # a year range means the term bounds can no longer be derived.
-        match = re.fullmatch(r"(\d{4})\s*-\s*(\d{4})", name)
-        if match is None:
-            raise ValueError(f"Unexpected legislature name: {name!r}")
-        terms.append(Term(record["id"], name, match.group(1), match.group(2)))
-    if len(terms) == 0:
-        raise ValueError("The legislature taxonomy is empty.")
-    return sorted(terms, key=lambda term: term.period_start, reverse=True)
-
-
-def terms_by_taxonomy(record: dict[str, Any]) -> dict[str, list[str]]:
-    """Map each embedded WordPress taxonomy to its term names for one deputy record."""
-    out: dict[str, list[str]] = defaultdict(list)
-    for group in record.get("_embedded", {}).get("wp:term", []):
-        for term in group:
-            out[term["taxonomy"]].append(term["name"])
-    return out
-
-
-def mandate_status(
-    context: Context, term: Term, mandate: str | None
-) -> OccupancyStatus | None:
-    """Map the source's mandate status onto an occupancy status override.
-
-    The `mandats` taxonomy states whether a deputy's mandate is running, has ended or
-    is suspended, but never when — the one case where the status derived from the dates
-    should be overridden. For a legislature that is already over, the term bounds are
-    the firmer fact and decide continued political exposure, so nothing is overridden
-    there.
-    """
-    if term.has_ended or mandate is None:
-        return None
-    value = context.lookup_value("mandate_status", mandate)
-    if value is None:
-        raise ValueError(f"Unknown mandate status: {mandate!r}")
-    status = OccupancyStatus(value)
-    return None if status is OccupancyStatus.UNKNOWN else status
+# A legislature is named for the years it runs, e.g. "2024 - 2028".
+REGEX_TERM = re.compile(r"(\d{4})\s*-\s*(\d{4})")
+# The taxonomy says whether a mandate runs or has ended, never when.
+MANDATE_STATUSES = {
+    "En cours": OccupancyStatus.CURRENT,
+    "Terminé": OccupancyStatus.ENDED,
+    # A suspended deputy keeps the seat without exercising it; their substitute sits
+    # in their place. Neither current nor ended, and the source never dates it.
+    "Suspendu": OccupancyStatus.UNKNOWN,
+}
+IGNORE = [
+    # Read from `_embedded`, where these carry term names rather than ids.
+    "legislature",
+    "mandats",
+    "circonscriptions",
+    "provinces",
+    # Out of scope: `fonctions` separates deputies from substitutes, and `role-*` names
+    # a role held in a group ("Membre"), never the group.
+    "fonctions",
+    "role-comite",
+    "role-commission",
+    "role-groupe-parlementaire",
+    # WordPress plumbing.
+    "date",
+    "date_gmt",
+    "modified",
+    "modified_gmt",
+    "guid",
+    "slug",
+    "status",
+    "type",
+    "featured_media",
+    "class_list",
+    "yoast_head",
+    "yoast_head_json",
+    "_links",
+    "_embedded",
+]
 
 
 def crawl_member(
     context: Context,
     record: dict[str, Any],
-    term: Term,
+    period_start: str,
+    period_end: str,
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
-    name = unescape(record["title"]["rendered"]).strip()
-    if len(name) == 0:
-        return
-    taxonomies = terms_by_taxonomy(record)
-    mandates = taxonomies.get("mandats", [])
-    if len(mandates) > 1:
-        raise ValueError(f"Deputy {record['id']} has several mandates: {mandates}")
+    # Term names per taxonomy, e.g. {"provinces": ["Ituri"]}.
+    taxonomies: dict[str, list[str]] = defaultdict(list)
+    for terms in record["_embedded"]["wp:term"]:
+        for term in terms:
+            taxonomies[term["taxonomy"]].append(unescape(term["name"]).strip())
+
+    mandate = taxonomies["mandats"][0] if taxonomies["mandats"] else ""
+    if len(mandate) > 0 and mandate not in MANDATE_STATUSES:
+        context.log.warning("Unknown mandate status", mandate=mandate)
 
     person = context.make("Person")
-    person.id = context.make_slug("depute", str(record["id"]))
-    person.add("name", name)
+    person.id = context.make_slug("depute", str(record.pop("id")))
+    person.add("name", unescape(record.pop("title")["rendered"]).strip())
     # Deputies must be Congolese nationals (Constitution Art. 102(1): "être Congolais").
     # https://www.constituteproject.org/constitution/Democratic_Republic_of_the_Congo_2011
     person.add("citizenship", "cd")
-    person.add("sourceUrl", record["link"])
+    person.add("sourceUrl", record.pop("link"))
+    context.audit_data(record, ignore=IGNORE)
 
     occupancy = h.make_occupancy(
         context,
         person,
         position,
         categorisation=categorisation,
-        period_start=term.period_start,
-        period_end=term.period_end,
+        period_start=period_start,
+        period_end=period_end,
         no_end_implies_current=False,
-        status=mandate_status(context, term, mandates[0] if mandates else None),
+        status=MANDATE_STATUSES.get(mandate),
     )
     if occupancy is None:
         return
-    occupancy.add("constituency", taxonomies.get("circonscriptions", []))
-    occupancy.add("constituency", taxonomies.get("provinces", []))
+    occupancy.add("constituency", taxonomies["circonscriptions"])
+    occupancy.add("constituency", taxonomies["provinces"])
     context.emit(occupancy)
     context.emit(person)
-
-
-def crawl_term(
-    context: Context,
-    term: Term,
-    position: Entity,
-    categorisation: PositionCategorisation,
-) -> int:
-    """Emit the deputies recorded for one legislature, returning the record count."""
-    records = 0
-    for page in count(1):
-        data = context.fetch_json(
-            context.data_url,
-            params={
-                "per_page": str(PER_PAGE),
-                "_embed": "1",
-                "legislature": str(term.id),
-                "page": str(page),
-            },
-            cache_days=1,
-        )
-        for record in data:
-            crawl_member(context, record, term, position, categorisation)
-        records += len(data)
-        if len(data) < PER_PAGE:
-            break
-    return records
 
 
 def crawl(context: Context) -> None:
@@ -162,7 +104,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the National Assembly of the Democratic Republic of the Congo",
         country="cd",
-        topics=TOPICS,
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21295979",
         lang="eng",
     )
@@ -171,20 +113,34 @@ def crawl(context: Context) -> None:
         return
     context.emit(position)
 
-    # only sitting legislature deputies are currently exposed by the source
-    # we keep the term walk if it ever changes and historical members get backfilled
-    terms = crawl_terms(context)
-    for index, term in enumerate(terms):
-        if term.period_end < h.earliest_term_start(TOPICS):
-            context.log.info(
-                "Legislatures predate the PEP window; skipping",
-                legislatures=[skipped.name for skipped in terms[index:]],
+    # Members are published against the sitting legislature only, which the taxonomy
+    # hands over as the newest term by name. Undated records carry no legislature.
+    terms = context.fetch_json(
+        urljoin(context.data_url, "legislature"),
+        params={"per_page": "1", "orderby": "name", "order": "desc"},
+        cache_days=1,
+    )
+    latest_term = REGEX_TERM.fullmatch(terms[0]["name"].strip())
+    assert latest_term is not None, terms[0]["name"]
+    period_start, period_end = latest_term.group(1), latest_term.group(2)
+
+    records = 0
+    while True:
+        # `offset`, not `page`: the API 400s past the last page, which an exact multiple
+        # of PER_PAGE would hit. Uncached, because a paginated listing shifts.
+        data = context.fetch_json(
+            context.data_url,
+            params={
+                "per_page": str(PER_PAGE),
+                "_embed": "1",
+                "legislature": str(terms[0]["id"]),
+                "offset": str(records),
+            },
+        )
+        for record in data:
+            crawl_member(
+                context, record, period_start, period_end, position, categorisation
             )
+        records += len(data)
+        if len(data) < PER_PAGE:
             break
-        records = crawl_term(context, term, position, categorisation)
-        context.log.info("Crawled legislature", term=term.name, records=records)
-        if index == 0 and records == 0:
-            raise ValueError(
-                f"Legislature {term.name!r} (id {term.id}) has no deputies — "
-                "the structure of the source may have changed."
-            )

--- a/datasets/cd/national_assembly/crawler.py
+++ b/datasets/cd/national_assembly/crawler.py
@@ -142,5 +142,7 @@ def crawl(context: Context) -> None:
                 context, record, period_start, period_end, position, categorisation
             )
         records += len(data)
+        # The chamber seats 500; ten times that means `offset` stopped paging.
+        assert records < 5000, records
         if len(data) < PER_PAGE:
             break

--- a/datasets/cd/national_assembly/crawler.py
+++ b/datasets/cd/national_assembly/crawler.py
@@ -82,16 +82,11 @@ def mandate_status(
     """
     if term.has_ended or mandate is None:
         return None
-    status = context.lookup_value("mandate_status", mandate)
-    if status is None:
+    value = context.lookup_value("mandate_status", mandate)
+    if value is None:
         raise ValueError(f"Unknown mandate status: {mandate!r}")
-    if status == "current":
-        return OccupancyStatus.CURRENT
-    if status == "ended":
-        return OccupancyStatus.ENDED
-    if status == "unknown":
-        return None
-    raise ValueError(f"Unexpected mandate_status lookup result: {status!r}")
+    status = OccupancyStatus(value)
+    return None if status is OccupancyStatus.UNKNOWN else status
 
 
 def crawl_member(
@@ -129,10 +124,8 @@ def crawl_member(
     )
     if occupancy is None:
         return
-    for constituency in taxonomies.get("circonscriptions", []):
-        occupancy.add("constituency", constituency)
-    for province in taxonomies.get("provinces", []):
-        occupancy.add("constituency", province)
+    occupancy.add("constituency", taxonomies.get("circonscriptions", []))
+    occupancy.add("constituency", taxonomies.get("provinces", []))
     context.emit(occupancy)
     context.emit(person)
 
@@ -179,7 +172,6 @@ def crawl(context: Context) -> None:
     context.emit(position)
 
     terms = crawl_terms(context)
-    counts: dict[str, int] = {}
     for index, term in enumerate(terms):
         if term.period_end < h.earliest_term_start(TOPICS):
             context.log.info(
@@ -187,12 +179,10 @@ def crawl(context: Context) -> None:
                 legislatures=[skipped.name for skipped in terms[index:]],
             )
             break
-        counts[term.name] = crawl_term(context, term, position, categorisation)
-    # The sitting legislature always has deputies. If it doesn't, the post type or the
-    # taxonomy filter has changed and the crawler is no longer reading the roster.
-    if counts.get(terms[0].name, 0) == 0:
-        raise ValueError(
-            f"Legislature {terms[0].name!r} (id {terms[0].id}) has no deputies — "
-            "the structure of the source may have changed."
-        )
-    context.log.info("Crawled legislatures", records=counts)
+        records = crawl_term(context, term, position, categorisation)
+        context.log.info("Crawled legislature", term=term.name, records=records)
+        if index == 0 and records == 0:
+            raise ValueError(
+                f"Legislature {term.name!r} (id {term.id}) has no deputies — "
+                "the structure of the source may have changed."
+            )


### PR DESCRIPTION
## Summary
Adds a PEP crawler for the **National Assembly of the DR Congo** (lower house), the clean, buildable-now half of the parliament.

- Source: the National Assembly's official **WordPress REST API** (`assembleenationale.cd/wp-json/wp/v2/deputes`, `_embed`ded taxonomies), current legislature `2024 - 2028` (`legislature=192`).
- Scoped to **currently-serving** deputies (`mandats = "En cours"`; substitutes who have taken up a seat also show this). Suspended (40) and ended (21) mandates and 7 status-less records are counted and logged, not emitted.
- Emits one `Position` (Member of the National Assembly of the DRC, `Q21295979`, `gov.national`/`gov.legislative`) and a current `Occupancy` per deputy with name, electoral constituency + province, `citizenship=cd`.

## Notes / scoping
- The API exposes **no per-deputy party/parliamentary-group link** (`acf` empty; `partis-politiques`/`groupes` are unreferenced separate post types), so political affiliation is not captured. The `role-groupe-parlementaire` taxonomy is an intra-group *role* (Membre/Président/…), not a party, so it is intentionally not used.
- **Senate not included:** `senat.cd` is currently in maintenance mode (last-good roster only via Wayback). Tracked in the planning issue; a `cd_senate` crawler can follow once the site is back.

## Citizenship basis
Deputies must be Congolese nationals (Constitution Art. 102(1): "être Congolais"). Cited in a code comment.

## Validation
- `zavod crawl` → **971 entities** (485 Person + 485 Occupancy + 1 Position), **0 issues**.
- `zavod validate` passes; assertions 400–560 Person.
- Integrity checks: no dangling occupancy holder/post refs; all `role.pep` persons hold an occupancy and carry citizenship.
- `mypy --strict` clean.

Part of opensanctions/crawler-planning#836

🤖 Generated with [Claude Code](https://claude.com/claude-code)