### PR TITLE
[zavod] Enricher: drop dangling references to unpublishable entities

### DIFF
--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -18,7 +18,12 @@ from zavod.context import Context
 from zavod.integration.dedupe import get_dataset_linker
 from zavod.entity import Entity
 from zavod.meta import Dataset, get_multi_dataset, get_catalog
-from zavod.runner.util import check_publishability, is_analyzer_stub, should_promote
+from zavod.runner.util import (
+    check_publishability,
+    is_analyzer_stub,
+    prune_unpublishable_references,
+    should_promote,
+)
 from zavod.store import get_store, View
 from zavod.reset import reset_caches
 
@@ -206,7 +211,10 @@ def save_match(
             # by the subject datasets and analyzers or being supporting schemata.
             publishable = check_publishability(expanded, subject_view, enrich_topics)
             for adj in expanded:
-                context.emit(adj, external=not should_promote(adj, publishable))
+                external = not should_promote(adj, publishable)
+                if not external:
+                    prune_unpublishable_references(context, adj, publishable)
+                context.emit(adj, external=external)
         else:
             for adj in expanded:
                 context.emit(adj, external=False)

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -20,6 +20,7 @@ from zavod.entity import Entity
 from zavod.meta import Dataset, get_multi_dataset, get_catalog
 from zavod.runner.util import (
     check_publishability,
+    emit_external_reference_stub,
     is_analyzer_stub,
     prune_unpublishable_references,
     should_promote,
@@ -214,17 +215,7 @@ def save_match(
                 external = not should_promote(adj, publishable)
                 if not external:
                     pruned = prune_unpublishable_references(context, adj, publishable)
-                    if pruned:
-                        # Keep the pruned references visible to the graph
-                        # analyzer via an external stub, so it can tag the
-                        # referenced entities and make them publishable on a
-                        # later run.
-                        assert adj.id is not None
-                        stub = context.make(adj.schema.name)
-                        stub.id = adj.id
-                        for prop, other_id in pruned:
-                            stub.add(prop, other_id)
-                        context.emit(stub, external=True)
+                    emit_external_reference_stub(context, adj, pruned)
                 context.emit(adj, external=external)
         else:
             for adj in expanded:

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -213,7 +213,18 @@ def save_match(
             for adj in expanded:
                 external = not should_promote(adj, publishable)
                 if not external:
-                    prune_unpublishable_references(context, adj, publishable)
+                    pruned = prune_unpublishable_references(context, adj, publishable)
+                    if pruned:
+                        # Keep the pruned references visible to the graph
+                        # analyzer via an external stub, so it can tag the
+                        # referenced entities and make them publishable on a
+                        # later run.
+                        assert adj.id is not None
+                        stub = context.make(adj.schema.name)
+                        stub.id = adj.id
+                        for prop, other_id in pruned:
+                            stub.add(prop, other_id)
+                        context.emit(stub, external=True)
                 context.emit(adj, external=external)
         else:
             for adj in expanded:

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -5,6 +5,7 @@ from followthemoney import registry
 from followthemoney.schema import Schema
 
 from zavod.constants import ANALYZER_DATASETS
+from zavod.context import Context
 from zavod.entity import Entity
 from zavod.store import View
 
@@ -101,3 +102,27 @@ def should_promote(entity: Entity, publishable: Mapping[str, bool]) -> bool:
         return all(publishable.get(eid, False) for eid in endpoints)
     assert entity.id is not None
     return publishable.get(entity.id, False)
+
+
+def prune_unpublishable_references(
+    context: Context, entity: Entity, publishable: Mapping[str, bool]
+) -> None:
+    """Drop references from a non-edge entity to entities that will not be
+    published (e.g. a security's issuer without a risk topic), so that the
+    published entity doesn't contain dangling references. Edges are only
+    published when all their endpoints are (see ``should_promote``), so they
+    are left untouched."""
+    if entity.schema.edge:
+        return
+    for prop in list(entity.iterprops()):
+        if prop.type != registry.entity:
+            continue
+        for other_id in entity.get(prop):
+            if not publishable.get(other_id, False):
+                entity.remove(prop, other_id)
+                context.log.info(
+                    "Removing reference to unpublishable entity",
+                    entity_id=entity.id,
+                    prop=prop.name,
+                    ref=other_id,
+                )

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -49,6 +49,10 @@ def endpoint_ids(entity: Entity) -> set[str]:
 
 
 def _is_publishable(entity_id: str, view: View, enrich_topics: frozenset[str]) -> bool:
+    """
+    Publishable means the (non-edge) entity has a risk topic or is a supporting schema,
+    and can therefore be emitted as 'internal' to be included in exports.
+    """
     canonical_id = view.store.linker.get_canonical(entity_id)
     entity = view.get_entity(canonical_id)
     if entity is None:
@@ -93,9 +97,10 @@ def check_publishability(
 
 
 def should_promote(entity: Entity, publishable: Mapping[str, bool]) -> bool:
-    """Publish non-edges iff the map says so (supporting schemata were seeded
-    True, risk targets need a topic) and edges iff every endpoint is itself
-    publishable."""
+    """Promote means emit as 'internal'.
+
+    Non-edges are promotable if they are publishable.
+    Edges are promotable iff each of its endpoints are publishable."""
     if entity.schema.edge:
         endpoints = endpoint_ids(entity)
         if not endpoints:
@@ -135,3 +140,20 @@ def prune_unpublishable_references(
                     ref=other_id,
                 )
     return pruned
+
+
+def emit_external_reference_stub(
+    context: Context, entity: Entity, pruned: list[tuple[Property, str]]
+) -> None:
+    """Re-emit references pruned from ``entity`` in an external stub, so the
+    graph analyzer (which reads the external view) can still discover the
+    relationship and tag the referenced entities, making them publishable on
+    a later run — while the exporter (internal view) doesn't see them."""
+    if not pruned:
+        return
+    assert entity.id is not None
+    stub = context.make(entity.schema.name)
+    stub.id = entity.id
+    for prop, other_id in pruned:
+        stub.add(prop, other_id)
+    context.emit(stub, external=True)

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -2,6 +2,7 @@ from functools import cache
 from collections.abc import Iterable, Mapping
 
 from followthemoney import registry
+from followthemoney.property import Property
 from followthemoney.schema import Schema
 
 from zavod.constants import ANALYZER_DATASETS
@@ -106,23 +107,31 @@ def should_promote(entity: Entity, publishable: Mapping[str, bool]) -> bool:
 
 def prune_unpublishable_references(
     context: Context, entity: Entity, publishable: Mapping[str, bool]
-) -> None:
+) -> list[tuple[Property, str]]:
     """Drop references from a non-edge entity to entities that will not be
     published (e.g. a security's issuer without a risk topic), so that the
     published entity doesn't contain dangling references. Edges are only
     published when all their endpoints are (see ``should_promote``), so they
-    are left untouched."""
+    are left untouched.
+
+    Returns the removed ``(prop, referenced_id)`` pairs so the caller can
+    re-emit them as external — keeping the relationship visible to the graph
+    analyzer (which reads the external view and may tag the referenced entity,
+    making it publishable on a later run) without the exporter seeing it."""
+    pruned: list[tuple[Property, str]] = []
     if entity.schema.edge:
-        return
+        return pruned
     for prop in list(entity.iterprops()):
         if prop.type != registry.entity:
             continue
         for other_id in entity.get(prop):
             if not publishable.get(other_id, False):
                 entity.remove(prop, other_id)
+                pruned.append((prop, other_id))
                 context.log.info(
-                    "Removing reference to unpublishable entity",
+                    "Demoting reference to unpublishable entity to external",
                     entity_id=entity.id,
                     prop=prop.name,
                     ref=other_id,
                 )
+    return pruned

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -1,5 +1,5 @@
 from functools import cache
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Set
 
 from followthemoney import registry
 from followthemoney.property import Property
@@ -65,12 +65,13 @@ def _is_publishable(entity_id: str, view: View, enrich_topics: frozenset[str]) -
 
 def check_publishability(
     expanded: Iterable[Entity], subject_view: View, enrich_topics: frozenset[str]
-) -> dict[str, bool]:
-    """Look up publishability once per entity ID that will need it.
+) -> set[str]:
+    """Look up publishability once per entity ID that will need it, returning
+    the set of publishable IDs.
 
     Non-edge supporting entities in the expansion are publishable by virtue of
     their schema, not due to risk topics, so they are seeded into the returned
-    map without a lookup in the subject view.
+    set without a lookup in the subject view.
 
     Non-supporting entities (the more common case - entities related via e.g.
     Ownership, Family) are looked up in the subject view where graph analyzer
@@ -79,7 +80,7 @@ def check_publishability(
     Edges (supporting and risk-connecting) are publishable if all their endpoints
     are publishable.
     """
-    publishable: dict[str, bool] = {}
+    publishable: set[str] = set()
     ids_to_check: set[str] = set()
     for entity in expanded:
         if entity.schema.edge:
@@ -87,16 +88,16 @@ def check_publishability(
         else:
             assert entity.id is not None
             if is_supporting_schema(entity.schema):
-                publishable[entity.id] = True
+                publishable.add(entity.id)
             else:
                 ids_to_check.add(entity.id)
     for eid in ids_to_check:
-        if eid not in publishable:
-            publishable[eid] = _is_publishable(eid, subject_view, enrich_topics)
+        if _is_publishable(eid, subject_view, enrich_topics):
+            publishable.add(eid)
     return publishable
 
 
-def should_promote(entity: Entity, publishable: Mapping[str, bool]) -> bool:
+def should_promote(entity: Entity, publishable: Set[str]) -> bool:
     """Promote means emit as 'internal'.
 
     Non-edges are promotable if they are publishable.
@@ -105,13 +106,13 @@ def should_promote(entity: Entity, publishable: Mapping[str, bool]) -> bool:
         endpoints = endpoint_ids(entity)
         if not endpoints:
             return False
-        return all(publishable.get(eid, False) for eid in endpoints)
+        return endpoints <= publishable
     assert entity.id is not None
-    return publishable.get(entity.id, False)
+    return entity.id in publishable
 
 
 def prune_unpublishable_references(
-    context: Context, entity: Entity, publishable: Mapping[str, bool]
+    context: Context, entity: Entity, publishable: Set[str]
 ) -> list[tuple[Property, str]]:
     """Drop references from a non-edge entity to entities that will not be
     published (e.g. a security's issuer without a risk topic), so that the
@@ -130,7 +131,7 @@ def prune_unpublishable_references(
         if prop.type != registry.entity:
             continue
         for other_id in entity.get(prop):
-            if not publishable.get(other_id, False):
+            if other_id not in publishable:
                 entity.remove(prop, other_id)
                 pruned.append((prop, other_id))
                 context.log.info(

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -263,7 +263,7 @@ def test_topic_gated_prunes_unpublishable_references(
     with capture_logs() as cap_logs:
         crawl_dataset(enricher_ds)
     assert {
-        "event": "Removing reference to unpublishable entity",
+        "event": "Demoting reference to unpublishable entity to external",
         "log_level": "info",
         "entity_id": "osv-isin-a",
         "prop": "issuer",
@@ -286,6 +286,12 @@ def test_topic_gated_prunes_unpublishable_references(
         # The issuer has no gating topic in the subject store → external only.
         assert view_internal.get_entity("osv-lei-a") is None
         assert view_all.get_entity("osv-lei-a") is not None
+
+        # The pruned reference is kept in an external stub so the graph
+        # analyzer can still discover the relationship and tag the issuer.
+        security_all = view_all.get_entity(canon_id)
+        assert security_all is not None
+        assert "osv-lei-a" in security_all.get("issuer")
         store.close()
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
 

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 
 import pytest
 from nomenklatura.judgement import Judgement
+from structlog.testing import capture_logs
 
 from zavod import settings
 from zavod.entity import Entity
@@ -226,6 +227,66 @@ def test_topic_gated_requires_topics(testdataset1: Dataset):
     enricher_ds = make_enricher_dataset(dataset_data, testdataset1.name)
     with pytest.raises(RunFailedException):
         crawl_dataset(enricher_ds)
+    shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
+
+
+def test_topic_gated_prunes_unpublishable_references(
+    testdataset_securities: Dataset, testdataset_enrich_subject: Dataset
+):
+    """A promoted entity referencing an entity that isn't published internally
+    (e.g. a security whose issuer has no risk topic) is emitted without that
+    reference, so the published dataset has no dangling references."""
+    clear_data_path(testdataset_enrich_subject.name)
+    crawl_dataset(testdataset_securities)  # enriching against this
+
+    # The subject store holds a security with a gating topic, but no issuer.
+    subject_security = {
+        "schema": "Security",
+        "id": "sub-isin-a",
+        "properties": {"name": ["AAA USD ISK"], "topics": ["reg.warn"]},
+    }
+    subject_ctx = Context(testdataset_enrich_subject)
+    subject_ctx.emit(Entity.from_data(testdataset_enrich_subject, subject_security))
+    subject_ctx.close()
+
+    # Confirm the match (committed on block exit, before the enrich crawl)
+    with make_session() as session:
+        resolver = get_resolver(session)
+        resolver.load_into_memory()
+        canon_id = resolver.decide("osv-isin-a", "sub-isin-a", Judgement.POSITIVE)
+
+    dataset_data = deepcopy(DATASET_DATA)
+    dataset_data["config"]["topic_gated"] = True
+    dataset_data["config"]["topics"] = ["reg.warn"]
+    enricher_ds = make_enricher_dataset(dataset_data, testdataset_securities.name)
+    clear_data_path(enricher_ds.name)
+    with capture_logs() as cap_logs:
+        crawl_dataset(enricher_ds)
+    assert {
+        "event": "Removing reference to unpublishable entity",
+        "log_level": "info",
+        "entity_id": "osv-isin-a",
+        "prop": "issuer",
+        "ref": "osv-lei-a",
+    } in cap_logs
+
+    with make_session() as session:
+        resolver = get_resolver(session)
+        resolver.load_into_memory()
+        store = get_store(enricher_ds, resolver)
+        store.sync(clear=True)
+        view_internal = store.view(enricher_ds, external=False)
+        view_all = store.view(enricher_ds, external=True)
+
+        # The matched security is published, without the dangling issuer ref.
+        security = view_internal.get_entity(canon_id)
+        assert security is not None
+        assert security.get("issuer") == [], security.get("issuer")
+
+        # The issuer has no gating topic in the subject store → external only.
+        assert view_internal.get_entity("osv-lei-a") is None
+        assert view_all.get_entity("osv-lei-a") is not None
+        store.close()
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
 
 

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -168,10 +168,12 @@ def test_prune_unpublishable_references(vcontext: Context) -> None:
     )
     publishable = {"sec": True, "pub": True, "unpub": False}
     with capture_logs() as cap_logs:
-        prune_unpublishable_references(vcontext, security, publishable)
+        pruned = prune_unpublishable_references(vcontext, security, publishable)
     assert security.get("issuer") == ["pub"]
+    # The removed pair is returned so the caller can re-emit it as external.
+    assert [(prop.name, ref) for prop, ref in pruned] == [("issuer", "unpub")]
     assert {
-        "event": "Removing reference to unpublishable entity",
+        "event": "Demoting reference to unpublishable entity to external",
         "log_level": "info",
         "entity_id": "sec",
         "prop": "issuer",
@@ -184,6 +186,7 @@ def test_prune_unpublishable_references(vcontext: Context) -> None:
         vcontext.dataset, "Ownership", "own", owner=["pub"], asset=["unpub"]
     )
     with capture_logs() as cap_logs:
-        prune_unpublishable_references(vcontext, ownership, publishable)
+        pruned = prune_unpublishable_references(vcontext, ownership, publishable)
+    assert pruned == []
     assert ownership.get("asset") == ["unpub"]
     assert cap_logs == []

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -1,11 +1,14 @@
 from followthemoney import model
+from structlog.testing import capture_logs
 
+from zavod.context import Context
 from zavod.entity import Entity
 from zavod.meta import Dataset
 from zavod.runner.util import (
     check_publishability,
     endpoint_ids,
     is_supporting_schema,
+    prune_unpublishable_references,
     should_promote,
 )
 
@@ -157,3 +160,30 @@ def test_check_publishability_missing_endpoint(testdataset1: Dataset) -> None:
     publishable = check_publishability([edge], view, ENRICH_TOPICS)
     assert publishable == {"tagged": True, "ghost": False}
     assert not should_promote(edge, publishable)
+
+
+def test_prune_unpublishable_references(vcontext: Context) -> None:
+    security = make(
+        vcontext.dataset, "Security", "sec", name=["AAA"], issuer=["pub", "unpub"]
+    )
+    publishable = {"sec": True, "pub": True, "unpub": False}
+    with capture_logs() as cap_logs:
+        prune_unpublishable_references(vcontext, security, publishable)
+    assert security.get("issuer") == ["pub"]
+    assert {
+        "event": "Removing reference to unpublishable entity",
+        "log_level": "info",
+        "entity_id": "sec",
+        "prop": "issuer",
+        "ref": "unpub",
+    } in cap_logs
+
+    # Edges are left untouched: promotion already guarantees their endpoints
+    # are publishable, and unpublishable edges aren't published at all.
+    ownership = make(
+        vcontext.dataset, "Ownership", "own", owner=["pub"], asset=["unpub"]
+    )
+    with capture_logs() as cap_logs:
+        prune_unpublishable_references(vcontext, ownership, publishable)
+    assert ownership.get("asset") == ["unpub"]
+    assert cap_logs == []

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -6,6 +6,7 @@ from zavod.entity import Entity
 from zavod.meta import Dataset
 from zavod.runner.util import (
     check_publishability,
+    emit_external_reference_stub,
     endpoint_ids,
     is_supporting_schema,
     prune_unpublishable_references,
@@ -190,3 +191,19 @@ def test_prune_unpublishable_references(vcontext: Context) -> None:
     assert pruned == []
     assert ownership.get("asset") == ["unpub"]
     assert cap_logs == []
+
+
+def test_emit_external_reference_stub(vcontext: Context) -> None:
+    security = make(
+        vcontext.dataset, "Security", "sec", name=["AAA"], issuer=["pub", "unpub"]
+    )
+    publishable = {"sec": True, "pub": True, "unpub": False}
+    pruned = prune_unpublishable_references(vcontext, security, publishable)
+
+    before = vcontext.stats.entities
+    emit_external_reference_stub(vcontext, security, pruned)
+    assert vcontext.stats.entities == before + 1
+
+    # Nothing pruned → nothing emitted.
+    emit_external_reference_stub(vcontext, security, [])
+    assert vcontext.stats.entities == before + 1

--- a/zavod/zavod/tests/enrich/test_util.py
+++ b/zavod/zavod/tests/enrich/test_util.py
@@ -87,29 +87,26 @@ def test_should_promote_non_edges(testdataset1: Dataset) -> None:
 
     # Risk targets publish iff their lookup found a matching topic.
     person = make(testdataset1, "Person", "per", name=["Jane"])
-    assert should_promote(person, {"per": True})
-    assert not should_promote(person, {"per": False})
-    assert not should_promote(person, {})
+    assert should_promote(person, {"per"})
+    assert not should_promote(person, set())
 
 
 def test_should_promote_edges(testdataset1: Dataset) -> None:
     ownership = make(testdataset1, "Ownership", "own", owner=["per"], asset=["com"])
-    assert should_promote(ownership, {"per": True, "com": True})
-    assert not should_promote(ownership, {"per": True, "com": False})
-    assert not should_promote(ownership, {"per": True})
+    assert should_promote(ownership, {"per", "com"})
+    assert not should_promote(ownership, {"per"})
 
     # An edge with no endpoint values never publishes.
     dangling = make(testdataset1, "Ownership", "own2", role=["shareholder"])
-    assert not should_promote(dangling, {})
+    assert not should_promote(dangling, set())
 
     # Documentation is an edge like any other: publishable iff its endpoints are,
     # regardless of it being an Interval subclass.
     documentation = make(
         testdataset1, "Documentation", "doc", entity=["per"], document=["art"]
     )
-    assert should_promote(documentation, {"per": True, "art": True})
-    assert not should_promote(documentation, {"per": True, "art": False})
-    assert not should_promote(documentation, {"per": True})
+    assert should_promote(documentation, {"per", "art"})
+    assert not should_promote(documentation, {"per"})
 
 
 def test_check_publishability(testdataset1: Dataset) -> None:
@@ -122,7 +119,7 @@ def test_check_publishability(testdataset1: Dataset) -> None:
     view = FakeView([tagged, untagged])
     expanded = [tagged, untagged, ownership]
     publishable = check_publishability(expanded, view, ENRICH_TOPICS)
-    assert publishable == {"tagged": True, "untagged": False}
+    assert publishable == {"tagged"}
 
     assert should_promote(tagged, publishable)
     assert not should_promote(untagged, publishable)
@@ -146,7 +143,7 @@ def test_check_publishability_supporting_absent_from_view(
     view = FakeView([tagged])
     expanded = [tagged, article, documentation]
     publishable = check_publishability(expanded, view, ENRICH_TOPICS)
-    assert publishable == {"tagged": True, "article": True}
+    assert publishable == {"tagged", "article"}
 
     assert should_promote(article, publishable)
     assert should_promote(documentation, publishable)
@@ -159,7 +156,7 @@ def test_check_publishability_missing_endpoint(testdataset1: Dataset) -> None:
     )
     view = FakeView([tagged])
     publishable = check_publishability([edge], view, ENRICH_TOPICS)
-    assert publishable == {"tagged": True, "ghost": False}
+    assert publishable == {"tagged"}
     assert not should_promote(edge, publishable)
 
 
@@ -167,7 +164,7 @@ def test_prune_unpublishable_references(vcontext: Context) -> None:
     security = make(
         vcontext.dataset, "Security", "sec", name=["AAA"], issuer=["pub", "unpub"]
     )
-    publishable = {"sec": True, "pub": True, "unpub": False}
+    publishable = {"sec", "pub"}
     with capture_logs() as cap_logs:
         pruned = prune_unpublishable_references(vcontext, security, publishable)
     assert security.get("issuer") == ["pub"]
@@ -197,7 +194,7 @@ def test_emit_external_reference_stub(vcontext: Context) -> None:
     security = make(
         vcontext.dataset, "Security", "sec", name=["AAA"], issuer=["pub", "unpub"]
     )
-    publishable = {"sec": True, "pub": True, "unpub": False}
+    publishable = {"sec", "pub"}
     pruned = prune_unpublishable_references(vcontext, security, publishable)
 
     before = vcontext.stats.entities


### PR DESCRIPTION
![Rube Goldberg machine](https://media.giphy.com/media/BM61CKd08ypJ6/giphy.gif)

*Visual representation of this fix*

Based on #5027. Addresses the dangling-reference warnings tracked in #4605 (e.g. `isin-US3682872078 property issuer references missing id lei-213800R54EFFINMY1P02` in `ext_eu_esma_firds`).

## Problem

In topic-gated enrichers, a promoted (internal) entity can reference an expansion neighbour that doesn't pass the topic gate — e.g. a security whose FIRDS-reported issuer carries no risk topic. The neighbour is emitted external-only, so the published dataset contains a reference to an entity that isn't there.

## Change

1. **Prune the reference from the published entity.** Before an internal emit, entity-type property values pointing at unpublishable targets are removed from non-edge entities, with an info log. Edges are untouched: `should_promote` already only publishes them when all endpoints are publishable.

2. **Keep the relationship visible externally.** Dropping the reference entirely would blind `ann_graph_topics`, which reads the external view to discover adjacency and emit topic patches (the convergence loop from #4875) — the referenced entity could then never become publishable. So the pruned references are re-emitted in an external stub entity (same id/schema, only the pruned props): the analyzer sees the relationship, the exporter and validators (internal view) don't. Once the analyzer tags the target and it passes the gate on a later run, the reference is published for real.

Tested at both levels: a unit test for the prune helper, and an end-to-end topic-gated run asserting the internal view has no `issuer` value while the external view retains it, alongside the external-only issuer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
