### PR TITLE
lint: pin ruff rule set to stop 0.16 default expansion

### DIFF
--- a/.github/workflows/lint_crawlers.yml
+++ b/.github/workflows/lint_crawlers.yml
@@ -66,8 +66,8 @@ jobs:
           while IFS= read -r dataset; do
             [ -z "$dataset" ] && continue
             echo Linting "$dataset"
-            ruff check "$dataset"
-            ruff format --check --diff "$dataset"
+            ruff check --config zavod/pyproject.toml "$dataset"
+            ruff format --check --diff --config zavod/pyproject.toml "$dataset"
           done <<< "$CHANGED_FILES"
       - name: Run prek pre-commit hooks on modified files
         if: ${{ steps.changed-python.outputs.all_changed_files != '' }}

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -107,3 +107,9 @@ combine_as_imports = true
 force_single_line = false
 force_alphabetical_sort_within_sections = true
 src_paths = ["zavod"]
+
+[tool.ruff.lint]
+# Pin the enforced rule set explicitly so a ruff upgrade can't opt the whole
+# codebase into new default rules at once. This is the pre-0.16 default set;
+# adopt further rules deliberately via extend-select.
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## What

Ruff 0.16.0 expanded its default rule set. Because the repo never configured a rule selection, ruff had always run on its defaults — so the upgrade silently opted the whole codebase into hundreds of new rules at once (**1310 errors, ~991 auto-"fixable"**: `UP*`, `B*`, `SIM*`, `C4*`, `RUF*`, `PIE790`, …). This is what broke the `python` lint job on ruff bumps.

## Fix

- **`zavod/pyproject.toml`** — add `[tool.ruff.lint]` with `select = ["E4", "E7", "E9", "F"]` (the pre-0.16 default). This pins the *enforced rule set* independent of the ruff version, so future upgrades no longer re-trigger the flood. `make lint` (`ruff check zavod/`) auto-discovers it. New rules can now be adopted deliberately via `extend-select`.
- **`.github/workflows/lint_crawlers.yml`** — the crawler lint runs from the repo root, where ruff wouldn't discover `zavod/pyproject.toml`. Pass `--config zavod/pyproject.toml` to `ruff check` / `ruff format --check` so both jobs share the one rule set.

## Verification (against real ruff 0.16.0)

- `ruff check zavod/` with the config → **All checks passed**
- `ruff check zavod/ --isolated` (0.16 defaults) → **1310 errors** (reproduces the CI failure)
- Crawler invocation `ruff check --config zavod/pyproject.toml <dataset>` → **All checks passed**

Enforcement is unchanged from before the bump — this freezes the rule set, not the tool.