### PR TITLE
[zavod] FIRDS: log when Issr LEI is the operator of the relevant trading venue

### DIFF
--- a/zavod/zavod/shed/firds.py
+++ b/zavod/zavod/shed/firds.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
+import csv
 import os
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Mapping, Tuple
 from lxml import etree
 from pathlib import Path
 from zipfile import ZipFile
@@ -13,9 +14,31 @@ from zavod import helpers as h
 
 REGEX_DATE = re.compile(r"_(20\d{6})_")
 NS = "{urn:iso:std:iso:20022:tech:xsd:auth.017.001.02}"
+# The ISO 10383 registry of Market Identifier Codes, which includes the LEI of
+# the operator of each market segment.
+MIC_REGISTRY_URL = (
+    "https://www.iso20022.org/sites/default/files/ISO10383_MIC/ISO10383_MIC.csv"
+)
 
 
-def parse_element(context: Context, file_name: str, elem: etree._Element) -> None:
+def load_lei_mics(context: Context) -> dict[str, set[str]]:
+    """Map market operator LEIs to the MICs they operate, per ISO 10383."""
+    path = context.fetch_resource("ISO10383_MIC.csv", MIC_REGISTRY_URL)
+    lei_mics: dict[str, set[str]] = defaultdict(set)
+    with open(path, encoding="utf-8-sig") as fh:
+        for row in csv.DictReader(fh):
+            lei = row["LEI"]
+            if lei != "":
+                lei_mics[lei].add(row["MIC"])
+    return dict(lei_mics)
+
+
+def parse_element(
+    context: Context,
+    file_name: str,
+    elem: etree._Element,
+    lei_mics: Mapping[str, set[str]],
+) -> None:
     attr = elem.find(f"./{NS}FinInstrmGnlAttrbts")
     if attr is None:
         return
@@ -37,6 +60,17 @@ def parse_element(context: Context, file_name: str, elem: etree._Element) -> Non
 
     lei = elem.findtext(f"./{NS}Issr")
     if lei is not None:
+        # The Issr field holds "the issuer or the operator of the trading
+        # venue". When its LEI belongs to the operator of the record's own
+        # relevant trading venue, it is likely not the actual issuer.
+        venue_mic = elem.findtext(f"./{NS}TechAttrbts/{NS}RlvntTradgVn")
+        if venue_mic is not None and venue_mic in lei_mics.get(lei, set()):
+            context.log.info(
+                "Issr LEI is the operator of the relevant trading venue",
+                isin=isin,
+                lei=lei,
+                mic=venue_mic,
+            )
         lei_id = f"lei-{lei}"
         issuer = context.make("Organization")
         issuer.id = lei_id
@@ -47,15 +81,18 @@ def parse_element(context: Context, file_name: str, elem: etree._Element) -> Non
     context.emit(security, origin=file_name)
 
 
-def parse_xml_doc(context: Context, file_name: str, path: str) -> None:
+def parse_xml_doc(
+    context: Context, file_name: str, path: str, lei_mics: Mapping[str, set[str]]
+) -> None:
     for _, elem in etree.iterparse(path, events=("end",), tag=f"{NS}RefData"):
-        parse_element(context, file_name, elem)
+        parse_element(context, file_name, elem, lei_mics)
         elem.clear()
         while elem.getprevious() is not None:
             del elem.getparent()[0]
 
 
 def parse_xml_file(context: Context, path: Path) -> None:
+    lei_mics = load_lei_mics(context)
     with TemporaryDirectory() as tmpdir:
         with ZipFile(path) as archive:
             for name in archive.namelist():
@@ -63,7 +100,7 @@ def parse_xml_file(context: Context, path: Path) -> None:
                     continue
                 tmpfile = archive.extract(name, path=tmpdir)
                 context.log.info("Reading XML file", path=tmpfile)
-                parse_xml_doc(context, name, tmpfile)
+                parse_xml_doc(context, name, tmpfile, lei_mics)
                 os.unlink(tmpfile)
 
 

--- a/zavod/zavod/tests/shed/test_firds.py
+++ b/zavod/zavod/tests/shed/test_firds.py
@@ -1,0 +1,80 @@
+from lxml import etree
+import requests_mock
+from structlog.testing import capture_logs
+
+from zavod.context import Context
+from zavod.meta import Dataset
+from zavod.shed.firds import MIC_REGISTRY_URL, load_lei_mics, parse_element
+
+MIC_CSV = (
+    '"MIC","OPERATING MIC","OPRT/SGMT","MARKET NAME-INSTITUTION DESCRIPTION",'
+    '"LEGAL ENTITY NAME","LEI","MARKET CATEGORY CODE","ACRONYM",'
+    '"ISO COUNTRY CODE (ISO 3166)","CITY","WEBSITE","STATUS","CREATION DATE",'
+    '"LAST UPDATE DATE","LAST VALIDATION DATE","EXPIRY DATE","COMMENTS"\r\n'
+    '"TPIR","TPIC","SGMT","TP ICAP EU - MTF - REGISTRATION","TP ICAP (EUROPE) SA",'
+    '"213800R54EFFINMY1P02","MLTF",,"FR","PARIS","WWW.TPICAP.COM","ACTIVE",'
+    '"20180924","20190225","","","MULTILATERAL TRADING FACILITY."\r\n'
+    '"TPIC","TPIC","OPRT","TP ICAP EU - MTF","TP ICAP (EUROPE) SA",'
+    '"213800R54EFFINMY1P02","MLTF",,"FR","PARIS","WWW.TPICAP.COM","ACTIVE",'
+    '"20180924","20190225","","",""\r\n'
+    '"XCNQ","XCNQ","OPRT","CANADIAN SECURITIES EXCHANGE","CNSX MARKETS, INC.",'
+    '"","RMKT","CSE LISTED","CA","TORONTO","WWW.THECSE.COM","ACTIVE",'
+    '"20090427","20210927","20210927","",""\r\n'
+)
+
+REF_DATA_XML = """
+<RefData xmlns="urn:iso:std:iso:20022:tech:xsd:auth.017.001.02">
+  <FinInstrmGnlAttrbts>
+    <Id>{isin}</Id>
+    <FullNm>Test Instrument</FullNm>
+    <ClssfctnTp>EDSXFR</ClssfctnTp>
+  </FinInstrmGnlAttrbts>
+  <Issr>{lei}</Issr>
+  <TechAttrbts>
+    <RlvntCmptntAuthrty>FR</RlvntCmptntAuthrty>
+    <RlvntTradgVn>{mic}</RlvntTradgVn>
+  </TechAttrbts>
+</RefData>
+"""
+
+
+def test_load_lei_mics(testdataset1: Dataset):
+    context = Context(testdataset1)
+    with requests_mock.Mocker() as m:
+        m.get(MIC_REGISTRY_URL, text=MIC_CSV)
+        lei_mics = load_lei_mics(context)
+    # Rows without an LEI are skipped, segment and operating MICs are grouped.
+    assert lei_mics == {"213800R54EFFINMY1P02": {"TPIR", "TPIC"}}
+    context.close()
+
+
+def test_parse_element_logs_venue_operator_issuer(testdataset1: Dataset):
+    context = Context(testdataset1)
+    lei_mics = {"213800R54EFFINMY1P02": {"TPIR", "TPIC"}}
+
+    # The Issr LEI operates the record's relevant trading venue:
+    elem = etree.fromstring(
+        REF_DATA_XML.format(isin="US3682872078", lei="213800R54EFFINMY1P02", mic="TPIR")
+    )
+    with capture_logs() as cap_logs:
+        parse_element(context, "test.xml", elem, lei_mics)
+    assert {
+        "event": "Issr LEI is the operator of the relevant trading venue",
+        "log_level": "info",
+        "isin": "US3682872078",
+        "lei": "213800R54EFFINMY1P02",
+        "mic": "TPIR",
+    } in cap_logs
+    # The issuer is still emitted and linked, not dropped:
+    assert context.stats.entities == 2
+
+    # An unrelated issuer LEI is not logged:
+    elem = etree.fromstring(
+        REF_DATA_XML.format(isin="GB00B71N6K86", lei="5493005B7DAN39RXLK23", mic="TPIR")
+    )
+    with capture_logs() as cap_logs:
+        parse_element(context, "test.xml", elem, lei_mics)
+    assert cap_logs == []
+    assert context.stats.entities == 4
+
+    context.close()


### PR DESCRIPTION
The FIRDS Issr field holds "the issuer or the operator of the trading venue". Cross-reference it against the ISO 10383 MIC registry to log records where the LEI belongs to the operator of the record's own relevant trading venue and is thus likely not the actual issuer, e.g. the PJSC Gazprom ADR US3682872078 reported with the LEI of TP ICAP (Europe) SA. The issuer reference is emitted unchanged for now.

Refs https://github.com/opensanctions/opensanctions/issues/4605