### PR TITLE
zavod: modernize type annotations (ruff pyupgrade / UP)

### DIFF
--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -24,7 +24,8 @@ import shutil
 from pathlib import Path
 from functools import lru_cache
 from typing import TYPE_CHECKING
-from typing import Optional, Generator, TextIO, Set
+from typing import TextIO
+from collections.abc import Generator
 from rigour.mime.types import JSON
 from followthemoney import Statement
 from followthemoney.statement.serialize import read_pack_statements_decoded
@@ -110,7 +111,7 @@ def get_dataset_artifact(
     dataset_name: str,
     resource: str,
     backfill: bool = True,
-    version: Optional[str] = None,
+    version: str | None = None,
 ) -> Path:
     path = dataset_resource_path(dataset_name, resource)
     if path.exists():
@@ -132,9 +133,7 @@ def get_dataset_artifact(
 # The right thing to do might be to have two functions, one to get the "root" version file
 # at artifacts/{dataset_name}/versions.json, and one to get the version file for a specific version.
 @lru_cache(maxsize=1000)
-def get_versions_data(
-    dataset_name: str, version: Optional[str] = None
-) -> Optional[str]:
+def get_versions_data(dataset_name: str, version: str | None = None) -> str | None:
     backend = get_archive_backend()
     name = f"{ARTIFACTS}/{dataset_name}/{VERSIONS_FILE}"
     if version is not None:
@@ -148,7 +147,7 @@ def get_versions_data(
 def iter_dataset_versions(dataset_name: str) -> Generator[Version, None, None]:
     """Iterate over all versions of a given dataset."""
     data = get_versions_data(dataset_name)
-    seen: Set[str] = set()
+    seen: set[str] = set()
     while True:
         if data is None:
             break
@@ -163,8 +162,8 @@ def iter_dataset_versions(dataset_name: str) -> Generator[Version, None, None]:
 
 
 def get_artifact_object(
-    dataset_name: str, resource: str, version: Optional[str] = None
-) -> Optional[ArchiveObject]:
+    dataset_name: str, resource: str, version: str | None = None
+) -> ArchiveObject | None:
     backend = get_archive_backend()
     if version is not None:
         name = f"{ARTIFACTS}/{dataset_name}/{version}/{resource}"
@@ -206,7 +205,7 @@ def archive_artifact(
     dataset_name: str,
     version: Version,
     resource: str,
-    mime_type: Optional[str] = None,
+    mime_type: str | None = None,
 ) -> None:
     """Publish a file in the given versions artifact directory of the dataset."""
     assert path.relative_to(dataset_data_path(dataset_name))
@@ -266,7 +265,7 @@ def iter_local_statements(dataset: "Dataset", external: bool = True) -> Statemen
         get_dataset_artifact(dataset.name, STATEMENTS_FILE)
     if not path.exists():
         raise FileNotFoundError(f"Statements not found: {dataset.name}")
-    with open(path, "r") as fh:
+    with open(path) as fh:
         yield from _read_fh_statements(fh, external)
 
 
@@ -291,7 +290,7 @@ def _iter_scope_statements(dataset: "Dataset", external: bool = True) -> Stateme
 
 
 def iter_previous_statements(
-    dataset: "Dataset", external: bool = True, version: Optional[str] = None
+    dataset: "Dataset", external: bool = True, version: str | None = None
 ) -> StatementGen:
     """Load the statements from the previous release of the dataset by streaming them
     from the data archive."""

--- a/zavod/zavod/archive/backend.py
+++ b/zavod/zavod/archive/backend.py
@@ -1,9 +1,10 @@
 import shutil
 import warnings
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from functools import cache
 from pathlib import Path
-from typing import Dict, Iterator, Optional, TextIO, Type, cast
+from typing import TextIO, cast
+from collections.abc import Iterator
 
 from google.cloud.storage import Blob, Client  # type: ignore
 
@@ -18,7 +19,7 @@ warnings.filterwarnings(
 )
 
 
-class ArchiveObject(object):
+class ArchiveObject:
     def __init__(self, name: str) -> None:
         self.name = name
 
@@ -37,12 +38,12 @@ class ArchiveObject(object):
     def publish(
         self,
         source: Path,
-        mime_type: Optional[str] = None,
-        ttl: Optional[int] = False,
+        mime_type: str | None = None,
+        ttl: int | None = False,
     ) -> None:
         raise NotImplementedError
 
-    def republish(self, source: str, ttl: Optional[int] = None) -> None:
+    def republish(self, source: str, ttl: int | None = None) -> None:
         """Copy the object inside the archive, avoid re-uploads"""
         pass
 
@@ -50,7 +51,7 @@ class ArchiveObject(object):
         raise NotImplementedError
 
 
-class ArchiveBackend(object):
+class ArchiveBackend:
     def get_object(self, name: str) -> ArchiveObject:
         raise NotImplementedError
 
@@ -70,10 +71,10 @@ class GoogleCloudObject(ArchiveObject):
     def __init__(self, backend: "GoogleCloudBackend", name: str) -> None:
         self.backend = backend
         self.name = name
-        self._blob: Optional[Blob] = None
+        self._blob: Blob | None = None
 
     @property
-    def blob(self) -> Optional[Blob]:
+    def blob(self) -> Blob | None:
         if self._blob is None:
             self._blob = self.backend.bucket.get_blob(self.name)
         return self._blob
@@ -88,27 +89,27 @@ class GoogleCloudObject(ArchiveObject):
 
     def updated_at(self) -> datetime:
         if self.blob is None:
-            raise RuntimeError("Object does not exist: %s" % self.name)
+            raise RuntimeError(f"Object does not exist: {self.name}")
         updated = self.blob.updated
         assert updated is not None
         return cast(datetime, updated)
 
     def open(self) -> TextIO:
         if self.blob is None:
-            raise RuntimeError("Object does not exist: %s" % self.name)
+            raise RuntimeError(f"Object does not exist: {self.name}")
         self.blob.reload()
         return cast(TextIO, self.blob.open(mode="r", chunk_size=BLOB_CHUNK))
 
     def backfill(self, dest: Path) -> None:
         if self.blob is None:
-            raise RuntimeError("Object does not exist: %s" % self.name)
+            raise RuntimeError(f"Object does not exist: {self.name}")
         self.blob.download_to_filename(dest)
 
     def publish(
         self,
         source: Path,
-        mime_type: Optional[str] = None,
-        ttl: Optional[int] = None,
+        mime_type: str | None = None,
+        ttl: int | None = None,
     ) -> None:
         self._blob = self.backend.bucket.blob(self.name)
         if ttl is not None:
@@ -116,10 +117,10 @@ class GoogleCloudObject(ArchiveObject):
         log.info(f"Uploading blob: {source.name}", blob_name=self.name, max_age=ttl)
         self._blob.upload_from_filename(source, content_type=mime_type)
 
-    def republish(self, source: str, ttl: Optional[int] = None) -> None:
+    def republish(self, source: str, ttl: int | None = None) -> None:
         source_blob = self.backend.bucket.get_blob(source)
         if source_blob is None:
-            raise RuntimeError("Object does not exist: %s" % source)
+            raise RuntimeError(f"Object does not exist: {source}")
         # TODO: add if_generation_match
         log.info(f"Copying blob: {self.name}", source=source, max_age=ttl)
         self._blob = self.backend.bucket.copy_blob(
@@ -172,10 +173,10 @@ class FileSystemObject(ArchiveObject):
         return self.path.stat().st_size
 
     def updated_at(self) -> datetime:
-        return datetime.fromtimestamp(self.path.stat().st_mtime, tz=timezone.utc)
+        return datetime.fromtimestamp(self.path.stat().st_mtime, tz=UTC)
 
     def open(self) -> TextIO:
-        return open(self.path, "r", buffering=BLOB_CHUNK)
+        return open(self.path, buffering=BLOB_CHUNK)
 
     def backfill(self, dest: Path) -> None:
         log.info(
@@ -189,7 +190,7 @@ class FileSystemObject(ArchiveObject):
         self,
         source: Path,
         mime_type: str | None = None,
-        ttl: Optional[int] = None,
+        ttl: int | None = None,
     ) -> None:
         log.info(
             f"Copying file: {self.path.name} to archive",
@@ -199,7 +200,7 @@ class FileSystemObject(ArchiveObject):
         self.path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, self.path)
 
-    def republish(self, source: str, ttl: Optional[int] = None) -> None:
+    def republish(self, source: str, ttl: int | None = None) -> None:
         source_path = settings.ARCHIVE_PATH / source
         log.info(
             f"Copying file: {self.path.name} to archive",
@@ -225,7 +226,7 @@ class FileSystemBackend(ArchiveBackend):
                 )
 
 
-backends: Dict[str, Type[ArchiveBackend]] = {
+backends: dict[str, type[ArchiveBackend]] = {
     "GoogleCloudBackend": GoogleCloudBackend,
     "FileSystemBackend": FileSystemBackend,
 }
@@ -234,6 +235,6 @@ backends: Dict[str, Type[ArchiveBackend]] = {
 @cache
 def get_archive_backend() -> ArchiveBackend:
     if settings.ARCHIVE_BACKEND not in backends:
-        msg = "Invalid archive backend: %s" % settings.ARCHIVE_BACKEND
+        msg = f"Invalid archive backend: {settings.ARCHIVE_BACKEND}"
         raise ConfigurationException(msg)
     return backends[settings.ARCHIVE_BACKEND]()

--- a/zavod/zavod/archive/cdn.py
+++ b/zavod/zavod/archive/cdn.py
@@ -36,6 +36,6 @@ def invalidate_archive_cache(path: str) -> None:
     try:
         response = _session.post(purge_url, headers=headers, params=params)
         response.raise_for_status()
-        log.info("Invalidated archive CDN cache: %s" % path)
+        log.info(f"Invalidated archive CDN cache: {path}")
     except requests.RequestException as e:
         log.error("Failed to invalidate archive CDN cache", path=path, error=str(e))

--- a/zavod/zavod/audit.py
+++ b/zavod/zavod/audit.py
@@ -1,12 +1,12 @@
 from lxml.etree import _Element, tostring
 from pprint import pformat
-from typing import Any, Optional
+from typing import Any
 from datapatch import Result
 
 from followthemoney.proxy import EntityProxy
 
 
-def inspect(obj: Any) -> Optional[str]:
+def inspect(obj: Any) -> str | None:
     """Deep-view an object for debug purposes."""
     if isinstance(obj, _Element):
         return tostring(obj, encoding="utf-8", pretty_print=True).decode("utf-8")

--- a/zavod/zavod/cli/__init__.py
+++ b/zavod/zavod/cli/__init__.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import List
 
 import click
 from click.shell_completion import CompletionItem
@@ -26,7 +25,7 @@ class DatasetPath(click.Path):
 
     def shell_complete(
         self, ctx: click.Context, param: click.Parameter, incomplete: str
-    ) -> List[CompletionItem]:
+    ) -> list[CompletionItem]:
         completions: list[CompletionItem] = []
         for path in sorted(Path("datasets").glob("**/*.yml")):
             if incomplete in path.name:
@@ -42,13 +41,13 @@ DatasetInPath = DatasetPath(
 def _load_dataset(path: Path) -> Dataset:
     dataset = load_dataset_from_path(path)
     if dataset is None:
-        raise click.BadParameter("Invalid dataset path: %s" % path)
+        raise click.BadParameter(f"Invalid dataset path: {path}")
     set_logging_context_dataset_name(dataset.name)
     return dataset
 
 
-def _load_datasets(paths: List[Path]) -> Dataset:
-    inputs: List[str] = []
+def _load_datasets(paths: list[Path]) -> Dataset:
+    inputs: list[str] = []
     for path in paths:
         inputs.append(_load_dataset(path).name)
     return get_multi_dataset(inputs)

--- a/zavod/zavod/cli/dedupe.py
+++ b/zavod/zavod/cli/dedupe.py
@@ -164,7 +164,7 @@ def wikidata_reconcile(
     if len(text):
         text += "\n"
     output.write_text(text)
-    log.info("Wrote %d QuickStatements commands: %s" % (len(commands), output))
+    log.info(f"Wrote {len(commands)} QuickStatements commands: {output}")
 
 
 @cli.command("explode-cluster", help="Destroy a cluster of deduplication matches")

--- a/zavod/zavod/cli/dedupe.py
+++ b/zavod/zavod/cli/dedupe.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-from typing import Optional, List, Tuple
 
 import click
 from followthemoney import Dataset as FTMDataset
@@ -28,13 +27,13 @@ from zavod.store import get_store
 @click.option("-t", "--threshold", type=float, default=None)
 @click.option("-d", "--discount-internal", "discount_internal", type=float, default=1.0)
 def xref(
-    dataset_paths: List[Path],
+    dataset_paths: list[Path],
     rebuild_store: bool,
     limit: int,
-    threshold: Optional[float],
+    threshold: float | None,
     algorithm: str,
-    focus: Tuple[str, ...] = tuple(),
-    schema: Optional[str] = None,
+    focus: tuple[str, ...] = tuple(),
+    schema: str | None = None,
     discount_internal: float = 1.0,
 ) -> None:
     dataset = _load_datasets(dataset_paths)
@@ -72,7 +71,7 @@ def xref_prune() -> None:
 @cli.command("dedupe", help="Interactively decide xref candidates")
 @click.argument("dataset_paths", type=DatasetInPath, nargs=-1)
 @click.option("-r", "--rebuild-store", is_flag=True, default=False)
-def dedupe(dataset_paths: List[Path], rebuild_store: bool = False) -> None:
+def dedupe(dataset_paths: list[Path], rebuild_store: bool = False) -> None:
     dataset = _load_datasets(dataset_paths)
     with make_session() as session:
         resolver = get_resolver(session)
@@ -100,11 +99,11 @@ def dedupe(dataset_paths: List[Path], rebuild_store: bool = False) -> None:
     help="QuickStatements output path (default: <dataset state>/wikidata.qs)",
 )
 def wikidata_reconcile(
-    dataset_paths: List[Path],
+    dataset_paths: list[Path],
     rebuild_store: bool = False,
     aliases: bool = True,
     algorithm: str = DedupeAlgorithm.NAME,
-    output: Optional[Path] = None,
+    output: Path | None = None,
 ) -> None:
     """Interactively reconcile dataset persons against Wikidata.
 
@@ -119,7 +118,7 @@ def wikidata_reconcile(
     dataset = _load_datasets(dataset_paths)
     algorithm_type = get_algorithm(algorithm)
     if algorithm_type is None:
-        raise click.UsageError("Unknown algorithm: %s" % algorithm)
+        raise click.UsageError(f"Unknown algorithm: {algorithm}")
     if output is None:
         output = dataset_state_path(dataset.name) / "wikidata.qs"
 
@@ -130,7 +129,7 @@ def wikidata_reconcile(
     store.sync(clear=rebuild_store)
 
     # Cite the dataset itself when an entity carries no sourceUrl/retrieved date.
-    retrieved: Optional[str] = None
+    retrieved: str | None = None
     if dataset.model.updated_at is not None:
         retrieved = dataset.model.updated_at.date().isoformat()
 
@@ -180,21 +179,21 @@ def explode(canonical_id: str) -> None:
 @cli.command("merge-cluster", help="Merge multiple entities as duplicates")
 @click.argument("entity_ids", type=str, nargs=-1)
 @click.option("-f", "--force", is_flag=True, default=False)
-def merge(entity_ids: List[str], force: bool = False) -> None:
+def merge(entity_ids: list[str], force: bool = False) -> None:
     try:
         with make_session() as session:
             resolver = get_resolver(session)
             resolver.load_into_memory()
             merge_entities(resolver, entity_ids, force=force)
     except ValueError as ve:
-        log.error("Cannot merge: %s" % ve)
+        log.error(f"Cannot merge: {ve}")
         sys.exit(1)
 
 
 @cli.command("dedupe-edges", help="Merge edge entities that are effectively duplicates")
 @click.argument("dataset_paths", type=DatasetInPath, nargs=-1)
 @click.option("-r", "--rebuild-store", is_flag=True, default=False)
-def dedupe_edges(dataset_paths: List[Path], rebuild_store: bool = False) -> None:
+def dedupe_edges(dataset_paths: list[Path], rebuild_store: bool = False) -> None:
     from zavod.integration import edges
 
     dataset = _load_datasets(dataset_paths)
@@ -206,5 +205,5 @@ def dedupe_edges(dataset_paths: List[Path], rebuild_store: bool = False) -> None
             store.sync(clear=rebuild_store)
             edges.dedupe_edges(resolver, session, store.view(dataset, external=True))
     except Exception:
-        log.exception("Failed to dedupe edge entities: %r" % dataset_paths)
+        log.exception(f"Failed to dedupe edge entities: {dataset_paths!r}")
         sys.exit(1)

--- a/zavod/zavod/cli/etl.py
+++ b/zavod/zavod/cli/etl.py
@@ -38,7 +38,7 @@ def crawl(dataset_path: Path, dry_run: bool = False, clear_data: bool = False) -
 def validate(dataset_path: Path, rebuild_store: bool = True) -> None:
     dataset = _load_dataset(dataset_path)
     if dataset.model.disabled:
-        log.info("Dataset is disabled, skipping: %s" % dataset.name)
+        log.info(f"Dataset is disabled, skipping: {dataset.name}")
         sys.exit(0)
     linker = get_dataset_linker(dataset)
     store = get_store(dataset, linker)
@@ -46,7 +46,7 @@ def validate(dataset_path: Path, rebuild_store: bool = True) -> None:
         store.sync(clear=rebuild_store)
         validate_dataset(dataset, store.view(dataset, external=False))
     except Exception:
-        log.exception("Validation failed for %r" % dataset_path)
+        log.exception(f"Validation failed for {dataset_path!r}")
         store.close()
         sys.exit(1)
 
@@ -57,7 +57,7 @@ def validate(dataset_path: Path, rebuild_store: bool = True) -> None:
 def export(dataset_path: Path, rebuild_store: bool = True) -> None:
     dataset = _load_dataset(dataset_path)
     if dataset.model.disabled:
-        log.info("Dataset is disabled, skipping: %s" % dataset.name)
+        log.info(f"Dataset is disabled, skipping: {dataset.name}")
         sys.exit(0)
     linker = get_dataset_linker(dataset)
     store = get_store(dataset, linker)
@@ -65,7 +65,7 @@ def export(dataset_path: Path, rebuild_store: bool = True) -> None:
         store.sync(clear=rebuild_store)
         export_dataset(dataset, store.view(dataset, external=False))
     except Exception:
-        log.exception("Failed to export: %s" % dataset_path)
+        log.exception(f"Failed to export: {dataset_path}")
         sys.exit(1)
 
 
@@ -78,7 +78,7 @@ def publish(dataset_path: Path, latest: bool = False) -> None:
     try:
         publish_dataset(dataset, republish_to_latest=latest)
     except Exception:
-        log.exception("Failed to publish: %s" % dataset_path)
+        log.exception(f"Failed to publish: {dataset_path}")
         sys.exit(1)
 
 
@@ -102,7 +102,7 @@ def run(
         clear_data_path(dataset.name)
 
     if dataset.model.disabled:
-        log.info("Dataset is disabled, skipping: %s" % dataset.name)
+        log.info(f"Dataset is disabled, skipping: {dataset.name}")
         archive_failure(dataset)
         sys.exit(0)
     # crawl if it's a dataset, just create a new version if it's a collection
@@ -125,7 +125,7 @@ def run(
         if not dataset.is_collection:
             validate_dataset(dataset, view)
     except Exception:
-        log.exception("Validation failed for %r" % dataset.name)
+        log.exception(f"Validation failed for {dataset.name!r}")
         archive_failure(dataset)
         store.close()
         sys.exit(1)
@@ -136,7 +136,7 @@ def run(
         # Set the version as successful in the version file, which will be archived by publish_dataset.
         set_last_successful_version(dataset, settings.RUN_VERSION)
     except Exception:
-        log.exception("Failed to export: %s" % dataset_path)
+        log.exception(f"Failed to export: {dataset_path}")
         archive_failure(dataset)
         store.close()
         sys.exit(1)
@@ -150,5 +150,5 @@ def run(
             load_dataset_to_db(dataset, linker, external=False)
         log.info("Dataset run is complete :)", dataset=dataset.name)
     except Exception:
-        log.exception("Failed to publish %r" % dataset.name)
+        log.exception(f"Failed to publish {dataset.name!r}")
         sys.exit(1)

--- a/zavod/zavod/cli/util.py
+++ b/zavod/zavod/cli/util.py
@@ -32,7 +32,7 @@ def load_db(
             external=external,
         )
     except Exception:
-        log.exception("Failed to load dataset into database: %s" % dataset_path)
+        log.exception(f"Failed to load dataset into database: {dataset_path}")
         sys.exit(1)
 
 
@@ -55,7 +55,7 @@ def dump_file(
             external=external,
         )
     except Exception:
-        log.exception("Failed to dump dataset to file: %s" % dataset_path)
+        log.exception(f"Failed to dump dataset to file: {dataset_path}")
         sys.exit(1)
 
 
@@ -66,5 +66,5 @@ def clear(dataset_path: Path) -> None:
         dataset = _load_dataset(dataset_path)
         clear_data_path(dataset.name)
     except Exception:
-        log.exception("Failed to clear dataset: %s" % dataset_path)
+        log.exception(f"Failed to clear dataset: {dataset_path}")
         sys.exit(1)

--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -1,7 +1,8 @@
 import orjson
 import contextvars
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Union, cast
+from typing import Any, cast
+from collections.abc import Mapping
 from datapatch import Lookup, LookupException, Result
 from followthemoney.dataset import DataResource, Version
 from followthemoney.schema import Schema
@@ -58,17 +59,17 @@ class Context:
         self.resources = DatasetResources(dataset)
         self.log = get_logger(dataset.name)
         self.http = make_session(dataset.http)
-        self._db: Optional[Session] = None
-        self._cache: Optional[Cache] = None
-        self._timestamps: Optional[TimeStampIndex] = None
-        self._resolver: Optional[Resolver[Entity]] = None
-        self._structlog_contextvars_tokens: Optional[
-            Mapping[str, contextvars.Token[Any]]
-        ] = None
+        self._db: Session | None = None
+        self._cache: Cache | None = None
+        self._timestamps: TimeStampIndex | None = None
+        self._resolver: Resolver[Entity] | None = None
+        self._structlog_contextvars_tokens: (
+            Mapping[str, contextvars.Token[Any]] | None
+        ) = None
         self._writer_path = dataset_resource_path(dataset.name, STATEMENTS_FILE)
-        self._writer: Optional[PackStatementWriter] = None
+        self._writer: PackStatementWriter | None = None
 
-        self.lang: Optional[str] = None
+        self.lang: str | None = None
         """Default language for statements emitted from this dataset"""
         if dataset.data is not None:
             self.lang = dataset.data.lang
@@ -124,7 +125,7 @@ class Context:
     def data_url(self) -> str:
         """The URL of the source data for the dataset."""
         if self.dataset.data is None or self.dataset.data.url is None:
-            raise ValueError("Dataset has no data URL: %r" % self.dataset)
+            raise ValueError(f"Dataset has no data URL: {self.dataset!r}")
         return self.dataset.data.url
 
     def begin(self, clear: bool = False) -> None:
@@ -206,7 +207,7 @@ class Context:
         return dataset_resource_path(self.dataset.name, str(name))
 
     def export_resource(
-        self, path: Path, mime_type: Optional[str] = None, title: Optional[str] = None
+        self, path: Path, mime_type: str | None = None, title: str | None = None
     ) -> DataResource:
         """Register a file as a data resource exported by the dataset.
 
@@ -229,10 +230,10 @@ class Context:
         self,
         name: str,
         url: str,
-        auth: Optional[Any] = None,
-        headers: Optional[Any] = None,
+        auth: Any | None = None,
+        headers: Any | None = None,
         method: str = "GET",
-        data: Optional[_Body] = None,
+        data: _Body | None = None,
     ) -> Path:
         """Fetch a URL into a file located in the current run folder,
         if it does not exist."""
@@ -253,7 +254,7 @@ class Context:
         headers: _Headers = None,
         auth: _Auth = None,
         method: str = "GET",
-        data: Optional[_Body] = None,
+        data: _Body | None = None,
     ) -> Response:
         """Execute an HTTP request using the contexts' session.
 
@@ -269,7 +270,7 @@ class Context:
         self.log.debug(f"HTTP {method}", url=url)
         timeout = (self.dataset.http.timeout, self.dataset.http.timeout)
 
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "headers": headers,
             "auth": auth,
             "timeout": timeout,
@@ -301,11 +302,11 @@ class Context:
         params: ParamsType = None,
         headers: _Headers = None,
         auth: _Auth = None,
-        cache_days: Optional[int] = None,
+        cache_days: int | None = None,
         method: str = "GET",
-        data: Optional[_Body] = None,
-        encoding: Optional[str] = None,
-    ) -> Optional[str]:
+        data: _Body | None = None,
+        encoding: str | None = None,
+    ) -> str | None:
         """Execute an HTTP request using the contexts' session and return
         the decoded response body. If a `cache_days` argument is provided, a
         cache will be used for the given number of days.
@@ -363,9 +364,9 @@ class Context:
         params: ParamsType = None,
         headers: _Headers = None,
         auth: _Auth = None,
-        cache_days: Optional[int] = None,
+        cache_days: int | None = None,
         method: str = "GET",
-        data: Optional[_Body] = None,
+        data: _Body | None = None,
     ) -> Any:
         """Execute an HTTP request using the contexts' session and return
         a JSON-decoded object based on the response. If a `cache_days` argument
@@ -405,11 +406,11 @@ class Context:
         params: ParamsType = None,
         headers: _Headers = None,
         auth: _Auth = None,
-        cache_days: Optional[int] = None,
+        cache_days: int | None = None,
         method: str = "GET",
-        data: Optional[_Body] = None,
+        data: _Body | None = None,
         absolute_links: bool = False,
-        encoding: Optional[str] = None,
+        encoding: str | None = None,
     ) -> Element:
         """Execute an HTTP request using the contexts' session and return
         an HTML DOM object based on the response. If a `cache_days` argument
@@ -444,7 +445,7 @@ class Context:
         )
         try:
             if text is None or len(text) == 0:
-                raise ValueError("Invalid HTML document: %s" % url)
+                raise ValueError(f"Invalid HTML document: {url}")
             doc = html.fromstring(text)
             if absolute_links and isinstance(doc, html.HtmlElement):
                 cast(html.HtmlElement, doc).make_links_absolute(url, params)
@@ -459,8 +460,8 @@ class Context:
         params: ParamsType = None,
         auth: _Auth = None,
         method: str = "GET",
-        data: Optional[_Body] = None,
-        encoding: Optional[str] = None,
+        data: _Body | None = None,
+        encoding: str | None = None,
     ) -> None:
         """Evict a cached response so the next fetch re-hits the server.
 
@@ -488,7 +489,7 @@ class Context:
         with open(file_path, "rb") as fh:
             return etree.parse(fh)
 
-    def make(self, schema: Union[str, Schema]) -> Entity:
+    def make(self, schema: str | Schema) -> Entity:
         """Make a new entity with some dataset context set.
 
         Args:
@@ -500,8 +501,8 @@ class Context:
         return Entity(self.dataset, {"schema": schema})
 
     def make_slug(
-        self, *parts: Optional[str], strict: bool = True, prefix: Optional[str] = None
-    ) -> Optional[str]:
+        self, *parts: str | None, strict: bool = True, prefix: str | None = None
+    ) -> str | None:
         """Make a slug-based entity ID from a list of strings, using the
         dataset prefix."""
         prefix = self.dataset.prefix if prefix is None else prefix
@@ -509,10 +510,10 @@ class Context:
 
     def make_id(
         self,
-        *parts: Optional[str],
-        prefix: Optional[str] = None,
-        hash_prefix: Optional[str] = None,
-    ) -> Optional[str]:
+        *parts: str | None,
+        prefix: str | None = None,
+        hash_prefix: str | None = None,
+    ) -> str | None:
         """Make a hash-based entity ID from a list of strings, prefixed with the
         dataset prefix.
 
@@ -531,11 +532,11 @@ class Context:
     def lookup_value(
         self,
         lookup: str,
-        value: Optional[str],
-        default: Optional[str] = None,
+        value: str | None,
+        default: str | None = None,
         *,
         warn_unmatched: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Invoke a datapatch lookup defined in the dataset metadata, returning the `value` attribute.
 
         Args:
@@ -557,8 +558,8 @@ class Context:
         return self.dataset.lookups[lookup]
 
     def lookup(
-        self, lookup: str, value: Optional[str], *, warn_unmatched: bool = False
-    ) -> Optional[Result]:
+        self, lookup: str, value: str | None, *, warn_unmatched: bool = False
+    ) -> Result | None:
         """Invoke a datapatch lookup defined in the dataset metadata.
 
         Args:
@@ -595,7 +596,7 @@ class Context:
         if text is not None:
             self.log.info(text)
 
-    def audit_data(self, data: Dict[Any, Any], ignore: List[Any] = []) -> None:
+    def audit_data(self, data: dict[Any, Any], ignore: list[Any] = []) -> None:
         """Print the formatted data object if it contains any fields not explicitly
         excluded by the ignore list. This is used to warn about unexpected data in
         the source by removing the fields one by one and then inspecting the rest.
@@ -618,7 +619,7 @@ class Context:
             )
 
     def emit(
-        self, entity: Entity, external: bool = False, origin: Optional[str] = None
+        self, entity: Entity, external: bool = False, origin: str | None = None
     ) -> None:
         """Send an entity from the crawling/runner process to be stored.
 
@@ -636,7 +637,7 @@ class Context:
         self.stats.entities += 1
         if self.stats.entities % 10000 == 0:
             self.log.info(
-                "Emitted %s entities" % self.stats.entities,
+                f"Emitted {self.stats.entities} entities",
                 statements=self.stats.statements,
             )
             self.flush()

--- a/zavod/zavod/crawl.py
+++ b/zavod/zavod/crawl.py
@@ -68,7 +68,7 @@ def crawl_dataset(dataset: Dataset, dry_run: bool = False) -> ContextStats:
             )
         raise RunFailedException() from rexc
     except Exception as exc:
-        context.log.exception("Runner failed: %s" % str(exc))
+        context.log.exception(f"Runner failed: {str(exc)}")
         raise RunFailedException() from exc
     finally:
         context.close()

--- a/zavod/zavod/entity.py
+++ b/zavod/zavod/entity.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Self, Union
+from typing import Any, Self
 from followthemoney import model
 from followthemoney.exc import InvalidData, InvalidModel
 from followthemoney.util import gettext
@@ -20,7 +20,7 @@ class Entity(StatementEntity):
     extracting data from sanctions lists and for auditing parsing errors to structured logging.
     """  # noqa
 
-    def __init__(self, dataset: Dataset, data: Dict[str, Any], cleaned: bool = True):
+    def __init__(self, dataset: Dataset, data: dict[str, Any], cleaned: bool = True):
         super().__init__(dataset, data, cleaned=cleaned)
         self.dataset: Dataset = dataset
 
@@ -30,17 +30,17 @@ class Entity(StatementEntity):
     def unsafe_add(
         self,
         prop: Property,
-        value: Optional[str],
+        value: str | None,
         cleaned: bool = False,
         fuzzy: bool = False,
-        format: Optional[str] = None,
+        format: str | None = None,
         quiet: bool = False,
-        schema: Optional[str] = None,
-        dataset: Optional[str] = None,
-        seen: Optional[str] = None,
-        lang: Optional[str] = None,
-        original_value: Optional[str] = None,
-        origin: Optional[str] = None,
+        schema: str | None = None,
+        dataset: str | None = None,
+        seen: str | None = None,
+        lang: str | None = None,
+        original_value: str | None = None,
+        origin: str | None = None,
         external: bool = False,
     ) -> None:
         """Add a statement to the entity, possibly the value."""
@@ -93,10 +93,10 @@ class Entity(StatementEntity):
         values: Any,
         cleaned: bool = False,
         fuzzy: bool = False,
-        format: Optional[str] = None,
-        lang: Optional[str] = None,
-        original_value: Optional[str] = None,
-        origin: Optional[str] = None,
+        format: str | None = None,
+        lang: str | None = None,
+        original_value: str | None = None,
+        origin: str | None = None,
     ) -> None:
         """Set a property on an entity. If the entity is of a schema that doesn't
         have the given property, also modify the schema (e.g. if something has a
@@ -108,10 +108,10 @@ class Entity(StatementEntity):
 
         schema_ = model.get(schema)
         if schema_ is None:
-            raise InvalidModel("Invalid schema: %s" % schema)
+            raise InvalidModel(f"Invalid schema: {schema}")
         prop_ = schema_.get(prop)
         if prop_ is None:
-            raise InvalidModel("Invalid prop: %s" % prop)
+            raise InvalidModel(f"Invalid prop: {prop}")
         for text in string_list(values):
             for norm_prop_, clean, origin_ in value_clean(
                 self,
@@ -134,7 +134,7 @@ class Entity(StatementEntity):
                     origin=origin_,
                 )
 
-    def adopt_statement(self, stmt: Statement, prop: Optional[str] = None) -> None:
+    def adopt_statement(self, stmt: Statement, prop: str | None = None) -> None:
         """Adopt a statement from another entity, copying it to this entity."""
         prop = prop or stmt.prop
         prop_ = self.schema.get(prop)
@@ -152,7 +152,7 @@ class Entity(StatementEntity):
             cleaned=True,
         )
 
-    def add_schema(self, schema: Union[str, Schema]) -> None:
+    def add_schema(self, schema: str | Schema) -> None:
         """Try to apply the given schema to the current entity, making it more
         specific (e.g. turning a `LegalEntity` into a `Company`). This raises an
         exception if the current and new type are incompatible."""
@@ -177,8 +177,8 @@ class Entity(StatementEntity):
         return all(s.external for s in self.statements)
 
     def _to_nested_dict(
-        self: Self, view: "View[Dataset, Entity]", depth: int, path: List[str]
-    ) -> Dict[str, Any]:
+        self: Self, view: "View[Dataset, Entity]", depth: int, path: list[str]
+    ) -> dict[str, Any]:
         next_depth = depth if self.schema.edge else depth - 1
         next_path = list(path)
         if self.id is not None:
@@ -186,7 +186,7 @@ class Entity(StatementEntity):
         data = self.to_dict()
         if next_depth < 0:
             return data
-        nested: Dict[str, List[Any]] = {}
+        nested: dict[str, list[Any]] = {}
         for prop, adjacent in view.get_adjacent(self):
             if adjacent.id in next_path:
                 continue
@@ -199,10 +199,10 @@ class Entity(StatementEntity):
 
     def to_nested_dict(
         self: Self, view: "View[Dataset, Entity]", depth: int = 1
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return self._to_nested_dict(view, depth=depth, path=[])
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["target"] = self.target or False
         return data

--- a/zavod/zavod/exporters/__init__.py
+++ b/zavod/zavod/exporters/__init__.py
@@ -1,5 +1,3 @@
-from typing import List, Dict, Type, Set
-
 from zavod.exporters.consolidate import consolidate_entity
 from zavod.logs import get_logger
 from zavod.store import View
@@ -23,7 +21,7 @@ from zavod.exporters.metadata import write_catalog, write_delta_index
 
 log = get_logger(__name__)
 
-DEFAULT_EXPORTERS: Set[str] = {
+DEFAULT_EXPORTERS: set[str] = {
     StatisticsExporter.FILE_NAME,
     FtMExporter.FILE_NAME,
     NestedTargetsJSONExporter.FILE_NAME,
@@ -32,7 +30,7 @@ DEFAULT_EXPORTERS: Set[str] = {
     SenzingExporter.FILE_NAME,
     DeltaExporter.FILE_NAME,
 }
-EXPORTERS: Dict[str, Type[Exporter]] = {
+EXPORTERS: dict[str, type[Exporter]] = {
     StatisticsExporter.FILE_NAME: StatisticsExporter,
     FtMExporter.FILE_NAME: FtMExporter,
     NestedTargetsJSONExporter.FILE_NAME: NestedTargetsJSONExporter,
@@ -53,7 +51,7 @@ def export_data(context: Context, view: View) -> None:
     if not len(exporter_names):
         exporter_names.update(DEFAULT_EXPORTERS)
     exporter_names.add(StatisticsExporter.FILE_NAME)
-    exporters: List[Exporter] = []
+    exporters: list[Exporter] = []
     for name in exporter_names:
         clazz = EXPORTERS.get(name)
         if clazz is None:
@@ -70,7 +68,7 @@ def export_data(context: Context, view: View) -> None:
 
     for idx, entity in enumerate(view.entities()):
         if idx > 0 and idx % 10000 == 0:
-            log.info("Exported %s entities..." % idx, scope=context.dataset.name)
+            log.info(f"Exported {idx} entities...", scope=context.dataset.name)
 
         # feed_unconsolidated must be called before consolidate_entity, because
         # consolidate_entity mutates the entity in place.
@@ -99,4 +97,4 @@ def export_dataset(dataset: Dataset, view: View) -> None:
     write_delta_index(dataset)
     write_dataset_index(dataset, DatasetVersionResult.SUCCESS)
     write_catalog(dataset)
-    log.info("Exported dataset: %s" % dataset.name)
+    log.info(f"Exported dataset: {dataset.name}")

--- a/zavod/zavod/exporters/common.py
+++ b/zavod/zavod/exporters/common.py
@@ -7,7 +7,7 @@ from zavod.context import Context
 ExportView = View[Dataset, Entity]
 
 
-class Exporter(object):
+class Exporter:
     """A common interface for file format exports at the end of the export pipeline."""
 
     FILE_NAME = ""
@@ -37,13 +37,13 @@ class Exporter(object):
                 title=self.TITLE,
             )
             self.context.log.info(
-                "Exported: %s" % self.TITLE,
+                f"Exported: {self.TITLE}",
                 path=self.path,
                 size=resource.size,
             )
         except ValueError as ve:
             self.context.log.warning(
-                "Export failed: %s" % ve,
+                f"Export failed: {ve}",
                 path=self.path,
             )
             return

--- a/zavod/zavod/exporters/consolidate.py
+++ b/zavod/zavod/exporters/consolidate.py
@@ -1,5 +1,4 @@
 from functools import lru_cache
-from typing import List, Tuple
 
 from normality import WS
 from followthemoney import registry
@@ -47,9 +46,9 @@ NEVER_REMOVE_NAMES_DATASETS = {
 
 
 @lru_cache(maxsize=10000)
-def _remove_prefix_date_values(values: Tuple[str, ...]) -> Tuple[str, ...]:
+def _remove_prefix_date_values(values: tuple[str, ...]) -> tuple[str, ...]:
     """See ``_simplify_dates``."""
-    kept: List[str] = []
+    kept: list[str] = []
     values_list = sorted(values, reverse=True)
     for index, value in enumerate(values_list):
         if index > 0:
@@ -105,8 +104,8 @@ def _simplify_undirected(entity: Entity) -> Entity:
         return entity
     sources = entity.get_statements(entity.schema.edge_source)
     targets = entity.get_statements(entity.schema.edge_target)
-    source_ids = set((s.value for s in sources))
-    target_ids = set((t.value for t in targets))
+    source_ids = set(s.value for s in sources)
+    target_ids = set(t.value for t in targets)
     common = source_ids.intersection(target_ids)
     if len(common) != 2:
         return entity

--- a/zavod/zavod/exporters/delta.py
+++ b/zavod/zavod/exporters/delta.py
@@ -1,4 +1,5 @@
-from typing import Any, Generator
+from typing import Any
+from collections.abc import Generator
 from zavod.entity import Entity
 from zavod.archive import DELTA_EXPORT_FILE
 from zavod.exporters.common import Exporter, ExportView

--- a/zavod/zavod/exporters/fragment.py
+++ b/zavod/zavod/exporters/fragment.py
@@ -60,8 +60,8 @@ class ViewFragment(View[Dataset, Entity]):
 
             if len(self._inverted[id]) > self.MAX_BUFFER:
                 log.debug(
-                    "Adjacency list for %s is greater than buffer limit (%d entries)"
-                    % (id, len(self._inverted[id])),
+                    f"Adjacency list for {id} is greater than buffer limit "
+                    f"({len(self._inverted[id])} entries)",
                 )
 
     def entities(

--- a/zavod/zavod/exporters/fragment.py
+++ b/zavod/zavod/exporters/fragment.py
@@ -1,4 +1,4 @@
-from typing import Generator, List, Optional, Dict, Tuple
+from collections.abc import Generator
 from followthemoney import Schema
 from nomenklatura.store import View
 from followthemoney.property import Property
@@ -22,15 +22,15 @@ class ViewFragment(View[Dataset, Entity]):
     def __init__(self, view: ZavodView, entity: Entity):
         self.view: ZavodView = view
         self.entity = entity
-        self._entities: Dict[str, Optional[Entity]] = {}
-        self._inverted: Dict[str, List[str]] = {}
+        self._entities: dict[str, Entity | None] = {}
+        self._inverted: dict[str, list[str]] = {}
         if entity.id is not None:
             self._entities[entity.id] = entity
 
     def has_entity(self, id: str) -> bool:
         return self.get_entity(id) is not None
 
-    def get_entity(self, id: str) -> Optional[Entity]:
+    def get_entity(self, id: str) -> Entity | None:
         if id in self._entities:
             return self._entities[id]
         entity = self.view.get_entity(id)
@@ -40,7 +40,7 @@ class ViewFragment(View[Dataset, Entity]):
                 self._entities[id] = entity
         return entity
 
-    def get_inverted(self, id: str) -> Generator[Tuple[Property, Entity], None, None]:
+    def get_inverted(self, id: str) -> Generator[tuple[Property, Entity], None, None]:
         if id in self._inverted:
             for inverted_id in self._inverted[id]:
                 entity = self.get_entity(inverted_id)
@@ -65,7 +65,7 @@ class ViewFragment(View[Dataset, Entity]):
                 )
 
     def entities(
-        self, include_schemata: Optional[List[Schema]] = None
+        self, include_schemata: list[Schema] | None = None
     ) -> Generator[Entity, None, None]:
         # Don't cache entities here
         raise NotImplementedError("This method should not be called on a ViewFragment!")

--- a/zavod/zavod/exporters/maritime.py
+++ b/zavod/zavod/exporters/maritime.py
@@ -1,5 +1,5 @@
 import csv
-from typing import Set, Iterable
+from collections.abc import Iterable
 from followthemoney import registry
 
 from normality import squash_spaces
@@ -27,7 +27,7 @@ log = get_logger(__name__)
 
 
 def join_cell(texts: Iterable[str], sep: str = ";") -> str:
-    values: Set[str] = set()
+    values: set[str] = set()
     for value in texts:
         if value is None:
             continue
@@ -51,8 +51,8 @@ class MaritimeExporter(Exporter):
         self._count_vessels = 0
         self._count_orgs = 0
 
-    def _get_aliases(self, entity: Entity) -> Set[str]:
-        names: Set[str] = set()
+    def _get_aliases(self, entity: Entity) -> set[str]:
+        names: set[str] = set()
         for name in entity.get_type_values(registry.name, matchable=True):
             if name == entity.caption:
                 continue

--- a/zavod/zavod/exporters/metadata.py
+++ b/zavod/zavod/exporters/metadata.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 from zavod import settings
 from zavod.logs import get_logger
@@ -24,9 +24,9 @@ class DatasetVersionResult(StrEnum):
     FAILURE = "failure"
 
 
-def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
+def get_base_dataset_metadata(dataset: Dataset) -> dict[str, Any]:
     """Build the barebones metadata block for a dataset, without artifact URLs."""
-    meta: Dict[str, Any] = {
+    meta: dict[str, Any] = {
         "issue_levels": {},
         "issue_count": 0,
         "updated_at": settings.RUN_TIME_ISO,
@@ -45,8 +45,8 @@ def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
     #  see https://github.com/opensanctions/opensanctions/pull/2483
     statistics_path = get_dataset_artifact(dataset.name, STATISTICS_FILE)
     if statistics_path.is_file():
-        with open(statistics_path, "r") as fh:
-            stats: Dict[str, Any] = json.load(fh)
+        with open(statistics_path) as fh:
+            stats: dict[str, Any] = json.load(fh)
             meta["entity_count"] = stats.get("entity_count", 0)
             targets = stats.get("targets", {})
             meta["target_count"] = targets.get("total", 0)
@@ -70,7 +70,7 @@ def get_base_dataset_metadata(dataset: Dataset) -> Dict[str, Any]:
                 last_change = settings.RUN_TIME_ISO
             meta["last_change"] = last_change
 
-    res_datas: List[Dict[str, Any]] = []
+    res_datas: list[dict[str, Any]] = []
     for res in DatasetResources(dataset).all():
         if res.name in UNLISTED_RESOURCES:
             continue
@@ -144,7 +144,7 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
         write_json(meta, fh)
 
 
-def get_catalog_dataset(dataset: Dataset) -> Dict[str, Any]:
+def get_catalog_dataset(dataset: Dataset) -> dict[str, Any]:
     """Get a metadata description of a single dataset for the catalog.
 
     Uses run information from the latest published index file, but patches it with the latest metadata from
@@ -156,7 +156,7 @@ def get_catalog_dataset(dataset: Dataset) -> Dict[str, Any]:
     # Use the latest published index file, if available.
     path = get_dataset_artifact(dataset.name, INDEX_FILE)
     if path.is_file():
-        with open(path, "r") as fh:
+        with open(path) as fh:
             meta.update(json.load(fh))
     else:
         log.warn(
@@ -172,7 +172,7 @@ def get_catalog_dataset(dataset: Dataset) -> Dict[str, Any]:
     return meta
 
 
-def get_catalog_datasets(scope: Dataset) -> List[Dict[str, Any]]:
+def get_catalog_datasets(scope: Dataset) -> list[dict[str, Any]]:
     datasets = []
     for dataset in scope.datasets:
         datasets.append(get_catalog_dataset(dataset))
@@ -184,7 +184,7 @@ def write_delta_index(
 ) -> None:
     """Export list of delta data versions for the dataset with their URLs
     associated."""
-    versions: Dict[str, str] = {}
+    versions: dict[str, str] = {}
 
     # This hasn't been uploaded yet, but will become available at the same
     # time as the index file:

--- a/zavod/zavod/exporters/names.py
+++ b/zavod/zavod/exporters/names.py
@@ -1,4 +1,3 @@
-from typing import Set
 from normality import squash_spaces
 from followthemoney import registry
 
@@ -14,7 +13,7 @@ class NamesExporter(Exporter):
     def setup(self) -> None:
         super().setup()
         self.fh = open(self.path, "w")
-        self.seen_hashes: Set[int] = set()
+        self.seen_hashes: set[int] = set()
 
     def feed(self, entity: Entity, view: ExportView) -> None:
         for name in entity.get_type_values(registry.name):

--- a/zavod/zavod/exporters/securities.py
+++ b/zavod/zavod/exporters/securities.py
@@ -31,7 +31,7 @@ securities universe.
 """
 
 import csv
-from typing import Set, Iterable
+from collections.abc import Iterable
 from normality import squash_spaces
 from followthemoney import registry
 from rigour.boolean import bool_text
@@ -68,7 +68,7 @@ log = get_logger(__name__)
 
 
 def join_cell(texts: Iterable[str], sep: str = ";") -> str:
-    values: Set[str] = set()
+    values: set[str] = set()
     for value in texts:
         if value is None:
             continue
@@ -93,15 +93,15 @@ class SecuritiesExporter(Exporter):
         self._count_isins = 0
         self._count_leis = 0
 
-    def _get_isins(self, entity: Entity, view: ExportView) -> Set[str]:
+    def _get_isins(self, entity: Entity, view: ExportView) -> set[str]:
         isins = set(entity.get("isinCode", quiet=True))
         for _, adjacent in view.get_adjacent(entity):
             if adjacent.schema.is_a("Security"):
                 isins.update(adjacent.get("isin"))
         return isins
 
-    def _get_aliases(self, entity: Entity) -> Set[str]:
-        names: Set[str] = set()
+    def _get_aliases(self, entity: Entity) -> set[str]:
+        names: set[str] = set()
         for name in entity.get_type_values(registry.name, matchable=True):
             name_ = squash_spaces(name)
             if len(name_) > 0:

--- a/zavod/zavod/exporters/senzing.py
+++ b/zavod/zavod/exporters/senzing.py
@@ -8,7 +8,7 @@
 import re
 from itertools import product
 from pprint import pprint  # noqa
-from typing import Any, Dict
+from typing import Any
 
 from followthemoney import registry
 from rigour.ids.wikidata import is_qid
@@ -34,7 +34,7 @@ SOURCE_NAME_OVERRIDES = {
 }
 
 
-def push(obj: Dict[str, Any], section: str, value: Dict[str, Any]) -> None:
+def push(obj: dict[str, Any], section: str, value: dict[str, Any]) -> None:
     if section not in obj:
         obj[section] = []
     for item in obj[section]:
@@ -44,14 +44,14 @@ def push(obj: Dict[str, Any], section: str, value: Dict[str, Any]) -> None:
 
 
 def map(
-    entity: Entity, prop: str, obj: Dict[str, Any], section: str, attr: str
+    entity: Entity, prop: str, obj: dict[str, Any], section: str, attr: str
 ) -> None:
     for value in entity.get(prop, quiet=True):
         push(obj, section, {attr: value})
 
 
-def clean(obj: Dict[str, Any]) -> Dict[str, Any]:
-    out: Dict[str, Any] = {}
+def clean(obj: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
     for k, v in obj.items():
         if v is not None:
             out[k] = v
@@ -104,7 +104,7 @@ class SenzingExporter(Exporter):
         elif entity.schema.is_a("Address"):
             return None
 
-        record: Dict[str, Any] = {
+        record: dict[str, Any] = {
             "DATA_SOURCE": self.source_name,
             "RECORD_ID": entity.id,
             "RECORD_TYPE": record_type,

--- a/zavod/zavod/exporters/simplecsv.py
+++ b/zavod/zavod/exporters/simplecsv.py
@@ -1,6 +1,6 @@
 import io
 import csv
-from typing import List, Iterable
+from collections.abc import Iterable
 from followthemoney import registry
 from followthemoney.util import join_text
 
@@ -86,7 +86,7 @@ class SimpleCSVExporter(Exporter):
                 identifiers.update(adjacent.get("number"))
                 countries.update(adjacent.get("country"))
 
-        datasets: List[str] = []
+        datasets: list[str] = []
         for dataset in entity.datasets:
             ds = get_catalog().require(dataset)
             datasets.append(ds.model.title)

--- a/zavod/zavod/exporters/statistics.py
+++ b/zavod/zavod/exporters/statistics.py
@@ -1,5 +1,5 @@
 from collections import defaultdict, namedtuple
-from typing import Dict, List, Any, Optional, Set
+from typing import Any
 from followthemoney import model, registry
 
 from zavod.entity import Entity
@@ -8,8 +8,8 @@ from zavod.exporters.common import Exporter, ExportView
 from zavod.util import write_json
 
 
-def get_schema_facets(schemata: Dict[str, int]) -> List[Any]:
-    facets: List[Any] = []
+def get_schema_facets(schemata: dict[str, int]) -> list[Any]:
+    facets: list[Any] = []
     for name, count in sorted(schemata.items(), key=lambda s: s[1], reverse=True):
         schema = model.get(name)
         if schema is None:
@@ -24,8 +24,8 @@ def get_schema_facets(schemata: Dict[str, int]) -> List[Any]:
     return facets
 
 
-def get_country_facets(countries: Dict[str, int]) -> List[Any]:
-    facets: List[Any] = []
+def get_country_facets(countries: dict[str, int]) -> list[Any]:
+    facets: list[Any] = []
     for code, count in sorted(countries.items(), key=lambda s: s[1], reverse=True):
         facet = {
             "code": code,
@@ -36,7 +36,7 @@ def get_country_facets(countries: Dict[str, int]) -> List[Any]:
     return facets
 
 
-def get_sanctions_programs_facets(sanctions_programs: Dict[str, int]) -> List[Any]:
+def get_sanctions_programs_facets(sanctions_programs: dict[str, int]) -> list[Any]:
     return [
         {
             "id": program_id,
@@ -52,10 +52,10 @@ SchemaProperty = namedtuple("SchemaProperty", ["schema", "property"])
 
 
 def get_entities_with_prop_facets(
-    properties: Dict[SchemaProperty, int],
-    schema_counts: Dict[str, int],
-) -> List[Any]:
-    facets: List[Any] = []
+    properties: dict[SchemaProperty, int],
+    schema_counts: dict[str, int],
+) -> list[Any]:
+    facets: list[Any] = []
     for prop, count in sorted(properties.items()):
         total = schema_counts.get(prop.schema, 0)
         fill_rate = count / total if total > 0 else 0.0
@@ -70,25 +70,25 @@ def get_entities_with_prop_facets(
     return facets
 
 
-class Statistics(object):
+class Statistics:
     def __init__(self) -> None:
         self.entity_count = 0
-        self.last_change: Optional[str] = None
-        self.schemata: Set[str] = set()
-        self.qnames: Set[str] = set()
+        self.last_change: str | None = None
+        self.schemata: set[str] = set()
+        self.qnames: set[str] = set()
 
-        self.entity_count_by_schema: Dict[str, int] = defaultdict(int)
+        self.entity_count_by_schema: dict[str, int] = defaultdict(int)
 
         self.thing_count = 0
-        self.thing_countries: Dict[str, int] = defaultdict(int)
-        self.thing_schemata: Dict[str, int] = defaultdict(int)
-        self.entities_with_prop_count: Dict[SchemaProperty, int] = defaultdict(int)
+        self.thing_countries: dict[str, int] = defaultdict(int)
+        self.thing_schemata: dict[str, int] = defaultdict(int)
+        self.entities_with_prop_count: dict[SchemaProperty, int] = defaultdict(int)
 
         self.target_count = 0
-        self.target_countries: Dict[str, int] = defaultdict(int)
-        self.target_schemata: Dict[str, int] = defaultdict(int)
+        self.target_countries: dict[str, int] = defaultdict(int)
+        self.target_schemata: dict[str, int] = defaultdict(int)
 
-        self.sanctions_programs: Dict[str, int] = defaultdict(int)
+        self.sanctions_programs: dict[str, int] = defaultdict(int)
 
     def observe(self, entity: Entity) -> None:
         self.entity_count += 1
@@ -125,7 +125,7 @@ class Statistics(object):
             else:
                 self.last_change = max(self.last_change, entity.last_change)
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "last_change": self.last_change,
             "schemata": list(self.schemata),

--- a/zavod/zavod/extract/llm.py
+++ b/zavod/zavod/extract/llm.py
@@ -6,7 +6,7 @@ import mimetypes
 from functools import cache
 from hashlib import sha1
 from pathlib import Path
-from typing import Any, Optional, Type, TypeVar
+from typing import Any, TypeVar
 
 from openai import OpenAI
 from pydantic import BaseModel
@@ -32,7 +32,7 @@ def get_client() -> OpenAI:
     return OpenAI(api_key=settings.OPENAI_API_KEY)
 
 
-def encode_file(file: Path, mime_type: Optional[str] = None) -> str:
+def encode_file(file: Path, mime_type: str | None = None) -> str:
     """Encode a file as a base64 data URL."""
     if mime_type is None:
         mime_type, _ = mimetypes.guess_type(file.name)
@@ -58,9 +58,9 @@ def run_image_prompt(
     cache_key = cache_hash.hexdigest()
     cached_data = context.cache.get_json(cache_key, max_age=cache_days)
     if cached_data is not None:
-        log.info("GPT cache hit: %s" % image_path.name)
+        log.info(f"GPT cache hit: {image_path.name}")
         return cached_data
-    log.info("Prompting %r for: %s" % (model, image_path.name))
+    log.info(f"Prompting {model!r} for: {image_path.name}")
     response = client.chat.completions.create(
         model=model,
         messages=[
@@ -83,11 +83,11 @@ def run_image_prompt(
     return data
 
 
-def run_typed_image_prompt(
+def run_typed_image_prompt[ResponseType: BaseModel](
     context: Context,
     prompt: str,
     image_path: Path,
-    response_type: Type[ResponseType],
+    response_type: type[ResponseType],
     max_tokens: int = 3000,
     cache_days: int = 100,
     model: str = DEFAULT_MODEL,
@@ -102,9 +102,9 @@ def run_typed_image_prompt(
     cache_key = cache_hash.hexdigest()
     cached_data = context.cache.get_json(cache_key, max_age=cache_days)
     if cached_data is not None:
-        log.info("GPT cache hit: %s" % image_path.name)
+        log.info(f"GPT cache hit: {image_path.name}")
         return response_type.model_validate(cached_data)
-    log.info("Prompting %r for: %s" % (model, image_path.name))
+    log.info(f"Prompting {model!r} for: {image_path.name}")
     response = client.chat.completions.parse(
         model=model,
         messages=[
@@ -156,9 +156,9 @@ def run_text_prompt(
     cache_key = cache_hash.hexdigest()
     cached_data = context.cache.get(cache_key, max_age=cache_days)
     if cached_data is not None:
-        log.info("GPT cache hit: %s" % string[:50])
+        log.info(f"GPT cache hit: {string[:50]}")
         return TextPromptResponse(content=cached_data, cache_key=cache_key)
-    log.info("Prompting %r for: %s" % (model, string[:50]))
+    log.info(f"Prompting {model!r} for: {string[:50]}")
     response = client.chat.completions.create(
         model=model,
         messages=[
@@ -182,11 +182,11 @@ def run_text_prompt(
     return TextPromptResponse(content=content, cache_key=cache_key)
 
 
-def run_typed_text_prompt(
+def run_typed_text_prompt[ResponseType: BaseModel](
     context: Context,
     prompt: str,
     string: str,
-    response_type: Type[ResponseType],
+    response_type: type[ResponseType],
     max_tokens: int = 3000,
     cache_days: int = 100,
     model: str = DEFAULT_MODEL,
@@ -200,9 +200,9 @@ def run_typed_text_prompt(
     cache_key = cache_hash.hexdigest()
     cached_data = context.cache.get_json(cache_key, max_age=cache_days)
     if cached_data is not None:
-        log.info("GPT cache hit: %s" % string[:50])
+        log.info(f"GPT cache hit: {string[:50]}")
         return response_type.model_validate(cached_data)
-    log.info("Prompting %r for: %s" % (model, string[:50]))
+    log.info(f"Prompting {model!r} for: {string[:50]}")
     response = client.chat.completions.parse(
         model=model,
         messages=[

--- a/zavod/zavod/extract/names/clean.py
+++ b/zavod/zavod/extract/names/clean.py
@@ -1,6 +1,7 @@
 from functools import cache
 from pathlib import Path
-from typing import Any, Generator, Optional, Sequence, Tuple
+from typing import Any
+from collections.abc import Generator, Sequence
 import json
 
 from pydantic import BaseModel
@@ -17,7 +18,7 @@ EXCLUDE_IF_EMPTY = {"previousName", "firstName", "middleName", "lastName"}
 
 class LangText(BaseModel):
     text: str
-    lang: Optional[str]
+    lang: str | None
     """ISO 639-2 (3-letter) language code, or None if not known"""
 
     def __hash__(self) -> int:
@@ -86,7 +87,7 @@ class Names(BaseModel):
             return False
         return True
 
-    def as_langtexts(self) -> Generator[Tuple[str, list[LangText]], None, None]:
+    def as_langtexts(self) -> Generator[tuple[str, list[LangText]], None, None]:
         """
         Generator yielding each property and a list of any associated non-empty name values.
 
@@ -108,9 +109,7 @@ class Names(BaseModel):
                 if nonempty_values:
                     yield key, nonempty_values
 
-    def add(
-        self, prop: str, value: Optional[str], *, lang: Optional[str] = None
-    ) -> None:
+    def add(self, prop: str, value: str | None, *, lang: str | None = None) -> None:
         """
         Add a value to a property. If set as a single value, the values are added to a list.
         Value is wrapped in LangText if lang is provided.
@@ -221,7 +220,7 @@ def _to_lang_text(value: str | LangText) -> LangText:
     return value
 
 
-def is_empty_string(text: Optional[str | LangText]) -> bool:
+def is_empty_string(text: str | LangText | None) -> bool:
     if text is None:
         return True
     if isinstance(text, LangText):

--- a/zavod/zavod/extract/names/dspy/clean.py
+++ b/zavod/zavod/extract/names/dspy/clean.py
@@ -1,5 +1,4 @@
 from functools import cache
-from typing import List
 
 from zavod.extract.names.clean import LLM_MODEL_VERSION, SINGLE_ENTITY_PROGRAM_PATH
 from zavod.settings import OPENAI_API_KEY
@@ -14,12 +13,12 @@ class CleanNamesSignature(dspy.Signature):  # type: ignore
     entity_schema: str = dspy.InputField(
         desc="The schema denotes the type of entity. Both Persons and Organizations are specialisation of LegalEntity. Company is a specialisation of Organization. Everything extends Thing."
     )
-    strings: List[str] = dspy.InputField(
+    strings: list[str] = dspy.InputField(
         desc="A list of raw name strings to be cleaned and categorised. Each string might contain multiple names."
     )
 
     # Outputs
-    name: List[str] = dspy.OutputField(
+    name: list[str] = dspy.OutputField(
         desc="A list of the primary names of this entity, potentially in various languages and transliterations."
     )
     alias: list[str] = dspy.OutputField(

--- a/zavod/zavod/extract/names/dspy/example_data.py
+++ b/zavod/zavod/extract/names/dspy/example_data.py
@@ -12,7 +12,7 @@ EXAMPLES_PATH = Path(__file__).parent / "single_entity_examples.yml"
 def load_data(
     examples_path: Path,
 ) -> tuple[list[dspy.Example], list[dspy.Example], list[dspy.Example]]:
-    with open(examples_path, "r", encoding="utf-8") as f:
+    with open(examples_path, encoding="utf-8") as f:
         cases = yaml.load(f, Loader=yaml.SafeLoader)
 
     dspy_dataset = []

--- a/zavod/zavod/extract/names/dspy/optimise.py
+++ b/zavod/zavod/extract/names/dspy/optimise.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from normality import slugify
 from zavod.extract.names.dspy.clean import init_module
@@ -24,8 +24,8 @@ def metric_with_feedback(
 
 
 def metric_with_feedback_dict(
-    example: Dict[str, List[str]],
-    pred: Dict[str, List[str]],
+    example: dict[str, list[str]],
+    pred: dict[str, list[str]],
 ) -> dspy.Prediction:
     feedback = ""
     score = 0.0
@@ -60,7 +60,7 @@ def optimise_single_entity(
     examples_path: Path,
     program_path: Path,
     level: str = "heavy",
-    threads: Optional[int] = 32,
+    threads: int | None = 32,
 ) -> None:
     train_set, val_set, _test_set = load_data(examples_path)
 

--- a/zavod/zavod/extract/zyte_api.py
+++ b/zavod/zavod/extract/zyte_api.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from email.message import Message
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, cast
 
 from lxml import html, etree
 from normality import predict_encoding
@@ -28,7 +28,7 @@ class UnblockFailedException(RuntimeError):
         )
 
 
-def get_content_type(headers: List[Dict[str, str]]) -> Tuple[str | None, str | None]:
+def get_content_type(headers: list[dict[str, str]]) -> tuple[str | None, str | None]:
     context_type_headers = [
         h["value"] for h in headers if h["name"].lower() == "content-type"
     ]
@@ -62,13 +62,13 @@ def fetch_resource(
     context: Context,
     filename: str,
     url: str,
-    expected_media_type: Optional[str] = None,
-    expected_charset: Optional[str] = None,
-    geolocation: Optional[str] = None,
-    method: Optional[str] = None,
-    body: Optional[bytes] = None,
-    headers: Optional[Dict[str, str]] = None,
-) -> Tuple[bool, str | None, str | None, Path]:
+    expected_media_type: str | None = None,
+    expected_charset: str | None = None,
+    geolocation: str | None = None,
+    method: str | None = None,
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[bool, str | None, str | None, Path]:
     """
     Fetch a resource using Zyte API and save to filesystem.
 
@@ -108,7 +108,7 @@ def fetch_resource(
     # a text response or a base64-encoded response to text, whereas here we want to
     # save the raw bytes to a file. Letting fetch cover both cases seems more complex than
     # just constructing the right request here.
-    zyte_data: Dict[str, Any] = {
+    zyte_data: dict[str, Any] = {
         "httpResponseBody": True,
         "httpResponseHeaders": True,
     }
@@ -159,17 +159,17 @@ class ZyteAPIRequest:
     """Container dataclass for possible arguments to the Zyte API."""
 
     url: str
-    method: Optional[str] = None  # Defaults to GET server-side
-    body: Optional[bytes] = None
+    method: str | None = None  # Defaults to GET server-side
+    body: bytes | None = None
 
     scrape_type: ZyteScrapeType = ZyteScrapeType.HTTP_RESPONSE_BODY
-    actions: Optional[List[Dict[str, Any]]] = None
-    headers: Optional[Dict[str, str]] = None
-    geolocation: Optional[str] = None
+    actions: list[dict[str, Any]] | None = None
+    headers: dict[str, str] | None = None
+    geolocation: str | None = None
     # Forces JavaScript execution on a browser request to be enabled
-    javascript: Optional[bool] = None
+    javascript: bool | None = None
     # Cookies sent with the request, e.g. [{"name": "x", "value": "y", "domain": ".example.com"}]
-    request_cookies: Optional[List[Dict[str, Any]]] = None
+    request_cookies: list[dict[str, Any]] | None = None
     # Request that response cookies be included in the ZyteResult
     response_cookies: bool = False
 
@@ -181,23 +181,23 @@ class ZyteResult:
     response_text: str
 
     # If the response is served from the cache, status_code is None
-    status_code: Optional[int]
+    status_code: int | None
 
     # The cache fingerprint
     cache_fingerprint: str
     from_cache: bool
 
     # As returned in the Content-Type header
-    media_type: Optional[str] = None
-    charset: Optional[str] = None
+    media_type: str | None = None
+    charset: str | None = None
     # Cookies returned by the server, populated when response_cookies=True
-    cookies: Optional[List[Dict[str, Any]]] = None
+    cookies: list[dict[str, Any]] | None = None
 
     def invalidate_cache(self, context: Context) -> None:
         context.cache.delete(self.cache_fingerprint)
 
 
-def get_cache_fingerprint(request_data: Dict[str, Any]) -> str:
+def get_cache_fingerprint(request_data: dict[str, Any]) -> str:
     # Slight abuse of the cache key to produce keys of the usual style.
     # Technically this isn't the data that's sent
     # to the target server (url), but technically we're not caching the response
@@ -210,7 +210,7 @@ def get_cache_fingerprint(request_data: Dict[str, Any]) -> str:
 def fetch(
     context: Context,
     zyte_request: ZyteAPIRequest,
-    cache_days: Optional[int] = None,
+    cache_days: int | None = None,
 ) -> ZyteResult:
     """
     Fetch using the Zyte API.
@@ -229,7 +229,7 @@ def fetch(
     if settings.ZYTE_API_KEY is None:
         raise RuntimeError("OPENSANCTIONS_ZYTE_API_KEY is not set")
 
-    zyte_data: Dict[str, Any] = {
+    zyte_data: dict[str, Any] = {
         "url": zyte_request.url,
         "httpResponseHeaders": True,
     }
@@ -314,11 +314,11 @@ def fetch(
 def fetch_text(
     context: Context,
     url: str,
-    geolocation: Optional[str] = None,
-    cache_days: Optional[int] = None,
-    expected_media_type: Optional[str] = None,
-    expected_charset: Optional[str] = None,
-) -> Tuple[bool, str | None, str | None, str]:
+    geolocation: str | None = None,
+    cache_days: int | None = None,
+    expected_media_type: str | None = None,
+    expected_charset: str | None = None,
+) -> tuple[bool, str | None, str | None, str]:
     """
     Fetch a text document using the Zyte API.
 
@@ -379,9 +379,9 @@ def fetch_text(
 def fetch_json(
     context: Context,
     url: str,
-    cache_days: Optional[int] = None,
-    expected_media_type: Optional[str] = "application/json",
-    geolocation: Optional[str] = None,
+    cache_days: int | None = None,
+    expected_media_type: str | None = "application/json",
+    geolocation: str | None = None,
 ) -> Any:
     """
     Returns:
@@ -424,12 +424,12 @@ def fetch_html(
     context: Context,
     url: str,
     unblock_validator: str,
-    actions: list[Dict[str, Any]] = [],
+    actions: list[dict[str, Any]] = [],
     html_source: str = "browserHtml",
-    javascript: Optional[bool] = None,
-    geolocation: Optional[str] = None,
-    request_cookies: Optional[List[Dict[str, Any]]] = None,
-    cache_days: Optional[int] = None,
+    javascript: bool | None = None,
+    geolocation: str | None = None,
+    request_cookies: list[dict[str, Any]] | None = None,
+    cache_days: int | None = None,
     retries: int = 3,
     backoff_factor: int = 3,
     previous_retries: int = 0,

--- a/zavod/zavod/helpers/addresses.py
+++ b/zavod/zavod/helpers/addresses.py
@@ -1,7 +1,6 @@
 import re
 from normality import slugify_text
 from functools import lru_cache
-from typing import Optional, Tuple
 from followthemoney import registry
 from followthemoney.util import join_text, make_entity_id
 from rigour.addresses import format_address_line
@@ -17,21 +16,21 @@ REGEX_POBOX = re.compile(r"^p\.?o\.? ?box [\d-]+$", re.IGNORECASE)
 
 @lru_cache(maxsize=10000)
 def format_address(
-    summary: Optional[str] = None,
-    po_box: Optional[str] = None,
-    street: Optional[str] = None,
-    street2: Optional[str] = None,
-    street3: Optional[str] = None,
-    house: Optional[str] = None,
-    house_number: Optional[str] = None,
-    postal_code: Optional[str] = None,
-    city: Optional[str] = None,
-    county: Optional[str] = None,
-    state: Optional[str] = None,
-    state_district: Optional[str] = None,
-    state_code: Optional[str] = None,
-    country: Optional[str] = None,
-    country_code: Optional[str] = None,
+    summary: str | None = None,
+    po_box: str | None = None,
+    street: str | None = None,
+    street2: str | None = None,
+    street3: str | None = None,
+    house: str | None = None,
+    house_number: str | None = None,
+    postal_code: str | None = None,
+    city: str | None = None,
+    county: str | None = None,
+    state: str | None = None,
+    state_district: str | None = None,
+    state_code: str | None = None,
+    country: str | None = None,
+    country_code: str | None = None,
 ) -> str:
     """Given the components of a postal address, format it into a single line
     using some country-specific templating logic.
@@ -86,10 +85,10 @@ def format_address(
 
 def _make_id(
     entity: Entity,
-    full: Optional[str],
-    country_code: Optional[str],
-    key: Optional[str] = None,
-) -> Optional[str]:
+    full: str | None,
+    country_code: str | None,
+    key: str | None = None,
+) -> str | None:
     if full is None or not len(full.strip()):
         country_id = make_entity_id(country_code, full, key)
         if country_id is None:
@@ -107,24 +106,24 @@ def _make_id(
 
 def make_address(
     context: Context,
-    full: Optional[str] = None,
-    remarks: Optional[str] = None,
-    summary: Optional[str] = None,
-    po_box: Optional[str] = None,
-    street: Optional[str] = None,
-    street2: Optional[str] = None,
-    street3: Optional[str] = None,
-    city: Optional[str] = None,
-    place: Optional[str] = None,
-    postal_code: Optional[str] = None,
-    state: Optional[str] = None,
-    region: Optional[str] = None,
-    country: Optional[str] = None,
-    country_code: Optional[str] = None,
-    key: Optional[str] = None,
-    lang: Optional[str] = None,
-    origin: Optional[str] = None,
-) -> Optional[Entity]:
+    full: str | None = None,
+    remarks: str | None = None,
+    summary: str | None = None,
+    po_box: str | None = None,
+    street: str | None = None,
+    street2: str | None = None,
+    street3: str | None = None,
+    city: str | None = None,
+    place: str | None = None,
+    postal_code: str | None = None,
+    state: str | None = None,
+    region: str | None = None,
+    country: str | None = None,
+    country_code: str | None = None,
+    key: str | None = None,
+    lang: str | None = None,
+    origin: str | None = None,
+) -> Entity | None:
     """Generate an address schema object adjacent to the main entity.
 
     Args:
@@ -215,7 +214,7 @@ def make_address(
     return address
 
 
-def apply_address(context: Context, entity: Entity, address: Optional[Entity]) -> None:
+def apply_address(context: Context, entity: Entity, address: Entity | None) -> None:
     """Link the given entity to the given address and emits the address.
 
     Args:
@@ -236,7 +235,7 @@ def apply_address(context: Context, entity: Entity, address: Optional[Entity]) -
         entity.add("address", address.get("full"))
 
 
-def copy_address(entity: Entity, address: Optional[Entity]) -> None:
+def copy_address(entity: Entity, address: Entity | None) -> None:
     """Assign to full address text and country directly to the given entity.
 
     This is an alternative to using `apply_address` when the address should
@@ -255,7 +254,7 @@ def copy_address(entity: Entity, address: Optional[Entity]) -> None:
                     entity.adopt_statement(stmt, prop="country")
 
 
-def postcode_pobox(text: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+def postcode_pobox(text: str | None) -> tuple[str | None, str | None]:
     """
     For when PO Box is stuffed into postcode, sometimes.
 

--- a/zavod/zavod/helpers/articles.py
+++ b/zavod/zavod/helpers/articles.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from zavod.context import Context
 from zavod.entity import Entity
 from zavod import helpers as h
@@ -8,9 +6,9 @@ from zavod import helpers as h
 def make_article(
     context: Context,
     url: str,
-    key_extra: Optional[str] = None,
-    title: Optional[str] = None,
-    published_at: Optional[str] = None,
+    key_extra: str | None = None,
+    title: str | None = None,
+    published_at: str | None = None,
 ) -> Entity:
     """
     Create an article entity based on the URL where it was published.
@@ -36,8 +34,8 @@ def make_documentation(
     context: Context,
     entity: Entity,
     article: Entity,
-    key_extra: Optional[str] = None,
-    date: Optional[str] = None,
+    key_extra: str | None = None,
+    date: str | None = None,
 ) -> Entity:
     """
     Creates a documentation entity to link an article to a related entity.

--- a/zavod/zavod/helpers/change.py
+++ b/zavod/zavod/helpers/change.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from lxml import etree
 from hashlib import sha1
-from typing import Any, Optional
+from typing import Any
 from normality import squash_spaces
 
 from zavod.logs import get_logger
@@ -16,8 +16,8 @@ def assert_url_hash(
     url: str,
     hash: str,
     raise_exc: bool = False,
-    auth: Optional[Any] = None,
-    headers: Optional[Any] = None,
+    auth: Any | None = None,
+    headers: Any | None = None,
 ) -> bool:
     """Assert that a document located at the URL has a given SHA1 hash."""
     digest = sha1()
@@ -32,7 +32,7 @@ def assert_url_hash(
             raise AssertionError(msg)
         else:
             log.warning(
-                "URL hash changed: %s" % url,
+                f"URL hash changed: {url}",
                 expected=hash,
                 actual=actual,
                 url=url,
@@ -57,7 +57,7 @@ def assert_file_hash(
             raise AssertionError(msg)
         else:
             log.warning(
-                "File hash changed: %s" % path.name,
+                f"File hash changed: {path.name}",
                 expected=hash,
                 actual=actual,
                 name=path.name,
@@ -67,8 +67,8 @@ def assert_file_hash(
 
 
 def _compute_node_hash(
-    node: Optional[ElementOrTree], text_only: bool = False
-) -> Optional[str]:
+    node: ElementOrTree | None, text_only: bool = False
+) -> str | None:
     digest = sha1()
     if node is None:
         return None
@@ -93,7 +93,7 @@ def _compute_node_hash(
 
 
 def assert_dom_hash(
-    node: Optional[ElementOrTree],
+    node: ElementOrTree | None,
     hash: str,
     raise_exc: bool = False,
     text_only: bool = False,
@@ -106,7 +106,7 @@ def assert_dom_hash(
             raise AssertionError(msg)
         else:
             log.warning(
-                "DOM hash changed: %s" % node,
+                f"DOM hash changed: {node}",
                 expected=hash,
                 actual=actual,
                 node=repr(node),
@@ -119,7 +119,7 @@ def assert_html_url_hash(
     context: Context,
     url: str,
     hash: str,
-    path: Optional[str] = None,
+    path: str | None = None,
     raise_exc: bool = False,
     text_only: bool = False,
 ) -> bool:

--- a/zavod/zavod/helpers/crypto.py
+++ b/zavod/zavod/helpers/crypto.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional, Dict
 
 # Credit: https://gist.github.com/MBrassey/623f7b8d02766fa2d826bf9eca3fe005
 
@@ -27,7 +26,7 @@ CRYPTOS = {
 CRYPTOS_RE = {k: re.compile(v) for k, v in CRYPTOS.items()}
 
 
-def extract_cryptos(text: Optional[str]) -> Dict[str, str]:
+def extract_cryptos(text: str | None) -> dict[str, str]:
     """Extract cryptocurrency addresses from text.
 
     Args:
@@ -36,7 +35,7 @@ def extract_cryptos(text: Optional[str]) -> Dict[str, str]:
     Returns:
         A set of cryptocurrency IDs, with currency code.
     """
-    out: Dict[str, str] = {}
+    out: dict[str, str] = {}
     if text is None:
         return out
     for currency, v in CRYPTOS_RE.items():

--- a/zavod/zavod/helpers/dates.py
+++ b/zavod/zavod/helpers/dates.py
@@ -4,7 +4,7 @@ from normality import stringify
 from prefixdate import parse_formats
 from rigour.dates import ended_before
 from datetime import datetime, date, timedelta, UTC
-from typing import Union, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from collections.abc import Iterable
 from followthemoney import registry
 
@@ -20,7 +20,7 @@ log = get_logger(__name__)
 NUMBERS = re.compile(r"\b\d+\b")
 # We always want to accept ISO prefix dates.
 ALWAYS_FORMATS = ["%Y-%m-%d", "%Y-%m", "%Y"]
-DateValue = Union[str, date, datetime, None]
+DateValue = str | date | datetime | None
 MAX_ENFORCEMENT_DAYS = 365 * 5
 
 __all__ = [

--- a/zavod/zavod/helpers/dates.py
+++ b/zavod/zavod/helpers/dates.py
@@ -3,8 +3,9 @@ from functools import lru_cache
 from normality import stringify
 from prefixdate import parse_formats
 from rigour.dates import ended_before
-from datetime import datetime, date, timedelta, timezone
-from typing import Tuple, Union, Iterable, Set, Optional, List, TYPE_CHECKING
+from datetime import datetime, date, timedelta, UTC
+from typing import Union, TYPE_CHECKING
+from collections.abc import Iterable
 from followthemoney import registry
 
 from zavod.logs import get_logger
@@ -33,7 +34,7 @@ __all__ = [
 ]
 
 
-def extract_years(text: str) -> List[str]:
+def extract_years(text: str) -> list[str]:
     """Try to locate year numbers in a string such as 'circa 1990'. This will fail if
     any numbers that don't look like years are found in the string, a strong indicator
     that a more precise date is encoded (e.g. '1990 Mar 03').
@@ -46,7 +47,7 @@ def extract_years(text: str) -> List[str]:
     Returns:
         a set of year strings.
     """
-    years: Set[str] = set()
+    years: set[str] = set()
     for match in NUMBERS.finditer(text):
         year = match.group()
         number = int(year)
@@ -76,9 +77,9 @@ def replace_months(dataset: Dataset, text: str) -> str:
 def extract_date(
     dataset: Dataset,
     text: DateValue,
-    formats: Optional[Tuple[str]] = None,
+    formats: tuple[str] | None = None,
     fallback_to_original: bool = True,
-) -> List[str]:
+) -> list[str]:
     """
     Extract a date from the provided text using predefined `formats` in the metadata.
     If the text doesn't match any format, returns the original text.
@@ -89,7 +90,7 @@ def extract_date(
         return [text.isoformat()]
     elif isinstance(text, datetime):
         if text.tzinfo is not None:
-            text = text.astimezone(timezone.utc)
+            text = text.astimezone(UTC)
         iso = text.date().isoformat()
         return [iso]
     elif isinstance(text, str):
@@ -114,8 +115,8 @@ def apply_date(
     entity: Entity,
     prop: str,
     text: DateValue,
-    formats: Optional[Tuple[str]] = None,
-    original_value: Optional[str] = None,
+    formats: tuple[str] | None = None,
+    original_value: str | None = None,
 ) -> None:
     """Apply a date value to an entity, parsing it if necessary and cleaning it up.
 
@@ -132,7 +133,7 @@ def apply_date(
     """
     prop_ = entity.schema.get(prop)
     if prop_ is None or prop_.type != registry.date:
-        log.warning("Property is not a date: %s" % prop, text=text)
+        log.warning(f"Property is not a date: {prop}", text=text)
         return
 
     if not isinstance(text, str):

--- a/zavod/zavod/helpers/excel.py
+++ b/zavod/zavod/helpers/excel.py
@@ -1,4 +1,4 @@
-from typing import Dict, Generator, Iterator, List, Optional, Union
+from collections.abc import Generator, Iterator
 from datetime import datetime
 from datapatch import Lookup
 from normality import slugify_text, stringify
@@ -17,7 +17,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 from zavod.context import Context
 
 
-def convert_excel_cell(book: Book, cell: Cell) -> Optional[str]:
+def convert_excel_cell(book: Book, cell: Cell) -> str | None:
     """Convert an Excel cell to a string, handling different types.
 
     Args:
@@ -43,7 +43,7 @@ def convert_excel_cell(book: Book, cell: Cell) -> Optional[str]:
         return str(cell.value)
 
 
-def convert_excel_date(value: Optional[Union[str, int, float]]) -> Optional[str]:
+def convert_excel_date(value: str | int | float | None) -> str | None:
     """Convert an Excel date to a string.
 
     Args:
@@ -73,7 +73,7 @@ def parse_xls_sheet(
     sheet: Sheet,
     skiprows: int = 0,
     join_header_rows: int = 0,
-) -> Generator[Dict[str, str | None], None, None]:
+) -> Generator[dict[str, str | None], None, None]:
     """
     Parse an Excel sheet into a sequence of dictionaries.
 
@@ -81,12 +81,12 @@ def parse_xls_sheet(
 
     Cells with links are included as keys with _url appended to the original key.
     """
-    headers: List[str] | None = None
+    headers: list[str] | None = None
     for row_ix, row in enumerate(sheet):
         if row_ix < skiprows:
             continue
-        cells: List[Optional[str]] = []
-        record: Dict[str, str | None] = {}
+        cells: list[str | None] = []
+        record: dict[str, str | None] = {}
         for cell_ix, xl_cell in enumerate(row):
             if xl_cell.ctype == XL_CELL_DATE:
                 # Convert Excel date format to zavod date
@@ -134,9 +134,9 @@ def parse_xlsx_sheet(
     context: Context,
     sheet: Worksheet,
     skiprows: int = 0,
-    header_lookup: Optional[Lookup] = None,
+    header_lookup: Lookup | None = None,
     extract_links: bool = False,
-) -> Iterator[Dict[str, str | None]]:
+) -> Iterator[dict[str, str | None]]:
     """
     Parse an Excel sheet into a sequence of dictionaries.
 
@@ -147,7 +147,7 @@ def parse_xlsx_sheet(
         header_lookup: The lookup key for translating headers.
         extract_links: Whether to extract hyperlinks. Only works when read_only=False
     """
-    headers: Optional[List[str]] = None
+    headers: list[str] | None = None
     row_counter = 0
 
     for row in sheet.iter_rows():

--- a/zavod/zavod/helpers/html.py
+++ b/zavod/zavod/helpers/html.py
@@ -1,5 +1,6 @@
 import re
-from typing import Dict, Generator, List, Optional, Set, cast
+from typing import cast
+from collections.abc import Generator
 
 from lxml.html import HtmlElement
 from normality import slugify, squash_spaces
@@ -58,10 +59,10 @@ def parse_html_table(
     table: Element,
     header_tag: str = "th",
     skiprows: int = 0,
-    ignore_colspan: Optional[Set[str]] = None,
+    ignore_colspan: set[str] | None = None,
     slugify_headers: bool = True,
     index_empty_headers: bool = False,
-) -> Generator[Dict[str, Element], None, None]:
+) -> Generator[dict[str, Element], None, None]:
     """
     Parse an HTML table into a generator yielding a dict for each row.
 
@@ -87,7 +88,7 @@ def parse_html_table(
         if headers is None:
             headers = []
             for colnum, el in enumerate(row.findall(f"./{header_tag}")):
-                header_text: Optional[str] = element_text(el)
+                header_text: str | None = element_text(el)
                 if slugify_headers:
                     header_text = slugify(header_text, sep="_")
                 if index_empty_headers and not header_text:
@@ -110,7 +111,7 @@ def parse_html_table(
         yield {hdr: c for hdr, c in zip(headers, cells)}
 
 
-def cells_to_str(row: Dict[str, Element]) -> Dict[str, str | None]:
+def cells_to_str(row: dict[str, Element]) -> dict[str, str | None]:
     """
     Return the string value of each HtmlElement value in the passed dictionary
 
@@ -123,7 +124,7 @@ def cells_to_str(row: Dict[str, Element]) -> Dict[str, str | None]:
     }
 
 
-def links_to_dict(el: Element) -> Dict[str | None, str | None]:
+def links_to_dict(el: Element) -> dict[str | None, str | None]:
     """
     Return a dictionary of the text content and href of each anchor element in the
     passed HtmlElement
@@ -136,8 +137,8 @@ def links_to_dict(el: Element) -> Dict[str | None, str | None]:
 
 
 def xpath_elements(
-    el: Element, xpath: str, *, expect_exactly: Optional[int] = None
-) -> List[Element]:
+    el: Element, xpath: str, *, expect_exactly: int | None = None
+) -> list[Element]:
     """
     Evaluate an XPath expression and return matching elements as a typed list.
 
@@ -179,8 +180,8 @@ def xpath_element(el: Element, xpath: str) -> Element:
 
 
 def xpath_strings(
-    el: Element, xpath: str, *, expect_exactly: Optional[int] = None
-) -> List[str]:
+    el: Element, xpath: str, *, expect_exactly: int | None = None
+) -> list[str]:
     """
     Evaluate an XPath expression and return matching strings as a typed list.
 
@@ -213,7 +214,7 @@ def xpath_string(el: Element, xpath: str) -> str:
     return xpath_strings(el, xpath, expect_exactly=1)[0]
 
 
-def split_html_newline_tags(string: str) -> List[str]:
+def split_html_newline_tags(string: str) -> list[str]:
     """
     Split a string on HTML <br> and <p> tags, returning a list of strings.
 

--- a/zavod/zavod/helpers/identification.py
+++ b/zavod/zavod/helpers/identification.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from zavod.logs import get_logger
 from zavod.entity import Entity
 from zavod.context import Context
@@ -11,17 +9,17 @@ log = get_logger(__name__)
 def make_identification(
     context: Context,
     entity: Entity,
-    number: Optional[str],
-    doc_type: Optional[str] = None,
-    country: Optional[str] = None,
-    summary: Optional[str] = None,
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
-    authority: Optional[str] = None,
-    key: Optional[str] = None,
+    number: str | None,
+    doc_type: str | None = None,
+    country: str | None = None,
+    summary: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    authority: str | None = None,
+    key: str | None = None,
     passport: bool = False,
-    origin: Optional[str] = None,
-) -> Optional[Entity]:
+    origin: str | None = None,
+) -> Entity | None:
     """Create an `Identification` or `Passport` object linked to a passport holder.
 
     Args:
@@ -49,7 +47,7 @@ def make_identification(
     assert holder_prop.range is not None
     if not entity.schema.is_a(holder_prop.range):
         log.warning(
-            "Holder is not a valid type for %s" % schema,
+            f"Holder is not a valid type for {schema}",
             entity_schema=entity.schema,
             entity_id=entity.id,
             number=number,

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 import re
-from typing import Dict, List, Optional, Tuple, cast
+from typing import cast
 
 from followthemoney.util import join_text
 from normality import squash_spaces
@@ -40,12 +40,12 @@ REGEX_CLEAN_COMMA = re.compile(
 REGEX_SPACES = re.compile(r"\s+")
 
 
-def _title_terms(terms: List[str]) -> List[str]:
+def _title_terms(terms: list[str]) -> list[str]:
     terms_ = [REGEX_SPACES.sub(" ", term) for term in terms]
     return sorted([term for term in terms_ if term.strip()], key=len, reverse=True)
 
 
-def _strip_title_prefixes(name: str, terms: List[str]) -> str:
+def _strip_title_prefixes(name: str, terms: list[str]) -> str:
     terms_ = _title_terms(terms)
     while True:
         for term in terms_:
@@ -65,7 +65,7 @@ def _strip_title_prefixes(name: str, terms: List[str]) -> str:
             return name
 
 
-def _strip_title_suffixes(name: str, terms: List[str]) -> str:
+def _strip_title_suffixes(name: str, terms: list[str]) -> str:
     terms_ = _title_terms(terms)
     while True:
         for term in terms_:
@@ -85,7 +85,7 @@ def _strip_title_suffixes(name: str, terms: List[str]) -> str:
             return name
 
 
-def strip_name_titles(context: Context, name: Optional[str]) -> Optional[str]:
+def strip_name_titles(context: Context, name: str | None) -> str | None:
     """Strip configured title affixes from a source name.
 
     Use when a dataset stores honorific prefixes or post-nominals as part of a
@@ -115,23 +115,23 @@ def strip_name_titles(context: Context, name: Optional[str]) -> Optional[str]:
 
 
 def make_name(
-    full: Optional[str] = None,
-    name1: Optional[str] = None,
-    first_name: Optional[str] = None,
-    given_name: Optional[str] = None,
-    name2: Optional[str] = None,
-    second_name: Optional[str] = None,
-    middle_name: Optional[str] = None,
-    name3: Optional[str] = None,
-    patronymic: Optional[str] = None,
-    matronymic: Optional[str] = None,
-    name4: Optional[str] = None,
-    name5: Optional[str] = None,
-    tail_name: Optional[str] = None,
-    last_name: Optional[str] = None,
-    prefix: Optional[str] = None,
-    suffix: Optional[str] = None,
-) -> Optional[str]:
+    full: str | None = None,
+    name1: str | None = None,
+    first_name: str | None = None,
+    given_name: str | None = None,
+    name2: str | None = None,
+    second_name: str | None = None,
+    middle_name: str | None = None,
+    name3: str | None = None,
+    patronymic: str | None = None,
+    matronymic: str | None = None,
+    name4: str | None = None,
+    name5: str | None = None,
+    tail_name: str | None = None,
+    last_name: str | None = None,
+    prefix: str | None = None,
+    suffix: str | None = None,
+) -> str | None:
     """Provides a standardised way of assembling the components of a human name.
     This does a whole lot of cultural ignorance work, so YMMV.
 
@@ -182,10 +182,10 @@ def make_name(
 def set_name_part(
     entity: Entity,
     prop: str,
-    value: Optional[str],
+    value: str | None,
     quiet: bool,
-    lang: Optional[str],
-    origin: Optional[str],
+    lang: str | None,
+    origin: str | None,
 ) -> None:
     if value is None:
         return
@@ -193,35 +193,35 @@ def set_name_part(
     if prop_ is None:
         if quiet:
             return
-        raise TypeError("Invalid prop: %s [value: %r]" % (prop, value))
+        raise TypeError(f"Invalid prop: {prop} [value: {value!r}]")
     entity.add(prop_, value, lang=lang, origin=origin)
 
 
 def apply_name(
     entity: Entity,
-    full: Optional[str] = None,
-    name1: Optional[str] = None,
-    first_name: Optional[str] = None,
-    given_name: Optional[str] = None,
-    name2: Optional[str] = None,
-    second_name: Optional[str] = None,
-    middle_name: Optional[str] = None,
-    name3: Optional[str] = None,
-    patronymic: Optional[str] = None,
-    matronymic: Optional[str] = None,
-    name4: Optional[str] = None,
-    name5: Optional[str] = None,
-    tail_name: Optional[str] = None,
-    last_name: Optional[str] = None,
-    maiden_name: Optional[str] = None,
-    prefix: Optional[str] = None,
-    suffix: Optional[str] = None,
+    full: str | None = None,
+    name1: str | None = None,
+    first_name: str | None = None,
+    given_name: str | None = None,
+    name2: str | None = None,
+    second_name: str | None = None,
+    middle_name: str | None = None,
+    name3: str | None = None,
+    patronymic: str | None = None,
+    matronymic: str | None = None,
+    name4: str | None = None,
+    name5: str | None = None,
+    tail_name: str | None = None,
+    last_name: str | None = None,
+    maiden_name: str | None = None,
+    prefix: str | None = None,
+    suffix: str | None = None,
     alias: bool = False,
     name_prop: str = "name",
     is_weak: bool = False,
     quiet: bool = False,
-    lang: Optional[str] = None,
-    origin: Optional[str] = None,
+    lang: str | None = None,
+    origin: str | None = None,
 ) -> None:
     """A standardised way to set a name for a person or other entity, which handles
     normalising the categories of names found in source data to the correct properties
@@ -299,7 +299,7 @@ def apply_name(
         entity.add(name_prop, full, quiet=quiet, lang=lang, origin=full_origin)
 
 
-def split_comma_names(context: Context, text: str) -> List[str]:
+def split_comma_names(context: Context, text: str) -> list[str]:
     """Split a string of multiple names that may contain company and individual names,
     some including commas, into individual names without breaking partnership names
     like "A, B and C Inc" or individuals like "Smith, Jane".
@@ -318,7 +318,7 @@ def split_comma_names(context: Context, text: str) -> List[str]:
     # Check early for overrides of cases where splitting on comma is a mistake.
     res = context.lookup("comma_names", text)
     if res:
-        return cast(List[str], res.names)
+        return cast(list[str], res.names)
 
     text = REGEX_CLEAN_COMMA.sub(r" \1", text)
     # If the string ends in a comma, the last comma is unnecessary (e.g. Goldman Sachs & Co. LLC,)
@@ -332,7 +332,7 @@ def split_comma_names(context: Context, text: str) -> List[str]:
         if ("," in text) or (" and " in text):
             res = context.lookup("comma_names", text)
             if res:
-                return cast("List[str]", res.names)
+                return cast("list[str]", res.names)
             else:
                 context.log.warning("Not sure how to split on comma or and.", text=text)
                 return [text]
@@ -343,7 +343,7 @@ def split_comma_names(context: Context, text: str) -> List[str]:
 @dataclass
 class Regularity:
     is_irregular: bool
-    suggested_prop: Optional[str] = None
+    suggested_prop: str | None = None
 
 
 def _is_single_token(string: str) -> bool:
@@ -360,7 +360,7 @@ def _is_single_token(string: str) -> bool:
 
 def _check_suggesting_heuristics(
     entity: Entity, string: str, names_spec: NamesSpec
-) -> Optional[Regularity]:
+) -> Regularity | None:
     # The flags for datasets to opt into suggesting heuristics are super verbose.
     # The idea is to rather introduce additional heuristics with different names
     # than have very general heuristics like 'suggest_person_weak_alias' and keep
@@ -400,7 +400,7 @@ def _check_suggesting_heuristics(
     return None
 
 
-def _check_schema_name_specs(string: str, spec: CleaningSpec) -> Optional[Regularity]:
+def _check_schema_name_specs(string: str, spec: CleaningSpec) -> Regularity | None:
     for char in spec.reject_chars_consolidated:
         if char in string:
             return Regularity(is_irregular=True)
@@ -436,7 +436,7 @@ def _check_schema_name_specs(string: str, spec: CleaningSpec) -> Optional[Regula
     return None
 
 
-def check_name_regularity(entity: Entity, string: Optional[str]) -> Regularity:
+def check_name_regularity(entity: Entity, string: str | None) -> Regularity:
     """Determine whether a name string potentially needs cleaning."""
     string = squash_spaces(string or "")
 
@@ -461,12 +461,12 @@ def check_name_regularity(entity: Entity, string: Optional[str]) -> Regularity:
     return Regularity(is_irregular=False)
 
 
-def is_name_irregular(entity: Entity, string: Optional[str]) -> bool:
+def is_name_irregular(entity: Entity, string: str | None) -> bool:
     """Determine whether a name string is irregular and needs cleaning."""
     return check_name_regularity(entity, string).is_irregular
 
 
-def check_names_regularity(entity: Entity, names: Names) -> Tuple[bool, LangNames]:
+def check_names_regularity(entity: Entity, names: Names) -> tuple[bool, LangNames]:
     """
     Determine whether any name string in the given Names instance is irregular
     and needs cleaning.
@@ -477,7 +477,7 @@ def check_names_regularity(entity: Entity, names: Names) -> Tuple[bool, LangName
     from "name" to "alias" or "weakAlias").
     """
     is_irregular = False
-    updated_suggested_data: Dict[str, List[LangText]] = defaultdict(list)
+    updated_suggested_data: dict[str, list[LangText]] = defaultdict(list)
     for key, names_values in names.as_langtexts():
         for name_val in names_values:
             regularity = check_name_regularity(entity, name_val.text)
@@ -491,7 +491,7 @@ def check_names_regularity(entity: Entity, names: Names) -> Tuple[bool, LangName
     return is_irregular, updated_suggested
 
 
-def derive_original_values(original: Names, extracted: Names) -> Dict[str, str]:
+def derive_original_values(original: Names, extracted: Names) -> dict[str, str]:
     """
     Derive an original_value for each value in extracted based on the values in original.
 
@@ -532,8 +532,8 @@ def apply_names(
     *,
     original: Names,
     names: Names,
-    lang: Optional[str] = None,
-    origin: Optional[str] = None,
+    lang: str | None = None,
+    origin: str | None = None,
 ) -> None:
     """
     Apply the given names to the entity in the indicated props.
@@ -561,7 +561,7 @@ def apply_names(
             )
 
 
-def review_key_parts(entity: Entity, original: Names) -> List[str]:
+def review_key_parts(entity: Entity, original: Names) -> list[str]:
     # Only use the non-empty props in the key so that adding props in
     # future doesn't change the key unless they're actually populated.
     # Both props and names within each prop are sorted for a stable key.
@@ -579,7 +579,7 @@ def _review_names(
     context: Context,
     entity: Entity,
     original: Names,
-    suggested: Optional[Names] = None,
+    suggested: Names | None = None,
     llm_cleaning: bool = False,
     default_accepted: bool = False,
 ) -> Review[Names]:
@@ -609,16 +609,16 @@ def _review_names(
 
     # For human readability, we only include the populated props in the source value.
     # Sort within each prop so the source_value JSON is stable when source order changes.
-    populated_props: Dict[str, List[str | Dict[str, str | None]]] = {}
+    populated_props: dict[str, list[str | dict[str, str | None]]] = {}
     for prop, vals in source_names.original.as_langtexts():
-        items: List[str | Dict[str, str | None]] = []
+        items: list[str | dict[str, str | None]] = []
         for v in sorted(vals, key=lambda v: (v.lang or "", v.text)):
             if v.lang is None:
                 items.append(v.text)
             else:
-                items.append(cast(Dict[str, str | None], v.model_dump()))
+                items.append(cast(dict[str, str | None], v.model_dump()))
         populated_props[prop] = items
-    source_value_data: Dict[str, str | Dict[str, List[str | Dict[str, str | None]]]] = {
+    source_value_data: dict[str, str | dict[str, list[str | dict[str, str | None]]]] = {
         "entity_schema": entity.schema.name,
         "original": populated_props,
     }
@@ -655,11 +655,11 @@ def review_names(
     entity: Entity,
     *,
     original: Names,
-    suggested: Optional[Names] = None,
+    suggested: Names | None = None,
     is_irregular: bool = False,
     llm_cleaning: bool = False,
     default_accepted: bool = False,
-) -> Optional[Review[Names]]:
+) -> Review[Names] | None:
     """
     Determines whether names need cleaning and if so, posts them for review.
 
@@ -734,9 +734,9 @@ def apply_reviewed_names(
     entity: Entity,
     *,
     original: Names,
-    suggested: Optional[Names] = None,
+    suggested: Names | None = None,
     is_irregular: bool = False,
-    lang: Optional[str] = None,
+    lang: str | None = None,
     llm_cleaning: bool = False,
     default_accepted: bool = False,
 ) -> None:
@@ -794,9 +794,9 @@ def apply_reviewed_name_string(
     context: Context,
     entity: Entity,
     *,
-    string: Optional[str],
+    string: str | None,
     original_prop: str = "name",
-    lang: Optional[str] = None,
+    lang: str | None = None,
     llm_cleaning: bool = False,
 ) -> None:
     """

--- a/zavod/zavod/helpers/numbers.py
+++ b/zavod/zavod/helpers/numbers.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Optional, Union
+from typing import Union
 from followthemoney import registry
 from rigour.units import normalize_unit
 
@@ -18,7 +18,7 @@ def _float_str(float: float) -> str:
 
 
 def apply_number(
-    entity: Entity, prop: str, value: NumberValue, origin: Optional[str] = None
+    entity: Entity, prop: str, value: NumberValue, origin: str | None = None
 ) -> None:
     """Apply a numeric value to a property of an entity. This will try and parse the
     number, round it, and normalize the present unit specifier (e.g. km, tons) if present.
@@ -40,7 +40,7 @@ def apply_number(
             separator=entity.dataset.numbers.separator,
         )
         if num is None:
-            log.warning("Cannot parse number: %s" % (value))
+            log.warning(f"Cannot parse number: {value}")
             return
         try:
             num = _float_str(float(num))

--- a/zavod/zavod/helpers/numbers.py
+++ b/zavod/zavod/helpers/numbers.py
@@ -1,12 +1,11 @@
 from decimal import Decimal
-from typing import Union
 from followthemoney import registry
 from rigour.units import normalize_unit
 
 from zavod.logs import get_logger
 from zavod.entity import Entity
 
-NumberValue = Union[str, int, float, Decimal]
+NumberValue = str | int | float | Decimal
 log = get_logger(__name__)
 
 

--- a/zavod/zavod/helpers/pdf.py
+++ b/zavod/zavod/helpers/pdf.py
@@ -2,7 +2,8 @@ import logging
 import subprocess
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+from typing import Any
+from collections.abc import Callable, Generator
 
 import pdfplumber
 from normality import squash_spaces, slugify
@@ -21,7 +22,7 @@ class IgnoredWarnings(logging.Filter):
 logging.getLogger("pdfminer.pdfpage").addFilter(IgnoredWarnings())
 
 
-def make_pdf_page_images(pdf_path: Path) -> List[Path]:
+def make_pdf_page_images(pdf_path: Path) -> list[Path]:
     """Split a PDF file into PNG images of its pages.
 
     This requires `pdftoppm` to be installed on the system, which is
@@ -54,11 +55,11 @@ def parse_pdf_table(
     path: Path,
     headers_per_page: bool = False,
     preserve_header_newlines: bool = False,
-    start_page: Optional[int] = None,
-    end_page: Optional[int] = None,
+    start_page: int | None = None,
+    end_page: int | None = None,
     skiprows: int = 0,
-    page_settings: Optional[Callable[[Page], Tuple[Page, Dict[str, Any]]]] = None,
-) -> Generator[Dict[str, Optional[str]], None, None]:
+    page_settings: Callable[[Page], tuple[Page, dict[str, Any]]] | None = None,
+) -> Generator[dict[str, str | None], None, None]:
     """
     Parse the largest table on each page of a PDF file and yield their rows as dictionaries.
 

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Iterable, List, Optional
+from collections.abc import Iterable
 
 from banal import ensure_list
 
@@ -21,19 +21,19 @@ from zavod.stateful.positions import (
 def make_position(
     context: Context,
     name: str,
-    summary: Optional[str] = None,
-    description: Optional[str] = None,
-    country: Optional[str | Iterable[str]] = None,
-    topics: Optional[List[str]] = None,
-    subnational_area: Optional[str] = None,
-    organization: Optional[Entity] = None,
-    inception_date: Optional[Iterable[str]] = None,
-    dissolution_date: Optional[Iterable[str]] = None,
-    number_of_seats: Optional[str] = None,
-    wikidata_id: Optional[str] = None,
-    source_url: Optional[str] = None,
-    lang: Optional[str] = None,
-    id_hash_prefix: Optional[str] = None,
+    summary: str | None = None,
+    description: str | None = None,
+    country: str | Iterable[str] | None = None,
+    topics: list[str] | None = None,
+    subnational_area: str | None = None,
+    organization: Entity | None = None,
+    inception_date: Iterable[str] | None = None,
+    dissolution_date: Iterable[str] | None = None,
+    number_of_seats: str | None = None,
+    wikidata_id: str | None = None,
+    source_url: str | None = None,
+    lang: str | None = None,
+    id_hash_prefix: str | None = None,
     translate_name: bool = False,
 ) -> Entity:
     """Creates a Position entity.
@@ -67,7 +67,7 @@ def make_position(
 
     position = context.make("Position")
 
-    parts: List[str] = [name]
+    parts: list[str] = [name]
     if country is not None:
         parts.extend(ensure_list(country))
     if inception_date is not None:
@@ -129,15 +129,15 @@ def make_occupancy(
     position: Entity,
     no_end_implies_current: bool = True,
     current_time: datetime = settings.RUN_TIME,
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
-    period_start: Optional[str] = None,
-    period_end: Optional[str] = None,
-    election_date: Optional[str] = None,
-    categorisation: Optional[PositionCategorisation] = None,
-    status: Optional[OccupancyStatus] = None,
-    key_prefix: Optional[str] = None,
-) -> Optional[Entity]:
+    start_date: str | None = None,
+    end_date: str | None = None,
+    period_start: str | None = None,
+    period_end: str | None = None,
+    election_date: str | None = None,
+    categorisation: PositionCategorisation | None = None,
+    status: OccupancyStatus | None = None,
+    key_prefix: str | None = None,
+) -> Entity | None:
     """Creates and returns an Occupancy entity if the arguments meet our criteria
     for PEP position occupancy, otherwise returns None. Also adds the `role.pep` topic
     to the person if an Occupancy is returned.
@@ -233,7 +233,7 @@ def make_occupancy(
     return occupancy
 
 
-def earliest_term_start(topics: List[str] = ["gov.national"]) -> str:
+def earliest_term_start(topics: list[str] = ["gov.national"]) -> str:
     """Returns a date that can be used as a cut-off date for parliamentary or government terms
     when crawling historical data. For example, if a dataset is known to include data from the
     inception of a country, but we only want to consider people as PEPs if they held a position

--- a/zavod/zavod/helpers/sanctions.py
+++ b/zavod/zavod/helpers/sanctions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from rigour.dates import ended_before, starts_after
 
 from zavod import helpers as h
@@ -12,9 +10,7 @@ from zavod.stateful import programs
 ALWAYS_FORMATS = ["%Y-%m-%d", "%Y-%m", "%Y"]
 
 
-def lookup_sanction_program_key(
-    context: Context, source_key: Optional[str]
-) -> Optional[str]:
+def lookup_sanction_program_key(context: Context, source_key: str | None) -> str | None:
     """Lookup the sanction program key based on the source key."""
     res = context.lookup("sanction.program", source_key)
     if res is None:
@@ -26,12 +22,12 @@ def lookup_sanction_program_key(
 def make_sanction(
     context: Context,
     entity: Entity,
-    key: Optional[str] = None,
-    program_name: Optional[str] = None,
-    source_program_key: Optional[str] = None,
-    program_key: Optional[str] = None,
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
+    key: str | None = None,
+    program_name: str | None = None,
+    source_program_key: str | None = None,
+    program_key: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
 ) -> Entity:
     """Create and return a sanctions object derived from the dataset metadata.
 

--- a/zavod/zavod/helpers/text.py
+++ b/zavod/zavod/helpers/text.py
@@ -1,6 +1,6 @@
 import re
 from banal import is_listish, ensure_list
-from typing import Optional, List, Sequence, Union, Iterable
+from collections.abc import Sequence, Iterable
 from normality import squash_spaces
 
 from zavod.logs import get_logger
@@ -15,7 +15,7 @@ INTERPOL_URL = re.compile(INTERPOL_URL_, re.IGNORECASE)
 BRACKETED = re.compile(r"\(.*?\)")
 
 
-def clean_note(text: Union[Optional[str], Sequence[Optional[str]]]) -> List[str]:
+def clean_note(text: str | None | Sequence[str | None]) -> list[str]:
     """Remove a set of specific text sections from notes supplied by sanctions data
     publishers. These include cross-references to the Security Council web site and
     the Interpol web site.
@@ -26,7 +26,7 @@ def clean_note(text: Union[Optional[str], Sequence[Optional[str]]]) -> List[str]
     Returns:
         A cleaned version of the text.
     """
-    out: List[str] = []
+    out: list[str] = []
     if text is None:
         return out
     if is_listish(text):
@@ -44,8 +44,8 @@ def clean_note(text: Union[Optional[str], Sequence[Optional[str]]]) -> List[str]
 
 
 def multi_split(
-    text: Optional[Union[str, Iterable[Optional[str]]]], splitters: Iterable[str]
-) -> List[str]:
+    text: str | Iterable[str | None] | None, splitters: Iterable[str]
+) -> list[str]:
     """Sequentially attempt to split a text based on an array of splitting criteria.
     This is useful for strings where multiple separators are used to separate values,
     e.g.: `test,other/misc`. A special case of this is itemised lists like `a) test
@@ -64,7 +64,7 @@ def multi_split(
     sorted_splitters = tuple(sorted(splitters, key=len, reverse=True))
 
     for splitter in sorted_splitters:
-        out: List[Optional[str]] = []
+        out: list[str | None] = []
         for fragment in fragments:
             if fragment is None:
                 continue
@@ -78,7 +78,7 @@ def multi_split(
     return result
 
 
-def is_empty(text: Optional[str]) -> bool:
+def is_empty(text: str | None) -> bool:
     """Check if the given text is empty: it can either be null, or
     the stripped version of the string could have 0 length.
 
@@ -96,7 +96,7 @@ def is_empty(text: Optional[str]) -> bool:
     return False
 
 
-def remove_bracketed(text: Optional[str]) -> Optional[str]:
+def remove_bracketed(text: str | None) -> str | None:
     """Helps to deal with property values where additional info has been supplied in
     brackets that makes it harder to parse the value. Examples:
 

--- a/zavod/zavod/helpers/vessels.py
+++ b/zavod/zavod/helpers/vessels.py
@@ -1,10 +1,8 @@
-from typing import Optional
-
 from normality import slugify
 from rigour.ids import IMO
 
 
-def _imo_id_key(value: Optional[str]) -> Optional[str]:
+def _imo_id_key(value: str | None) -> str | None:
     """Derive the IMO portion of an entity id from a raw IMO string.
 
     A valid IMO is reduced to its canonical seven digits. A present-but-invalid one (bad
@@ -20,7 +18,7 @@ def _imo_id_key(value: Optional[str]) -> Optional[str]:
     return slugify(value)
 
 
-def make_vessel_imo_id(value: Optional[str]) -> Optional[str]:
+def make_vessel_imo_id(value: str | None) -> str | None:
     """Build a stable entity id for a vessel from its IMO number.
 
     Reach for this when keying vessels so that records describing the same ship across
@@ -33,7 +31,7 @@ def make_vessel_imo_id(value: Optional[str]) -> Optional[str]:
     return None if key is None else f"imo-vsl-{key}"
 
 
-def make_org_imo_id(value: Optional[str]) -> Optional[str]:
+def make_org_imo_id(value: str | None) -> str | None:
     """Build a stable entity id for an organisation from its IMO company number.
 
     The maritime equivalent of a company register id: registered owners, managers and other

--- a/zavod/zavod/helpers/wikidata.py
+++ b/zavod/zavod/helpers/wikidata.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from requests.exceptions import RequestException
 from zavod.context import Context
 from nomenklatura.wikidata.client import WikidataClient
@@ -7,8 +6,8 @@ from rigour.ids.wikidata import is_qid
 
 
 def deref_wikidata_id(
-    context: Context, qid: Optional[str], cache_days: int = 60
-) -> Optional[str]:
+    context: Context, qid: str | None, cache_days: int = 60
+) -> str | None:
     """Check if a Wikidata QID is a redirect, and return the target QID if so.
 
     This is used with static data sources that reference Wikidata items that may have

--- a/zavod/zavod/integration/dedupe.py
+++ b/zavod/zavod/integration/dedupe.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Set
+from typing import Any, TYPE_CHECKING
 
 from pathlib import Path
 from followthemoney import model
@@ -25,7 +25,7 @@ def get_resolver(session: Session) -> Resolver[Entity]:
     The session owns the unit of work: callers commit/checkpoint it (e.g. a
     zavod Context shares its own session; a standalone CLI command owns one)."""
     resolver = Resolver[Entity](session, create=True)
-    log.info("Using resolver: %r" % resolver)
+    log.info(f"Using resolver: {resolver!r}")
     return resolver
 
 
@@ -35,7 +35,7 @@ def get_dataset_linker(dataset: Dataset) -> Linker[Entity]:
         return Linker[Entity]({})
     with make_session() as session:
         resolver = get_resolver(session)
-        log.info("Loading linker from: %r" % resolver)
+        log.info(f"Loading linker from: {resolver!r}")
         return resolver.get_linker()
 
 
@@ -46,14 +46,14 @@ def blocking_xref(
     state_path: Path,
     limit: int = 5000,
     patience: int = 500000,
-    auto_threshold: Optional[float] = None,
+    auto_threshold: float | None = None,
     algorithm: str = DefaultAlgorithm.NAME,
-    focus_datasets: Set[str] = set(),
-    schema_range: Optional[str] = None,
+    focus_datasets: set[str] = set(),
+    schema_range: str | None = None,
     user: str = "zavod/xref",
     discount_internal: float = 1.0,
     min_threshold: float = 0.01,
-    blocker_options: Optional[Dict[str, Any]] = None,
+    blocker_options: dict[str, Any] | None = None,
 ) -> None:
     """This runs the deduplication process, which compares all entities in the given
     dataset against each other, and stores the highest-scoring candidates for human
@@ -61,12 +61,12 @@ def blocking_xref(
     """
     # resolver.prune()
     log.info(
-        "Xref running, algorithm: %r" % algorithm,
+        f"Xref running, algorithm: {algorithm!r}",
         auto_threshold=auto_threshold,
     )
     algorithm_type = get_algorithm(algorithm)
     if algorithm_type is None:
-        raise ValueError("Invalid algorithm: %s" % algorithm)
+        raise ValueError(f"Invalid algorithm: {algorithm}")
     range = model.get(schema_range) if schema_range is not None else None
     index_dir = state_path / "dedupe-index"
 
@@ -98,7 +98,7 @@ def explode_cluster(resolver: Resolver[Entity], entity_id: str) -> None:
 
 
 def merge_entities(
-    resolver: Resolver[Entity], entity_ids: List[str], force: bool = False
+    resolver: Resolver[Entity], entity_ids: list[str], force: bool = False
 ) -> str:
     """Merge multiple entities into a canonical identity. This should be really easy
     but there are cases where a negative (or "unsure") judgement has been made, and
@@ -119,11 +119,10 @@ def merge_entities(
                     resolver._remove_edge(edge)
                 else:
                     raise ValueError(
-                        "Cannot merge %r and %r: %r exists!"
-                        % (canonical_id, other_id, edge)
+                        f"Cannot merge {canonical_id!r} and {other_id!r}: {edge!r} exists!"
                     )
-        log.info("Merge: %s -> %s" % (other_id, canonical_id))
+        log.info(f"Merge: {other_id} -> {canonical_id}")
         canonical_id_ = resolver.decide(canonical_id, other_id, Judgement.POSITIVE)
         canonical_id = str(canonical_id_)
-    log.info("Canonical: %s" % canonical_id)
+    log.info(f"Canonical: {canonical_id}")
     return str(canonical_id)

--- a/zavod/zavod/integration/edges.py
+++ b/zavod/zavod/integration/edges.py
@@ -333,7 +333,7 @@ def group_edges(view: View) -> list[list[str]]:
 
     for idx, entity in enumerate(view.entities()):
         if idx > 0 and idx % 100000 == 0:
-            log.info("Keyed %s entities..." % idx)
+            log.info(f"Keyed {idx} entities...")
 
         key = bucket_key(entity)
         if key is None:
@@ -393,7 +393,7 @@ def merge_groups(
             other = view.get_entity(other_id)
             assert other is not None
 
-            log.info("Merge edge: %s (%s -> %s)" % (other, other_canon, canonical))
+            log.info(f"Merge edge: {other} ({other_canon} -> {canonical})")
             canonical = resolver.decide(
                 canonical,
                 other_canon,
@@ -409,11 +409,11 @@ def merge_groups(
         cluster_count += 1
         if uncommitted >= commit_every:
             session.checkpoint()
-            log.info("Committed %s merge decisions..." % merged_count)
+            log.info(f"Committed {merged_count} merge decisions...")
             uncommitted = 0
-    log.info("Merged %s edge entities into %s clusters" % (merged_count, cluster_count))
+    log.info(f"Merged {merged_count} edge entities into {cluster_count} clusters")
     for dataset, count in dataset_counts.items():
-        log.info("Merged %s edges in dataset %s" % (count, dataset))
+        log.info(f"Merged {count} edges in dataset {dataset}")
 
 
 def dedupe_edges(resolver: Resolver[Entity], session: Session, view: View) -> None:

--- a/zavod/zavod/integration/logic.py
+++ b/zavod/zavod/integration/logic.py
@@ -1,4 +1,3 @@
-from typing import List, Optional
 from followthemoney import Schema, model, registry
 from nomenklatura import Resolver, Judgement
 
@@ -16,7 +15,7 @@ def logic_unique(
     left: Entity,
     right: Entity,
     score: float,
-) -> Optional[float]:
+) -> float | None:
     """We consider the legal entities on the given unique lists to be, de jure, different."""
     if common.is_a("Address"):
         return score
@@ -37,7 +36,7 @@ def logic_vessel_match(
     left: Entity,
     right: Entity,
     score: float,
-) -> Optional[float]:
+) -> float | None:
     """Custom logic for matching vessels based on IMO number."""
     if not common.is_a("Vessel"):
         return score
@@ -52,7 +51,7 @@ def logic_vessel_match(
     if not len(left_names.intersection(right_names)) > 0:
         return score
     if left.id is not None and right.id is not None:
-        log.info("Vessel positive match: %s %s" % (left.id, right.id))
+        log.info(f"Vessel positive match: {left.id} {right.id}")
         resolver.decide(left.id, right.id, Judgement.POSITIVE, user=USER)
     return score
 
@@ -63,7 +62,7 @@ def logic_securities_mismatch(
     left: Entity,
     right: Entity,
     score: float,
-) -> Optional[float]:
+) -> float | None:
     """Custom logic for avoiding matches between securities with different ISINs."""
     if not common.is_a("Security"):
         return score
@@ -78,7 +77,7 @@ def logic_securities_mismatch(
     return score
 
 
-def _perfect_identifier_match(left: List[str], right: List[str]) -> bool:
+def _perfect_identifier_match(left: list[str], right: list[str]) -> bool:
     left_set = set(left)
     right_set = set(right)
     longest = max(len(left_set), len(right_set))
@@ -93,7 +92,7 @@ def logic_identifiers(
     left: Entity,
     right: Entity,
     score: float,
-) -> Optional[float]:
+) -> float | None:
     """Custom logic for avoiding matches between Russian entities with different identifiers."""
     if not common.is_a("LegalEntity") or left.id is None or right.id is None:
         return score
@@ -105,14 +104,14 @@ def logic_identifiers(
             left_inns = left.get("innCode")
             right_inns = right.get("innCode")
             if _perfect_identifier_match(left_inns, right_inns):
-                log.info("Russian INN match: %s %s" % (left.id, right.id))
+                log.info(f"Russian INN match: {left.id} {right.id}")
                 resolver.decide(left.id, right.id, Judgement.POSITIVE, user=USER)
                 return None
         if common.is_a("Organization"):
             left_ogrns = left.get("ogrnCode")
             right_ogrns = right.get("ogrnCode")
             if _perfect_identifier_match(left_ogrns, right_ogrns):
-                log.info("Russian OGRN match: %s %s" % (left.id, right.id))
+                log.info(f"Russian OGRN match: {left.id} {right.id}")
                 resolver.decide(left.id, right.id, Judgement.POSITIVE, user=USER)
                 return None
     if common.is_a("Organization"):
@@ -132,7 +131,7 @@ def logic_pkpro_ids(
     left: Entity,
     right: Entity,
     score: float,
-) -> Optional[float]:
+) -> float | None:
     """Custom logic for avoiding matches between entities from Pakistan."""
     if not common.is_a("Person"):
         return score
@@ -145,7 +144,7 @@ def logic_pkpro_ids(
     right_ids = set([s.value for s in right_ids_ if s.dataset == PK])
     if len(left_ids) > 0 and len(right_ids) > 0 and left_ids.isdisjoint(right_ids):
         if left.id is not None and right.id is not None:
-            log.info("PK proscribed negative match: %s %s" % (left.id, right.id))
+            log.info(f"PK proscribed negative match: {left.id} {right.id}")
             resolver.decide(left.id, right.id, Judgement.NEGATIVE, user=USER)
             return None
     return score
@@ -153,7 +152,7 @@ def logic_pkpro_ids(
 
 def logic_decide(
     resolver: Resolver[Entity], left: Entity, right: Entity, score: float
-) -> Optional[float]:
+) -> float | None:
     """Decide whether to automatically merge two entities based on custom logic."""
     common = model.common_schema(left.schema, right.schema)
     res_score = logic_vessel_match(resolver, common, left, right, score)

--- a/zavod/zavod/logs.py
+++ b/zavod/zavod/logs.py
@@ -5,7 +5,8 @@ import sys
 import banal
 from rigour.env import TZ_NAME
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any
+from collections.abc import Callable
 
 import structlog
 from followthemoney.proxy import EntityProxy
@@ -52,7 +53,7 @@ class RedactingProcessor:
     it needs to recurse into and modify nested structures and structlog's copy is shallow.
     """
 
-    def __init__(self, replace_patterns: Dict[str, str | Callable[[str], str]]) -> None:
+    def __init__(self, replace_patterns: dict[str, str | Callable[[str], str]]) -> None:
         self.repl_regexes = {re.compile(p): r for p, r in replace_patterns.items()}
 
     def __call__(self, logger: Any, method_name: str, event_dict: Event) -> Event:
@@ -89,7 +90,7 @@ class RedactingProcessor:
             dict_[key] = value
         return dict_
 
-    def redact_list(self, list_: List[Any]) -> List[Any]:
+    def redact_list(self, list_: list[Any]) -> list[Any]:
         for ix, value in enumerate(list_):
             if isinstance(value, dict):
                 value = self.redact_dict(value)
@@ -121,7 +122,7 @@ def configure_redactor() -> Callable[[Any, str, Event], Event]:
     Configure a redacting processor redacting env var values with some variable
     that contained that value.
     """
-    pattern_map: Dict[str, str | Callable[[str], str]] = dict()
+    pattern_map: dict[str, str | Callable[[str], str]] = dict()
     env_vars_longest_first = sorted(
         os.environ.items(),
         key=lambda kv: len(kv[1]),
@@ -145,7 +146,7 @@ def set_logging_context_dataset_name(dataset_name: str) -> None:
 def configure_logging(level: int = logging.DEBUG) -> logging.Logger:
     """Configure log levels and structured logging."""
 
-    base_processors: List[Processor] = [
+    base_processors: list[Processor] = [
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,
         structlog.processors.StackInfoRenderer(),
@@ -155,8 +156,8 @@ def configure_logging(level: int = logging.DEBUG) -> logging.Logger:
         structlog.processors.UnicodeDecoder(),
     ]
 
-    emitting_processors: List[Processor] = [log_issue]
-    formatting_processors: List[Processor]
+    emitting_processors: list[Processor] = [log_issue]
+    formatting_processors: list[Processor]
 
     if settings.LOG_JSON:
         formatting_processors = [
@@ -170,7 +171,7 @@ def configure_logging(level: int = logging.DEBUG) -> logging.Logger:
             )
         ]
 
-    processors: List[Processor] = (
+    processors: list[Processor] = (
         base_processors
         + [configure_redactor()]
         + emitting_processors
@@ -266,9 +267,9 @@ def issue_event_value(value: Any) -> Any:
 
 
 def log_issue(_: Any, __: str, event_dict: Event) -> Event:
-    data: Dict[str, Any] = dict(event_dict)
+    data: dict[str, Any] = dict(event_dict)
     context = data.pop("context", None)
-    level: Optional[str] = data.get("level")
+    level: str | None = data.get("level")
     if level is not None:
         level_num = getattr(logging, level.upper(), logging.ERROR)
         if level_num > logging.INFO and context is not None:

--- a/zavod/zavod/meta/__init__.py
+++ b/zavod/zavod/meta/__init__.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from banal import hash_data
-from typing import Optional, List
 from functools import cache
 from followthemoney.exc import MetadataException
 
@@ -18,26 +17,26 @@ def get_catalog() -> ArchiveBackedCatalog:
     return ArchiveBackedCatalog()
 
 
-def load_dataset_from_path(path: Path) -> Optional[Dataset]:
+def load_dataset_from_path(path: Path) -> Dataset | None:
     """Load a dataset from a given path."""
     return get_catalog().load_yaml(path)
 
 
-def get_multi_dataset(names: List[str]) -> Dataset:
+def get_multi_dataset(names: list[str]) -> Dataset:
     """The scopes of a dataset is the set of other datasets on which analysis or
     enrichment should be performed by the runner."""
     catalog = get_catalog()
-    inputs: List[Dataset] = []
+    inputs: list[Dataset] = []
     for input_name in names:
         try:
             inputs.append(catalog.require(input_name))
         except MetadataException as exc:
             log.error(
-                "Invalid dataset input: %s" % exc,
+                f"Invalid dataset input: {exc}",
                 input=input_name,
             )
     if not len(inputs):
-        raise MetadataException("No valid input datasets: %r" % names)
+        raise MetadataException(f"No valid input datasets: {names!r}")
     if len(inputs) == 1:
         return inputs[0]
     # Weird: if there are many scopes, we're making up a synthetic collection

--- a/zavod/zavod/meta/assertion.py
+++ b/zavod/zavod/meta/assertion.py
@@ -1,7 +1,8 @@
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Generator
+from typing import Any
+from collections.abc import Generator
 
 
 class Metric(Enum):
@@ -64,8 +65,8 @@ class Assertion:
 
 
 def merge_assertions_config(
-    base: Dict[str, Any], override: Dict[str, Any]
-) -> Dict[str, Any]:
+    base: dict[str, Any], override: dict[str, Any]
+) -> dict[str, Any]:
     """Deep-merge two assertion config dicts, with `override` winning at the leaf.
 
     Nested dicts (comparison -> metric -> schema -> property) are merged
@@ -81,7 +82,7 @@ def merge_assertions_config(
     return result
 
 
-def parse_assertions(config: Dict[str, Any]) -> Generator[Assertion, None, None]:
+def parse_assertions(config: dict[str, Any]) -> Generator[Assertion, None, None]:
     for key, metrics_config in config.items():
         match key:
             case "min":

--- a/zavod/zavod/meta/catalog.py
+++ b/zavod/zavod/meta/catalog.py
@@ -1,5 +1,4 @@
 import yaml
-from typing import Optional
 from pathlib import Path
 from followthemoney.dataset import DataCatalog
 
@@ -11,8 +10,8 @@ class ArchiveBackedCatalog(DataCatalog[Dataset]):
     def __init__(self) -> None:
         super().__init__(Dataset, {})
 
-    def load_yaml(self, path: Path) -> Optional[Dataset]:
-        with open(path, "r") as fh:
+    def load_yaml(self, path: Path) -> Dataset | None:
+        with open(path) as fh:
             data = yaml.safe_load(fh)
         if "name" not in data:
             data["name"] = path.stem
@@ -23,7 +22,7 @@ class ArchiveBackedCatalog(DataCatalog[Dataset]):
             self.get(name)
         return dataset
 
-    def get(self, name: str) -> Optional[Dataset]:
+    def get(self, name: str) -> Dataset | None:
         dataset = super().get(name)
         if dataset is not None:
             return dataset

--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -2,7 +2,7 @@ import mimetypes
 from functools import cached_property
 from hashlib import sha1
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 from banal import ensure_dict, ensure_list
 from datapatch import Lookup, get_lookups
@@ -40,7 +40,7 @@ log = get_logger(__name__)
 # `property_fill_rate` only applies to schemata the dataset actually emits: the
 # validator skips any schema with zero entities, so naming schemata a dataset
 # doesn't produce here is harmless.
-DEFAULT_ASSERTIONS: Dict[str, Any] = {
+DEFAULT_ASSERTIONS: dict[str, Any] = {
     "min": {
         "property_fill_rate": {
             "Person": {"name": 0.95},
@@ -53,7 +53,7 @@ DEFAULT_ASSERTIONS: Dict[str, Any] = {
 
 
 class Dataset(FollowTheMoneyDataset):
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: dict[str, Any]):
         super().__init__(data)
         self.model: ZavodDatasetModel = ZavodDatasetModel.model_validate(data)
         self.prefix = self.model.prefix
@@ -64,13 +64,13 @@ class Dataset(FollowTheMoneyDataset):
                 self.model.coverage = DataCoverage()
             self.model.coverage.frequency = "never"
 
-        self.config: Dict[str, Any] = ensure_dict(data.get("config", {}))
+        self.config: dict[str, Any] = ensure_dict(data.get("config", {}))
         _inputs = ensure_list(data.get("inputs", []))
-        self.inputs: List[str] = [str(x) for x in _inputs]
+        self.inputs: list[str] = [str(x) for x in _inputs]
         """List of other datasets that this dataset depends on as processing inputs."""
 
         self._data = data
-        self.base_path: Optional[Path] = None
+        self.base_path: Path | None = None
 
         # TODO: this is for backward compatibility, get rid of it one day
         _type = "collection" if self.is_collection else "source"
@@ -81,7 +81,7 @@ class Dataset(FollowTheMoneyDataset):
         assertions_config = merge_assertions_config(
             DEFAULT_ASSERTIONS, user_assertions_config
         )
-        self.assertions: List[Assertion] = list(parse_assertions(assertions_config))
+        self.assertions: list[Assertion] = list(parse_assertions(assertions_config))
         """
         List of assertions which should be considered warnings if they fail.
 
@@ -115,27 +115,27 @@ class Dataset(FollowTheMoneyDataset):
         """Number parsing configuration for this dataset."""
 
     @cached_property
-    def lookups(self) -> Dict[str, Lookup]:
+    def lookups(self) -> dict[str, Lookup]:
         config = self._data.get("lookups", {})
         return get_lookups(config, debug=settings.DEBUG)
 
     @property
-    def url(self) -> Optional[str]:
+    def url(self) -> str | None:
         return self.model.url
 
     @property
-    def data(self) -> Optional[DataModel]:
+    def data(self) -> DataModel | None:
         return self.model.data
 
     def resource_from_path(
         self,
         path: Path,
-        mime_type: Optional[str] = None,
-        title: Optional[str] = None,
+        mime_type: str | None = None,
+        title: str | None = None,
     ) -> "DataResource":
         """Create a resource description object from a local file path."""
         if not path.exists():
-            raise ValueError("File does not exist: %s" % path)
+            raise ValueError(f"File does not exist: {path}")
         if mime_type is None:
             mime_type, _ = mimetypes.guess_type(path.as_posix(), strict=False)
         dataset_path_ = dataset_data_path(self.name)
@@ -160,7 +160,7 @@ class Dataset(FollowTheMoneyDataset):
             url=make_published_url(self.name, name),
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Generate a metadata export, not including operational details."""
         data = super().to_dict()
         data["hidden"] = self.model.hidden
@@ -181,7 +181,7 @@ class Dataset(FollowTheMoneyDataset):
             data.pop("children", None)
         return data
 
-    def to_opensanctions_dict(self, catalog: "ArchiveBackedCatalog") -> Dict[str, Any]:
+    def to_opensanctions_dict(self, catalog: "ArchiveBackedCatalog") -> dict[str, Any]:
         """Generate a metadata export in the format expected by the OpenSanctions catalog."""
         data = self.to_dict()
         assert self._type in ("collection", "source", "external"), self._type

--- a/zavod/zavod/meta/dates.py
+++ b/zavod/zavod/meta/dates.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Any, Optional, List
+from typing import Any
 from pydantic import BaseModel, Field
 from banal import ensure_list
 
@@ -12,10 +12,10 @@ class DatesSpec(BaseModel):
     """A standardised configuration for date parsing in the context of a dataset."""
 
     year_only: bool = False
-    formats: List[str] = []
-    months: Dict[str | int, str | List[str]] = {}
-    mappings: Dict[str, str] = Field(default_factory=dict, exclude=True, init=False)
-    months_re: Optional[re.Pattern[str]] = Field(default=None, exclude=True, init=False)
+    formats: list[str] = []
+    months: dict[str | int, str | list[str]] = {}
+    mappings: dict[str, str] = Field(default_factory=dict, exclude=True, init=False)
+    months_re: re.Pattern[str] | None = Field(default=None, exclude=True, init=False)
 
     def model_post_init(self, _: Any) -> None:
         """Process months mapping after model initialization."""

--- a/zavod/zavod/meta/http.py
+++ b/zavod/zavod/meta/http.py
@@ -1,7 +1,7 @@
 import logging
 from banal import ensure_list
 from urllib3.util import Retry
-from typing import Any, Dict, List, Set
+from typing import Any
 from followthemoney.settings import USER_AGENT
 
 from zavod import settings
@@ -10,13 +10,13 @@ from zavod import settings
 DEFAULT_RETRY_STATUS_CODES = [500, 502, 504] + list(Retry.RETRY_AFTER_STATUS_CODES)
 
 
-class HTTP(object):
-    def __init__(self, data: Dict[str, Any]) -> None:
+class HTTP:
+    def __init__(self, data: dict[str, Any]) -> None:
         self.total_retries: int = data.get("total_retries", settings.HTTP_RETRY_TOTAL)
         self.backoff_factor: float = data.get(
             "backoff_factor", settings.HTTP_RETRY_BACKOFF_FACTOR
         )
-        statuses: Set[int] = set(
+        statuses: set[int] = set(
             data.get("retry_statuses", DEFAULT_RETRY_STATUS_CODES)
             + data.get("additional_retry_statuses", [])
         )
@@ -29,9 +29,9 @@ class HTTP(object):
         # HTTP session and Zyte API requests.
         self.timeout: int = data.get("timeout", settings.HTTP_TIMEOUT)
         self.backoff_max: int = settings.HTTP_RETRY_BACKOFF_MAX
-        self.retry_statuses: List[int] = list(statuses)
-        retry_methods: List[str] = ensure_list(
+        self.retry_statuses: list[int] = list(statuses)
+        retry_methods: list[str] = ensure_list(
             data.get("retry_methods", list(Retry.DEFAULT_ALLOWED_METHODS))
         )
-        self.retry_methods: List[str] = retry_methods
+        self.retry_methods: list[str] = retry_methods
         self.user_agent: str = data.get("user_agent") or USER_AGENT

--- a/zavod/zavod/meta/model.py
+++ b/zavod/zavod/meta/model.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import os
-from typing import Optional, Set
 from pydantic import BaseModel, Field, field_validator
 
 from normality import slugify
@@ -12,14 +11,14 @@ from zavod import settings
 
 class DataModel(BaseModel):
     url: Url
-    mode: Optional[str] = None
-    format: Optional[str] = None
-    api_key: Optional[str] = Field(None, exclude=True)
-    lang: Optional[str] = Field(None, exclude=True)
+    mode: str | None = None
+    format: str | None = None
+    api_key: str | None = Field(None, exclude=True)
+    lang: str | None = Field(None, exclude=True)
 
     @field_validator("api_key", mode="before")
     @classmethod
-    def expand_api_key(cls, value: Optional[str]) -> Optional[str]:
+    def expand_api_key(cls, value: str | None) -> str | None:
         if value is not None:
             return os.path.expandvars(value)
         return value
@@ -34,10 +33,10 @@ class DataModel(BaseModel):
 
 
 class ZavodDatasetModel(FTMDatasetModel):
-    entry_point: Optional[str] = None
+    entry_point: str | None = None
     """Code location for the crawler script"""
 
-    prefix: Optional[str] = Field(None, exclude=True)
+    prefix: str | None = Field(None, exclude=True)
     """A prefix for the dataset, used to generate entity IDs."""
 
     disabled: bool = False
@@ -49,9 +48,9 @@ class ZavodDatasetModel(FTMDatasetModel):
     resolve: bool = Field(True, exclude=True)
     """Resolve entities in this dataset to canonical IDs."""
 
-    updated_at: Optional[datetime] = Field(default_factory=lambda: settings.RUN_TIME)
+    updated_at: datetime | None = Field(default_factory=lambda: settings.RUN_TIME)
 
-    exports: Set[str] = Field(set(), exclude=True)
+    exports: set[str] = Field(set(), exclude=True)
     """Names of all the exporters enabled for this dataset."""
 
     ci_test: bool = Field(True, exclude=True)
@@ -60,13 +59,13 @@ class ZavodDatasetModel(FTMDatasetModel):
     load_statements: bool = Field(False, exclude=True)
     """Whether this dataset should be loaded into the database."""
 
-    full_dataset: Optional[str] = None
+    full_dataset: str | None = None
     """The name of the full dataset that this dataset is derived from, if any."""
 
-    data: Optional[DataModel] = None
+    data: DataModel | None = None
     """Data source specification."""
 
-    summary: Optional[str] = Field(
+    summary: str | None = Field(
         default=None,
         description="A short summary of the dataset, used in the website and other UIs.",
         min_length=50,
@@ -74,7 +73,7 @@ class ZavodDatasetModel(FTMDatasetModel):
 
     @field_validator("prefix", mode="after")
     @classmethod
-    def check_prefix(cls, prefix: Optional[str]) -> Optional[str]:
+    def check_prefix(cls, prefix: str | None) -> str | None:
         if prefix is None:
             return None
         if prefix != slugify(prefix, sep="-"):

--- a/zavod/zavod/meta/names.py
+++ b/zavod/zavod/meta/names.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Any, Dict, Optional, Set
+from typing import Any
 from logging import getLogger
 
 from followthemoney import Model
@@ -51,7 +51,7 @@ class CleaningSpec(BaseModel):
     Some organisation names really have leading digits in the name."""
 
     @cached_property
-    def reject_chars_consolidated(self) -> Set[str]:
+    def reject_chars_consolidated(self) -> set[str]:
         """Get the full set of characters to reject for this spec."""
         baseline = set(self.reject_chars_baseline)
         reject_extra = set(self.reject_chars)
@@ -59,7 +59,7 @@ class CleaningSpec(BaseModel):
         return (baseline | reject_extra) - allow
 
 
-_DEFAULT_SCHEMA_RULES: Dict[str, CleaningSpec] = {
+_DEFAULT_SCHEMA_RULES: dict[str, CleaningSpec] = {
     ###################
     # Beware that when introducing defaults for more specific schemata, these could take
     # precedence over extensions to the existing defaults in some datasets' metadata.
@@ -80,7 +80,7 @@ _DEFAULT_SCHEMA_RULES: Dict[str, CleaningSpec] = {
 class NamesSpec(BaseModel):
     """Name cleaning requirements and heuristics for a dataset."""
 
-    schema_rules: Dict[str, CleaningSpec] = dict(_DEFAULT_SCHEMA_RULES)
+    schema_rules: dict[str, CleaningSpec] = dict(_DEFAULT_SCHEMA_RULES)
     """Name cleaning requirements by schema. All matching schema configurations will apply."""
 
     prefixes_strip: list[str] = []
@@ -95,13 +95,13 @@ class NamesSpec(BaseModel):
     are suggested as weakAlias rather than name.
     """
 
-    suggest_abbreviation_uppercase_org_single_token_shorter_than: Optional[int] = None
+    suggest_abbreviation_uppercase_org_single_token_shorter_than: int | None = None
     """
     If set, Organization names that are all-uppercase, contain no spaces, and are
     shorter than this threshold are suggested as abbreviation rather than name.
     """
 
-    suggest_abbreviation_non_person_single_token_shorter_than: Optional[int] = None
+    suggest_abbreviation_non_person_single_token_shorter_than: int | None = None
     """
     If set, LegalEntity-but-not-Person names (i.e. companies, organisations, vessels, etc.)
     that are all-uppercase, contain no spaces, and are shorter than this threshold are
@@ -131,7 +131,7 @@ class NamesSpec(BaseModel):
             return instance
         raise TypeError(f"object must be a dict, got {type(obj)}")
 
-    def get_spec(self, schema: Schema) -> Optional[CleaningSpec]:
+    def get_spec(self, schema: Schema) -> CleaningSpec | None:
         """Returns the spec for the most specific schema that matches the entity."""
         matching_specs = [
             (Model.instance().get(name), spec)

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rigour.mime.types import JSON
 
 from zavod.archive.backend import get_archive_backend
@@ -37,7 +35,7 @@ def _archive_artifacts(dataset: Dataset, extra_artifacts: list[str] = []) -> Non
     for resource in DatasetResources(dataset).all():
         path = dataset_resource_path(dataset.name, resource.name)
         if not path.is_file():
-            log.error("Resource not found: %s" % path, dataset=dataset.name)
+            log.error(f"Resource not found: {path}", dataset=dataset.name)
             continue
         archive_artifact(
             path,
@@ -73,7 +71,7 @@ def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
     """
 
     extra_artifacts = []
-    all_published_files: List[str] = [
+    all_published_files: list[str] = [
         r.name
         for r in DatasetResources(dataset).all()
         if r.name not in UNLISTED_RESOURCES
@@ -140,7 +138,7 @@ def archive_failure(dataset: Dataset) -> None:
     write_dataset_index(dataset, DatasetVersionResult.FAILURE)
     path = dataset_resource_path(dataset.name, INDEX_FILE)
     if not path.is_file():
-        log.error("Metadata file not found: %s" % path, dataset=dataset.name)
+        log.error(f"Metadata file not found: {path}", dataset=dataset.name)
         return
     _archive_artifacts(dataset)
     dataset_resource_path(dataset.name, RESOURCES_FILE).unlink(missing_ok=True)

--- a/zavod/zavod/runner/enrich.py
+++ b/zavod/zavod/runner/enrich.py
@@ -28,7 +28,7 @@ def save_match(
 
     # Store previously confirmed matches to the database and make them visible:
     if judgement == Judgement.POSITIVE:
-        context.log.info("Enrich [%s]: %r" % (entity, match))
+        context.log.info(f"Enrich [{entity}]: {match!r}")
         expanded = [adjacent for adjacent in enricher.expand_wrapped(entity, match)]
         if not expanded:
             return
@@ -50,9 +50,7 @@ def save_match(
 
 def enrich(context: Context) -> None:
     scope = get_multi_dataset(context.dataset.inputs)
-    context.log.info(
-        "Enriching %s (%s)" % (scope.name, [d.name for d in scope.datasets])
-    )
+    context.log.info(f"Enriching {scope.name} ({[d.name for d in scope.datasets]})")
     store = get_store(scope, context.resolver)
     # Commit the resolver's load-time read so no transaction is held open across
     # the (potentially long) store sync below; the resolver is in-memory after.
@@ -70,13 +68,13 @@ def enrich(context: Context) -> None:
             if entity_idx > 0 and entity_idx % 100 == 0:
                 context.flush()
             if entity_idx > 0 and entity_idx % 10000 == 0:
-                context.log.info("Enriched %s entities..." % entity_idx)
-            context.log.debug("Enrich query: %r" % entity)
+                context.log.info(f"Enriched {entity_idx} entities...")
+            context.log.debug(f"Enrich query: {entity!r}")
             try:
                 for match in enricher.match_wrapped(entity):
                     save_match(context, enricher, entity, match, view)
             except EnrichmentException as exc:
-                context.log.error("Enrichment error %r: %s" % (entity, str(exc)))
+                context.log.error(f"Enrichment error {entity!r}: {str(exc)}")
         context.log.info("Enrichment process complete.")
     finally:
         enricher.close()

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -1,6 +1,6 @@
 import logging
 from decimal import Decimal
-from typing import Generator, Iterator, List, Tuple
+from collections.abc import Generator, Iterator
 from followthemoney import registry, model
 from followthemoney.helpers import check_person_cutoff
 
@@ -92,7 +92,7 @@ class LocalEnricher(BaseEnricher[Dataset]):
 
     def candidates(
         self, subjects: Iterator[Entity]
-    ) -> Generator[Tuple[Identifier, BlockingMatches], None, None]:
+    ) -> Generator[tuple[Identifier, BlockingMatches], None, None]:
         entity_generator = (e for e in subjects if self._filter_entity(e))
         yield from self._index.match_entities(entity_generator)
 
@@ -106,7 +106,7 @@ class LocalEnricher(BaseEnricher[Dataset]):
         if same_id_match is not None:
             yield same_id_match
 
-        scores: List[Tuple[float, Entity]] = []
+        scores: list[tuple[float, Entity]] = []
         last_rounded_score = None
         bin = 0
 
@@ -136,7 +136,7 @@ class LocalEnricher(BaseEnricher[Dataset]):
             yield proxy
 
     def _traverse_nested(
-        self, entity: Entity, path: List[str] = []
+        self, entity: Entity, path: list[str] = []
     ) -> Generator[Entity, None, None]:
         """Expand starting from a match, recursing to related non-edge entities"""
         assert entity.id is not None
@@ -190,7 +190,7 @@ def save_match(
     # Store previously confirmed matches to the database and make
     # them visible:
     if judgement == Judgement.POSITIVE:
-        context.log.info("Enrich [%s]: %r" % (entity, match))
+        context.log.info(f"Enrich [{entity}]: {match!r}")
         expanded = list(enricher.expand_wrapped(entity, match))
         expanded = [adj for adj in expanded if not check_person_cutoff(adj)]
 
@@ -207,9 +207,7 @@ def enrich(context: Context) -> None:
     scope = get_multi_dataset(context.dataset.inputs)
     # The Context resolver is read-only here (save_match only reads judgements),
     # so its load commits as a no-op along with the cache via context.close().
-    context.log.info(
-        "Enriching %s (%s)" % (scope.name, [d.name for d in scope.datasets])
-    )
+    context.log.info(f"Enriching {scope.name} ({[d.name for d in scope.datasets]})")
 
     config = dict(context.dataset.config)
     topic_gated: bool = bool(config.get("topic_gated", False))
@@ -241,10 +239,10 @@ def enrich(context: Context) -> None:
             if entity_idx > 0 and entity_idx % 100 == 0:
                 context.flush()
             if entity_idx > 0 and entity_idx % 10000 == 0:
-                context.log.info("Enriched %s entities..." % entity_idx)
+                context.log.info(f"Enriched {entity_idx} entities...")
             subject_entity = subject_view.get_entity(entity_id.id)
             if subject_entity is None:
-                context.log.error("Missing entity: %r" % entity_id)
+                context.log.error(f"Missing entity: {entity_id!r}")
                 continue
             try:
                 for match in enricher.match_candidates(subject_entity, candidate_set):
@@ -258,9 +256,7 @@ def enrich(context: Context) -> None:
                         enrich_topics,
                     )
             except EnrichmentException as exc:
-                context.log.error(
-                    "Enrichment error %r: %s" % (subject_entity, str(exc))
-                )
+                context.log.error(f"Enrichment error {subject_entity!r}: {str(exc)}")
         context.log.info("Enrichment process complete.")
     finally:
         enricher.close()

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 from zavod.entity import Entity
 from zavod.store import View

--- a/zavod/zavod/runtime/cleaning.py
+++ b/zavod/zavod/runtime/cleaning.py
@@ -1,6 +1,6 @@
 import unicodedata
 from typing import TYPE_CHECKING
-from typing import Optional, Generator, Tuple
+from collections.abc import Generator
 from rigour.ids import get_identifier_format
 from rigour.names import is_name
 from prefixdate.precision import Precision
@@ -46,8 +46,8 @@ VALIDATE_AS_NAME_PROPS = {
 log = get_logger(__name__)
 
 
-def clean_identifier(prop: Property, value: str) -> Optional[str]:
-    normalized: Optional[str] = value
+def clean_identifier(prop: Property, value: str) -> str | None:
+    normalized: str | None = value
     if prop.format in VALIDATE_FORMATS:
         format_ = get_identifier_format(prop.format)
         if format_ is not None:
@@ -66,22 +66,22 @@ def clean_identifier(prop: Property, value: str) -> Optional[str]:
 def value_clean(
     entity: "Entity",
     prop: Property,
-    value: Optional[str],
+    value: str | None,
     cleaned: bool = False,
     fuzzy: bool = False,
-    format: Optional[str] = None,
-    origin: Optional[str] = None,
-) -> Generator[Tuple[Property, str, Optional[str]], None, None]:
+    format: str | None = None,
+    origin: str | None = None,
+) -> Generator[tuple[Property, str, str | None], None, None]:
     if prop.deprecated:
         log.warning(
-            "Deprecated property used: %s" % prop.name,
+            f"Deprecated property used: {prop.name}",
             entity_id=entity.id,
             schema=entity.schema.name,
             prop=prop.name,
         )
 
     for prop_, item in prop_lookup(entity, prop, value):
-        clean: Optional[str] = item
+        clean: str | None = item
         if origin is None and item != value:
             origin = ORIGIN_LOOKUP
         if not cleaned:

--- a/zavod/zavod/runtime/delta.py
+++ b/zavod/zavod/runtime/delta.py
@@ -1,7 +1,7 @@
 from hashlib import sha1
 import shutil
 import plyvel  # type: ignore
-from typing import Optional, Generator, Tuple
+from collections.abc import Generator
 from followthemoney.dataset import Version
 
 from zavod.logs import get_logger
@@ -14,11 +14,11 @@ from zavod.runtime.versions import get_latest
 log = get_logger(__name__)
 
 
-class HashDelta(object):
+class HashDelta:
     def __init__(self, dataset: Dataset):
         self.dataset = dataset
         self.curr = get_latest(dataset.name, backfill=False)
-        self.prev: Optional[Version] = None
+        self.prev: Version | None = None
         self.curr_path = dataset_resource_path(dataset.name, HASH_FILE)
         self.fh = self.curr_path.open("w")
         self.db_path = dataset_state_path(dataset.name) / "hashes"
@@ -38,7 +38,7 @@ class HashDelta(object):
             with obj.open() as fh:
                 for line in fh:
                     entity_id, entity_hash = line.strip().split(":", 1)
-                    key = f"{entity_id}:{version.id}".encode("utf-8")
+                    key = f"{entity_id}:{version.id}".encode()
                     self.db.put(key, entity_hash.encode("utf-8"))
             return
         log.info("No previous hash data found.")
@@ -59,20 +59,20 @@ class HashDelta(object):
         #     f"Hash mismatch for {entity.id}: {entity_hash} != {digest.hexdigest()}"
         # )
         self.fh.write(f"{entity.id}:{entity_hash}\n")
-        key = f"{entity.id}:{self.curr.id}".encode("utf-8")
+        key = f"{entity.id}:{self.curr.id}".encode()
         self.db.put(key, entity_hash.encode("utf-8"))
 
     def _collect(
         self,
-    ) -> Generator[Tuple[str, Optional[str], Optional[str]], None, None]:
+    ) -> Generator[tuple[str, str | None, str | None], None, None]:
         # Use entity_id:version key ordering to set prev_hash if available and
         # compare with curr_hash in the final iteration for that entity_id.
         # More efficient than random access.
 
         with self.db.iterator(include_key=True, fill_cache=False) as it:
-            entity_id: Optional[str] = None
-            prev_hash: Optional[str] = None
-            curr_hash: Optional[str] = None
+            entity_id: str | None = None
+            prev_hash: str | None = None
+            curr_hash: str | None = None
             for key, value in it:
                 new_id, version_id = key.decode("utf-8").split(":", 1)
                 hash = value.decode("utf-8")
@@ -90,7 +90,7 @@ class HashDelta(object):
             if entity_id is not None:
                 yield entity_id, prev_hash, curr_hash
 
-    def generate(self) -> Generator[Tuple[str, str], None, None]:
+    def generate(self) -> Generator[tuple[str, str], None, None]:
         for entity_id, prev_hash, curr_hash in self._collect():
             if prev_hash == curr_hash:
                 continue

--- a/zavod/zavod/runtime/http_.py
+++ b/zavod/zavod/runtime/http_.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Optional, Union
+from typing import Any
 from collections.abc import Mapping, Iterable
 from functools import partial
 from pathlib import Path
@@ -17,10 +17,10 @@ from zavod.meta.http import HTTP
 log = get_logger(__name__)
 warnings.filterwarnings("ignore", category=InsecureRequestWarning)
 
-_Auth = Optional[tuple[str, str]]
-_Headers = Optional[Mapping[str, str]]
+_Auth = tuple[str, str] | None
+_Headers = Mapping[str, str] | None
 # Copied from requests-stubs because it's impossible to import from stubs
-_Body = Union[
+_Body = (
     Iterable[bytes]
     | str
     | bytes
@@ -28,7 +28,7 @@ _Body = Union[
     | list[tuple[Any, Any]]
     | tuple[tuple[Any, Any], ...]
     | Mapping[Any, Any]
-]
+)
 
 
 def make_session(http_conf: HTTP) -> Session:

--- a/zavod/zavod/runtime/http_.py
+++ b/zavod/zavod/runtime/http_.py
@@ -1,5 +1,6 @@
 import warnings
-from typing import Any, Optional, Tuple, Mapping, Iterable, Union
+from typing import Any, Optional, Union
+from collections.abc import Mapping, Iterable
 from functools import partial
 from pathlib import Path
 
@@ -16,7 +17,7 @@ from zavod.meta.http import HTTP
 log = get_logger(__name__)
 warnings.filterwarnings("ignore", category=InsecureRequestWarning)
 
-_Auth = Optional[Tuple[str, str]]
+_Auth = Optional[tuple[str, str]]
 _Headers = Optional[Mapping[str, str]]
 # Copied from requests-stubs because it's impossible to import from stubs
 _Body = Union[
@@ -56,10 +57,10 @@ def make_session(http_conf: HTTP) -> Session:
 
 def request_hash(
     url: str,
-    auth: Optional[_Auth] = None,
+    auth: _Auth | None = None,
     method: str = "GET",
     data: Any = None,
-    encoding: Optional[str] = None,
+    encoding: str | None = None,
 ) -> str:
     """
     Generate a unique fingerprint for an HTTP request.
@@ -84,10 +85,10 @@ def fetch_file(
     url: str,
     name: str,
     data_path: Path = settings.DATA_PATH,
-    auth: Optional[Any] = None,
-    headers: Optional[Any] = None,
+    auth: Any | None = None,
+    headers: Any | None = None,
     method: str = "GET",
-    data: Optional[_Body] = None,
+    data: _Body | None = None,
 ) -> Path:
     """Fetch a (large) file via HTTP to the data path."""
     out_path = data_path.joinpath(name)

--- a/zavod/zavod/runtime/issues.py
+++ b/zavod/zavod/runtime/issues.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from rigour.time import utc_now, datetime_iso
 from banal import is_mapping, hash_data
 from datetime import datetime
-from typing import Any, Dict, Generator, Optional, TypedDict, BinaryIO, cast
+from typing import Any, TypedDict, BinaryIO, cast
+from collections.abc import Generator
 
 from zavod.meta import Dataset
 from zavod.archive import dataset_resource_path, get_dataset_artifact
@@ -14,22 +15,22 @@ class Issue(TypedDict):
     id: int
     timestamp: datetime
     level: str
-    module: Optional[str]
+    module: str | None
     dataset: str
-    message: Optional[str]
-    entity_id: Optional[str]
-    entity_schema: Optional[str]
-    data: Dict[str, Any]
+    message: str | None
+    entity_id: str | None
+    entity_schema: str | None
+    data: dict[str, Any]
 
 
-class DatasetIssues(object):
+class DatasetIssues:
     """A log of issues that occurred during the running and export of a dataset."""
 
     def __init__(self, dataset: Dataset) -> None:
         self.dataset = dataset
-        self.fh: Optional[BinaryIO] = None
+        self.fh: BinaryIO | None = None
 
-    def write(self, event: Dict[str, Any]) -> None:
+    def write(self, event: dict[str, Any]) -> None:
         if self.fh is None:
             path = dataset_resource_path(self.dataset.name, ISSUES_LOG)
             self.fh = open(path, "ab")
@@ -87,16 +88,16 @@ class DatasetIssues(object):
             for line in fh:
                 yield cast(Issue, orjson.loads(line))
 
-    def by_level(self) -> Dict[str, int]:
+    def by_level(self) -> dict[str, int]:
         """Count the number of issues by severity level."""
-        levels: Dict[str, int] = {}
+        levels: dict[str, int] = {}
         for issue in self.all():
             level = issue.get("level")
             if level is not None:
                 levels[level] = levels.get(level, 0) + 1
         return levels
 
-    def export(self, path: Optional[Path] = None) -> None:
+    def export(self, path: Path | None = None) -> None:
         """Export the issues log to a consolidated file."""
         if path is None:
             path = dataset_resource_path(self.dataset.name, ISSUES_FILE)

--- a/zavod/zavod/runtime/loader.py
+++ b/zavod/zavod/runtime/loader.py
@@ -2,7 +2,8 @@ import re
 import sys
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, Any, Optional, cast
+from typing import Any, cast
+from collections.abc import Callable
 from importlib import import_module, invalidate_caches
 from importlib.util import module_from_spec, spec_from_file_location
 
@@ -21,7 +22,7 @@ def load_entry_point(dataset: Dataset, method: str = "crawl") -> Callable[[Any],
     module_name = dataset.model.entry_point
     if ":" in module_name:
         module_name, method = module_name.rsplit(":", 1)
-    module: Optional[ModuleType] = None
+    module: ModuleType | None = None
     try:
         module = import_module(module_name)
     except ModuleNotFoundError:
@@ -40,12 +41,12 @@ def load_entry_point(dataset: Dataset, method: str = "crawl") -> Callable[[Any],
                     spec.loader.exec_module(module)
                     break
     if module is None:
-        raise RuntimeError("Could not load entry point: %s" % dataset.model.entry_point)
+        raise RuntimeError(f"Could not load entry point: {dataset.model.entry_point}")
     try:
         method_ = getattr(module, method)
         return cast(Callable[[Any], None], method_)
     except AttributeError:
-        raise RuntimeError("Function does not exist: %r (on %r)" % (method, module))
+        raise RuntimeError(f"Function does not exist: {method!r} (on {module!r})")
 
 
 def example_function() -> None:

--- a/zavod/zavod/runtime/lookups.py
+++ b/zavod/zavod/runtime/lookups.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING
 from datapatch import Result
 from datapatch.lookup import Lookup
 from followthemoney import Property
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
-def get_type_lookup(dataset: Dataset, type_: PropertyType) -> Optional[Lookup]:
+def get_type_lookup(dataset: Dataset, type_: PropertyType) -> Lookup | None:
     """Get a type-based lookup from the dataset by name."""
     return dataset.lookups.get(f"type.{type_.name}")
 
@@ -32,15 +32,13 @@ def is_type_lookup_value(entity: "Entity", type_: PropertyType, value: str) -> b
 
 
 def match_type_lookup(
-    entity: "Entity", type_: PropertyType, value: Optional[str]
+    entity: "Entity", type_: PropertyType, value: str | None
 ) -> Result | None:
     lookup = get_type_lookup(entity.dataset, type_)
     return lookup.match(value) if lookup is not None else None
 
 
-def type_lookup(
-    dataset: Dataset, type_: PropertyType, value: Optional[str]
-) -> List[str]:
+def type_lookup(dataset: Dataset, type_: PropertyType, value: str | None) -> list[str]:
     """Given a value and a certain property type, check to see if there is a
     normalised override available. This uses the lookups defined in the dataset
     metadata. If no override is available, the value is returned as-is."""
@@ -52,8 +50,8 @@ def type_lookup(
 
 
 def prop_lookup(
-    entity: "Entity", prop: Property, value: Optional[str]
-) -> List[Tuple[Property, str]]:
+    entity: "Entity", prop: Property, value: str | None
+) -> list[tuple[Property, str]]:
     """Given a value and a certain property, check to see if there is a type-based
     normalised override available. This uses the lookups defined in the dataset
     metadata. If no override is available, the value is returned as-is."""

--- a/zavod/zavod/runtime/resources.py
+++ b/zavod/zavod/runtime/resources.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Any, List
+from typing import Any
 from followthemoney.dataset import DataResource
 
 from zavod.meta import Dataset
@@ -7,7 +7,7 @@ from zavod.archive import dataset_resource_path
 from zavod.archive import RESOURCES_FILE
 
 
-class DatasetResources(object):
+class DatasetResources:
     """Store information about the resources in the dataset that have been emitted
     from the context during runtime."""
 
@@ -15,9 +15,9 @@ class DatasetResources(object):
         self.dataset = dataset
         self.path = dataset_resource_path(dataset.name, RESOURCES_FILE)
 
-    def _store_resources(self, resources: List[DataResource]) -> None:
+    def _store_resources(self, resources: list[DataResource]) -> None:
         with open(self.path, "w") as fh:
-            objs: List[Dict[str, Any]] = []
+            objs: list[dict[str, Any]] = []
             for resource in resources:
                 data = resource.model_dump(mode="json", exclude_none=True)
                 data["path"] = resource.name
@@ -34,13 +34,13 @@ class DatasetResources(object):
         resources = [r for r in self.all() if r.name != name]
         self._store_resources(resources)
 
-    def all(self) -> List[DataResource]:
-        resources: List[DataResource] = []
-        data: Dict[str, Any] = {}
+    def all(self) -> list[DataResource]:
+        resources: list[DataResource] = []
+        data: dict[str, Any] = {}
         # if not self.path.exists():
         #     self.path = get_dataset_artifact(self.dataset.name, RESOURCES_FILE)
         if self.path.exists():
-            with open(self.path, "r") as fh:
+            with open(self.path) as fh:
                 data = json.load(fh)
         for raw in data.get("resources", []):
             resources.append(DataResource.model_validate(raw))

--- a/zavod/zavod/runtime/safety.py
+++ b/zavod/zavod/runtime/safety.py
@@ -1,5 +1,5 @@
 import re
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from followthemoney import registry, Property
 
@@ -45,7 +45,7 @@ SILENCE_WARNING_TYPE = "xss-html-smell"
 
 
 def check_xss_html_smell(
-    entity: "Entity", prop: Property, *, raw_value: Optional[str], cleaned_value: str
+    entity: "Entity", prop: Property, *, raw_value: str | None, cleaned_value: str
 ) -> str | None:
     """A very basic HTML entity and XSS check.
 

--- a/zavod/zavod/runtime/stats.py
+++ b/zavod/zavod/runtime/stats.py
@@ -1,7 +1,7 @@
 # from zavod.entity import Entity
 
 
-class ContextStats(object):
+class ContextStats:
     """A simple object for tracking the number of statements, entities and targets
     emitted by a dataset context while running the dataset method."""
 

--- a/zavod/zavod/runtime/timestamps.py
+++ b/zavod/zavod/runtime/timestamps.py
@@ -1,6 +1,6 @@
 import plyvel  # type: ignore
 import shutil
-from typing import Dict, Iterable
+from collections.abc import Iterable
 from rigour.env import ENCODING as E
 from followthemoney import Statement
 
@@ -11,7 +11,7 @@ from zavod.archive import dataset_state_path, iter_previous_statements
 log = get_logger(__name__)
 
 
-class TimeStampIndex(object):
+class TimeStampIndex:
     BUFFER = 10 * 1024 * 1024
 
     def __init__(self, dataset: Dataset) -> None:
@@ -55,8 +55,8 @@ class TimeStampIndex(object):
         index.index(iter_previous_statements(dataset, external=False))
         return index
 
-    def get(self, entity_id: str) -> Dict[str, str]:
-        timestamps: Dict[str, str] = {}
+    def get(self, entity_id: str) -> dict[str, str]:
+        timestamps: dict[str, str] = {}
         prefix = f"{entity_id}:".encode(E)
         with self.db.iterator(prefix=prefix) as it:
             for key, value in it:

--- a/zavod/zavod/runtime/urls.py
+++ b/zavod/zavod/runtime/urls.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
 
 import zavod
 from zavod import settings
@@ -19,7 +18,7 @@ def make_artifact_url(dataset_name: str, version: str, path: str) -> str:
     return f"{settings.ARCHIVE_SITE}/{ARTIFACTS}/{dataset_name}/{version}/{path}"
 
 
-def make_entity_url(entity: "zavod.entity.Entity") -> Optional[str]:
+def make_entity_url(entity: zavod.entity.Entity) -> str | None:
     """Generate a public URL for a file within the dataset context."""
     # TODO: implement check if the entity is in default, if not return None
     if entity.id is None:

--- a/zavod/zavod/runtime/versions.py
+++ b/zavod/zavod/runtime/versions.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional
 from followthemoney.dataset import Version, VersionHistory
 
 from zavod.meta import Dataset
@@ -41,7 +40,7 @@ def set_last_successful_version(dataset: Dataset, version: Version) -> None:
         raise RuntimeError(
             f"Version history file does not exist for dataset {dataset.name}"
         )
-    with open(path, "r") as fh:
+    with open(path) as fh:
         history = VersionHistory.from_json(fh.read())
     if version not in history.items:
         raise RuntimeError(
@@ -57,11 +56,11 @@ def get_history(dataset_name: str, backfill: bool = True) -> VersionHistory:
     path = get_dataset_artifact(dataset_name, VERSIONS_FILE, backfill=backfill)
     if not path.exists():
         return VersionHistory([])
-    with open(path, "r") as fh:
+    with open(path) as fh:
         return VersionHistory.from_json(fh.read())
 
 
-def get_latest(dataset_name: str, backfill: bool = True) -> Optional[Version]:
+def get_latest(dataset_name: str, backfill: bool = True) -> Version | None:
     """Get the latest version for a dataset."""
     history = get_history(dataset_name, backfill=backfill)
     return history.latest

--- a/zavod/zavod/shed/bods.py
+++ b/zavod/zavod/shed/bods.py
@@ -175,7 +175,7 @@ def parse_bods_fh(context: Context, fh: BinaryIO) -> None:
         parse_statement(context, data)
         index += 1
         if index > 0 and index % 10000 == 0:
-            context.log.info("BODS statements: %d..." % index)
+            context.log.info(f"BODS statements: {index}...")
 
 
 def parse_bods_file(context: Context, file_name: Path) -> None:

--- a/zavod/zavod/shed/bods.py
+++ b/zavod/zavod/shed/bods.py
@@ -1,6 +1,6 @@
 import orjson
 from pathlib import Path
-from typing import Any, Dict, BinaryIO
+from typing import Any, BinaryIO
 
 from zavod.context import Context
 
@@ -52,7 +52,7 @@ SCHEME_PROPS = {
 }
 
 
-def parse_statement(context: Context, data: Dict[str, Any]) -> None:
+def parse_statement(context: Context, data: dict[str, Any]) -> None:
     statement_type = data.pop("statementType")
     statement_id = data.pop("statementID")
     proxy_id = context.make_slug(statement_id)

--- a/zavod/zavod/shed/bs_tokyo_mou_psc.py
+++ b/zavod/zavod/shed/bs_tokyo_mou_psc.py
@@ -15,17 +15,16 @@ This module is shared between two MoU crawlers:
 
 import re
 from lxml import html
-from typing import Optional, Dict
 from urllib3 import Retry
 
 from zavod import Context, helpers as h
 
 
-def make_search_data(page: int, search_data: Dict[str, str]) -> Dict[str, str]:
+def make_search_data(page: int, search_data: dict[str, str]) -> dict[str, str]:
     return {**search_data, "Page": str(page)}
 
 
-def parse_total_pages(tree: html.HtmlElement) -> Optional[int]:
+def parse_total_pages(tree: html.HtmlElement) -> int | None:
     found_li = tree.xpath(
         "//ul[@class='navigate']/li[starts-with(normalize-space(.), 'Found')]"
     )
@@ -50,7 +49,7 @@ def emit_unknown_link(
 
 
 def crawl_vessel_row(
-    context: Context, str_row: Dict[str, str | None], inspection_date: str
+    context: Context, str_row: dict[str, str | None], inspection_date: str
 ) -> str:
     ship_name = str_row.pop("ship_name")
     imo = str_row.pop("imo_number")
@@ -101,7 +100,7 @@ def crawl_vessel_row(
     return vessel.id
 
 
-def crawl_company_details(context: Context, str_row: Dict[str, str | None]) -> str:
+def crawl_company_details(context: Context, str_row: dict[str, str | None]) -> str:
     company_name = str_row.pop("name")
     company_imo = str_row.pop("imo_number")
     company = context.make("Company")
@@ -122,7 +121,7 @@ def crawl_company_details(context: Context, str_row: Dict[str, str | None]) -> s
 def crawl_vessel_page(
     context: Context,
     shipuid: str,
-    headers: Dict[str, str],
+    headers: dict[str, str],
     getships_url: str,
 ) -> None:
     context.log.debug(f"Processing shipuid: {shipuid}")
@@ -193,8 +192,8 @@ def crawl_vessel_page(
 def crawl_psc_records(
     context: Context,
     *,
-    headers: Dict[str, str],
-    search_data: Dict[str, str],
+    headers: dict[str, str],
+    search_data: dict[str, str],
     getinspection_url: str,
     getships_url: str,
 ) -> None:

--- a/zavod/zavod/shed/firds.py
+++ b/zavod/zavod/shed/firds.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import csv
 import os
-from typing import Iterable, List, Mapping, Tuple
+from collections.abc import Iterable, Mapping
 from lxml import etree
 from pathlib import Path
 from zipfile import ZipFile
@@ -105,8 +105,8 @@ def parse_xml_file(context: Context, path: Path) -> None:
 
 
 def latest_full_set(
-    context: Context, dump_urls: Iterable[Tuple[str, str]]
-) -> List[Tuple[str, str]]:
+    context: Context, dump_urls: Iterable[tuple[str, str]]
+) -> list[tuple[str, str]]:
     """Given a list of (file_name, url) tuples, return the items for the latest date
     occurring in the list."""
     date_sets = defaultdict(list)

--- a/zavod/zavod/shed/fsf.py
+++ b/zavod/zavod/shed/fsf.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 from banal import as_bool
 from followthemoney import registry
@@ -19,7 +18,7 @@ REGEX_LEADER_ALIAS = re.compile(r"led by .+ alias")
 LETTER_SPLITS = ["(a)", "(b)", "(c)", "(d)", "(e)"]
 
 
-def parse_country(node: Element) -> Optional[str]:
+def parse_country(node: Element) -> str | None:
     description = node.get("countryDescription")
     if description == "UNKNOWN":
         return None
@@ -32,7 +31,7 @@ def parse_country(node: Element) -> Optional[str]:
     return code
 
 
-def parse_address(context: Context, el: Element) -> Optional[Entity]:
+def parse_address(context: Context, el: Element) -> Entity | None:
     country = el.get("countryDescription")
     if country == "UNKNOWN":
         country = None

--- a/zavod/zavod/shed/internal_data.py
+++ b/zavod/zavod/shed/internal_data.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Generator
+from collections.abc import Generator
 from google.cloud.storage import Client, Bucket  # type: ignore
 
 

--- a/zavod/zavod/shed/trans.py
+++ b/zavod/zavod/shed/trans.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Optional, NamedTuple, List, Sequence
+from typing import NamedTuple
+from collections.abc import Sequence
 import orjson
 
 from zavod.context import Context
@@ -82,8 +83,8 @@ def make_position_translation_prompt(input_code: str) -> str:
 
 @dataclass(frozen=True, kw_only=True)
 class TranslationResult:
-    texts: List[LangText]
-    cache_key: Optional[str]
+    texts: list[LangText]
+    cache_key: str | None
     """Cache key of the underlying run_text_prompt response, set only when
     the response was parsed and accepted. Callers that do additional
     per-result validation can drop this entry via context.cache.delete()
@@ -92,7 +93,7 @@ class TranslationResult:
     """The model that produced the translation. Suitable for passing as the
     ``origin`` when applying the resulting values to an entity."""
 
-    def get_preferred_language(self) -> Optional[LangText]:
+    def get_preferred_language(self) -> LangText | None:
         """Return the ``LangText`` for the preferred output language, or None
         if absent. The preferred language is currently English."""
         for text in self.texts:
@@ -106,7 +107,7 @@ def run_translation_prompt(
     *,
     prompt: str,
     text: str,
-    output_langs: List[str] = ["eng"],
+    output_langs: list[str] = ["eng"],
     model: str = DEFAULT_MODEL,
 ) -> TranslationResult:
     """Run a translation/transliteration prompt and return the result as
@@ -128,7 +129,7 @@ def run_translation_prompt(
     try:
         response = run_text_prompt(context, prompt, text, model=model)
     except ConfigurationException as ce:
-        context.log.error("LLM translation skipped: %s" % ce.message)
+        context.log.error(f"LLM translation skipped: {ce.message}")
         return TranslationResult(texts=[], cache_key=None, origin=model)
     try:
         trans_by_lang = orjson.loads(response.content)
@@ -153,7 +154,7 @@ def run_translation_prompt(
             expected=sorted(output_langs),
         )
         return TranslationResult(texts=[], cache_key=None, origin=model)
-    results: List[LangText] = []
+    results: list[LangText] = []
     for lang in output_langs:
         value = trans_by_lang.get(lang)
         if not isinstance(value, str) or not value.strip():
@@ -188,7 +189,7 @@ def apply_translit_names(
     input_code: str,
     first_name: str,
     last_name: str,
-    output_spec: List[TransliterationLanguageSpec] = [ENGLISH],
+    output_spec: list[TransliterationLanguageSpec] = [ENGLISH],
     model: str = DEFAULT_MODEL,
 ) -> None:
     """
@@ -258,7 +259,7 @@ def apply_translit_full_name(
     name: LangText,
     *,
     output: Sequence[TransliterationLanguageSpec] = (PREFERRED_LANGUAGE,),
-    prompt: Optional[str] = None,
+    prompt: str | None = None,
     alias: bool = False,
     model: str = DEFAULT_MODEL,
 ) -> None:

--- a/zavod/zavod/shed/un_sc.py
+++ b/zavod/zavod/shed/un_sc.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import Generator, List, Optional, Tuple
+from collections.abc import Generator
 from lxml.etree import _Element as Element
 
 from zavod import Context, Entity
@@ -30,8 +30,8 @@ def get_persons(
     context: Context,
     prefix: str,
     doc: ElementOrTree,
-    include_prefixes: Optional[List[Regime]] = None,
-) -> Generator[Tuple[Element, Entity], None, None]:
+    include_prefixes: list[Regime] | None = None,
+) -> Generator[tuple[Element, Entity], None, None]:
     yield from get_entities(
         context, prefix, doc, include_prefixes, "INDIVIDUAL", "Person"
     )
@@ -41,8 +41,8 @@ def get_legal_entities(
     context: Context,
     prefix: str,
     doc: ElementOrTree,
-    include_prefixes: Optional[List[Regime]] = None,
-) -> Generator[Tuple[Element, Entity], None, None]:
+    include_prefixes: list[Regime] | None = None,
+) -> Generator[tuple[Element, Entity], None, None]:
     yield from get_entities(
         context, prefix, doc, include_prefixes, "ENTITY", "LegalEntity"
     )
@@ -52,10 +52,10 @@ def get_entities(
     context: Context,
     prefix: str,
     doc: ElementOrTree,
-    include_prefixes: Optional[List[Regime]],
+    include_prefixes: list[Regime] | None,
     tag: str,
     schema: str,
-) -> Generator[Tuple[Element, Entity], None, None]:
+) -> Generator[tuple[Element, Entity], None, None]:
     for node in doc.findall(f".//{tag}"):
         perm_ref = node.findtext("./REFERENCE_NUMBER")
         if (
@@ -90,7 +90,7 @@ def make_entity(context: Context, prefix: str, schema: str, node: Element) -> En
 
 
 def apply_un_name_list(
-    context: Context, entity: Entity, names: List[str], lang: Optional[str] = None
+    context: Context, entity: Entity, names: list[str], lang: str | None = None
 ) -> None:
     """Apply the list of names given by the UN to an entity.
 
@@ -114,7 +114,7 @@ def apply_un_name_list(
         entity.add("name", h.make_name(**name_args), lang=lang)
 
 
-def load_un_sc(context: Context) -> Tuple[Dataset, ElementOrTree]:
+def load_un_sc(context: Context) -> tuple[Dataset, ElementOrTree]:
     un_sc_path = (
         Path(__file__).parent.parent.parent.parent
         / "datasets/_global/un_sc_sanctions/un_sc_sanctions.yml"

--- a/zavod/zavod/shed/wikidata/country.py
+++ b/zavod/zavod/shed/wikidata/country.py
@@ -1,4 +1,3 @@
-from typing import Set, Tuple
 from functools import lru_cache
 from nomenklatura.wikidata import WikidataClient, LangText
 from rigour.territories import get_territory_by_qid
@@ -23,19 +22,19 @@ def is_historical_country(client: WikidataClient, qid: str) -> bool:
 
 
 @lru_cache(maxsize=5000)
-def item_countries(client: WikidataClient, qid: str) -> Set[LangText]:
+def item_countries(client: WikidataClient, qid: str) -> set[LangText]:
     """Extract the countries linked to an item, traversing up an administrative hierarchy
     via jurisdiction/part of properties."""
     return _crawl_item_countries(client, qid, (qid,))
 
 
 def _crawl_item_countries(
-    client: WikidataClient, qid: str, seen: Tuple[str, ...]
-) -> Set[LangText]:
+    client: WikidataClient, qid: str, seen: tuple[str, ...]
+) -> set[LangText]:
     item = client.fetch_item(qid)
     if item is None:
         return set()
-    countries: Set[LangText] = set()
+    countries: set[LangText] = set()
     territory = get_territory_by_qid(item.id)
     if territory is not None and territory.ftm_country is not None:
         text = LangText(territory.ftm_country, original=item.id)

--- a/zavod/zavod/shed/wikidata/human.py
+++ b/zavod/zavod/shed/wikidata/human.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from datetime import timedelta
 from followthemoney import registry
 from nomenklatura.wikidata import Item, WikidataClient
@@ -13,7 +12,7 @@ BLOCKED_PERSONS = {"Q1045488"}
 
 def wikidata_basic_human(
     context: Context, client: WikidataClient, item: Item, strict: bool = False
-) -> Optional[Entity]:
+) -> Entity | None:
     if item.id in BLOCKED_PERSONS:
         return None
     types = item.types

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict, Optional, Set
 
 from followthemoney import registry
 from nomenklatura.wikidata import Item, WikidataClient, Claim
@@ -18,13 +17,13 @@ from zavod.stateful.positions import categorise, categorise_many
 from zavod.shed.wikidata.country import is_historical_country, item_countries
 
 
-POSITION_BASICS: Set[str] = {
+POSITION_BASICS: set[str] = {
     "Q4164871",  # position
     "Q29645880",  # ambassador of a country
     "Q29645886",  # ambassador to a country
     "Q707492",  # military chief of staff
 }
-SUB_TYPES: Dict[str, Set[str]] = {
+SUB_TYPES: dict[str, set[str]] = {
     "Q30185": {"role.pep", "gov.executive", "gov.muni"},  # mayor
     "Q17279032": {"role.pep"},  # elective office
     "Q109862464": {"gov.executive", "gov.muni"},  # lord mayor
@@ -83,7 +82,7 @@ POSITION_ABOLISHED_CUTOFF = "1990-12-26"
 # the bar for adding entries is high: only classes that are unambiguously
 # non-PEP-conferring belong here. When in doubt, leave the candidate to the
 # review workflow, where the decision is recorded and reversible.
-EXCLUDE_TYPES: Set[str] = {
+EXCLUDE_TYPES: set[str] = {
     "Q114962596",  # historical position
     "Q193622",  # order
     "Q60754876",  # grade of an order
@@ -101,7 +100,7 @@ EXCLUDE_TYPES: Set[str] = {
 # Types that keep an item in the candidate set even when its ancestry hits
 # EXCLUDE_TYPES or misses POSITION_BASICS (allow beats exclude; a reviewed
 # position DB row beats both — see the `vetted` flag on wikidata_position).
-ALLOW_TYPES: Set[str] = {
+ALLOW_TYPES: set[str] = {
     # Members of the College of Cardinals are recognised by the Holy See as
     # PEPs, despite their religious-occupation ancestry:
     "Q45722",  # cardinal
@@ -147,7 +146,7 @@ MUNI_COUNTRIES = {
 
 def wikidata_position(
     context: Context, client: WikidataClient, item: Item
-) -> Optional[Entity]:
+) -> Entity | None:
     # Precedence: a position DB verdict beats the type-based heuristics below,
     # and ALLOW_TYPES beats EXCLUDE_TYPES. The DB check also runs first so a
     # reviewed-rejected position skips the more expensive work (country
@@ -246,7 +245,7 @@ def wikidata_position(
                         origin=result.origin,
                     )
 
-    topics: Set[str] = set()
+    topics: set[str] = set()
     for sub_type, type_topics in SUB_TYPES.items():
         if sub_type in types:
             topics.update(type_topics)
@@ -279,9 +278,7 @@ def wikidata_position(
     return position
 
 
-def position_holders(
-    client: WikidataClient, item: Item
-) -> Dict[str, Optional[datetime]]:
+def position_holders(client: WikidataClient, item: Item) -> dict[str, datetime | None]:
     """Find persons who have held the position defined by `item`, combining the
     inverted lookup on property P39 (position held) with the position item's own
     P1308 (officeholder) claims.
@@ -297,7 +294,7 @@ def position_holders(
         ?person schema:dateModified ?modifiedAt .
     }}
     """
-    holders: Dict[str, Optional[datetime]] = {}
+    holders: dict[str, datetime | None] = {}
     # Holder lists (and the dateModified values that drive person cache
     # invalidation) change slowly; at 1 day, every crawl re-runs tens of
     # thousands of WDQS queries.
@@ -317,10 +314,10 @@ def position_holders(
 
 def wikidata_occupancy(
     context: Context, person: Entity, position: Entity, claim: Claim
-) -> Optional[Entity]:
+) -> Entity | None:
     """Create an Occupancy entity for the given person and position based on the claim,
     which identifies relevant qualifiers."""
-    start_date: Optional[str] = None
+    start_date: str | None = None
     for qual in claim.get_qualifier("P580"):
         qual_date = qual.text.text
         if qual_date is not None:
@@ -329,7 +326,7 @@ def wikidata_occupancy(
             else:
                 start_date = min(start_date, qual_date)
 
-    end_date: Optional[str] = None
+    end_date: str | None = None
     for qual in claim.get_qualifier("P582"):
         qual_date = qual.text.text
         if qual_date is not None:

--- a/zavod/zavod/stateful/positions.py
+++ b/zavod/zavod/stateful/positions.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from enum import Enum
 from functools import lru_cache
-from typing import List, Optional
 
 from rigour.dates import ended_before, starts_after
 from rigour.ids.wikidata import is_qid
@@ -30,15 +29,15 @@ class OccupancyStatus(Enum):
     UNKNOWN = "unknown"
 
 
-class PositionCategorisation(object):
-    is_pep: Optional[bool]
+class PositionCategorisation:
+    is_pep: bool | None
     """Whether the position denotes a politically exposed person or not"""
-    topics: List[str]
+    topics: list[str]
     """The topics linked to the position, as a list"""
 
     __slots__ = ["topics", "is_pep"]
 
-    def __init__(self, topics: List[str], is_pep: Optional[bool]):
+    def __init__(self, topics: list[str], is_pep: bool | None):
         self.topics = topics
         self.is_pep = is_pep
 
@@ -48,7 +47,7 @@ def categorise(
     context: Context,
     position: Entity,
     *,
-    default_is_pep: Optional[bool] = True,
+    default_is_pep: bool | None = True,
 ) -> PositionCategorisation:
     """Return the reviewed categorisation (topics, is_pep) for a position.
 
@@ -109,8 +108,8 @@ def categorise(
 
 
 def categorise_many(
-    contextL: Context, position_ids: List[str]
-) -> List[PositionCategorisation]:
+    contextL: Context, position_ids: list[str]
+) -> list[PositionCategorisation]:
     """Categorise multiple positions at once. This is a performance optimisation to
     avoid multiple database queries."""
     stmt = position_table.select()
@@ -128,7 +127,7 @@ def categorise_many(
     return categorisations
 
 
-def categorised_position_qids(context: Context) -> List[str]:
+def categorised_position_qids(context: Context) -> list[str]:
     """Return a list of position QIDs that have been categorised."""
     stmt = select(position_table.c.entity_id)
     stmt = stmt.filter(position_table.c.is_pep.is_(True))
@@ -142,7 +141,7 @@ def categorised_position_qids(context: Context) -> List[str]:
     return qids
 
 
-def get_after_office(topics: List[str]) -> timedelta:
+def get_after_office(topics: list[str]) -> timedelta:
     if "gov.national" in topics:
         if "gov.head" in topics:
             return NO_EXPIRATION
@@ -160,10 +159,10 @@ def occupancy_status(
     occupancy: Entity,
     no_end_implies_current: bool = True,
     current_time: datetime = settings.RUN_TIME,
-    birth_date: Optional[str] = None,
-    death_date: Optional[str] = None,
-    categorisation: Optional[PositionCategorisation] = None,
-) -> Optional[OccupancyStatus]:
+    birth_date: str | None = None,
+    death_date: str | None = None,
+    categorisation: PositionCategorisation | None = None,
+) -> OccupancyStatus | None:
     """Determine the occupancy status of a person in a position given a set of dates.
 
     Dates are extracted from the occupancy entity. The effective start date is

--- a/zavod/zavod/stateful/programs.py
+++ b/zavod/zavod/stateful/programs.py
@@ -1,6 +1,6 @@
 import functools
 import yaml
-from typing import Literal, Optional
+from typing import Literal
 from pydantic import BaseModel, Field
 
 from zavod import settings
@@ -84,18 +84,18 @@ Measure = Literal[
 class Issuer(BaseModel):
     """An organization or governmental body that issues sanctions programs."""
 
-    id: Optional[int] = None  # from Directus, drop after migration
+    id: int | None = None  # from Directus, drop after migration
     name: str = Field(
         description="Name of the organization (e.g., 'UN Security Council', 'Office of Foreign Asset Control')"
     )
-    acronym: Optional[str] = Field(
+    acronym: str | None = Field(
         default=None, description="Abbreviation (e.g., 'DFAT', 'UNSC', 'OFAC')"
     )
-    organisation: Optional[str] = Field(
+    organisation: str | None = Field(
         default=None,
         description="Parent organization (e.g., 'United Nations', 'Government of Australia')",
     )
-    territory: Optional[str] = Field(
+    territory: str | None = Field(
         default=None,
         description="ISO alpha-2 country code (e.g., 'au', 'us', 'ae'), null for international bodies",
     )
@@ -104,7 +104,7 @@ class Issuer(BaseModel):
 class Program(BaseModel):
     """A sanctions regime."""
 
-    id: Optional[int] = None  # from Directus, drop after migration
+    id: int | None = None  # from Directus, drop after migration
     # Convention: {ISSUER}-{TARGET} or {ISSUER}-{SHORTNAME}. Uppercase,
     # alphanumeric with hyphens only.
     key: str = Field(
@@ -115,24 +115,24 @@ class Program(BaseModel):
     title: str = Field(
         description="Official or near-official English title of the program."
     )
-    url: Optional[str] = Field(
+    url: str | None = Field(
         default=None,
         description="Authoritative public-facing page at the issuing authority, "
         "e.g. SECO program page, EU sanctions map entry, UN SC committee page.",
     )
     # Two to four sentences, consistent with the measures field.
-    summary: Optional[str] = Field(
+    summary: str | None = Field(
         default=None,
         description="Plain-language description: who the program targets, why, "
         "and what measures it imposes.",
     )
     # Some programs are covered by multiple datasets; pick one as the primary.
-    dataset: Optional[str] = Field(
+    dataset: str | None = Field(
         default=None,
         description="Related OpenSanctions dataset that ingests data from this "
         "program, e.g. eu_fsf, ch_seco_sanctions.",
     )
-    issuer: Optional[Issuer] = Field(
+    issuer: Issuer | None = Field(
         default=None,
         description="Issuing authority from the controlled vocabulary, "
         "e.g. eu_council, ch_seco, zz_unsc, us_ofac.",
@@ -217,5 +217,5 @@ def get_all_programs_by_key() -> dict[str, Program]:
     return by_key
 
 
-def get_program_by_key(program_key: str) -> Optional[Program]:
+def get_program_by_key(program_key: str) -> Program | None:
     return get_all_programs_by_key().get(program_key, None)

--- a/zavod/zavod/stateful/review.py
+++ b/zavod/zavod/stateful/review.py
@@ -1,8 +1,9 @@
 from abc import ABC
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from hashlib import sha1
 from logging import getLogger
-from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar
+from typing import Any, Optional, TypeVar
+from collections.abc import Callable
 
 import orjson
 from lxml.html import fromstring, tostring
@@ -34,19 +35,19 @@ MODIFIED_BY_CRAWLER = "zavod"
 class SchemaGenerator(GenerateJsonSchema):
     def generate(
         self, schema: CoreSchema, mode: JsonSchemaMode = "validation"
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         json_schema = super().generate(schema, mode=mode)
         json_schema["$schema"] = self.schema_dialect
         return json_schema
 
 
-class Review(BaseModel, Generic[ModelType]):
+class Review[ModelType: BaseModel](BaseModel):
     """
     A review is the smallest unit of data that's convenient to extract data from and review,
     along with info about the source data, whether it's been accepted, and by who.
     """
 
-    id: Optional[int] = None
+    id: int | None = None
     key: str
     """A SHA1 hash derived from key_parts that uniquely and consistently identifies
     the review within the dataset."""
@@ -61,12 +62,12 @@ class Review(BaseModel, Generic[ModelType]):
     source_label: str
     """Used to indicate the context of the source value to the reviewer,
     e.g. "Banking Organization field in CSV" or "Screenshot of PDF page"."""
-    source_url: Optional[str] = None
-    data_model: Type[ModelType]
+    source_url: str | None = None
+    data_model: type[ModelType]
     crawler_version: int
     _original_extraction: JsonValue = PrivateAttr()
     """Only to be edited by the crawler"""
-    origin: Optional[str] = None
+    origin: str | None = None
     _extracted_data: JsonValue = PrivateAttr()
     """Editable by the reviewer"""
     accepted: bool
@@ -74,7 +75,7 @@ class Review(BaseModel, Generic[ModelType]):
     """The crawl version that last saw this review key"""
     modified_at: datetime
     modified_by: str
-    deleted_at: Optional[datetime] = None
+    deleted_at: datetime | None = None
 
     # Lazily validating the pydantic model fields lets us populate the Review
     # and check self.crawler_version before validating the data, which is useful
@@ -111,7 +112,7 @@ class Review(BaseModel, Generic[ModelType]):
     def load(
         cls,
         session: Session,
-        data_model: Type[ModelType],
+        data_model: type[ModelType],
         stmt: Select,  # type: ignore
     ) -> Optional["Review[ModelType]"]:
         res = session.execute(stmt)
@@ -128,7 +129,7 @@ class Review(BaseModel, Generic[ModelType]):
 
     @classmethod
     def by_key(
-        cls, session: Session, data_model: Type[ModelType], dataset: str, key: str
+        cls, session: Session, data_model: type[ModelType], dataset: str, key: str
     ) -> Optional["Review[ModelType]"]:
         select_stmt = select(review_table).where(
             review_table.c.dataset == dataset,
@@ -160,7 +161,7 @@ class Review(BaseModel, Generic[ModelType]):
                 session.execute(
                     update(review_table)
                     .where(review_table.c.id == self.id)
-                    .values(deleted_at=datetime.now(timezone.utc))
+                    .values(deleted_at=datetime.now(UTC))
                 )
             ins = insert(review_table).values(**values)
             result = session.execute(ins)
@@ -220,11 +221,11 @@ class SourceValue(ABC):
     re-review.
     """
 
-    key_parts: str | List[str]
+    key_parts: str | list[str]
     """Parts that are SHA1-hashed to produce the review key."""
     mime_type: str
     label: str
-    url: Optional[str]
+    url: str | None
     value_string: str
 
     def matches(self, review: Review[ModelType]) -> bool:
@@ -236,10 +237,10 @@ class TextSourceValue(SourceValue):
 
     def __init__(
         self,
-        key_parts: str | List[str],
+        key_parts: str | list[str],
         label: str,
         text: str,
-        url: Optional[str] = None,
+        url: str | None = None,
     ):
         """
         Args:
@@ -273,10 +274,10 @@ class JSONSourceValue(SourceValue):
 
     def __init__(
         self,
-        key_parts: str | List[str],
+        key_parts: str | list[str],
         label: str,
         data: JsonValue,
-        url: Optional[str] = None,
+        url: str | None = None,
     ):
         """
         Args:
@@ -303,7 +304,7 @@ class HtmlSourceValue(SourceValue):
 
     def __init__(
         self,
-        key_parts: str | List[str],
+        key_parts: str | list[str],
         label: str,
         element: Element,
         url: str,
@@ -334,7 +335,7 @@ class HtmlSourceValue(SourceValue):
         return element_text_hash(seen_element) == element_text_hash(self.element)
 
 
-def review_key(parts: str | List[str]) -> str:
+def review_key(parts: str | list[str]) -> str:
     """Generates a stable 40-char SHA1 key for a review.
     String normalization should be no more aggressive than source value matching,
     so that two source values don't match as keys but appear to be changing source values.
@@ -350,7 +351,7 @@ def review_key(parts: str | List[str]) -> str:
     return digest.hexdigest()
 
 
-def review_extraction(
+def review_extraction[ModelType: BaseModel](
     context: Context,
     source_value: SourceValue,
     original_extraction: ModelType,
@@ -389,7 +390,7 @@ def review_extraction(
 
     data_model = type(original_extraction)
     schema = data_model.model_json_schema(schema_generator=SchemaGenerator)
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     review = Review[ModelType].by_key(
         context.db, data_model, dataset=context.dataset.name, key=key_slug

--- a/zavod/zavod/store.py
+++ b/zavod/zavod/store.py
@@ -1,6 +1,5 @@
 import shutil
 import plyvel  # type: ignore
-from typing import List, Optional
 from followthemoney.exc import InvalidData
 from followthemoney import Statement
 from nomenklatura.resolver import Linker
@@ -34,7 +33,7 @@ class Store(LevelDBStore[Dataset, Entity]):
     def view(self, scope: Dataset, external: bool = False) -> View:
         return LevelDBView(self, scope, external=external)
 
-    def assemble(self, statements: List[Statement]) -> Optional[Entity]:
+    def assemble(self, statements: list[Statement]) -> Entity | None:
         """Build an entity proxy from a set of cached statements, considering
         only those statements that belong to the given sources."""
         try:
@@ -43,14 +42,14 @@ class Store(LevelDBStore[Dataset, Entity]):
             dbg_stmts = [
                 [s.dataset, s.entity_id, s.schema, s.prop, s.value] for s in statements
             ]
-            log.error("Assemble error: %s" % inv, statements=dbg_stmts)
+            log.error(f"Assemble error: {inv}", statements=dbg_stmts)
             return None
         return entity
 
     def sync(self, clear: bool = False) -> None:
         if clear:
             self.clear()
-        ds_key = f"dataset:{self.dataset.name}".encode("utf-8")
+        ds_key = f"dataset:{self.dataset.name}".encode()
         if self.db.get(ds_key):
             return
         log.info("Building local LevelDB aggregator...", scope=self.dataset.name)

--- a/zavod/zavod/tests/conftest.py
+++ b/zavod/zavod/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 import pytest
 import shutil
 from pathlib import Path

--- a/zavod/zavod/tests/enrich/test_enrichment.py
+++ b/zavod/zavod/tests/enrich/test_enrichment.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 from followthemoney import SE
 from nomenklatura.enrich import Enricher

--- a/zavod/zavod/tests/exporters/test_consolidate_edges.py
+++ b/zavod/zavod/tests/exporters/test_consolidate_edges.py
@@ -1,9 +1,9 @@
-from typing import Dict, Any
+from typing import Any
 from followthemoney import StatementEntity
 from zavod.exporters.consolidate import _simplify_undirected
 
 
-def _e(schema: str, **props: Dict[str, Any]) -> StatementEntity:
+def _e(schema: str, **props: dict[str, Any]) -> StatementEntity:
     data = {"schema": schema, "properties": props, "id": "test"}
     return StatementEntity.from_dict(data)
 

--- a/zavod/zavod/tests/exporters/test_delta.py
+++ b/zavod/zavod/tests/exporters/test_delta.py
@@ -1,7 +1,7 @@
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 from followthemoney.dataset import Version
 from nomenklatura.judgement import Judgement
@@ -26,7 +26,7 @@ ENTITY_CX = {
 ENTITY_D = {"id": "ED", "schema": "Person", "properties": {"name": ["Dory"]}}
 
 
-def _assert_delta_index_matches_expected(path: Path, expected_versions: List[str]):
+def _assert_delta_index_matches_expected(path: Path, expected_versions: list[str]):
     index = json.loads(path.read_text())
 
     # Check the "versions" key
@@ -53,7 +53,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     dataset_path = settings.DATA_PATH / DATASETS / testdataset1.name
     store = get_store(testdataset1, resolver)
 
-    def e(data: Dict[str, Any]) -> Entity:
+    def e(data: dict[str, Any]) -> Entity:
         return resolver.apply(Entity.from_data(testdataset1, data))
 
     version = Version.new("aaa")
@@ -70,7 +70,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
     export_dataset(testdataset1, view)
 
     assert dataset_path.joinpath(DELTA_EXPORT_FILE).exists()
-    with open(dataset_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
+    with open(dataset_path.joinpath(DELTA_EXPORT_FILE)) as fh:
         objects = [json.loads(line) for line in fh.readlines()]
         assert len(objects) == 4, objects
         for data in objects:
@@ -97,7 +97,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
 
     export_dataset(testdataset1, view)
     assert dataset_path.joinpath(DELTA_EXPORT_FILE).exists()
-    with open(dataset_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
+    with open(dataset_path.joinpath(DELTA_EXPORT_FILE)) as fh:
         objects = [json.loads(line) for line in fh.readlines()]
         assert len(objects) == 3, [o["entity"]["id"] for o in objects]
         for data in objects:
@@ -132,7 +132,7 @@ def test_delta_exporter(testdataset1: Dataset, resolver: Resolver):
 
     export_dataset(testdataset1, view)
     assert dataset_path.joinpath(DELTA_EXPORT_FILE).exists()
-    with open(dataset_path.joinpath(DELTA_EXPORT_FILE), "r") as fh:
+    with open(dataset_path.joinpath(DELTA_EXPORT_FILE)) as fh:
         objects = [json.loads(line) for line in fh.readlines()]
         assert len(objects) == 3, [o["entity"]["id"] for o in objects]
         for data in objects:

--- a/zavod/zavod/tests/exporters/test_exporters.py
+++ b/zavod/zavod/tests/exporters/test_exporters.py
@@ -1,5 +1,4 @@
 from csv import DictReader
-from typing import Optional
 import uuid
 from followthemoney.cli.util import path_entities
 from followthemoney import Statement, ValueEntity
@@ -39,7 +38,7 @@ default_exports = {
 def emit_entity(
     ds: Dataset,
     schema: str,
-    id_: Optional[str] = None,
+    id_: str | None = None,
     properties: dict[str, list[str]] = {},
 ) -> Entity:
     context = Context(ds)

--- a/zavod/zavod/tests/exporters/test_metadata.py
+++ b/zavod/zavod/tests/exporters/test_metadata.py
@@ -28,7 +28,7 @@ def test_metadata_collection_export(
     index_path = ds_path / "index.json"
     assert index_path.is_file()
 
-    with open(index_path, "r") as fh:
+    with open(index_path) as fh:
         index = json.load(fh)
         assert index["updated_at"] == settings.RUN_TIME_ISO
         assert len(index["resources"]) > 2
@@ -40,7 +40,7 @@ def test_metadata_collection_export(
     export_dataset(collection, view)
     assert collection_path.is_dir()
 
-    with open(collection_path / "index.json", "r") as fh:
+    with open(collection_path / "index.json") as fh:
         collection_index = json.load(fh)
         # When resolve is true, the resolve key is not exported.
         assert collection.model.resolve is True
@@ -49,7 +49,7 @@ def test_metadata_collection_export(
     catalog_path = collection_path / "catalog.json"
     assert catalog_path.is_file()
 
-    with open(catalog_path, "r") as fh:
+    with open(catalog_path) as fh:
         catalog = json.load(fh)
 
     assert catalog["updated_at"] == settings.RUN_TIME_ISO
@@ -74,7 +74,7 @@ def test_metadata_collection_issue_count(
     write_dataset_index(collection, DatasetVersionResult.SUCCESS)
 
     index_path = settings.DATA_PATH / "datasets" / collection.name / "index.json"
-    with open(index_path, "r") as fh:
+    with open(index_path) as fh:
         index = json.load(fh)
     assert index["issue_count"] == 2, index
     assert index["issue_levels"] == {"error": 1, "warning": 1}, index

--- a/zavod/zavod/tests/extract/test_zyte_api.py
+++ b/zavod/zavod/tests/extract/test_zyte_api.py
@@ -59,7 +59,7 @@ def test_fetch_html_http_response_body(testdataset1: Dataset):
             "https://api.zyte.com/v1/extract",
             json={
                 "httpResponseBody": b64encode(
-                    "<html><h1>Hello, World!</h1></html>".encode()
+                    b"<html><h1>Hello, World!</h1></html>"
                 ).decode(),
                 "httpResponseHeaders": [
                     {"name": "content-type", "value": "text/html; charset=iso-8859-1"}
@@ -205,9 +205,7 @@ def test_fetch_resource(testdataset1: Dataset):
         m.post(
             "https://api.zyte.com/v1/extract",
             json={
-                "httpResponseBody": b64encode(
-                    "name,surname\nSally,Sue".encode()
-                ).decode(),
+                "httpResponseBody": b64encode(b"name,surname\nSally,Sue").decode(),
                 "httpResponseHeaders": [
                     {"name": "content-type", "value": "text/csv; charset=latin-1"}
                 ],
@@ -260,7 +258,7 @@ def test_fetch_text(testdataset1: Dataset):
         m.post(
             "https://api.zyte.com/v1/extract",
             json={
-                "httpResponseBody": b64encode("Hello, World!".encode()).decode(),
+                "httpResponseBody": b64encode(b"Hello, World!").decode(),
                 "httpResponseHeaders": [
                     {"name": "content-type", "value": "text/plain; charset=utf-8"}
                 ],
@@ -287,7 +285,7 @@ def test_fetch_json(testdataset1: Dataset):
         m.post(
             "https://api.zyte.com/v1/extract",
             json={
-                "httpResponseBody": b64encode('{"name": "Sally"}'.encode()).decode(),
+                "httpResponseBody": b64encode(b'{"name": "Sally"}').decode(),
                 "httpResponseHeaders": [
                     {"name": "content-type", "value": "application/json; charset=utf-8"}
                 ],
@@ -317,7 +315,7 @@ def test_fetch_json_expect_json(testdataset1: Dataset):
         m.post(
             "https://api.zyte.com/v1/extract",
             json={
-                "httpResponseBody": b64encode("Go away".encode()).decode(),
+                "httpResponseBody": b64encode(b"Go away").decode(),
                 "httpResponseHeaders": [
                     {"name": "content-type", "value": "text/html; charset=utf-8"}
                 ],

--- a/zavod/zavod/tests/fixtures/testdataset1/testentrypoint1.py
+++ b/zavod/zavod/tests/fixtures/testdataset1/testentrypoint1.py
@@ -1,6 +1,5 @@
 import csv
 from pathlib import Path
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod.context import Context
@@ -9,7 +8,7 @@ from zavod.helpers.addresses import make_address
 LOCAL_PATH = Path(__file__).parent / "dataset.csv"
 
 
-def crawl_row(context: Context, row: Dict[str, str]):
+def crawl_row(context: Context, row: dict[str, str]):
     schema = row.pop("type")
     entity = context.make(schema)
     entity.id = context.make_slug(row.pop("id"))
@@ -57,7 +56,7 @@ def crawl_row(context: Context, row: Dict[str, str]):
 
 def crawl(context: Context):
     data_path = context.get_resource_path("source.csv")
-    with open(LOCAL_PATH, "r") as fh:
+    with open(LOCAL_PATH) as fh:
         with open(data_path, "w") as out:
             out.write(fh.read())
 
@@ -70,7 +69,7 @@ def crawl(context: Context):
         return
 
     context.export_resource(data_path, CSV, title=context.SOURCE_TITLE)
-    with open(data_path, "r") as fh:
+    with open(data_path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)
 

--- a/zavod/zavod/tests/fixtures/testdataset2/testentrypoint2.py
+++ b/zavod/zavod/tests/fixtures/testdataset2/testentrypoint2.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Dict
 import csv
 from datetime import datetime
 
@@ -9,7 +8,7 @@ from zavod import helpers as h
 LOCAL_PATH = Path(__file__).parent / "dataset.csv"
 
 
-def crawl_row(context: Context, row: Dict[str, str]):
+def crawl_row(context: Context, row: dict[str, str]):
     person = context.make("Person")
     name = row.pop("name")
     person.id = context.make_slug(name)
@@ -35,6 +34,6 @@ def crawl_row(context: Context, row: Dict[str, str]):
 
 
 def crawl(context: Context):
-    with open(LOCAL_PATH, "r") as fh:
+    with open(LOCAL_PATH) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/zavod/zavod/tests/fixtures/testdataset3/testentrypoint3.py
+++ b/zavod/zavod/tests/fixtures/testdataset3/testentrypoint3.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Dict
 import csv
 
 from zavod.context import Context
@@ -7,7 +6,7 @@ from zavod.context import Context
 LOCAL_PATH = Path(__file__).parent / "dataset.csv"
 
 
-def crawl_row(context: Context, row: Dict[str, str]):
+def crawl_row(context: Context, row: dict[str, str]):
     entity = context.make("Company")
     id = row.pop("id")
     entity.id = context.make_slug(id)
@@ -29,6 +28,6 @@ def crawl_row(context: Context, row: Dict[str, str]):
 
 
 def crawl(context: Context):
-    with open(LOCAL_PATH, "r") as fh:
+    with open(LOCAL_PATH) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/zavod/zavod/tests/fixtures/testdataset_dedupe/crawler.py
+++ b/zavod/zavod/tests/fixtures/testdataset_dedupe/crawler.py
@@ -8,11 +8,11 @@ LOCAL_PATH = Path(__file__).parent / "dataset.csv"
 
 def crawl(context: Context):
     data_path = context.get_resource_path("source.csv")
-    with open(LOCAL_PATH, "r") as fh:
+    with open(LOCAL_PATH) as fh:
         with open(data_path, "w") as out:
             out.write(fh.read())
 
-    with open(data_path, "r") as fh:
+    with open(data_path) as fh:
         for row in csv.DictReader(fh):
             entity = context.make(row.pop("schema"))
             entity.id = context.make_slug(list(row.values()))

--- a/zavod/zavod/tests/fixtures/testdataset_maritime/testentrypoint_maritime.py
+++ b/zavod/zavod/tests/fixtures/testdataset_maritime/testentrypoint_maritime.py
@@ -1,13 +1,12 @@
 import csv
 from pathlib import Path
-from typing import Dict
 
 from zavod.context import Context
 
 LOCAL_PATH = Path(__file__).parent / "dataset.csv"
 
 
-def crawl_row(context: Context, row: Dict[str, str]):
+def crawl_row(context: Context, row: dict[str, str]):
     schema = row.pop("type")
     entity = context.make(schema)
     entity.id = context.make_slug(row.pop("id"))
@@ -21,6 +20,6 @@ def crawl_row(context: Context, row: Dict[str, str]):
 
 
 def crawl(context: Context):
-    with open(LOCAL_PATH, "r") as fh:
+    with open(LOCAL_PATH) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/zavod/zavod/tests/fixtures/testdataset_securities/testentrypoint_securities.py
+++ b/zavod/zavod/tests/fixtures/testdataset_securities/testentrypoint_securities.py
@@ -1,13 +1,12 @@
 import csv
 from pathlib import Path
-from typing import Dict
 
 from zavod.context import Context
 
 LOCAL_PATH = Path(__file__).parent / "dataset.csv"
 
 
-def crawl_row(context: Context, row: Dict[str, str]):
+def crawl_row(context: Context, row: dict[str, str]):
     schema = row.pop("type")
     entity = context.make(schema)
     entity.id = context.make_slug(row.pop("id"))
@@ -25,6 +24,6 @@ def crawl_row(context: Context, row: Dict[str, str]):
 
 
 def crawl(context: Context):
-    with open(LOCAL_PATH, "r") as fh:
+    with open(LOCAL_PATH) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from structlog.testing import capture_logs
 
 from zavod.context import Context
@@ -94,7 +94,7 @@ def test_apply_date(testdataset1: Dataset):
     # datetime
 
     now = datetime.now()
-    bd = now.astimezone(timezone.utc).date().isoformat()
+    bd = now.astimezone(UTC).date().isoformat()
     with capture_logs() as cap_logs:
         apply_date(person, "birthDate", now)
     assert bd in person.pop("birthDate")

--- a/zavod/zavod/tests/helpers/test_xml.py
+++ b/zavod/zavod/tests/helpers/test_xml.py
@@ -4,7 +4,7 @@ from zavod.tests.conftest import XML_DOC
 
 
 def test_xml_remove_namespace():
-    with open(XML_DOC, "r") as fh:
+    with open(XML_DOC) as fh:
         doc = etree.parse(fh)
     assert doc.find(".//name") is None
     new_doc = remove_namespace(doc)

--- a/zavod/zavod/tests/integration/test_edges.py
+++ b/zavod/zavod/tests/integration/test_edges.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 from nomenklatura import Resolver, Store
 from nomenklatura.db import Session
@@ -26,9 +24,9 @@ def e(
     dataset: Dataset,
     schema: str,
     id: str,
-    start: Optional[str] = None,
-    end: Optional[str] = None,
-    properties: Optional[dict[str, str | list[str] | None]] = None,
+    start: str | None = None,
+    end: str | None = None,
+    properties: dict[str, str | list[str] | None] | None = None,
 ) -> Entity:
     assert type(start) is str or start is None
     assert type(end) is str or end is None

--- a/zavod/zavod/tests/runtime/test_issues.py
+++ b/zavod/zavod/tests/runtime/test_issues.py
@@ -36,7 +36,7 @@ def test_issue_logger(testdataset1: Dataset, logger: logging.Logger):
     issues_path.unlink()
     context.issues.export()
     assert issues_path.exists()
-    with open(issues_path, "r") as fh:
+    with open(issues_path) as fh:
         data = json.load(fh)
         assert len(data["issues"]) == 2
         for issue in data["issues"]:

--- a/zavod/zavod/tests/test_cli.py
+++ b/zavod/zavod/tests/test_cli.py
@@ -85,7 +85,7 @@ def test_run_dataset(testdataset1: Dataset):
     assert latest_path.joinpath("index.json").exists()
     assert latest_path.joinpath("entities.ftm.json").exists()
     # Validation issues in a published run are published
-    with open(artifacts_path / "issues.json", "r") as f:
+    with open(artifacts_path / "issues.json") as f:
         assert "This is a test warning" in f.read()
     shutil.rmtree(latest_path)
 
@@ -112,7 +112,7 @@ def test_run_validation_failed(testdataset3: Dataset):
     assert result.exit_code != 0, result.output
     # Validation issues in an aborted run are published
     assert "Assertion countries failed" in result.output, result.output
-    with open(artifacts_path / "issues.json", "r") as f:
+    with open(artifacts_path / "issues.json") as f:
         assert "Assertion countries failed" in f.read()
     shutil.rmtree(settings.DATA_PATH)
 

--- a/zavod/zavod/tests/test_context.py
+++ b/zavod/zavod/tests/test_context.py
@@ -118,7 +118,7 @@ def test_context_get_fetchers(testdataset1: Dataset):
         m.get("/bla", text=long)
         path = context.fetch_resource("world.txt", "https://test.com/bla")
     assert path.stem == "world"
-    with open(path, "r") as fh:
+    with open(path) as fh:
         assert fh.read() == long
 
     with requests_mock.Mocker() as m:
@@ -131,12 +131,12 @@ def test_context_get_fetchers(testdataset1: Dataset):
         )
     assert path.stem == "world-post"
     assert m.request_history[0].body == "foo=bar"
-    with open(path, "r") as fh:
+    with open(path) as fh:
         assert fh.read() == long
 
     path = context.get_resource_path("doc.xml")
     with open(path, "w") as fh:
-        with open(XML_DOC, "r") as src:
+        with open(XML_DOC) as src:
             fh.write(src.read())
     xml_doc = context.parse_resource_xml("doc.xml")
     assert "MyAddress" in xml_doc.getroot().tag
@@ -153,7 +153,7 @@ def test_context_get_fetchers(testdataset1: Dataset):
 def test_context_fetch_text_encoding_cache(testdataset1: Dataset):
     context = Context(testdataset1)
     url = "https://test.com/encoding"
-    body = "商务部".encode("utf-8")
+    body = "商务部".encode()
 
     with requests_mock.Mocker() as m:
         m.get(url, content=body, headers={"Content-Type": "text/html"})

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 
 import pytest
 from followthemoney.dataset import Version, VersionHistory
@@ -31,11 +30,11 @@ STANDARD_EXPORTS = {
 }
 
 
-def _read_history(dataset_name: str) -> Optional[VersionHistory]:
+def _read_history(dataset_name: str) -> VersionHistory | None:
     fn = settings.ARCHIVE_PATH / ARTIFACTS / dataset_name / VERSIONS_FILE
     if not fn.exists():
         return None
-    with open(fn, "r") as fh:
+    with open(fn) as fh:
         return VersionHistory.from_json(fh.read())
 
 

--- a/zavod/zavod/tests/test_tune.py
+++ b/zavod/zavod/tests/test_tune.py
@@ -34,11 +34,9 @@ examples = [example, deepcopy(example), deepcopy(example)]
 def assert_exit_status_zero(result: Result) -> None:
     if result.exit_code != 0:
         raise AssertionError(
-            (
-                "'zavod-run compare' invocation exited non-zero.\n\n"
-                f"Output: {result.output}\n"
-                f"{''.join(format_exception(*result.exc_info))}"
-            )
+            "'zavod-run compare' invocation exited non-zero.\n\n"
+            f"Output: {result.output}\n"
+            f"{''.join(format_exception(*result.exc_info))}"
         )
 
 

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -1,4 +1,3 @@
-from typing import Type
 import uuid
 
 from structlog.testing import capture_logs
@@ -24,7 +23,7 @@ BASE_DATASET_CONFIG = {
 }
 
 
-def run_validator(clazz: Type[BaseValidator], dataset: Dataset):
+def run_validator(clazz: type[BaseValidator], dataset: Dataset):
     context = Context(dataset)
     linker = get_dataset_linker(dataset)
     store = get_store(dataset, linker)

--- a/zavod/zavod/tools/export_catalog.py
+++ b/zavod/zavod/tools/export_catalog.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Any
+from typing import Any
 from followthemoney import model, registry
 
 from zavod import settings
@@ -15,7 +15,7 @@ from zavod.logs import get_logger
 log = get_logger(__name__)
 
 
-def get_opensanctions_catalog(scope: Dataset) -> Dict[str, Any]:
+def get_opensanctions_catalog(scope: Dataset) -> dict[str, Any]:
     """Get the OpenSanctions-style catalog, including all datasets in the given
     scope."""
     datasets = get_catalog_datasets(scope)
@@ -23,8 +23,8 @@ def get_opensanctions_catalog(scope: Dataset) -> Dict[str, Any]:
     schemata = set()
     statistics_path = get_dataset_artifact(scope.name, STATISTICS_FILE)
     if statistics_path.is_file():
-        with open(statistics_path, "r") as fh:
-            stats: Dict[str, Any] = json.load(fh)
+        with open(statistics_path) as fh:
+            stats: dict[str, Any] = json.load(fh)
             schemata.update(stats.get("schemata", []))
 
     log.info("Generating catalog", schemata=len(schemata), datasets=len(datasets))
@@ -49,7 +49,7 @@ def get_opensanctions_catalog(scope: Dataset) -> Dict[str, Any]:
     }
 
 
-def get_nk_catalog(scope: Dataset) -> Dict[str, Any]:
+def get_nk_catalog(scope: Dataset) -> dict[str, Any]:
     """Get the Nomenklatura-style catalog, including all datasets in the given
     scope."""
     datasets = get_catalog_datasets(scope)

--- a/zavod/zavod/tools/util.py
+++ b/zavod/zavod/tools/util.py
@@ -1,4 +1,4 @@
-from typing import Generator, Set
+from collections.abc import Generator
 from followthemoney import Statement
 from nomenklatura.resolver import Linker
 
@@ -22,7 +22,7 @@ def iter_output_statements(
         A generator of statements.
     """
     assert not scope.is_collection
-    seen_ids: Set[str] = set()
+    seen_ids: set[str] = set()
     for stmt in iter_dataset_statements(scope, external=external):
         if stmt.entity_id is None:
             continue

--- a/zavod/zavod/tune.py
+++ b/zavod/zavod/tune.py
@@ -21,7 +21,7 @@ LEVEL_OPTIONS = click.Choice(LEVELS, case_sensitive=False)
 
 class IndentedListDumper(yaml.Dumper):
     def increase_indent(self, flow=False, indentless=False):  # type: ignore
-        return super(IndentedListDumper, self).increase_indent(flow, indentless=False)
+        return super().increase_indent(flow, indentless=False)
 
 
 @click.group(help="Zavod DSPy optimisation and evaluation tools")

--- a/zavod/zavod/util.py
+++ b/zavod/zavod/util.py
@@ -3,13 +3,13 @@ import logging
 from dataclasses import dataclass
 from lxml import etree
 from functools import cache
-from typing import Union, IO, Any
+from typing import IO, Any
 from normality import slugify
 from followthemoney.util import ENTITY_ID_LEN
 
 log = logging.getLogger(__name__)
 Element = etree._Element
-ElementOrTree = Union[etree._Element, etree._ElementTree]
+ElementOrTree = etree._Element | etree._ElementTree
 ID_SEP = "-"
 
 

--- a/zavod/zavod/util.py
+++ b/zavod/zavod/util.py
@@ -3,7 +3,7 @@ import logging
 from dataclasses import dataclass
 from lxml import etree
 from functools import cache
-from typing import Optional, Union, IO, Any, Dict
+from typing import Union, IO, Any
 from normality import slugify
 from followthemoney.util import ENTITY_ID_LEN
 
@@ -22,20 +22,20 @@ class LangText:
     """
 
     text: str
-    lang: Optional[str]
+    lang: str | None
     """ISO 639-2 (3-letter) language code, or None if not known."""
 
 
 @cache
-def slugify_prefix(prefix: Optional[str]) -> Optional[str]:
+def slugify_prefix(prefix: str | None) -> str | None:
     return slugify(prefix, sep=ID_SEP)
 
 
 def join_slug(
-    *parts: Optional[str],
-    prefix: Optional[str] = None,
+    *parts: str | None,
+    prefix: str | None = None,
     strict: bool = True,
-) -> Optional[str]:
+) -> str | None:
     """Make a text-based ID which is strongly normalized."""
     sections = [slugify(p, sep=ID_SEP) for p in parts]
     if strict and None in sections:
@@ -66,7 +66,7 @@ def json_default(obj: Any) -> Any:
     raise TypeError
 
 
-def write_json(data: Dict[str, Any], fh: IO[bytes]) -> None:
+def write_json(data: dict[str, Any], fh: IO[bytes]) -> None:
     """Write a JSON object to the given open file handle."""
     opt = orjson.OPT_APPEND_NEWLINE | orjson.OPT_NON_STR_KEYS
     fh.write(orjson.dumps(data, option=opt, default=json_default))

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -1,4 +1,3 @@
-from typing import List, Type
 from followthemoney import registry
 
 from zavod.archive import dataset_data_path
@@ -62,7 +61,7 @@ class EmptyValidator(BaseValidator):
             self.context.log.warning("No entities validated.")
 
 
-VALIDATORS: List[Type[BaseValidator]] = [
+VALIDATORS: list[type[BaseValidator]] = [
     DanglingReferencesValidator,
     SelfReferenceValidator,
     StatisticsAssertionsValidator,
@@ -87,7 +86,7 @@ def validate_dataset(dataset: Dataset, view: View) -> None:
         validators = [validator(context, view) for validator in VALIDATORS]
         for idx, entity in enumerate(view.entities()):
             if idx > 0 and idx % 10000 == 0:
-                context.log.info("Validated %s entities..." % idx, dataset=dataset.name)
+                context.log.info(f"Validated {idx} entities...", dataset=dataset.name)
 
             for validator in validators:
                 validator.feed(entity)

--- a/zavod/zavod/validators/assertions.py
+++ b/zavod/zavod/validators/assertions.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 from banal import ensure_dict
 
 from zavod.context import Context
@@ -27,7 +27,7 @@ def is_assertion_fatal(assertion: Assertion) -> bool:
 
 def check_assertion(
     context: Context,
-    stats: Dict[str, Any],
+    stats: dict[str, Any],
     assertion: Assertion,
 ) -> bool:
     """Returns true if the assertion is valid, false otherwise."""

--- a/zavod/zavod/validators/common.py
+++ b/zavod/zavod/validators/common.py
@@ -3,7 +3,7 @@ from zavod.store import View
 from zavod.entity import Entity
 
 
-class BaseValidator(object):
+class BaseValidator:
     def __init__(self, context: Context, view: View) -> None:
         self.context = context
         self.view = view


### PR DESCRIPTION
Follow-up to #5090 (ruff rule-set pin, now merged).

## What

Runs ruff's pyupgrade (`UP`) rules across `zavod/` and clears every finding, so the code adopts PEP 585 / PEP 604 annotations.

**Commit 1 — autofixes** (`ruff check zavod/ --select UP --fix --unsafe-fixes` + `ruff format`, 986 fixes):
- PEP 585 builtin generics: `List`/`Dict`/`Tuple`/`Set` → `list`/`dict`/`tuple`/`set`
- PEP 604 unions: `Optional[X]` → `X | None`, `Union[...]` → `... | ...`
- dropped deprecated `typing` imports; assorted (`%`→f-string where autofixable, redundant open modes, useless `object` inheritance)
- removed the now-unused `typing` imports left in package `__init__.py` files (none were re-exported)

**Commit 2 — manual** (the 9 ruff would not autofix):
- module-level `Union`/`Optional` **type aliases** → PEP 604 (`DateValue`, `NumberValue`, `ElementOrTree`, and `http_` `_Auth`/`_Headers`/`_Body`)
- remaining `%`-format log calls → f-strings (`dedupe`, `fragment`, `bods`)

## Verification

- `ruff check zavod/ --select UP` → **All checks passed**
- `ruff check zavod/` (E/F) + `ruff format --check` → clean
- `mypy --strict` → **no new errors**. (One pre-existing error remains — `local_enricher.py` accesses `enricher._filter_topics`, but nomenklatura exposes it as public `filter_topics`; unrelated to this change, tracked separately.)

## Not included

Does **not** yet enforce `UP` (no `extend-select`), because the shared `zavod/pyproject.toml` config is also used by the crawler lint over `datasets/`, which isn't migrated. Enforcement is a follow-up once we decide scope.