### PR TITLE
datasets: modernize type annotations (ruff pyupgrade / UP)

### DIFF
--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -66,7 +66,7 @@ Requirements and invariants that make this correct:
   target entities downstream rather than replacing them.
 """
 
-from typing import Iterator, Set, Tuple
+from collections.abc import Iterator
 
 from followthemoney import registry
 from followthemoney.property import Property
@@ -110,7 +110,7 @@ SANCTION_CONTROL_SEEDS = frozenset({"sanction", "sanction.control"})
 EXPORT_CONTROL_SEEDS = frozenset({"export.control", "export.control.linked"})
 
 
-def non_graph_topics(context: Context, entity: Entity) -> Set[str]:
+def non_graph_topics(context: Context, entity: Entity) -> set[str]:
     """Return topics on ``entity`` that were contributed by other datasets.
 
     Used to decide whether a candidate target is *already* tagged without
@@ -126,7 +126,7 @@ def emit_patch(
     risk_source: Entity,
     related_entity: Entity,
     topic: str,
-    existing_topics: Set[str],
+    existing_topics: set[str],
 ) -> None:
     context.log.info(
         f"Adding topic: {topic}",
@@ -148,7 +148,7 @@ def emit_patch(
 
 def walk_edge(
     view: View, edge: Entity, prop: Property
-) -> Iterator[Tuple[Entity, Property]]:
+) -> Iterator[tuple[Entity, Property]]:
     """Yield ``(other_end, counterpart_prop)`` pairs across an edge entity.
 
     ``prop`` is the property on the *source* entity that reached ``edge``. The
@@ -174,7 +174,7 @@ def rule_pep_family_to_rca(
     context: Context,
     view: View,
     source: Entity,
-    source_topics: Set[str],
+    source_topics: set[str],
     prop: Property,
     adjacent: Entity,
 ) -> None:
@@ -198,7 +198,7 @@ def rule_sanction_adjacency(
     context: Context,
     view: View,
     source: Entity,
-    source_topics: Set[str],
+    source_topics: set[str],
     prop: Property,
     adjacent: Entity,
 ) -> None:
@@ -239,7 +239,7 @@ def rule_ownership_descent(
     context: Context,
     view: View,
     source: Entity,
-    source_topics: Set[str],
+    source_topics: set[str],
     prop: Property,
     adjacent: Entity,
 ) -> None:
@@ -271,7 +271,7 @@ def rule_sanction_control_descent(
     context: Context,
     view: View,
     source: Entity,
-    source_topics: Set[str],
+    source_topics: set[str],
     prop: Property,
     adjacent: Entity,
 ) -> None:
@@ -298,7 +298,7 @@ def rule_export_control_descent(
     context: Context,
     view: View,
     source: Entity,
-    source_topics: Set[str],
+    source_topics: set[str],
     prop: Property,
     adjacent: Entity,
 ) -> None:
@@ -341,7 +341,7 @@ RULES = (
 
 
 def analyze_entity(context: Context, view: View, entity: Entity) -> None:
-    source_topics: Set[str] = set(entity.get_type_values(registry.topic))
+    source_topics: set[str] = set(entity.get_type_values(registry.topic))
     for prop, adjacent in view.get_adjacent(entity):
         if len(adjacent.get("endDate", quiet=True)) > 0:
             context.log.info(
@@ -364,5 +364,5 @@ def crawl(context: Context) -> None:
 
     for entity_idx, entity in enumerate(view.entities()):
         if entity_idx > 0 and entity_idx % 1000 == 0:
-            context.log.info("Processed %s entities" % entity_idx)
+            context.log.info(f"Processed {entity_idx} entities")
         analyze_entity(context, view, entity)

--- a/datasets/_analysis/ann_graph_topics/test_ann_graph_topics.py
+++ b/datasets/_analysis/ann_graph_topics/test_ann_graph_topics.py
@@ -6,8 +6,6 @@ that captures emitted patches, and asserts on the set of ``(target_id, topic)``
 pairs that came out.
 """
 
-from typing import Dict, List, Optional, Tuple
-
 from nomenklatura.resolver import Linker
 from nomenklatura.store.memory import MemoryStore
 from zavod import Context, Dataset, Entity
@@ -31,13 +29,13 @@ class FakeContext(Context):
     def __init__(self, dataset: Dataset = GRAPH) -> None:
         self.dataset = dataset
         self.log = get_logger(dataset.name)
-        self.emitted: List[Tuple[Entity, bool]] = []
+        self.emitted: list[tuple[Entity, bool]] = []
 
     def emit(
         self,
         entity: Entity,
         external: bool = False,
-        origin: Optional[str] = None,
+        origin: str | None = None,
     ) -> None:
         self.emitted.append((entity, external))
 
@@ -45,7 +43,7 @@ class FakeContext(Context):
 def _entity(
     schema: str,
     id: str,
-    properties: Optional[Dict[str, List[str]]] = None,
+    properties: dict[str, list[str]] | None = None,
     dataset: Dataset = SOURCE,
 ) -> Entity:
     return Entity.from_data(
@@ -55,7 +53,7 @@ def _entity(
 
 
 def _store(
-    entities: List[Entity], scope: Dataset = SOURCE
+    entities: list[Entity], scope: Dataset = SOURCE
 ) -> MemoryStore[Dataset, Entity]:
     linker: Linker[Entity] = Linker({})
     store: MemoryStore[Dataset, Entity] = MemoryStore(scope, linker)
@@ -69,9 +67,9 @@ def _store(
     return store
 
 
-def _emits(ctx: FakeContext) -> List[Tuple[str, str]]:
+def _emits(ctx: FakeContext) -> list[tuple[str, str]]:
     """Flatten captured emits to ``(target_id, topic)`` pairs."""
-    out: List[Tuple[str, str]] = []
+    out: list[tuple[str, str]] = []
     for entity, _external in ctx.emitted:
         assert entity.id is not None
         for topic in entity.get("topics"):
@@ -79,7 +77,7 @@ def _emits(ctx: FakeContext) -> List[Tuple[str, str]]:
     return out
 
 
-def _analyze(entities: List[Entity], source_id: str) -> FakeContext:
+def _analyze(entities: list[Entity], source_id: str) -> FakeContext:
     store = _store(entities)
     view = store.view(SOURCE, external=True)
     source = view.get_entity(source_id)

--- a/datasets/_analysis/ann_pep_positions/analyzer.py
+++ b/datasets/_analysis/ann_pep_positions/analyzer.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Dict, Set, Optional
 
 from zavod import Context, Entity
 from zavod.constants import ORIGIN_INFERRED
@@ -37,7 +36,7 @@ def get_best_occupancy_status(occupancy: Entity) -> OccupancyStatus:
     return OccupancyStatus.UNKNOWN
 
 
-def get_best_influence_status(statuses: Set[OccupancyStatus]) -> OccupancyStatus:
+def get_best_influence_status(statuses: set[OccupancyStatus]) -> OccupancyStatus:
     """Get the best status from all occupancies for a given influence level."""
 
     # If any of the occupancies at this influence level is CURRENT, we prefer that
@@ -57,7 +56,7 @@ def get_best_influence_status(statuses: Set[OccupancyStatus]) -> OccupancyStatus
     return OccupancyStatus.UNKNOWN
 
 
-def format_influence_label(topic: str, status: OccupancyStatus) -> Optional[str]:
+def format_influence_label(topic: str, status: OccupancyStatus) -> str | None:
     level_label = INFLUENCE_TOPIC_LABELS.get(topic, None)
     status_label = OCCUPANCY_STATUS_LABELS.get(status, None)
     # If it's not an influence topic, we don't want it
@@ -68,7 +67,7 @@ def format_influence_label(topic: str, status: OccupancyStatus) -> Optional[str]
 
 
 def build_consolidated_influence_labels(
-    topic_to_seen_statuses: dict[str, Set[OccupancyStatus]],
+    topic_to_seen_statuses: dict[str, set[OccupancyStatus]],
 ) -> list[str]:
     """For a mapping of influence topics to sets of seen statuses for their occupancies,
     build human-readable influence labels for each of them."""
@@ -79,9 +78,9 @@ def build_consolidated_influence_labels(
     return [f for f in formatted if f is not None]
 
 
-def analyze_position(context: Context, entity: Entity) -> Set[str]:
+def analyze_position(context: Context, entity: Entity) -> set[str]:
     """Analyze a position entity and emit the categorisation."""
-    topics: Set[str] = set()
+    topics: set[str] = set()
 
     # Skip if this is the only dataset containing this Position. This should be implicit
     # from other conditions, but let's be sure this dataset doesn't feed itself
@@ -119,7 +118,7 @@ def crawl(context: Context) -> None:
 
     for entity_idx, entity in enumerate(view.entities()):
         if entity_idx > 0 and entity_idx % 10000 == 0:
-            context.log.info("Processed %s entities" % entity_idx)
+            context.log.info(f"Processed {entity_idx} entities")
 
         if not entity.schema.is_a("Person") or "role.pep" not in entity.get("topics"):
             continue
@@ -132,9 +131,9 @@ def crawl(context: Context) -> None:
 
         pep_count += 1
         if pep_count > 0 and pep_count % 10000 == 0:
-            context.log.info("Processed %s PEPs" % pep_count)
+            context.log.info(f"Processed {pep_count} PEPs")
 
-        topic_to_seen_statuses: Dict[str, Set[OccupancyStatus]] = defaultdict(set)
+        topic_to_seen_statuses: dict[str, set[OccupancyStatus]] = defaultdict(set)
 
         for prop, adjacent in view.get_adjacent(entity):
             if prop.name != "positionOccupancies":

--- a/datasets/_global/adb_sanctions/crawler.py
+++ b/datasets/_global/adb_sanctions/crawler.py
@@ -1,6 +1,5 @@
 import json
 import re
-from typing import Dict
 
 from pydantic import BaseModel, JsonValue
 from rigour.names import contains_split_phrase
@@ -72,7 +71,7 @@ def apply_entity_data(entity: Entity, data: EntityData) -> None:
             entity.add(prop, val)
 
 
-def crawl_row(context: Context, row: Dict[str, str | None]) -> None:
+def crawl_row(context: Context, row: dict[str, str | None]) -> None:
     full_name = row.pop("name") or ""
     other_name = (row.pop("otherName") or "").replace("\\", "")
     country = row.pop("nationality") or ""

--- a/datasets/_global/c4ads_xinjiang/crawler.py
+++ b/datasets/_global/c4ads_xinjiang/crawler.py
@@ -9,7 +9,7 @@ def crawl(context: Context) -> None:
     path = context.get_resource_path("source.csv")
     fetch_internal_data("c4ads_xinjiang/xpcc_public_dissemination.csv", path)
 
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             name_zho = row.pop("Company_Name_Chinese")
             addr_zho = row.pop("Registered_Address")

--- a/datasets/_global/c4ads_xinjiang_mining/crawler.py
+++ b/datasets/_global/c4ads_xinjiang_mining/crawler.py
@@ -1,11 +1,10 @@
 import csv
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod import Context, helpers as h
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     mine_name = row.pop("Mine_Name_English")
     mine_name_zh = row.pop("Mine_Name_Chinese")
     company_name = row.pop("Company_Name_English")
@@ -39,6 +38,6 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r", encoding="utf-8-sig") as fh:
+    with open(path, encoding="utf-8-sig") as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/_global/ebrd_ineligible/crawler.py
+++ b/datasets/_global/ebrd_ineligible/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from normality import collapse_spaces
 
@@ -6,7 +6,7 @@ from zavod import Context
 from zavod import helpers as h
 
 
-def crawl_entity(context: Context, data: Dict[str, Any]) -> None:
+def crawl_entity(context: Context, data: dict[str, Any]) -> None:
     name_raw = data.pop("title")
     if not name_raw:
         return

--- a/datasets/_global/eiti_soe/crawler.py
+++ b/datasets/_global/eiti_soe/crawler.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict
+from typing import Any
 from zavod import Context
 
 
-def crawl_entity(context: Context, item: Dict[str, Any]) -> None:
+def crawl_entity(context: Context, item: dict[str, Any]) -> None:
     entity = context.make("LegalEntity")
 
     soe = item.pop("SOE")

--- a/datasets/_global/everypolitician/crawler.py
+++ b/datasets/_global/everypolitician/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Optional, Set
+from typing import Any
 from urllib.parse import urljoin, unquote
 from followthemoney.helpers import post_summary
 
@@ -45,7 +45,7 @@ def crawl(context: Context) -> None:
     for country in data:
         for legislature in country.get("legislatures", []):
             code = country.get("code").lower()
-            context.log.info("Country: %s" % code)
+            context.log.info(f"Country: {code}")
             crawl_legislature(context, code, legislature)
 
 
@@ -57,7 +57,7 @@ def crawl_legislature(
     # this isn't being updated, hence long interval:
     data = context.fetch_json(url, cache_days=30)
 
-    organizations: Dict[str, Optional[str]] = {}
+    organizations: dict[str, str | None] = {}
     for org in data.pop("organizations", []):
         org_id = org.pop("id", None)
         org_id = context.lookup_value("org_id", org_id, org_id)
@@ -70,8 +70,8 @@ def crawl_legislature(
     events = data.pop("events", [])
     events = {e.get("id"): e for e in events}
 
-    birth_dates: Dict[str, str] = {}
-    death_dates: Dict[str, str] = {}
+    birth_dates: dict[str, str] = {}
+    death_dates: dict[str, str] = {}
     for person in data.get("persons"):
         death_date = person.get("death_date", None)
         if death_date is not None:
@@ -80,7 +80,7 @@ def crawl_legislature(
         if birth_date is not None:
             birth_dates[person.get("id")] = birth_date
 
-    peps: Set[str] = set()
+    peps: set[str] = set()
     for membership in data.pop("memberships"):
         person_id = parse_membership(
             context,
@@ -165,11 +165,11 @@ def parse_membership(
     context: Context,
     country: str,
     data: dict[str, Any],
-    organizations: Dict[str, Optional[str]],
+    organizations: dict[str, str | None],
     events: dict[str | None, Any],
-    birth_dates: Dict[str, str],
-    death_dates: Dict[str, str],
-) -> Optional[str]:
+    birth_dates: dict[str, str],
+    death_dates: dict[str, str],
+) -> str | None:
     person_id: str | None = data.pop("person_id", None)
     org_name = organizations.get(data.pop("organization_id", None))
 

--- a/datasets/_global/gem_energy_ownership/crawler.py
+++ b/datasets/_global/gem_energy_ownership/crawler.py
@@ -1,6 +1,5 @@
 import openpyxl
 import re
-from typing import Dict, List, Set, Tuple
 
 from zavod import Context
 from zavod import helpers as h
@@ -41,13 +40,13 @@ REGEX_URL_SPLIT = re.compile(r",\s*http")
 REGEX_POSSIBLE_ASSOCIATES = re.compile(r"（[^（）]*、[^（）]*）| \(\s*[^()]*,[^()]*\)")
 
 
-def split_urls(value: str) -> List[str]:
+def split_urls(value: str) -> list[str]:
     return REGEX_URL_SPLIT.sub("\nhttp", value).split("\n")
 
 
 def split_associates(
     context: Context, name: str
-) -> Tuple[str, str, Set[Tuple[str, str]]]:
+) -> tuple[str, str, set[tuple[str, str]]]:
     if REGEX_POSSIBLE_ASSOCIATES.search(name):
         result = context.lookup("associates", name)
         if result is None:
@@ -61,7 +60,7 @@ def split_associates(
 
 
 def crawl_company(
-    context: Context, row: Dict[str, str | None], skipped: Set[str]
+    context: Context, row: dict[str, str | None], skipped: set[str]
 ) -> None:
     id_ = row.pop("entity_id")
     if id_ is None:
@@ -100,8 +99,8 @@ def crawl_company(
         row.pop("name_local"),
     ]
     # (potentially trimmed name, original string)
-    associates: Set[Tuple[str, str]] = set()
-    names: Set[Tuple[str, str]] = set()
+    associates: set[tuple[str, str]] = set()
+    names: set[tuple[str, str]] = set()
     for name in original_names:
         if name is None:
             continue
@@ -177,7 +176,7 @@ def crawl_company(
     )
 
 
-def crawl_rel(context: Context, row: Dict[str, str | None], skipped: Set[str]) -> None:
+def crawl_rel(context: Context, row: dict[str, str | None], skipped: set[str]) -> None:
     subject_entity_id = row.pop("subject_entity_id")
     interested_party_id = row.pop("interested_party_id")
 
@@ -195,7 +194,7 @@ def crawl_rel(context: Context, row: Dict[str, str | None], skipped: Set[str]) -
     ownership.add("asset", context.make_slug(subject_entity_id))
     ownership.add("owner", context.make_slug(interested_party_id))
     percentage = row.pop("share_of_ownership")
-    ownership.add("percentage", "%.2f" % float(percentage) if percentage else None)
+    ownership.add("percentage", f"{float(percentage):.2f}" if percentage else None)
     source_urls = row.pop("data_source_url")
     if source_urls is not None:
         ownership.add("sourceUrl", split_urls(source_urls))
@@ -213,7 +212,7 @@ def crawl(context: Context) -> None:
         path,
     )
     workbook: openpyxl.Workbook = openpyxl.load_workbook(path, read_only=True)
-    skipped: Set[str] = set()
+    skipped: set[str] = set()
 
     for row in h.parse_xlsx_sheet(context, sheet=workbook["All Entities"]):
         crawl_company(context, row, skipped)

--- a/datasets/_global/gleif/crawler.py
+++ b/datasets/_global/gleif/crawler.py
@@ -2,7 +2,8 @@ import csv
 from contextlib import contextmanager
 from io import TextIOWrapper
 from pathlib import Path
-from typing import IO, Dict, Generator, List, Optional, Tuple, Union
+from typing import IO
+from collections.abc import Generator
 from urllib.parse import urljoin
 from zipfile import ZipFile
 
@@ -22,7 +23,7 @@ BIC_URL = "https://mapping.gleif.org/api/v2/bic-lei/latest/download"
 ISIN_URL = "https://mapping.gleif.org/api/v2/isin-lei/latest/download"
 OC_URL = "https://mapping.gleif.org/api/v2/oc-lei/latest/download"
 
-RELATIONSHIPS: Dict[str, Tuple[str, str, str]] = {
+RELATIONSHIPS: dict[str, tuple[str, str, str]] = {
     "IS_FUND-MANAGED_BY": ("Directorship", "organization", "director"),
     "IS_SUBFUND_OF": ("Directorship", "organization", "director"),
     "IS_DIRECTLY_CONSOLIDATED_BY": ("Ownership", "asset", "owner"),
@@ -32,7 +33,7 @@ RELATIONSHIPS: Dict[str, Tuple[str, str, str]] = {
 }
 
 
-ADDRESS_PARTS: Dict[str, str] = {
+ADDRESS_PARTS: dict[str, str] = {
     # map paths to zavod.parse.format_address input
     "City": "city",
     "Region": "state",
@@ -43,10 +44,10 @@ ADDRESS_PARTS: Dict[str, str] = {
 }
 
 
-def parse_address(entity: Entity, el: Optional[Element]) -> None:
+def parse_address(entity: Entity, el: Element | None) -> None:
     if el is None:
         return
-    parts: Dict[str, Union[str, None]] = {}  # FirstAddressLine
+    parts: dict[str, str | None] = {}  # FirstAddressLine
     for tag, key in ADDRESS_PARTS.items():
         parts[key] = el.findtext(tag)
     country_code = parts.get("country_code")
@@ -62,7 +63,7 @@ def parse_address(entity: Entity, el: Optional[Element]) -> None:
         entity.add("address", address, lang=el.get("lang"))
 
 
-def load_elfs() -> Dict[str, str]:
+def load_elfs() -> dict[str, str]:
     names = {}
     # https://www.gleif.org/en/about-lei/code-lists/iso-20275-entity-legal-forms-code-list#
     elf_path = Path(__file__).parent / "ref" / "elf-codes-1.4.1.csv"
@@ -80,13 +81,13 @@ def lei_id(lei: str) -> str:
     return f"lei-{lei}"
 
 
-def parse_date(text: Optional[str]) -> Optional[str]:
+def parse_date(text: str | None) -> str | None:
     if text is None:
         return None
     return text.split("T")[0]
 
 
-def fetch_cat_file(context: Context, url_part: str, name: str) -> Optional[Path]:
+def fetch_cat_file(context: Context, url_part: str, name: str) -> Path | None:
     doc = context.fetch_html(CAT_URL)
     for link in doc.findall(".//a"):
         url = urljoin(CAT_URL, link.get("href"))
@@ -114,14 +115,14 @@ def fetch_rr_file(context: Context) -> Path:
 def read_zip_file(context: Context, path: Path) -> Generator[IO[bytes], None, None]:
     with ZipFile(path, "r") as zip:
         for name in zip.namelist():
-            context.log.info("Reading: %s in %s" % (name, path))
+            context.log.info(f"Reading: {name} in {path}")
             with zip.open(name, "r") as fh:
                 yield fh
 
 
-def load_bic_mapping(context: Context) -> Dict[str, List[str]]:
+def load_bic_mapping(context: Context) -> dict[str, list[str]]:
     zip_path = context.fetch_resource("bic_lei.zip", BIC_URL)
-    mapping: Dict[str, List[str]] = {}
+    mapping: dict[str, list[str]] = {}
     with read_zip_file(context, zip_path) as fh:
         textfh = TextIOWrapper(fh, encoding="utf-8")
         for row in csv.DictReader(textfh):
@@ -135,9 +136,9 @@ def load_bic_mapping(context: Context) -> Dict[str, List[str]]:
     return mapping
 
 
-def load_oc_mapping(context: Context) -> Dict[str, List[str]]:
+def load_oc_mapping(context: Context) -> dict[str, list[str]]:
     zip_path = context.fetch_resource("oc_lei.zip", OC_URL)
-    mapping: Dict[str, List[str]] = {}
+    mapping: dict[str, list[str]] = {}
     with read_zip_file(context, zip_path) as fh:
         textfh = TextIOWrapper(fh, encoding="utf-8")
         for row in csv.DictReader(textfh):
@@ -152,9 +153,9 @@ def load_oc_mapping(context: Context) -> Dict[str, List[str]]:
     return mapping
 
 
-def load_isin_mapping(context: Context) -> Dict[str, List[str]]:
+def load_isin_mapping(context: Context) -> dict[str, list[str]]:
     zip_path = context.fetch_resource("isin_lei.zip", ISIN_URL)
-    mapping: Dict[str, List[str]] = {}
+    mapping: dict[str, list[str]] = {}
     with read_zip_file(context, zip_path) as fh:
         textfh = TextIOWrapper(fh, encoding="utf-8")
         for row in csv.DictReader(textfh):
@@ -172,10 +173,10 @@ def parse_lei_record(
     context: Context,
     el: Element,
     *,
-    bics: Dict[str, List[str]],
-    ocurls: Dict[str, List[str]],
-    isins: Dict[str, List[str]],
-    elfs: Dict[str, str],
+    bics: dict[str, list[str]],
+    ocurls: dict[str, list[str]],
+    isins: dict[str, list[str]],
+    elfs: dict[str, str],
 ) -> None:
     elc = h.remove_namespace(el)
     proxy = context.make("Organization")
@@ -279,7 +280,7 @@ def parse_lei_file(context: Context, fh: IO[bytes]) -> None:
     isins = load_isin_mapping(context)
 
     idx = 0
-    for idx, (_, el) in enumerate(etree.iterparse(fh, tag="{%s}LEIRecord" % LEI)):
+    for idx, (_, el) in enumerate(etree.iterparse(fh, tag=f"{{{LEI}}}LEIRecord")):
         if idx > 0 and idx % 10000 == 0:
             context.log.info("Parse LEIRecord: %d..." % idx)
         parse_lei_record(context, el, bics=bics, ocurls=ocurls, isins=isins, elfs=elfs)
@@ -359,7 +360,7 @@ def parse_relationship_record(context: Context, el: etree._Element) -> None:
 
 
 def parse_rr_file(context: Context, fh: IO[bytes]) -> None:
-    tag = "{%s}RelationshipRecord" % RR
+    tag = f"{{{RR}}}RelationshipRecord"
     idx = 0
     for idx, (_, el) in enumerate(etree.iterparse(fh, tag=tag)):
         if idx > 0 and idx % 10000 == 0:

--- a/datasets/_global/gleif/crawler.py
+++ b/datasets/_global/gleif/crawler.py
@@ -282,7 +282,7 @@ def parse_lei_file(context: Context, fh: IO[bytes]) -> None:
     idx = 0
     for idx, (_, el) in enumerate(etree.iterparse(fh, tag=f"{{{LEI}}}LEIRecord")):
         if idx > 0 and idx % 10000 == 0:
-            context.log.info("Parse LEIRecord: %d..." % idx)
+            context.log.info(f"Parse LEIRecord: {idx}...")
         parse_lei_record(context, el, bics=bics, ocurls=ocurls, isins=isins, elfs=elfs)
         el.clear()
 
@@ -364,7 +364,7 @@ def parse_rr_file(context: Context, fh: IO[bytes]) -> None:
     idx = 0
     for idx, (_, el) in enumerate(etree.iterparse(fh, tag=tag)):
         if idx > 0 and idx % 10000 == 0:
-            context.log.info("Parse RelationshipRecord: %d..." % idx)
+            context.log.info(f"Parse RelationshipRecord: {idx}...")
         parse_relationship_record(context, el)
         el.clear()
 

--- a/datasets/_global/iadb_sanctions/crawler.py
+++ b/datasets/_global/iadb_sanctions/crawler.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterator, Optional, List
+from typing import Any
+from collections.abc import Iterator
 
 from normality import slugify, stringify
 from openpyxl import load_workbook
@@ -18,8 +19,8 @@ GET_TOKEN_URL = "https://www.iadb.org/en/idb_powerbi_refresh_token/0a2a387d-99f5
 REQUEST_DATA = b"""{"exportDataType":2,"executeSemanticQueryRequest":{"version":"1.0.0","queries":[{"Query":{"Commands":[{"SemanticQueryDataShapeCommand":{"Query":{"Version":2,"From":[{"Name":"s","Entity":"Sanctions","Type":0}],"Select":[{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"Title"},"Name":"Sanctions.Title","NativeReferenceName":"Title"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"Entity"},"Name":"Sanctions.Entity","NativeReferenceName":"Entity"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"Nationality"},"Name":"Sanctions.Nationality","NativeReferenceName":"Nationality"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"Country"},"Name":"Sanctions.Country","NativeReferenceName":"Country"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"Grounds"},"Name":"Sanctions.Grounds","NativeReferenceName":"Grounds"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"Source"},"Name":"Sanctions.Source","NativeReferenceName":"Source"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"IDB Sanction Type"},"Name":"Sanctions.IDB Sanction Type","NativeReferenceName":"IDB Sanction Type"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"IDB Sanction Source"},"Name":"Sanctions.IDB Sanction Source","NativeReferenceName":"IDB Sanction Source"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"Other Name"},"Name":"Sanctions.Other Name","NativeReferenceName":"Other Name"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"From"},"Name":"Sanctions.From","NativeReferenceName":"From1"},{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"To"},"Name":"Sanctions.To","NativeReferenceName":"To1"}],"Where":[{"Condition":{"Comparison":{"ComparisonKind":2,"Left":{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"From Date"}},"Right":{"Literal":{"Value":"datetime\'2007-03-23T00:00:00\'"}}}}}],"OrderBy":[{"Direction":1,"Expression":{"Column":{"Expression":{"SourceRef":{"Source":"s"}},"Property":"Title"}}}]},"Binding":{"Primary":{"Groupings":[{"Projections":[0,1,2,3,4,5,6,7,8,9,10],"Subtotal":1}]},"DataReduction":{"Primary":{"Top":{"Count":1000000}},"Secondary":{"Top":{"Count":100}}},"Version":1}}},{"ExportDataCommand":{"Columns":[{"QueryName":"Sanctions.Title","Name":"Title"},{"QueryName":"Sanctions.Entity","Name":"Entity"},{"QueryName":"Sanctions.Nationality","Name":"Nationality"},{"QueryName":"Sanctions.Country","Name":"Country"},{"QueryName":"Sanctions.Grounds","Name":"Grounds"},{"QueryName":"Sanctions.Source","Name":"Source"},{"QueryName":"Sanctions.IDB Sanction Type","Name":"IDB Sanction Type"},{"QueryName":"Sanctions.IDB Sanction Source","Name":"IDB Sanction Source"},{"QueryName":"Sanctions.Other Name","Name":"Other Name"},{"QueryName":"Sanctions.From","Name":"From"},{"QueryName":"Sanctions.To","Name":"To"}],"Ordering":[0,1,2,3,9,10,4,5,6,7,8],"FiltersDescription":"Applied filters:\\nFrom Date is on or after March 23, 2007"}}]}}],"cancelQueries":[],"modelId":8885050,"userPreferredLocale":"en-GB"},"artifactId":9296919})"""
 
 
-def parse_countries(countries: Optional[str]) -> List[str]:
-    parsed: List[str] = []
+def parse_countries(countries: str | None) -> list[str]:
+    parsed: list[str] = []
     if countries is None:
         return parsed
     for country in countries.split(", "):

--- a/datasets/_global/icij_offshoreleaks/crawler.py
+++ b/datasets/_global/icij_offshoreleaks/crawler.py
@@ -1,6 +1,6 @@
 import io
 from pathlib import Path
-from typing import Iterator
+from collections.abc import Iterator
 from csv import DictReader
 from zipfile import ZipFile
 from normality import stringify
@@ -175,7 +175,7 @@ def make_row_relationship(context: Context, row: dict[str, str | None]) -> None:
     try:
         res = context.lookup("relationships", link)
     except Exception:
-        context.log.exception("Unknown link: %s" % link)
+        context.log.exception(f"Unknown link: {link}")
         return
 
     if start_ent is None or end_ent is None:

--- a/datasets/_global/interpol/interpol_api.py
+++ b/datasets/_global/interpol/interpol_api.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import time
-from typing import Dict, Any, List, Optional, Set
+from typing import Any
 from requests.exceptions import HTTPError
 from rigour.text import is_nullword
 
@@ -21,8 +21,8 @@ IGNORE_FIELDS = [
     # "eyes_colors_id",
 ]
 MAX_RESULTS = 160
-SEEN_URLS: Set[str] = set()
-SEEN_IDS: Set[str] = set()
+SEEN_URLS: set[str] = set()
+SEEN_IDS: set[str] = set()
 COUNTRIES_URL = "https://www.interpol.int/en/notices/data/countries"
 GENDERS = ["M", "F", "U"]
 AGE_MIN = 20
@@ -48,20 +48,20 @@ HEADERS = {
 PROGRAM_KEY = "INTERPOL-RN"
 
 
-def get_countries(context: Context) -> List[str]:
+def get_countries(context: Context) -> list[str]:
     doc = context.fetch_json(COUNTRIES_URL, cache_days=CACHE_VSHORT, headers=HEADERS)
     return [v["value"] for v in doc]
 
 
-def patch(query: Dict[str, Any], update: Dict[str, Any]) -> Dict[str, Any]:
+def patch(query: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
     new = query.copy()
     new.update(update)
     return new
 
 
-def crawl_notice(context: Context, notice: Dict[str, Any]) -> None:
-    _links: Dict[str, Any] = notice.pop("_links", {})
-    url: Optional[str] = _links.get("self", {}).get("href")
+def crawl_notice(context: Context, notice: dict[str, Any]) -> None:
+    _links: dict[str, Any] = notice.pop("_links", {})
+    url: str | None = _links.get("self", {}).get("href")
     if url in SEEN_URLS or url is None:
         return
     SEEN_URLS.add(url)
@@ -121,7 +121,7 @@ def crawl_notice(context: Context, notice: Dict[str, Any]) -> None:
     context.emit(entity, origin=url)
 
 
-def crawl_query(context: Context, query: Dict[str, Any]) -> int:
+def crawl_query(context: Context, query: dict[str, Any]) -> int:
     context.log.info(f"Running query: {query}", query=query)
     params = query.copy()
     params["resultPerPage"] = MAX_RESULTS
@@ -213,4 +213,4 @@ def crawl(context: Context) -> None:
     )
 
     if any([key > 200 for key in STATUSES.keys()]):
-        raise RuntimeError("non-200 HTTP statuse codes %r" % STATUSES)
+        raise RuntimeError(f"non-200 HTTP statuse codes {STATUSES!r}")

--- a/datasets/_global/paris_mou_banned/crawler.py
+++ b/datasets/_global/paris_mou_banned/crawler.py
@@ -1,5 +1,5 @@
 from normality import stringify
-from typing import Dict, Any, Optional
+from typing import Any
 
 from zavod import Context, helpers as h
 
@@ -7,14 +7,14 @@ from zavod import Context, helpers as h
 # https://portal.emsa.europa.eu/o/portlet-public/rest/ban/getBanShips.json?banSituationIds=VALIDATED&page=1&start=0&limit=200
 
 
-def clean(value: Optional[str]) -> Optional[str]:
+def clean(value: str | None) -> str | None:
     value_str = stringify(value)
     if value_str and value_str.lower() in ("n/a", "unknown", "any"):
         return None
     return value_str
 
 
-def crawl_vessel(context: Context, item: Dict[str, Any]) -> None:
+def crawl_vessel(context: Context, item: dict[str, Any]) -> None:
     ship_id = item.pop("id")
     vessel = context.make("Vessel")
     vessel.id = context.make_slug("vessel", ship_id)

--- a/datasets/_global/ransomwhere/crawler.py
+++ b/datasets/_global/ransomwhere/crawler.py
@@ -7,7 +7,7 @@ from zavod import Context, helpers as h
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         data = json.load(fh)
     for entry in data.get("result", []):
         wallet = context.make("CryptoWallet")

--- a/datasets/_global/research/crawler.py
+++ b/datasets/_global/research/crawler.py
@@ -43,7 +43,7 @@ def crawl_sec_row(context: Context, row: dict[str, str]) -> None:
 def crawl_sec(context: Context) -> None:
     path = context.fetch_resource("sec-source.csv", SECURITIES_STATEMENTS_CSV)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         entity: Entity | None = None
         for row in csv.DictReader(fh):
             entity_id = stringify(row.pop("entity_id"))
@@ -72,7 +72,7 @@ def crawl_sec(context: Context) -> None:
 
     path = context.fetch_resource("securities.csv", SECURITIES_CUSTOM_CSV)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_sec_row(context, row)
 
@@ -152,7 +152,7 @@ def crawl_sanction_ownership(context: Context) -> None:
         "sanction-ownership-source.csv", SANCTION_OWNERSHIP_CSV
     )
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_sanction_ownership_row(context, row)
 

--- a/datasets/_global/ror/crawler.py
+++ b/datasets/_global/ror/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 import ijson  # type: ignore[import-untyped]  # ijson has no type stubs
 import zipfile
 from urllib.parse import urljoin
@@ -19,7 +19,7 @@ def get_download_url(context: Context) -> str:
     raise ValueError("No download link found")
 
 
-def crawl_item(context: Context, item: Dict[str, Any]) -> None:
+def crawl_item(context: Context, item: dict[str, Any]) -> None:
     ror_uri = item.pop("id")
     entity = context.make("Organization")
     entity.id = context.make_slug(ror_uri.rsplit("/", 1)[-1])

--- a/datasets/_global/thesentry_atlas/crawler.py
+++ b/datasets/_global/thesentry_atlas/crawler.py
@@ -1,13 +1,13 @@
 import csv
 from io import TextIOWrapper
-from typing import Generator, Dict
+from collections.abc import Generator
 import zipfile
 from rigour.mime.types import ZIP
 
 from zavod import Context
 from zavod import helpers as h
 
-CSVIter = Generator[Dict[str, str], None, None]
+CSVIter = Generator[dict[str, str], None, None]
 
 SOURCES = {
     "aliyev-empire.zip": "https://atlas.thesentry.org/wp-content/uploads/2024/10/Aliyev-Empire-Data.zip",
@@ -76,8 +76,7 @@ def iter_zf_csv(zf: zipfile.ZipFile, name: str) -> CSVIter:
         wrapper = TextIOWrapper(fh)
         wrapper.read(1)
         reader = csv.DictReader(wrapper)
-        for row in reader:
-            yield row
+        yield from reader
 
 
 def crawl_assets(context: Context, rows: CSVIter) -> None:
@@ -172,7 +171,7 @@ def crawl(context: Context) -> None:
         path = context.fetch_resource(file_name, data_url)
         context.export_resource(path, ZIP, title=context.SOURCE_TITLE)
         # entity_schema: Dict[str, str] = {}
-        context.log.info("Crawling: %r" % path)
+        context.log.info(f"Crawling: {path!r}")
 
         with zipfile.ZipFile(path, "r") as zf:
             for name in zf.namelist():

--- a/datasets/_global/un_1718_vessels/crawler.py
+++ b/datasets/_global/un_1718_vessels/crawler.py
@@ -39,7 +39,7 @@ def crawl(context: Context) -> None:
     # Fetch the CSV file, no need for Zyte since it's from Google Sheets
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             int_id = row.pop("#")
             name = row.pop("vessel_name")

--- a/datasets/_global/un_ga_protocol/crawler.py
+++ b/datasets/_global/un_ga_protocol/crawler.py
@@ -57,7 +57,7 @@ def crawl(context: Context) -> None:
             entity.add("topics", "role.pep")
             if norm_name != holder.get("person_name"):
                 context.log.debug(
-                    "Modified name: %r" % holder.get("person_name"),
+                    "Modified name: {!r}".format(holder.get("person_name")),
                     clean=norm_name,
                 )
             entity.add("name", norm_name)

--- a/datasets/_global/un_sc_sanctions/crawler.py
+++ b/datasets/_global/un_sc_sanctions/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional, List, Dict
 from normality import squash_spaces
 from lxml.etree import _Element as Element
 
@@ -8,7 +7,7 @@ from zavod import helpers as h
 from zavod.shed.un_sc import get_legal_entities, get_persons
 
 
-NAME_QUALITY: Dict[str, Optional[str]] = {
+NAME_QUALITY: dict[str, str | None] = {
     "Low": "weakAlias",
     "Good": "alias",
     "a.k.a.": "alias",
@@ -17,7 +16,7 @@ NAME_QUALITY: Dict[str, Optional[str]] = {
 }
 
 
-def values(node: Optional[Element]) -> List[str]:
+def values(node: Element | None) -> list[str]:
     if node is None:
         return []
     return [c.text for c in node.findall("./VALUE") if c.text is not None]
@@ -34,7 +33,7 @@ def parse_alias(entity: Entity, node: Element) -> None:
         entity.add(name_prop, squash_spaces(name))
 
 
-def parse_address(context: Context, node: Element) -> Optional[Entity]:
+def parse_address(context: Context, node: Element) -> Entity | None:
     post_code = node.findtext("./ZIP_CODE")
     state_province = node.findtext("./STATE_PROVINCE")
     if post_code and not re.search(r"\d", post_code):
@@ -146,7 +145,7 @@ def parse_common(context: Context, entity: Entity, node: Element) -> Entity:
     return sanction
 
 
-def crawl_index(context: Context) -> Optional[str]:
+def crawl_index(context: Context) -> str | None:
     doc = context.fetch_html(context.data_url, cache_days=1)
     for link in doc.findall(".//a"):
         href = link.get("href")

--- a/datasets/_testing/alert_testing/crawler.py
+++ b/datasets/_testing/alert_testing/crawler.py
@@ -1,5 +1,4 @@
 import csv
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod import Context
@@ -7,7 +6,7 @@ from zavod import Context
 # from zavod import helpers as h
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     entity = context.make("Person")
     entity.id = context.make_slug(row.pop("id"))
     entity.add("name", row.pop("name"))
@@ -21,6 +20,6 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/_testing/validation/crawler.py
+++ b/datasets/_testing/validation/crawler.py
@@ -1,12 +1,11 @@
 import csv
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod import Context
 from zavod import helpers as h
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     schema = row.pop("type")
     entity = context.make(schema)
     entity.id = context.make_slug(row.pop("id"))
@@ -54,6 +53,6 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from io import StringIO
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 from urllib.parse import urlencode
 
 from nomenklatura.wikidata import Claim, Item
@@ -39,12 +39,12 @@ ALWAYS_PERSONS = ["Q21258544"]
 
 @dataclass
 class FoundRecord:
-    from_categories: Set[str] = field(default_factory=set)
-    from_positions: Set[str] = field(default_factory=set)
+    from_categories: set[str] = field(default_factory=set)
+    from_positions: set[str] = field(default_factory=set)
     from_declarator: bool = False
 
 
-class CrawlState(object):
+class CrawlState:
     def __init__(self, context: Context):
         self.context = context
         self.client = create_wikidata_client(context)
@@ -52,20 +52,20 @@ class CrawlState(object):
         # Position QID -> evaluated position entity, None if the item is not
         # a usable PEP position. Positions recur across the whole person set,
         # so each distinct QID is fetched and categorised only once per run.
-        self.positions: Dict[str, Optional[Entity]] = {}
+        self.positions: dict[str, Entity | None] = {}
 
-        self.persons: Dict[str, FoundRecord] = defaultdict(FoundRecord)
+        self.persons: dict[str, FoundRecord] = defaultdict(FoundRecord)
         self.persons.update({qid: FoundRecord() for qid in ALWAYS_PERSONS})
 
-        self.person_title: Dict[str, str] = {}
-        self.person_countries: Dict[str, Set[str]] = {}
-        self.person_topics: Dict[str, Set[str]] = {}
-        self.person_positions: Dict[str, Set[Entity]] = {}
-        self._emitted_positions: Set[str] = set()
-        self._crawled_officeholder_positions: Set[str] = set()
+        self.person_title: dict[str, str] = {}
+        self.person_countries: dict[str, set[str]] = {}
+        self.person_topics: dict[str, set[str]] = {}
+        self.person_positions: dict[str, set[Entity]] = {}
+        self._emitted_positions: set[str] = set()
+        self._crawled_officeholder_positions: set[str] = set()
         exc = [str(x) for x in context.dataset.config.get("exclusion_checks", [])]
-        self.exclusion_checks: Set[str] = set(exc)
-        self.person_modified_at: Dict[str, datetime] = {}
+        self.exclusion_checks: set[str] = set(exc)
+        self.person_modified_at: dict[str, datetime] = {}
 
     def emit_position(self, position: Entity) -> None:
         if position.id is None:
@@ -75,11 +75,11 @@ class CrawlState(object):
             self.context.emit(position)
 
 
-def title_name(title: str) -> Optional[str]:
+def title_name(title: str) -> str | None:
     return clean_wikidata_name(title.replace("_", " "))
 
 
-def get_position(state: CrawlState, qid: str) -> Optional[Entity]:
+def get_position(state: CrawlState, qid: str) -> Entity | None:
     """Reuse evaluated positions across people who hold the same office."""
     if qid in state.positions:
         return state.positions[qid]
@@ -130,12 +130,12 @@ def crawl_position(state: CrawlState, person: Entity, claim: Claim) -> None:
         crawl_officeholders(state, item, position)
     occupancy = wikidata_occupancy(state.context, person, position, claim)
     if occupancy is not None:
-        state.log.info("  -> %s (%s)" % (position.first("name"), position.id))
+        state.log.info("  -> {} ({})".format(position.first("name"), position.id))
         state.emit_position(position)
         state.context.emit(occupancy)
 
 
-def crawl_person(state: CrawlState, qid: str, recurse: bool = True) -> Optional[Entity]:
+def crawl_person(state: CrawlState, qid: str, recurse: bool = True) -> Entity | None:
     modified_at = state.person_modified_at.get(qid)
     item = state.client.fetch_item(qid, modified_at=modified_at)
     if item is None:
@@ -154,20 +154,20 @@ def crawl_person(state: CrawlState, qid: str, recurse: bool = True) -> Optional[
     return entity
 
 
-def crawl_category(state: CrawlState, category_crawl_spec: Dict[str, Any]) -> None:
-    topics: List[str] = category_crawl_spec.pop("topics", [])
+def crawl_category(state: CrawlState, category_crawl_spec: dict[str, Any]) -> None:
+    topics: list[str] = category_crawl_spec.pop("topics", [])
     if "topic" in category_crawl_spec:
         topics.append(category_crawl_spec.pop("topic"))
-    country: Optional[str] = category_crawl_spec.pop("country", None)
+    country: str | None = category_crawl_spec.pop("country", None)
 
     query = dict(QUERY)
     cat: str = category_crawl_spec.pop("category", "")
     query["categories"] = cat.strip()
     query.update(category_crawl_spec)
-    state.log.info("Crawl category: %s" % cat)
+    state.log.info(f"Crawl category: {cat}")
 
-    position_data: Dict[str, Any] = category_crawl_spec.pop("position", {})
-    position: Optional[Entity] = None
+    position_data: dict[str, Any] = category_crawl_spec.pop("position", {})
+    position: Entity | None = None
     if "name" in position_data:
         position = h.make_position(
             state.context,
@@ -211,15 +211,15 @@ def crawl_category(state: CrawlState, category_crawl_spec: Dict[str, Any]) -> No
             state.person_title[person_qid] = person_title
 
     state.log.info(
-        "PETScanning category: %s" % cat,
+        f"PETScanning category: {cat}",
         topics=topics,
         results=results,
     )
     state.context.flush()
 
 
-def crawl_position_holder(state: CrawlState, position_qid: str) -> Set[str]:
-    persons: Set[str] = set([])
+def crawl_position_holder(state: CrawlState, position_qid: str) -> set[str]:
+    persons: set[str] = set([])
 
     position = get_position(state, position_qid)
     if position is None:
@@ -253,8 +253,8 @@ def crawl_position_holder(state: CrawlState, position_qid: str) -> Set[str]:
 
 
 def crawl_position_seeds(state: CrawlState) -> None:
-    seeds: List[str] = state.context.dataset.config.get("seeds", [])
-    roles: Set[str] = set(categorised_position_qids(state.context))
+    seeds: list[str] = state.context.dataset.config.get("seeds", [])
+    roles: set[str] = set(categorised_position_qids(state.context))
     for seed in seeds:
         query = f"""
         SELECT ?role WHERE {{
@@ -358,7 +358,7 @@ def crawl(context: Context) -> None:
     state = CrawlState(context)
     crawl_declarator(state)
     crawl_position_seeds(state)
-    category_crawl_specs: List[Dict[str, Any]] = context.dataset.config.get(
+    category_crawl_specs: list[dict[str, Any]] = context.dataset.config.get(
         "categories", []
     )
     for category_crawl_spec in category_crawl_specs:

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -246,9 +246,7 @@ def crawl_position_holder(state: CrawlState, position_qid: str) -> set[str]:
             if claim.qid is not None:
                 persons.add(claim.qid)
 
-    state.log.info(
-        "Found %d holders of %s [%s]" % (len(persons), item.label, position_qid)
-    )
+    state.log.info(f"Found {len(persons)} holders of {item.label} [{position_qid}]")
     return persons
 
 
@@ -268,7 +266,7 @@ def crawl_position_seeds(state: CrawlState) -> None:
             if role is not None:
                 roles.add(role)
 
-    state.log.info("Found %d seed positions" % len(roles))
+    state.log.info(f"Found {len(roles)} seed positions")
     for role in roles:
         for position_holder_qid in crawl_position_holder(state, role):
             state.persons[position_holder_qid].from_positions.add(role)
@@ -287,7 +285,7 @@ def crawl_declarator(state: CrawlState) -> None:
     }
     """
     response = state.client.query(query, cache_days=WIKIDATA_QUERY_CACHE)
-    state.log.info("Found %d declarator profiles" % len(response.results))
+    state.log.info(f"Found {len(response.results)} declarator profiles")
     for result in response.results:
         person_qid = result.plain("person")
         if person_qid is None:
@@ -307,7 +305,7 @@ def crawl_declarator(state: CrawlState) -> None:
 
 
 def crawl_persons(state: CrawlState) -> None:
-    state.context.log.info("Generated %d persons" % len(state.persons))
+    state.context.log.info(f"Generated {len(state.persons)} persons")
     for idx, (person_qid, found_record) in enumerate(state.persons.items()):
         entity = crawl_person(state, person_qid)
         if entity is None:

--- a/datasets/_wikidata/curated/crawler.py
+++ b/datasets/_wikidata/curated/crawler.py
@@ -1,12 +1,11 @@
 import csv
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod import Context
 from zavod import helpers as h
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     qid_raw = row.get("qid", "").strip()
     qid = h.deref_wikidata_id(context, qid_raw)
     if qid is None:
@@ -25,6 +24,6 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/_wikidata/oligarchs/crawler.py
+++ b/datasets/_wikidata/oligarchs/crawler.py
@@ -1,5 +1,4 @@
 import csv
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod import Context
@@ -8,7 +7,7 @@ from zavod import helpers as h
 CAATSA_URL = "https://prod-upp-image-read.ft.com/40911a30-057c-11e8-9650-9c0ad2d7c5b5"
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     qid_raw = row.get("qid", "").strip()
     qid = h.deref_wikidata_id(context, qid_raw)
     if qid is None:
@@ -31,6 +30,6 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from functools import lru_cache
-from typing import Dict, Generator, Optional, Set
+from collections.abc import Generator
 
 from rigour.ids.wikidata import is_qid
 from rigour.territories import get_territories
@@ -42,8 +42,8 @@ def all_territories() -> Generator[Territory, None, None]:
         yield territory
 
 
-def collect_positions(context: Context, client: WikidataClient, query: str) -> Set[str]:
-    positions: Set[str] = set()
+def collect_positions(context: Context, client: WikidataClient, query: str) -> set[str]:
+    positions: set[str] = set()
     response = client.query(query, cache_days=WIKIDATA_QUERY_CACHE)
     for bind in response.results:
         position_qid = bind.plain("position")
@@ -59,7 +59,7 @@ def collect_positions(context: Context, client: WikidataClient, query: str) -> S
 
 def query_usage_positions(
     context: Context, client: WikidataClient, territory: Territory
-) -> Set[str]:
+) -> set[str]:
     """Positions in use that are tied to the territory via jurisdiction (P1001)
     or country (P17): they either have a human holder (P39 inverse) or name an
     officeholder themselves (P1308).
@@ -82,7 +82,7 @@ def query_usage_positions(
 
 def query_occupation_positions(
     context: Context, client: WikidataClient, territory: Territory
-) -> Set[str]:
+) -> set[str]:
     """Positions held by politicians, diplomats and judges who are citizens of
     the country. This catches positions with no country/jurisdiction statement
     of their own, including diplomatic postings and foreign or IGO offices."""
@@ -98,11 +98,11 @@ def query_occupation_positions(
     return collect_positions(context, client, query)
 
 
-def discover_candidates(context: Context, client: WikidataClient) -> Set[str]:
+def discover_candidates(context: Context, client: WikidataClient) -> set[str]:
     """Enumerate candidate position QIDs. Positions already categorised as PEP
     in the review database are always included, so a failing discovery query
     can delay new positions but never drop known ones."""
-    candidates: Set[str] = set(categorised_position_qids(context))
+    candidates: set[str] = set(categorised_position_qids(context))
     context.log.info(f"Loaded {len(candidates)} positions from the review database")
     for territory in all_territories():
         context.log.info(f"Crawling territory: {territory.qid} ({territory.name})")
@@ -124,9 +124,7 @@ def discover_candidates(context: Context, client: WikidataClient) -> Set[str]:
 
 
 @lru_cache(maxsize=5000)
-def get_position(
-    context: Context, client: WikidataClient, qid: str
-) -> Optional[Entity]:
+def get_position(context: Context, client: WikidataClient, qid: str) -> Entity | None:
     """Build (or rebuild) the Position entity for a QID. Bounded cache: evicted
     entries are reconstructed from the SQL-cached item data, so run-level memory
     does not grow with the number of accepted positions."""
@@ -139,16 +137,16 @@ def get_position(
 def crawl_person(
     context: Context,
     client: WikidataClient,
-    accepted: Set[str],
-    aliases: Dict[str, str],
+    accepted: set[str],
+    aliases: dict[str, str],
     person_qid: str,
-    modified_at: Optional[datetime],
-) -> Set[str]:
+    modified_at: datetime | None,
+) -> set[str]:
     """Emit a person and one occupancy for every P39 claim that points to an
     accepted position — not just the position that discovered them. Returns the
     QIDs of the positions this person occupies; the Position entities themselves
     are emitted at the end of the run, once it's known they have holders."""
-    occupied_positions: Set[str] = set()
+    occupied_positions: set[str] = set()
     if not is_qid(person_qid):
         return occupied_positions
     item = client.fetch_item(person_qid, modified_at=modified_at)
@@ -188,8 +186,8 @@ def crawl(context: Context) -> None:
 
     # Classification must complete over all territories before any person is
     # processed, so that occupancies are built against the final accepted set.
-    accepted: Set[str] = set()
-    aliases: Dict[str, str] = {}
+    accepted: set[str] = set()
+    aliases: dict[str, str] = {}
     for idx, qid in enumerate(sorted(candidates)):
         item = client.fetch_item(qid)
         if item is None:
@@ -209,8 +207,8 @@ def crawl(context: Context) -> None:
     # One pass over the holders of every accepted position. Each person is
     # fetched and emitted exactly once, with occupancies for all their accepted
     # positions; only QID-keyed bookkeeping is retained across the run.
-    done_persons: Set[str] = set()
-    has_holders: Set[str] = set()
+    done_persons: set[str] = set()
+    has_holders: set[str] = set()
     for idx, position_qid in enumerate(sorted(accepted)):
         position_item = client.fetch_item(position_qid)
         if position_item is None:
@@ -218,7 +216,7 @@ def crawl(context: Context) -> None:
         position = get_position(context, client, position_qid)
         if position is None:
             continue
-        context.log.info("Position [%s]: %s" % (position.id, position.caption))
+        context.log.info(f"Position [{position.id}]: {position.caption}")
         for person_qid, modified_at in position_holders(client, position_item).items():
             if person_qid in done_persons:
                 continue

--- a/datasets/ae/local_terrorists/crawler.py
+++ b/datasets/ae/local_terrorists/crawler.py
@@ -1,7 +1,7 @@
 import xlrd
 import re
 
-from typing import List, Optional, NamedTuple
+from typing import NamedTuple
 from pathlib import Path
 from normality import collapse_spaces, squash_spaces
 from rigour.mime.types import XLS
@@ -25,8 +25,8 @@ DATES = [
 
 def parse_row(
     context: Context,
-    headers: List[HeaderSpec],
-    row: List[Optional[str]],
+    headers: list[HeaderSpec],
+    row: list[str | None],
     sanctioned: bool,
 ) -> None:
     entity_id = context.make_id(*row)
@@ -141,7 +141,7 @@ def parse_excel(context: Context, path: Path) -> None:
             for r in range(rlo, rhi)
             for c in range(clo, chi)
         }
-        headers: Optional[List[HeaderSpec]] = None
+        headers: list[HeaderSpec] | None = None
         for r in range(1, sheet.nrows):
             row = []
             for c in range(sheet.ncols):

--- a/datasets/am/hetq/crawler.py
+++ b/datasets/am/hetq/crawler.py
@@ -5,7 +5,7 @@ Crawler for PEP data downloaded from data.hetq.am
 import itertools
 import json
 import re
-from typing import Dict, List, Literal, Any, Optional, Tuple, Union
+from typing import Literal, Any
 from zipfile import ZipFile
 
 from lxml.html import document_fromstring, HtmlElement
@@ -60,7 +60,7 @@ def fix_trans_spill(text: str) -> str:
 
 def get_birth_info(
     context: Context, zipfh: ZipFile, person_id: int
-) -> Tuple[Union[None, str], Union[None, str]]:
+) -> tuple[None | str, None | str]:
     """Get birth date and place from person page."""
     # We might have valid HTML, but we might also have an incomplete
     # page with a "Parse Error".  In any case we are really just
@@ -98,8 +98,8 @@ def crawl_person(
     context: Context,
     zipfh: ZipFile,
     person_id: int,
-    data: Dict[str, Any],
-) -> Optional[Entity]:
+    data: dict[str, Any],
+) -> Entity | None:
     """Create person and position/occupancy if applicable."""
     birth_date, birth_place = get_birth_info(context, zipfh, person_id)
     name_en = data.get("name_en", "").strip()
@@ -167,8 +167,8 @@ def crawl_person(
 
 def crawl_list(
     context: Context,
-    peps: Dict[int, Dict[str, Any]],
-    data: List[Dict[str, Any]],
+    peps: dict[int, dict[str, Any]],
+    data: list[dict[str, Any]],
     year: int,
     lang: SupportedLanguage,
 ) -> None:
@@ -206,8 +206,8 @@ def crawl_list(
 def crawl_missing_pois(
     context: Context,
     zipfh: ZipFile,
-    missing_pois: Dict[int, Any],
-    persons: Dict[int, Dict[str, Any]],
+    missing_pois: dict[int, Any],
+    persons: dict[int, dict[str, Any]],
 ) -> None:
     """Create an entity for a person of interest not named in the
     front-page list of PEPs."""
@@ -223,7 +223,7 @@ def crawl_missing_pois(
 
 
 def crawl_relations(
-    context: Context, zipfh: ZipFile, persons: Dict[int, Dict[str, Any]], person_id: int
+    context: Context, zipfh: ZipFile, persons: dict[int, dict[str, Any]], person_id: int
 ) -> None:
     """Read relation graph and create entities."""
     # There should always be a person / entity for the source
@@ -293,7 +293,7 @@ def crawl_relations(
 def crawl_lists(context: Context, zipfh: ZipFile) -> None:
     """Read lists of persons for each year covered, matching names and
     accumulating years in which the person was active."""
-    persons: Dict[int, Dict[str, Any]] = {}
+    persons: dict[int, dict[str, Any]] = {}
     for info in zipfh.infolist():
         # zipfile.Path would be good for this but it may not work
         # correctly in all versions of Python

--- a/datasets/am/hetq/download.py
+++ b/datasets/am/hetq/download.py
@@ -10,7 +10,7 @@ import requests
 import lxml.html
 from pathlib import Path
 from urllib.parse import urlencode
-from typing import Literal, Set
+from typing import Literal
 
 WEBPAGE = r"https://data.hetq.am/%(lang)s"
 FRONTPAGE = r"https://data.hetq.am/api/v2/%(lang)s/front/filters"
@@ -55,9 +55,9 @@ def download_front_page(lang: LANGUAGE, outdir: Path) -> None:
         url = WEBPAGE % {"lang": "" if lang == "hy" else lang}
         r = requests.get(url, headers=CHROME_HEADER)
         r.raise_for_status()
-        with open(pagepath, "wt") as page:
+        with open(pagepath, "w") as page:
             page.write(r.text)
-    with open(pagepath, "rt") as page:
+    with open(pagepath) as page:
         root = lxml.html.parse(page).getroot()
     yeardiv = root.find_class("filter-year")
     for label in yeardiv[0].findall(".//label"):
@@ -80,7 +80,7 @@ def download_front_page(lang: LANGUAGE, outdir: Path) -> None:
                 break
             entries.extend(these_entries)
             offset += len(these_entries)
-        with open(frontpath, "wt") as outfh:
+        with open(frontpath, "w") as outfh:
             json.dump(entries, outfh, indent=2, ensure_ascii=False)
 
 
@@ -96,17 +96,17 @@ def download_people_page(lang: LANGUAGE, outdir: Path, person: int) -> None:
         r.raise_for_status()
     elif r.status_code != 200:
         LOGGER.warning("Got weird status %d for %s", r.status_code, url)
-    with open(personpath, "wt") as page:
+    with open(personpath, "w") as page:
         page.write(r.text)
 
 
-def download_people_pages(lang: LANGUAGE, outdir: Path) -> Set[int]:
+def download_people_pages(lang: LANGUAGE, outdir: Path) -> set[int]:
     """Get the page for each PEP (no JSON available it seems)."""
     frontdir = outdir / "front"
     # Merge all of them to get unique person ids
-    person_ids: Set[int] = set()
+    person_ids: set[int] = set()
     for path in frontdir.glob("*.json"):
-        with open(path, "rt") as infh:
+        with open(path) as infh:
             person_ids.update(e["personID"] for e in json.load(infh))
     LOGGER.info("Got %d unique person IDs for %s", len(person_ids), lang)
     (outdir / "person").mkdir(parents=True, exist_ok=True)
@@ -116,7 +116,7 @@ def download_people_pages(lang: LANGUAGE, outdir: Path) -> Set[int]:
 
 
 def download_relations_pages(
-    person_ids: Set[int], lang: LANGUAGE, outdir: Path
+    person_ids: set[int], lang: LANGUAGE, outdir: Path
 ) -> None:
     """Get relation graph for each PEP (in JSON not SVG thankfully)."""
     (outdir / "relations").mkdir(parents=True, exist_ok=True)
@@ -133,9 +133,9 @@ def download_relations_pages(
                 r.raise_for_status()
             elif r.status_code != 200:
                 LOGGER.warning("Got weird status %d for %s", r.status_code, url)
-            with open(personpath, "wt") as page:
+            with open(personpath, "w") as page:
                 json.dump(r.json(), page, indent=2, ensure_ascii=False)
-        with open(personpath, "rt") as infh:
+        with open(personpath) as infh:
             graph = json.load(infh)
         if not graph:
             continue
@@ -164,7 +164,7 @@ def download_officialtypes(outdir: Path) -> None:
         r.raise_for_status()
     elif r.status_code != 200:
         LOGGER.warning("Got weird status %d for %s", r.status_code, url)
-    with open(officialtypes, "wt") as page:
+    with open(officialtypes, "w") as page:
         json.dump(r.json(), page, indent=2, ensure_ascii=False)
 
 

--- a/datasets/ar/parliament/crawler.py
+++ b/datasets/ar/parliament/crawler.py
@@ -8,7 +8,7 @@ from zavod.stateful.positions import categorise
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             person = context.make("Person")
             person.id = context.make_slug(row.pop("ID"))

--- a/datasets/ar/repet/crawler.py
+++ b/datasets/ar/repet/crawler.py
@@ -100,9 +100,9 @@ def parse_address(context: Context, data: dict[str, str]) -> Entity | None:
 
 
 def fetch(context: Context, part: str) -> Any:
-    path = context.fetch_resource("%s.json" % part, URL % part)
+    path = context.fetch_resource(f"{part}.json", URL % part)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         return json.load(fh)
 
 

--- a/datasets/at/nbter_sanctions/crawler.py
+++ b/datasets/at/nbter_sanctions/crawler.py
@@ -69,7 +69,7 @@ def crawl(context: Context) -> None:
     # Kundmachung DL 1/2009 der OeNB – März 2009 (PDF, 72,8 KB)
 
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/au/dfat_sanctions/crawler.py
+++ b/datasets/au/dfat_sanctions/crawler.py
@@ -1,7 +1,7 @@
 import string
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import openpyxl
 from normality import slugify
@@ -10,7 +10,7 @@ from rigour.mime.types import XLSX
 from zavod import Context
 from zavod import helpers as h
 
-SPLITS = [" %s)" % char for char in string.ascii_lowercase]
+SPLITS = [f" {char})" for char in string.ascii_lowercase]
 ADDRESS_SPLITS = [
     ";",
     "iii) ",
@@ -75,7 +75,7 @@ def clean_date(date: str) -> list[str]:
     return dates
 
 
-def clean_reference(ref: str) -> Optional[str]:
+def clean_reference(ref: str) -> str | None:
     """Given a reference like 101a, return 101"""
     number = ref
     while len(number):
@@ -111,7 +111,7 @@ def parse_reference(
         return
     entity = context.make(schemata.pop())
 
-    primary_name: Optional[str] = None
+    primary_name: str | None = None
     names: list[tuple[str, str]] = []
     for row in rows:
         name = row.pop("name_of_individual_or_entity")
@@ -211,7 +211,7 @@ def crawl(context: Context) -> None:
     reference_blocks_seen_count: dict[str, int] = dict()
     last_clean_ref = None
     for sheet in workbook.worksheets:
-        headers: Optional[list[str]] = None
+        headers: list[str] | None = None
         for row_num, raw_row in enumerate(sheet.rows):
             cells = [c.value for c in raw_row]
             if headers is None:

--- a/datasets/au/listed_terrorist_orgs/crawler.py
+++ b/datasets/au/listed_terrorist_orgs/crawler.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from zavod import Context
 from zavod import helpers as h
 
@@ -7,7 +5,7 @@ from zavod import helpers as h
 PROGRAM_KEY = "AU-TERROR"
 
 
-def parse_listing_dates(date_text: Optional[str]) -> Optional[str]:
+def parse_listing_dates(date_text: str | None) -> str | None:
     """Parse the listing date text to extract the initial listing date."""
     if not date_text:
         return None

--- a/datasets/az/fiu_sanctions/crawler.py
+++ b/datasets/az/fiu_sanctions/crawler.py
@@ -10,7 +10,7 @@ def crawl(context: Context) -> None:
     xml_url = h.xpath_string(html_doc, ".//a[contains(text(), 'XML')]/@href")
     path = context.fetch_resource("source.xml", xml_url)
     context.export_resource(path, XML, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         doc = etree.parse(fh)
     # date = doc.getroot().get("dateGenerated")
     # if date is None:
@@ -46,7 +46,7 @@ def crawl(context: Context) -> None:
             lang="eng",
         )
         if ind.findtext("FOURTH_NAME"):
-            context.log.warn("Fourth name found in individual: %s" % data_id)
+            context.log.warn(f"Fourth name found in individual: {data_id}")
 
         entity.add("birthDate", ind.findtext("./INDIVIDUAL_DATE_OF_BIRTH/DATE"))
         entity.add("country", "az")

--- a/datasets/be/flemish_parliament/crawler.py
+++ b/datasets/be/flemish_parliament/crawler.py
@@ -1,6 +1,6 @@
 import orjson
 from rigour.mime.types import JSON
-from typing import Any, Dict, NamedTuple
+from typing import Any, NamedTuple
 
 from zavod import Context, helpers as h
 from zavod.entity import Entity
@@ -39,7 +39,7 @@ def get_member_detail(
     )
 
 
-def crawl_member(context: Context, position: Entity, node: Dict[str, Any]) -> None:
+def crawl_member(context: Context, position: Entity, node: dict[str, Any]) -> None:
     member_id = node.pop("id")
     assert member_id is not None
 

--- a/datasets/be/fod_sanctions/crawler.py
+++ b/datasets/be/fod_sanctions/crawler.py
@@ -1,5 +1,4 @@
 from csv import DictReader
-from typing import Dict, List
 
 from rigour.mime.types import CSV
 
@@ -38,7 +37,7 @@ def apply_identifier(context: Context, entity: Entity, id_number_line: str) -> N
 
 
 def crawl_row(
-    context: Context, entity_id: str | None, row: Dict[str, List[str]]
+    context: Context, entity_id: str | None, row: dict[str, list[str]]
 ) -> None:
     schema = context.lookup_value(
         "subject_type",
@@ -97,7 +96,7 @@ def crawl_row(
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r", encoding="utf-8-sig") as fh:
+    with open(path, encoding="utf-8-sig") as fh:
         reader = DictReader(fh, delimiter=";")
         for row in reader:
             # Use raw values before any splitting/replacing for entity id

--- a/datasets/be/walloon_parliament/crawler.py
+++ b/datasets/be/walloon_parliament/crawler.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 from rigour.mime.types import JSON
 
 from zavod import Context, helpers as h
@@ -28,7 +28,7 @@ IGNORE = [
 ]
 
 
-def crawl_item(context: Context, item: Dict[str, Any]) -> None:
+def crawl_item(context: Context, item: dict[str, Any]) -> None:
     dep_id = item.pop("dep_id")
     full_name = item.pop("dep_nomcomplet")
 
@@ -78,7 +78,7 @@ def crawl_item(context: Context, item: Dict[str, Any]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         data = json.load(fh)
     for item in data["deputes"]:
         crawl_item(context, item)

--- a/datasets/bg/jud_declarations/crawler.py
+++ b/datasets/bg/jud_declarations/crawler.py
@@ -4,7 +4,7 @@ from requests.exceptions import HTTPError
 from rigour.text.distance import levenshtein_similarity
 from rigour.env import MAX_NAME_LENGTH
 from normality import normalize, slugify
-from typing import Dict, Iterator, List, Optional
+from collections.abc import Iterator
 
 from zavod import Context, helpers as h
 from zavod.stateful.positions import categorise, OccupancyStatus
@@ -36,7 +36,7 @@ BROKEN_LINKS = {
 
 def extract_judicial_declaration(
     context: Context, name: str, url: str, doc_id_date: str
-) -> Dict[str, Optional[str]]:
+) -> dict[str, str | None]:
     """Extract name, role, and organization from the first page of a judicial declaration PDF."""
     try:
         pdf_path = context.fetch_resource(f"{slugify([name, doc_id_date])}.pdf", url)
@@ -80,8 +80,8 @@ def extract_judicial_declaration(
 
 def parse_html_table(
     table: Element,
-    headers: List[str] = [],
-) -> Iterator[Dict[str, Element]]:
+    headers: list[str] = [],
+) -> Iterator[dict[str, Element]]:
     first_row = table.find(".//tr[1]")
     assert first_row is not None, "Table has no rows"
     assert len(headers) == len(first_row.findall("./td")), (
@@ -93,7 +93,7 @@ def parse_html_table(
         yield {hdr: c for hdr, c in zip(headers, cells)}
 
 
-def crawl_row(context: Context, row: Dict[str, Element], index_url: str) -> None:
+def crawl_row(context: Context, row: dict[str, Element], index_url: str) -> None:
     str_row = h.cells_to_str(row)
     name = str_row.pop("name")
     doc_id_date = str_row.pop("doc_id_date")

--- a/datasets/bg/omnio/crawler.py
+++ b/datasets/bg/omnio/crawler.py
@@ -1,5 +1,4 @@
 import csv
-from typing import Dict
 from rigour.mime.types import CSV
 
 from zavod import Context
@@ -12,7 +11,7 @@ TYPES = {
 }
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     entity = context.make(TYPES[row.pop("Entity_Type")])
     row.pop("Entity_Type_BG")
     entity.id = context.make_id(
@@ -113,6 +112,6 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/br/bcb_disqualified_persons/crawler.py
+++ b/datasets/br/bcb_disqualified_persons/crawler.py
@@ -1,5 +1,6 @@
 import itertools
-from typing import Any, Iterable, Tuple
+from typing import Any
+from collections.abc import Iterable
 
 from zavod import Context
 from zavod import helpers as h
@@ -32,7 +33,7 @@ def crawl_person(context: Context, name: str, lines: Iterable[dict[str, Any]]) -
         # The ID of the process
         sanction.add(
             "description",
-            "Administrative Sanctioning Process Number: {}".format(pas_number),
+            f"Administrative Sanctioning Process Number: {pas_number}",
         )
 
         # The duration is always in years
@@ -73,7 +74,7 @@ def crawl(context: Context) -> None:
         return
     data = response["value"]
 
-    lines_by_name: Iterable[Tuple[str, Iterable[dict[str, Any]]]] = itertools.groupby(
+    lines_by_name: Iterable[tuple[str, Iterable[dict[str, Any]]]] = itertools.groupby(
         data, lambda line: line["Nome"]
     )
 

--- a/datasets/br/bcb_prohibited/crawler.py
+++ b/datasets/br/bcb_prohibited/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, List, cast
+from typing import Any, cast
 
 from zavod.entity import Entity
 
@@ -6,7 +6,7 @@ from zavod import Context
 from zavod import helpers as h
 
 
-def fetch_data(context: Context) -> List[dict[str, Any]]:
+def fetch_data(context: Context) -> list[dict[str, Any]]:
     """
     Fetches data from the website, or raises an exception on failure.
 
@@ -17,7 +17,7 @@ def fetch_data(context: Context) -> List[dict[str, Any]]:
     if "value" not in response:
         context.log.error("Value not found in JSON")
         return []
-    return cast(List[dict[str, Any]], response["value"])
+    return cast(list[dict[str, Any]], response["value"])
 
 
 def create_entity(input_dict: dict[str, Any], context: Context) -> Entity:
@@ -83,7 +83,7 @@ def create_sanction(
     # The ID of the process
     sanction.add(
         "description",
-        "Administrative Sanctioning Process Number: {}".format(pas),
+        f"Administrative Sanctioning Process Number: {pas}",
     )
 
     # The duration is always in years

--- a/datasets/br/pep/crawler.py
+++ b/datasets/br/pep/crawler.py
@@ -1,5 +1,5 @@
 import csv
-from typing import Dict, Any
+from typing import Any
 from zipfile import ZipFile
 
 from zavod import Context
@@ -29,7 +29,7 @@ def get_csv_url(context: Context) -> str:
     return h.xpath_string(doc, "//a[contains(@href, '/download-de-dados/pep/')]/@href")
 
 
-def create_entity(raw_entity: Dict[str, Any], context: Context) -> None:
+def create_entity(raw_entity: dict[str, Any], context: Context) -> None:
     """
     Creates entities from the data fetched from the website.
 
@@ -90,7 +90,7 @@ def crawl(context: Context) -> None:
         for file_name in zip_file.namelist():
             context.log.info(f"Extracting {file_name}")
             file_path = zip_file.extract(file_name, work_dir)
-            with open(file_path, "r", encoding="iso-8859-1") as fh:
+            with open(file_path, encoding="iso-8859-1") as fh:
                 reader = csv.DictReader(fh, delimiter=";")
                 for row in reader:
                     create_entity(row, context)

--- a/datasets/br/slavery/crawler.py
+++ b/datasets/br/slavery/crawler.py
@@ -80,7 +80,7 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r", encoding="latin-1") as fh:
+    with open(path, encoding="latin-1") as fh:
         # Skip garbage at beginning of file
         while True:
             prev_pos = fh.tell()

--- a/datasets/bz/national_assembly/crawler.py
+++ b/datasets/bz/national_assembly/crawler.py
@@ -25,8 +25,7 @@ def parse_members(doc: _Element) -> list[tuple[str, str]]:
     ]
     if len(names) != len(roles):
         raise ValueError(
-            "Member name/role count mismatch: %d names, %d roles"
-            % (len(names), len(roles))
+            f"Member name/role count mismatch: {len(names)} names, {len(roles)} roles"
         )
     return list(zip(names, roles))
 
@@ -104,7 +103,7 @@ def crawl_senators(context: Context) -> None:
     senate_doc = context.fetch_html(context.data_url + "senate/", cache_days=1)
     senators = parse_members(senate_doc)
     if len(senators) < 10:
-        raise ValueError("Expected at least 10 senators, found %d" % len(senators))
+        raise ValueError(f"Expected at least 10 senators, found {len(senators)}")
     pres_pos, pres_cat = make_chamber_position(
         context, "President of the Senate of Belize", "Q6594868"
     )

--- a/datasets/ca/facfoa/crawler.py
+++ b/datasets/ca/facfoa/crawler.py
@@ -8,7 +8,7 @@ from zavod import helpers as h
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             proxy = context.make("Person")
             name = row.pop("name").strip()

--- a/datasets/ca/named_research_orgs/crawler.py
+++ b/datasets/ca/named_research_orgs/crawler.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, Iterator
+from typing import Any
+from collections.abc import Iterator
 
 from zavod.context import Context
 from zavod import helpers as h

--- a/datasets/ca/sema_sanctions_news/crawler.py
+++ b/datasets/ca/sema_sanctions_news/crawler.py
@@ -1,6 +1,5 @@
 from itertools import chain
 from lxml.etree import _Element
-from typing import Dict
 
 from nomenklatura.resolver import Linker
 
@@ -13,7 +12,7 @@ MAX_AGE_DAYS = 15
 
 
 def crawl_entity_notice(
-    context: Context, row: Dict[str, _Element], row_index: int
+    context: Context, row: dict[str, _Element], row_index: int
 ) -> None:
     str_row = h.cells_to_str(row)
     listing_date = str_row.pop("date")
@@ -97,7 +96,7 @@ def crawl_entity_notice(
 
 
 def crawl_vessel(
-    context: Context, row: Dict[str, _Element], linker: Linker[Entity]
+    context: Context, row: dict[str, _Element], linker: Linker[Entity]
 ) -> None:
     str_row = h.cells_to_str(row)
     imo_number = str_row.pop("ship_imo_number")

--- a/datasets/ch/finma/crawler.py
+++ b/datasets/ch/finma/crawler.py
@@ -24,7 +24,7 @@ def crawl(context: Context, data: dict[str, Any]) -> None:
         except Exception as exc:
             if "404" in str(exc):
                 continue
-            context.log.warn("Cannot fetch item: %s" % url)
+            context.log.warn(f"Cannot fetch item: {url}")
             continue
         for row in html.findall('.//div[@class="l-main"]//table//tr'):
             header = row.findtext("./th")
@@ -47,7 +47,7 @@ def crawl(context: Context, data: dict[str, Any]) -> None:
             elif header in ("Commercial register"):
                 continue
             else:
-                context.log.warn("Unknown header: %s" % header, value=value, url=url)
+                context.log.warn(f"Unknown header: {header}", value=value, url=url)
 
         context.emit(entity)
 

--- a/datasets/ch/seco_sanctions/crawler.py
+++ b/datasets/ch/seco_sanctions/crawler.py
@@ -10,7 +10,7 @@
 #   or include_in_notes is true so that the unextracted information is captured in notes.
 
 from itertools import product
-from typing import Literal, Optional
+from typing import Literal
 
 from followthemoney.types import registry
 from followthemoney.util import join_text
@@ -27,7 +27,7 @@ from zavod import Context, Entity
 from zavod import helpers as h
 
 # TODO: sanctions-program full parse
-MayStr = Optional[str]
+MayStr = str | None
 
 SKIP_OLD = {"41406"}
 NAME_QUALITY_WEAK: dict[MayStr, bool] = {"good": False, "low": True}

--- a/datasets/ch/seco_sanctions/crawler.py
+++ b/datasets/ch/seco_sanctions/crawler.py
@@ -10,7 +10,7 @@
 #   or include_in_notes is true so that the unextracted information is captured in notes.
 
 from itertools import product
-from typing import Dict, List, Literal, Optional, Tuple
+from typing import Literal, Optional
 
 from followthemoney.types import registry
 from followthemoney.util import join_text
@@ -30,13 +30,13 @@ from zavod import helpers as h
 MayStr = Optional[str]
 
 SKIP_OLD = {"41406"}
-NAME_QUALITY_WEAK: Dict[MayStr, bool] = {"good": False, "low": True}
-NAME_TYPE: Dict[MayStr, str] = {
+NAME_QUALITY_WEAK: dict[MayStr, bool] = {"good": False, "low": True}
+NAME_TYPE: dict[MayStr, str] = {
     "primary-name": "name",
     "alias": "alias",
     "formerly-known-as": "previousName",
 }
-NAME_PARTS: Dict[MayStr, MayStr] = {
+NAME_PARTS: dict[MayStr, MayStr] = {
     "title": "title",
     "given-name": "firstName",
     "further-given-name": "firstName",
@@ -87,13 +87,13 @@ class RelatedEntity(BaseModel):
     # (asset/owner props) right is more important than other relationships
     # and adds complexity.
     relationship_schema: Literal["Family", "UnknownLink"]
-    related_entity_name: List[str]
-    relationship: Optional[str] = None
+    related_entity_name: list[str]
+    relationship: str | None = None
 
 
 class OtherInfo(BaseModel):
-    simple_values: List[SimpleValue] = []
-    related_entities: List[RelatedEntity] = []
+    simple_values: list[SimpleValue] = []
+    related_entities: list[RelatedEntity] = []
     include_in_notes: bool = Field(
         description="If True, the original value will be included in notes.",
         default=False,
@@ -246,7 +246,7 @@ def parse_name(context: Context, entity: Entity, node: Element) -> None:
         name_prop = "weakAlias"
 
     max_order: int = 0
-    parts: List[Tuple[str, MayStr, MayStr, int, str]] = []
+    parts: list[tuple[str, MayStr, MayStr, int, str]] = []
     for part_node in node.findall("./name-part"):
         part_type = part_node.get("name-part-type")
         order_str = part_node.get("order")
@@ -265,7 +265,7 @@ def parse_name(context: Context, entity: Entity, node: Element) -> None:
                 continue
             parts.append((part_type, lang, script, order, spelling.text))
 
-    ordered: Dict[Tuple[MayStr, MayStr], Dict[int, List[MayStr]]] = {}
+    ordered: dict[tuple[MayStr, MayStr], dict[int, list[MayStr]]] = {}
     for part_type, lang, script, order, value in parts:
         # if part_type in ("suffix", "title"):
         #     print("XXX", part_type, value)
@@ -293,7 +293,7 @@ def parse_name(context: Context, entity: Entity, node: Element) -> None:
             entity.add(part_prop, value, lang=lang, quiet=True)
 
     for (lang, script), ords in ordered.items():
-        whole_parts: List[List[MayStr]] = []
+        whole_parts: list[list[MayStr]] = []
         for order in range(1, max_order + 1):
             values = ords.get(order, ordered[(None, None)][order])
             whole_parts.append(values)
@@ -364,7 +364,7 @@ def parse_identity(
 
 def make_related_entities(
     context: Context, entity: Entity, relationship: RelatedEntity
-) -> List[Entity]:
+) -> list[Entity]:
     other = context.make("LegalEntity")
     other.id = context.make_id(*relationship.related_entity_name)
     other.add("name", relationship.related_entity_name)
@@ -542,7 +542,7 @@ def parse_entry(
     foreign_id = target.findtext("./foreign-identifier")
     sanction.add("unscId", foreign_id)
 
-    justifications: List[Tuple[str, str]] = []
+    justifications: list[tuple[str, str]] = []
     for justification in node.findall("./justification"):
         just_ssid = justification.get("ssid")
         if just_ssid is not None and justification.text is not None:
@@ -599,7 +599,7 @@ def crawl(context: Context) -> None:
     #     context.data_time = datetime.strptime(date, "%Y-%m-%d")
 
     # TODO(Leon Handreke): Add a lookup to see if a new sanctions program shows up that we don't have in the database
-    programs: Dict[str, MayStr] = {}
+    programs: dict[str, MayStr] = {}
     for sanc in doc.findall(".//sanctions-program"):
         sanc_set = sanc.find("./sanctions-set")
         if sanc_set is None:

--- a/datasets/cl/info_probidad/crawler.py
+++ b/datasets/cl/info_probidad/crawler.py
@@ -164,7 +164,7 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.dataset.data.url)
     json_path = dataset_data_path(context.dataset.name) / "source.json"
 
-    with open(path, "r") as fh:
+    with open(path) as fh:
         html = fh.read()
     match = REGEX_DATOS.search(html)
     assert match is not None, "Could not find `var datos = ...` in source HTML"

--- a/datasets/cn/peoples_congress_wikipedia/crawler.py
+++ b/datasets/cn/peoples_congress_wikipedia/crawler.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, Generator, cast
+from typing import cast
+from collections.abc import Generator
 from normality import squash_spaces
 from lxml.html import HtmlElement
 import re
@@ -196,7 +197,7 @@ def expand_rowspan_cells(
 
 def parse_table(
     context: Context, table: HtmlElement
-) -> Generator[Dict[str, HtmlElement], None, None]:
+) -> Generator[dict[str, HtmlElement], None, None]:
     headers = None
     rowspans: dict[int, PendingRowspan] = {}
     for row in table.findall(".//tr"):

--- a/datasets/cn/sanctions/crawler.py
+++ b/datasets/cn/sanctions/crawler.py
@@ -4,7 +4,8 @@ import shutil
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any, Mapping, cast
+from typing import Any, cast
+from collections.abc import Mapping
 from urllib.parse import urljoin, urlparse
 
 import requests

--- a/datasets/co/funcion_publica/crawler.py
+++ b/datasets/co/funcion_publica/crawler.py
@@ -229,7 +229,7 @@ def crawl(context: Context) -> None:
     seen: set[str | None] = set()
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             seen.add(crawl_sheet_row(context, row))
 

--- a/datasets/co/join_dots/crawler.py
+++ b/datasets/co/join_dots/crawler.py
@@ -129,13 +129,13 @@ def crawl(context: Context) -> None:
     peps: dict[str, Entity] = {}
     dupes = set()
 
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             name_slug, entity = crawl_row(context, row)
             if name_slug in peps:
                 context.log.info("Dropping name with duplicate entry", name=name_slug)
                 dupes.add(name_slug)
-                peps.pop((name_slug))
+                peps.pop(name_slug)
             else:
                 if name_slug not in dupes:
                     peps[name_slug] = entity

--- a/datasets/cr/legislature/crawler.py
+++ b/datasets/cr/legislature/crawler.py
@@ -49,7 +49,7 @@ def latest_report_url(context: Context) -> str:
             latest_key = key
             latest_path = entry["ServerRelativeUrl"]
     if latest_path is None:
-        raise ValueError("No monthly salary report found in %s" % SALARY_FOLDER)
+        raise ValueError(f"No monthly salary report found in {SALARY_FOLDER}")
     # ServerRelativeUrl contains spaces and accented characters; percent-encode the path.
     return SITE + quote(latest_path)
 
@@ -69,7 +69,7 @@ def crawl_deputy(
         return
     # Every real row should be a deputy; fail loudly if the role column is unexpected.
     if clase not in ("Diputado", "Diputada"):
-        raise ValueError("Unexpected role %r for %r" % (clase, name))
+        raise ValueError(f"Unexpected role {clase!r} for {name!r}")
 
     person = context.make("Person")
     person.id = context.make_id("cr-diputado", name)

--- a/datasets/cy/companies/crawler.py
+++ b/datasets/cy/companies/crawler.py
@@ -150,7 +150,7 @@ def crawl(context: Context) -> None:
 
     office_path = get_path(files, "registered_office_")
     addresses = load_addresses(iter_rows(office_path))
-    context.log.info("Loaded %d addresses" % len(addresses))
+    context.log.info(f"Loaded {len(addresses)} addresses")
 
     org_path = get_path(files, "organisations_")
     parse_organisations(context, iter_rows(org_path), addresses)

--- a/datasets/cy/companies/crawler.py
+++ b/datasets/cy/companies/crawler.py
@@ -1,6 +1,6 @@
 import csv
 from pathlib import Path
-from typing import Dict, Generator, Iterable, Optional
+from collections.abc import Generator, Iterable
 
 from followthemoney.util import join_text
 from normality.cleaning import remove_unsafe_chars, squash_spaces
@@ -11,7 +11,7 @@ from zavod import helpers as h
 TYPES = {"C": "HE", "P": "S", "O": "AE", "N": "BN", "B": "B"}
 
 
-def company_id(org_type: str, reg_nr: Optional[str]) -> Optional[str]:
+def company_id(org_type: str, reg_nr: str | None) -> str | None:
     if reg_nr is None:
         return None
     org_type_oc = TYPES.get(org_type)
@@ -20,8 +20,8 @@ def company_id(org_type: str, reg_nr: Optional[str]) -> Optional[str]:
     return f"oc-companies-cy-{org_type_oc}{reg_nr}".lower()
 
 
-def iter_rows(path: Path) -> Generator[Dict[str, str], None, None]:
-    with open(path, "r") as fh:
+def iter_rows(path: Path) -> Generator[dict[str, str], None, None]:
+    with open(path) as fh:
         fh.read(1)  # bom
         for row in csv.DictReader(fh):
             data = {}
@@ -33,7 +33,7 @@ def iter_rows(path: Path) -> Generator[Dict[str, str], None, None]:
 
 
 def parse_organisations(
-    context: Context, rows: Iterable[Dict[str, str]], addresses: Dict[str, str]
+    context: Context, rows: Iterable[dict[str, str]], addresses: dict[str, str]
 ) -> None:
     for row in rows:
         org_type = row.pop("ORGANISATION_TYPE_CODE", None)
@@ -78,7 +78,7 @@ def parse_organisations(
         context.audit_data(row, ignore=["NAME_STATUS_CODE", "NAME_STATUS"])
 
 
-def parse_officials(context: Context, rows: Iterable[Dict[str, str]]) -> None:
+def parse_officials(context: Context, rows: Iterable[dict[str, str]]) -> None:
     org_types = list(TYPES.keys())
     for row in rows:
         org_type = row.pop("ORGANISATION_TYPE_CODE", None)
@@ -110,8 +110,8 @@ def parse_officials(context: Context, rows: Iterable[Dict[str, str]]) -> None:
         context.emit(link)
 
 
-def load_addresses(rows: Iterable[Dict[str, str]]) -> Dict[str, str]:
-    addresses: Dict[str, str] = {}
+def load_addresses(rows: Iterable[dict[str, str]]) -> dict[str, str]:
+    addresses: dict[str, str] = {}
     for row in rows:
         seq_no = row.pop("ADDRESS_SEQ_NO")
         if seq_no is None:
@@ -129,7 +129,7 @@ def load_addresses(rows: Iterable[Dict[str, str]]) -> Dict[str, str]:
     return addresses
 
 
-def get_path(file_paths: Dict[str, Path], prefix: str) -> Path:
+def get_path(file_paths: dict[str, Path], prefix: str) -> Path:
     matched_files = [
         path for name, path in file_paths.items() if name.startswith(prefix)
     ]
@@ -141,7 +141,7 @@ def crawl(context: Context) -> None:
     headers = {"Accept": "application/json"}
     meta = context.fetch_json(context.data_url, headers=headers)
 
-    files: Dict[str, Path] = {}
+    files: dict[str, Path] = {}
     for dist in meta["dcat:Distribution"]:
         dist_url = dist["dcat:downloadURL"]["@rdf:resource"]
         file_name = dist_url.rsplit("/")[-1]

--- a/datasets/cz/business_register/crawler.py
+++ b/datasets/cz/business_register/crawler.py
@@ -1,6 +1,6 @@
 import tarfile
 from normality import slugify
-from typing import Optional, IO
+from typing import IO
 
 from followthemoney.util import make_entity_id
 from lxml import etree
@@ -11,22 +11,22 @@ from zavod.util import ElementOrTree
 
 
 def company_id(
-    context: Context, reg_nr: Optional[str], name: Optional[str] = None
-) -> Optional[str]:
+    context: Context, reg_nr: str | None, name: str | None = None
+) -> str | None:
     if reg_nr:
         return f"oc-companies-cz-{reg_nr}"
     return context.make_slug("company", name)
 
 
 def person_id(
-    context: Context, name: str, address: Optional[str], company_id: str
-) -> Optional[str]:
+    context: Context, name: str, address: str | None, company_id: str
+) -> str | None:
     if slugify(address) is not None:
         return context.make_slug("person", name, make_entity_id(address))
     return context.make_slug("person", name, make_entity_id(company_id))
 
 
-def make_address(tree: Optional[ElementOrTree] = None) -> Optional[str]:
+def make_address(tree: ElementOrTree | None = None) -> str | None:
     if tree is None:
         return None
 
@@ -53,7 +53,7 @@ def make_address(tree: Optional[ElementOrTree] = None) -> Optional[str]:
     return h.format_address(country_code="cz", **data)
 
 
-def make_company(context: Context, tree: ElementOrTree) -> Optional[Entity]:
+def make_company(context: Context, tree: ElementOrTree) -> Entity | None:
     tree = h.remove_namespace(tree)
     name = tree.findtext(".//ObchodniFirma")
     proxy = context.make("Company")
@@ -73,7 +73,7 @@ def parse_xml(context: Context, reader: IO[bytes], file_name: str) -> None:
     try:
         tree = etree.parse(reader)
     except etree.XMLSyntaxError:
-        context.log.warning("Invalid XML file: %s" % file_name)
+        context.log.warning(f"Invalid XML file: {file_name}")
         return
     company = make_company(context, tree)
     if company is None or company.id is None:
@@ -117,7 +117,7 @@ def crawl(context: Context) -> None:
             idx += 1
             res = f.extractfile(archive_member)
             if res is None:
-                context.log.warn("Cannot read: %s" % archive_member.name)
+                context.log.warn(f"Cannot read: {archive_member.name}")
                 continue
             with res:
                 parse_xml(context, res, archive_member.name)

--- a/datasets/cz/business_register/crawler.py
+++ b/datasets/cz/business_register/crawler.py
@@ -123,5 +123,5 @@ def crawl(context: Context) -> None:
                 parse_xml(context, res, archive_member.name)
             archive_member = f.next()
             if idx and idx % 10_000 == 0:
-                context.log.info("Parse item %d ..." % idx)
-    context.log.info("Parsed %d items." % idx, fp=data_path.name)
+                context.log.info(f"Parse item {idx} ...")
+    context.log.info(f"Parsed {idx} items.", fp=data_path.name)

--- a/datasets/cz/national_sanctions/crawler.py
+++ b/datasets/cz/national_sanctions/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict
 from openpyxl import load_workbook
 from rigour.mime.types import XLSX
 from rigour.names import pick_name
@@ -10,7 +9,7 @@ from zavod import Context, helpers as h
 REGEX_LAST_NAME = re.compile(r"^[\w\?]+( ?/\s*[\w\?]+)*$")
 
 
-def crawl_item(context: Context, row: Dict[str, str | None]) -> None:
+def crawl_item(context: Context, row: dict[str, str | None]) -> None:
     # Jméno fyzické osoby
     # -> First name of the natural person
 

--- a/datasets/cz/pep_declarations/crawler.py
+++ b/datasets/cz/pep_declarations/crawler.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from requests.exceptions import HTTPError
 
@@ -37,7 +37,7 @@ IGNORE = [
 ]
 
 
-def crawl_person(context: Context, item: Dict[str, Any]) -> None:
+def crawl_person(context: Context, item: dict[str, Any]) -> None:
     person_id = item.pop("id")
     first_name = item.pop("firstName")
     last_name = item.pop("lastName")

--- a/datasets/de/abgeordnetenwatch/crawler.py
+++ b/datasets/de/abgeordnetenwatch/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from rigour.ids.wikidata import is_qid
 from zavod.stateful.positions import categorise
@@ -8,8 +8,8 @@ from zavod import helpers as h
 
 
 def make_position(
-    context: Context, parliamentary_period: Dict[str, Any]
-) -> Optional[Entity]:
+    context: Context, parliamentary_period: dict[str, Any]
+) -> Entity | None:
     parliament_detail = context.fetch_json(
         parliamentary_period["parliament"]["api_url"],
         cache_days=1,
@@ -31,7 +31,7 @@ def make_position(
     )
 
 
-def crawl_mandate(context: Context, mandate: Dict[str, Any]) -> None:
+def crawl_mandate(context: Context, mandate: dict[str, Any]) -> None:
     politician = mandate.pop("politician")
     period = mandate.pop("parliament_period")
     period_detail = context.fetch_json(period["api_url"], cache_days=1).pop("data")

--- a/datasets/de/bka_wanted/crawler.py
+++ b/datasets/de/bka_wanted/crawler.py
@@ -1,4 +1,4 @@
-from typing import List, cast
+from typing import cast
 
 from lxml import html
 from lxml.etree import _Element
@@ -8,7 +8,7 @@ from zavod import Context
 from zavod import helpers as h
 
 
-def get_element_text(doc: _Element, xpath_value: str, join_str: str = " ") -> List[str]:
+def get_element_text(doc: _Element, xpath_value: str, join_str: str = " ") -> list[str]:
     """Extract text from from an xpath
 
     Args:

--- a/datasets/de/bundesrat/crawler.py
+++ b/datasets/de/bundesrat/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 from datapatch import Lookup
 from lxml.etree import _Element
@@ -18,7 +17,7 @@ NO_DETAILS_LIST = [
 ]
 
 
-def extract_dob(context: Context, lookup: Lookup, text: str) -> Optional[str]:
+def extract_dob(context: Context, lookup: Lookup, text: str) -> str | None:
     """Try to extract a date from text using regex, fallback to context lookup, log if missing."""
     match = DOB_REGEX.search(text)
     if match:
@@ -35,7 +34,7 @@ def extract_dob(context: Context, lookup: Lookup, text: str) -> Optional[str]:
 
 def extract_position_and_memberships(
     context: Context, details: _Element, url: str
-) -> tuple[Optional[str], list[str]]:
+) -> tuple[str | None, list[str]]:
     position_el = details.find(".//h2")
     memberships_els = details.findall(".//ul/li")
     if position_el is None and not memberships_els:

--- a/datasets/de/offeneregister/parse.py
+++ b/datasets/de/offeneregister/parse.py
@@ -185,6 +185,6 @@ def crawl(context: Context) -> None:
             parse_record(context, record)
             idx += 1
             if idx and idx % 10_000 == 0:
-                context.log.info("Parse record %d ..." % idx)
+                context.log.info(f"Parse record {idx} ...")
         if idx:
-            context.log.info("Parsed %d records." % (idx + 1), fp=data_fp.name)
+            context.log.info(f"Parsed {idx + 1} records.", fp=data_fp.name)

--- a/datasets/de/offeneregister/parse.py
+++ b/datasets/de/offeneregister/parse.py
@@ -1,7 +1,7 @@
 import bz2
 import re
 from functools import lru_cache
-from typing import Any, Optional
+from typing import Any
 
 import orjson
 from followthemoney.util import join_text, make_entity_id
@@ -73,7 +73,7 @@ def make_rel(
     company: Entity,
     officer: Entity,
     data: dict[str, Any],
-    summary: Optional[str] = None,
+    summary: str | None = None,
 ) -> None:
     type_ = data.pop("position")
     schema = REL_SCHEMS[type_]
@@ -131,7 +131,7 @@ def make_officer_and_rel(
         proxy.id = context.make_slug("officer", make_entity_id(company.id, name))
         proxy.add("name", name)
     else:
-        context.log.warning("Unknown type: %s" % type_)
+        context.log.warning(f"Unknown type: {type_}")
         proxy = context.make("LegalEntity")
         proxy.id = context.make_slug("officer", make_entity_id(company.id, name))
         proxy.add("name", name)

--- a/datasets/ee/ariregister/crawler.py
+++ b/datasets/ee/ariregister/crawler.py
@@ -1,12 +1,13 @@
 import ijson  # type: ignore
 import zipfile
-from typing import Any, Generator, Optional, Tuple, Dict, TypeVar, Union
+from typing import Any, TypeVar
+from collections.abc import Generator
 from followthemoney.util import make_entity_id
 
 from zavod import Context, Entity
 from zavod import helpers as h
 
-Item = Dict[str, Any]
+Item = dict[str, Any]
 Default = TypeVar("Default")
 
 SOURCES = {
@@ -28,8 +29,8 @@ NULL_NAME = {"-", ".", "#", "##"}
 
 
 def get_value(
-    data: Item, keys: Tuple[str, ...], default: Optional[Default] = None
-) -> Union[Default, Any]:
+    data: Item, keys: tuple[str, ...], default: Default | None = None
+) -> Default | Any:
     for key in keys:
         val = data.pop(key, None)
         if val is not None:
@@ -37,10 +38,8 @@ def get_value(
     return default
 
 
-def get_address(data: Item) -> Optional[str]:
-    value: Optional[str] = data.pop(
-        "aadress_ads__ads_normaliseeritud_taisaadress", None
-    )
+def get_address(data: Item) -> str | None:
+    value: str | None = data.pop("aadress_ads__ads_normaliseeritud_taisaadress", None)
     if value is not None:
         return value
     parts = []
@@ -53,7 +52,7 @@ def get_address(data: Item) -> Optional[str]:
     return None
 
 
-def make_proxy(context: Context, row: Item, schema: Optional[str] = None) -> Entity:
+def make_proxy(context: Context, row: Item, schema: str | None = None) -> Entity:
     if schema is None:
         schema = "LegalEntity"
     proxy = context.make(schema)
@@ -115,7 +114,7 @@ def make_rel(
     officer: Entity,
     schema: str,
     data: Item,
-    role: Optional[str] = None,
+    role: str | None = None,
 ) -> Entity:
     rel = context.make(schema)
     rel.id = context.make_id(rel.schema.name, company.id, officer.id, role)

--- a/datasets/ee/ariregister/crawler.py
+++ b/datasets/ee/ariregister/crawler.py
@@ -215,8 +215,8 @@ def parse_json(context: Context, source: str) -> Generator[Item, None, None]:
                     for idx, item in enumerate(items):
                         yield item
                         if idx and idx % 10_000 == 0:
-                            context.log.info("Parse ijson item %d ..." % idx)
-    context.log.info("Parsed %d ijson items." % (idx + 1), fp=data_path.name)
+                            context.log.info(f"Parse ijson item {idx} ...")
+    context.log.info(f"Parsed {idx + 1} ijson items.", fp=data_path.name)
 
 
 def crawl(context: Context) -> None:

--- a/datasets/eg/terrorists/crawler.py
+++ b/datasets/eg/terrorists/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from normality import collapse_spaces
 from openpyxl import load_workbook
@@ -30,7 +30,7 @@ def arabic_to_latin(arabic_date: str) -> str:
     return arabic_date.translate(transtable)
 
 
-def clean_date(date_str: str) -> List[str]:
+def clean_date(date_str: str) -> list[str]:
     if not date_str:
         return []
     latin_date = arabic_to_latin(date_str)

--- a/datasets/es/cnp_wanted/crawler.py
+++ b/datasets/es/cnp_wanted/crawler.py
@@ -1,18 +1,18 @@
 from lxml import html
 from normality import slugify
-from typing import Any, Dict, List
+from typing import Any
 from urllib.parse import urljoin
 
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 # The site redirects to a cookies-consent page until this cookie is set.
-CONSENT_COOKIES: List[Dict[str, Any]] = [
+CONSENT_COOKIES: list[dict[str, Any]] = [
     {"name": "cookiesPoliciaNacional", "value": "aceptada", "domain": ".policia.es"},
 ]
 
 
-def crawl_item(context: Context, row: Dict[str, str]) -> None:
+def crawl_item(context: Context, row: dict[str, str]) -> None:
     # Create the entity based on the schema
     first_name = row.pop("first_name")
     last_name = row.pop("last_name")
@@ -59,7 +59,7 @@ def crawl_item(context: Context, row: Dict[str, str]) -> None:
 
 def parse_link_element(
     link_element: html.HtmlElement, context: Context
-) -> Dict[str, str]:
+) -> dict[str, str]:
     # Extract link directly
     link = urljoin(context.data_url, link_element.attrib["href"])
 

--- a/datasets/es/mayors_councillors/crawler.py
+++ b/datasets/es/mayors_councillors/crawler.py
@@ -1,6 +1,5 @@
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
-from typing import Dict, Optional
 
 from zavod import Context, helpers as h
 from zavod.stateful.positions import categorise
@@ -25,9 +24,9 @@ COUNCILLOR_TOPICS = ["gov.muni", "gov.legislative"]
 
 def crawl_item(
     context: Context,
-    row: Dict[str, str | None],
+    row: dict[str, str | None],
     period_start: str,
-    period_end: Optional[str],
+    period_end: str | None,
 ) -> None:
     start_date = row.pop("start_date")
     end_date = row.pop("end_date", None)
@@ -116,7 +115,7 @@ def process_excel(
     title: str,
     skiprows: int,
     period_start: str,
-    period_end: Optional[str],
+    period_end: str | None,
 ) -> None:
     path = context.fetch_resource(filename, url)
     context.export_resource(path, XLSX, title=title)

--- a/datasets/es/parliament/crawler.py
+++ b/datasets/es/parliament/crawler.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 
 from zavod.stateful.positions import categorise
@@ -31,12 +30,12 @@ def emit_pep_entities(
     person: Entity,
     position_name: str,
     lang: str,
-    start_date: Optional[str],
-    end_date: Optional[str],
-    constituency: Optional[str] = None,
-    political_group: Optional[str] = None,
+    start_date: str | None,
+    end_date: str | None,
+    constituency: str | None = None,
+    political_group: str | None = None,
     is_pep: bool,
-    wikidata_id: Optional[str] = None,
+    wikidata_id: str | None = None,
     translate_name: bool = False,
 ) -> bool:
     person.add("position", position_name)

--- a/datasets/eu/cor_members/crawler.py
+++ b/datasets/eu/cor_members/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from zavod import Context
 from zavod import helpers as h
@@ -12,7 +12,7 @@ STATUS = {
 }
 
 
-def crawl_person(context: Context, item: Dict[str, Any]) -> None:
+def crawl_person(context: Context, item: dict[str, Any]) -> None:
     person_id = item.pop("id")
     person = context.make("Person")
     person.id = context.make_slug(person_id)
@@ -24,10 +24,10 @@ def crawl_person(context: Context, item: Dict[str, Any]) -> None:
         last_name=item.pop("lastName"),
     )
 
-    country: Dict[str, str] = item.pop("country", {})
+    country: dict[str, str] = item.pop("country", {})
     person.add("citizenship", country.pop("value"))
 
-    function: Dict[str, str] = item.pop("memberFunction")
+    function: dict[str, str] = item.pop("memberFunction")
     function_name = function.pop("value")
     position_name = f"{function_name} of the European Committee of the Regions"
     position = h.make_position(

--- a/datasets/eu/esma_firds/crawler.py
+++ b/datasets/eu/esma_firds/crawler.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Iterator
+from collections.abc import Iterator
 from zavod import Context
 from zavod.shed.firds import parse_xml_file, latest_full_set
 
@@ -37,6 +37,6 @@ def get_recent_full_dump_urls(context: Context) -> Iterator[tuple[str, str]]:
 
 def crawl(context: Context) -> None:
     for file_name, url in latest_full_set(context, get_recent_full_dump_urls(context)):
-        context.log.info("Fetching %s" % file_name, url=url)
+        context.log.info(f"Fetching {file_name}", url=url)
         path = context.fetch_resource(file_name, url)
         parse_xml_file(context, path)

--- a/datasets/eu/esma_sanctions/crawler.py
+++ b/datasets/eu/esma_sanctions/crawler.py
@@ -1,5 +1,6 @@
 import re
-from typing import Optional, Dict, Any, Generator
+from typing import Any
+from collections.abc import Generator
 from rigour.ids import LEI
 from lxml import html
 
@@ -8,8 +9,8 @@ from zavod import Context, helpers as h
 
 def get_json(
     context: Context, batch_size: int
-) -> Generator[Dict[str, Any], None, None]:
-    params: Dict[str, Any] = {
+) -> Generator[dict[str, Any], None, None]:
+    params: dict[str, Any] = {
         "q": "*",
         "rows": batch_size,
         "start": 0,
@@ -18,13 +19,12 @@ def get_json(
     cont = True
     while cont:
         resp = context.fetch_json(context.data_url, params=params)
-        for doc in resp["response"]["docs"]:
-            yield doc
+        yield from resp["response"]["docs"]
         params["start"] += batch_size
         cont = resp["response"]["numFound"] >= params["start"]
 
 
-def parse_name(name_markup: str) -> Optional[str]:
+def parse_name(name_markup: str) -> str | None:
     """
     Remove markup from name if present.
     """

--- a/datasets/eu/esma_saris/crawler.py
+++ b/datasets/eu/esma_saris/crawler.py
@@ -36,7 +36,7 @@ def fetch_source(context: Context) -> Path:
         # Set the session cookie used by the export endpoint.
         context.http.post(SEARCH_URL, json=data)
         source_file = context.fetch_resource("source.csv", context.data_url)
-        with open(source_file, "r") as f:
+        with open(source_file) as f:
             header = f.readline()
         if "instrumentIdentifier" in header:
             return source_file
@@ -58,7 +58,7 @@ def fetch_source(context: Context) -> Path:
 
 def crawl(context: Context) -> None:
     source_file = fetch_source(context)
-    with open(source_file, "r") as f:
+    with open(source_file) as f:
         reader = csv.DictReader(f)
         for row in reader:
             isin = row.pop("instrumentIdentifier")

--- a/datasets/eu/journal_sanctions/crawler.py
+++ b/datasets/eu/journal_sanctions/crawler.py
@@ -430,7 +430,7 @@ def crawl(context: Context) -> None:
     # Current journal rows that are not yet present in the canonical EU feeds.
     path = context.fetch_resource("unconsolidated.csv", context.data_url)
     linker = get_dataset_linker(context.dataset)
-    with open(path, "rt") as infh:
+    with open(path) as infh:
         for idx, row in enumerate(csv.DictReader(infh)):
             crawl_unconsolidated_row(context, linker, idx + 2, row)
 
@@ -438,7 +438,7 @@ def crawl(context: Context) -> None:
     context_url = context.data_url.replace("gid=0", "gid=1314630186")
     assert context_url != context.data_url
     path = context.fetch_resource("context.csv", context_url)
-    with open(path, "rt") as infh:
+    with open(path) as infh:
         for idx, row in enumerate(csv.DictReader(infh)):
             crawl_context_row(context, idx + 2, row)
 

--- a/datasets/eu/journal_sanctions/extract/extract.py
+++ b/datasets/eu/journal_sanctions/extract/extract.py
@@ -24,7 +24,6 @@ reported in the run summary, so gaps are visible rather than silently dropped.
 import csv
 import re
 from pathlib import Path
-from typing import Optional
 
 import click
 import requests
@@ -197,7 +196,7 @@ def fetch_from_cellar(celex: str) -> HtmlElement:
     return html.fromstring(response.content)
 
 
-def categorized_tables(doc: HtmlElement) -> list[tuple[Optional[str], HtmlElement]]:
+def categorized_tables(doc: HtmlElement) -> list[tuple[str | None, HtmlElement]]:
     """Pair each annex table with the "Persons"/"Entities" heading above it.
 
     The headings are plain spans preceding their table in document order, so we
@@ -205,8 +204,8 @@ def categorized_tables(doc: HtmlElement) -> list[tuple[Optional[str], HtmlElemen
     heading above it keeps None and is classified later from its content.
     """
     tables = set(doc.xpath("//table[contains(@class, 'oj-table')]"))
-    current: Optional[str] = None
-    result: list[tuple[Optional[str], HtmlElement]] = []
+    current: str | None = None
+    result: list[tuple[str | None, HtmlElement]] = []
     for element in doc.iter():
         text = (element.text or "").strip()
         if text in ("Persons", "Entities"):

--- a/datasets/eu/journal_sanctions/extract_tables.py
+++ b/datasets/eu/journal_sanctions/extract_tables.py
@@ -13,7 +13,6 @@
 
 import csv
 from pathlib import Path
-from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
 import click
@@ -49,7 +48,7 @@ def extract_identifying(identifying_information: str) -> dict[str, str]:
 @click.command()
 @click.option("--url", type=str)
 @click.option("--path", type=InPath)
-def extract_tables(url: Optional[str], path: Optional[Path]) -> None:
+def extract_tables(url: str | None, path: Path | None) -> None:
     """
     Args:
         url: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=...
@@ -62,7 +61,7 @@ def extract_tables(url: Optional[str], path: Optional[Path]) -> None:
         query_params = parse_qs(urlparse(url).query)
         doc_reference = query_params.get("uri")[0].replace(":", "_")
     else:
-        with open(path, "r") as f:
+        with open(path) as f:
             html_content = f.read()
         doc_reference = path.stem.replace(":", "_").replace(" ", "_")
 

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -25,7 +25,7 @@ def crawl_node(
     mep_id = node.findtext(".//id")
     person = context.make("Person")
     person.id = context.make_slug(mep_id)
-    url = "http://www.europarl.europa.eu/meps/en/%s" % mep_id
+    url = f"http://www.europarl.europa.eu/meps/en/{mep_id}"
     person.add("sourceUrl", url)
     name = node.findtext(".//fullName")
     assert name is not None

--- a/datasets/eu/public_functions/crawler.py
+++ b/datasets/eu/public_functions/crawler.py
@@ -25,6 +25,6 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
 
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/fi/eduskunta/crawler.py
+++ b/datasets/fi/eduskunta/crawler.py
@@ -60,7 +60,7 @@ def crawl(context: Context) -> None:
     _, _, _, path = zyte_api.fetch_resource(
         context, "data.json", f"{context.data_url}seating/"
     )
-    with open(path, "r") as fh:
+    with open(path) as fh:
         data = json.load(fh)
     for item in data:
         pep_id = item.pop("hetekaId")
@@ -69,7 +69,7 @@ def crawl(context: Context) -> None:
             f"item_{pep_id}.json",
             f"{context.data_url}memberofparliament/{pep_id}/fi",
         )
-        with open(raw_path, "r") as fh:
+        with open(raw_path) as fh:
             raw_data = json.load(fh)
         translated_data: dict[str, Any] = translate_keys(context, raw_data)
         pep_data: dict[str, Any] = translated_data.get("jsonNode", {}).get("person", {})

--- a/datasets/fr/amf_regulatory_sanctions/crawler.py
+++ b/datasets/fr/amf_regulatory_sanctions/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from normality import squash_spaces
 from zavod import Context, helpers as h
@@ -40,7 +40,7 @@ prefix_anon = "(" + "|".join(PREFIXES) + r")[\. \b]+[A-Z]\b"
 comma_anon = r"(,|et) +[A-Z]\b"
 
 
-def clean_names_str(names_str: str) -> Optional[str]:
+def clean_names_str(names_str: str) -> str | None:
     names_str = re.sub(comma_prefix_anon, "", names_str)
     names_str = re.sub(prefix_anon, "", names_str)
     names_str = re.sub(comma_anon, "", names_str)
@@ -48,7 +48,7 @@ def clean_names_str(names_str: str) -> Optional[str]:
     return names_str
 
 
-def entity_id(context: Context, name: str, listing_date: Optional[str]) -> str:
+def entity_id(context: Context, name: str, listing_date: str | None) -> str:
     id_ = context.make_id(name, listing_date)
     assert id_ is not None
     return id_
@@ -59,9 +59,9 @@ def crawl_entity(
     *,
     name: str,
     reason: str,
-    listing_date: Optional[str],
+    listing_date: str | None,
     source_urls: list[str],
-    title: Optional[str],
+    title: str | None,
 ) -> None:
     """Process a legal entity entry."""
     entity = context.make("LegalEntity")
@@ -100,7 +100,7 @@ def crawl(context: Context) -> None:
         entities_res = context.lookup("entities", names_str)
         # No mapping yet
         if entities_res is None:
-            context.log.warning("No entity mapping for %r" % names_str)
+            context.log.warning(f"No entity mapping for {names_str!r}")
             continue
 
         # No entities for remaining names str

--- a/datasets/fr/amf_regulatory_sanctions/crawler.py
+++ b/datasets/fr/amf_regulatory_sanctions/crawler.py
@@ -92,8 +92,8 @@ def crawl(context: Context) -> None:
         reason = unescape(str(data_entry.get("theme")))
         infos_dict = data_entry.get("infos", {})
 
-        names_str = unescape(infos_dict.pop("text_egard", ""))
-        names_str = clean_names_str(names_str)
+        raw_names = unescape(infos_dict.pop("text_egard", ""))
+        names_str = clean_names_str(raw_names)
         if not names_str:
             continue
 

--- a/datasets/fr/assemblee/crawler.py
+++ b/datasets/fr/assemblee/crawler.py
@@ -4,7 +4,8 @@ Crawler for members of the French National Assembly.
 
 import json
 import re
-from typing import Any, Iterator
+from typing import Any
+from collections.abc import Iterator
 from zipfile import ZipFile
 
 from zavod import Context, Entity

--- a/datasets/fr/hatvp_declarations/crawler.py
+++ b/datasets/fr/hatvp_declarations/crawler.py
@@ -1,13 +1,12 @@
 import csv
 from rigour.mime.types import CSV
-from typing import Dict
 from urllib.parse import urljoin
 
 from zavod import Context, helpers as h
 from zavod.stateful.positions import categorise, OccupancyStatus
 
 
-def crawl_row(context: Context, row: Dict[str, str | None]) -> None:
+def crawl_row(context: Context, row: dict[str, str | None]) -> None:
     person = context.make("Person")
     person.id = context.make_id(row.pop("person_slug"))
     h.apply_name(
@@ -90,7 +89,7 @@ def crawl(context: Context) -> None:
     )
     path = context.fetch_resource("source.csv", url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as f:
+    with open(path) as f:
         dict_reader = csv.DictReader(f, delimiter=";")
         assert dict_reader.fieldnames is not None
         headers: dict[str, str] = {}

--- a/datasets/fr/illegal_financial_services/crawler.py
+++ b/datasets/fr/illegal_financial_services/crawler.py
@@ -39,7 +39,7 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", csv_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
 
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for record in csv.DictReader(fh, delimiter=";"):
             row_ = {slugify(k, "_"): str(v) for k, v in record.items() if v is not None}
             row = {k: v for k, v in row_.items() if k is not None}

--- a/datasets/fr/maires/crawler.py
+++ b/datasets/fr/maires/crawler.py
@@ -79,6 +79,6 @@ def crawl_row(
 def crawl(context: Context) -> None:
     """Retrieve list of mayors as CSV and emit PEP entities."""
     path = context.fetch_resource("elus-maires.csv", context.data_url)
-    with open(path, "rt", encoding="utf-8") as infh:
+    with open(path, encoding="utf-8") as infh:
         for row in csv.DictReader(infh, delimiter=";"):
             crawl_row(context, row)

--- a/datasets/fr/senat/crawler.py
+++ b/datasets/fr/senat/crawler.py
@@ -4,7 +4,8 @@ Crawler for active French senators.
 
 import csv
 from collections import defaultdict
-from typing import Optional, Iterator, NamedTuple
+from typing import NamedTuple
+from collections.abc import Iterator
 from urllib.parse import urljoin
 
 from zavod import Context, Entity
@@ -13,9 +14,9 @@ from zavod.stateful.positions import categorise
 
 
 class Mandate(NamedTuple):
-    start_date: Optional[str]
-    end_date: Optional[str]
-    election_date: Optional[str]
+    start_date: str | None
+    end_date: str | None
+    election_date: str | None
 
 
 UNUSED_FIELDS = [
@@ -157,14 +158,14 @@ def crawl(context: Context) -> None:
     # Keyed by senator matricule (senid); one senator can have multiple mandates
     # covering different terms, each with its own start/end/election dates.
     mandates_by_senid: defaultdict[str, list[Mandate]] = defaultdict(list)
-    with open(path, "rt", encoding="cp1252") as infh:
+    with open(path, encoding="cp1252") as infh:
         decomment = (spam for spam in infh if spam[0] != "%")
         for senid, mandate in crawl_mandates(context, csv.DictReader(decomment)):
             mandates_by_senid[senid].append(mandate)
 
     # Main CSV: one row per senator with biographical and status fields
     path = context.fetch_resource("senators.csv", context.data_url)
-    with open(path, "rt", encoding="cp1252") as infh:
+    with open(path, encoding="cp1252") as infh:
         decomment = (spam for spam in infh if spam[0] != "%")
         for row in csv.DictReader(decomment):
             crawl_row(context, row, mandates_by_senid)

--- a/datasets/fr/tresor/crawler.py
+++ b/datasets/fr/tresor/crawler.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, Optional
+from typing import Any
 
 from banal import ensure_list
 from datapatch import Lookup
@@ -85,7 +85,7 @@ TEXT_KEYS = {
 }
 
 
-def clean_key(key: str) -> Optional[str]:
+def clean_key(key: str) -> str | None:
     return slugify(key)
 
 
@@ -168,7 +168,7 @@ def identifier_value_is_single_value(context: Context, value: str) -> bool:
 def parse_identification(
     context: Context,
     entity: Entity,
-    value: Dict[str, str],
+    value: dict[str, str],
 ) -> None:
     """Parse the identification field and add the appropriate properties to the entity."""
     comment = value.pop("Commentaire")
@@ -238,7 +238,7 @@ def apply_prop(
     entity: Entity,
     sanction: Entity,
     field: str,
-    value: Dict[str, Any],
+    value: dict[str, Any],
 ) -> None:
     if field == "ALIAS":
         entity.add("alias", value.pop("Alias"), lang="fra")
@@ -301,7 +301,7 @@ def apply_prop(
         )
 
 
-def crawl_entity(context: Context, data: Dict[str, Any]) -> None:
+def crawl_entity(context: Context, data: dict[str, Any]) -> None:
     # context.inspect(data)
     nature = data.pop("Nature")
     reg_id = data.pop("IdRegistre")
@@ -364,7 +364,7 @@ def crawl_entity(context: Context, data: Dict[str, Any]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url, headers=HEADERS)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         data = json.load(fh)
 
     publications = data.get("Publications")

--- a/datasets/gb/coh/disqualified.py
+++ b/datasets/gb/coh/disqualified.py
@@ -2,7 +2,7 @@ import os
 import re
 import string
 from itertools import count
-from typing import Dict, Any, Optional
+from typing import Any
 from urllib.parse import urljoin
 
 from requests.exceptions import HTTPError, RetryError
@@ -26,9 +26,9 @@ SLEEP = 315
 def http_get(
     context: Context,
     url: str,
-    params: Optional[Dict[str, Any]] = None,
-    cache_days: Optional[int] = None,
-) -> Optional[Dict[str, Any]]:
+    params: dict[str, Any] | None = None,
+    cache_days: int | None = None,
+) -> dict[str, Any] | None:
     for attempt in count(1):
         try:
             return context.fetch_json(
@@ -47,13 +47,13 @@ def http_get(
                 )
                 time.sleep(SLEEP)
             else:
-                context.log.exception("Failed to fetch data: %s" % url)
+                context.log.exception(f"Failed to fetch data: {url}")
                 return None
 
 
 def build_address(
-    context: Context, full: str, address_data: dict[str, Optional[str]]
-) -> Optional[Entity]:
+    context: Context, full: str, address_data: dict[str, str | None]
+) -> Entity | None:
     address_components = {
         "street": address_data.get("address_line_1"),
         "street2": address_data.get("premises"),
@@ -92,9 +92,7 @@ def build_address(
     return h.make_address(context, **cleaned_address_components)
 
 
-def resolve_company_name_by_number(
-    context: Context, company_number: str
-) -> Optional[str]:
+def resolve_company_name_by_number(context: Context, company_number: str) -> str | None:
     """If the company_number is found on Companies House, return its name, else None."""
     search_url = f"https://find-and-update.company-information.service.gov.uk/search?q={company_number}"
     doc = context.fetch_html(search_url, cache_days=7)
@@ -108,7 +106,7 @@ def resolve_company_name_by_number(
     return None
 
 
-def crawl_item(context: Context, listing: Dict[str, Any]) -> None:
+def crawl_item(context: Context, listing: dict[str, Any]) -> None:
     links = listing.get("links", {})
     url = urljoin(API_URL, links.get("self"))
     data = http_get(context, url, cache_days=45)
@@ -237,7 +235,7 @@ def crawl(context: Context) -> None:
                 data = http_get(context, context.data_url, params=params, cache_days=1)
                 if data is None:
                     break
-                context.log.info("Search: %s" % letter, start_index=start_index)
+                context.log.info(f"Search: {letter}", start_index=start_index)
                 for item in data.pop("items", []):
                     crawl_item(context, item)
                 start_index = data["start_index"] + data["items_per_page"]

--- a/datasets/gb/coh/psc_parse.py
+++ b/datasets/gb/coh/psc_parse.py
@@ -2,7 +2,8 @@ import csv
 import json
 import re
 import yaml
-from typing import Optional, Generator, Dict, Any, cast
+from typing import Any, cast
+from collections.abc import Generator
 from zipfile import ZipFile
 from functools import lru_cache
 from io import TextIOWrapper
@@ -74,12 +75,12 @@ def fetch_psc_short_descriptions(context: Context) -> dict[str, str]:
     map is logged so new CH taxonomy additions surface in the run.
     """
     path = context.fetch_resource("psc_descriptions.yml", PSC_DESCRIPTIONS_URL)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         data = cast(dict[str, Any], yaml.safe_load(fh))
     return cast(dict[str, str], data.get("short_description", {}))
 
 
-def percentage_range(slug: str) -> Optional[str]:
+def percentage_range(slug: str) -> str | None:
     """Render the share-range encoded in a PSC slug as ``"25–50%"`` etc."""
     match = PERCENTAGE_RE.search(slug)
     if match is None:
@@ -88,7 +89,7 @@ def percentage_range(slug: str) -> Optional[str]:
 
 
 @lru_cache(maxsize=MEMO_MEDIUM)
-def parse_country(name: str, default: Optional[str] = None) -> Optional[str]:
+def parse_country(name: str, default: str | None = None) -> str | None:
     code = registry.country.clean(name)
     if code is None:
         return default
@@ -112,7 +113,7 @@ def get_base_data_url(context: Context) -> str:
     raise RuntimeError("No base data URL found!")
 
 
-def read_base_data_csv(path: PathLike) -> Generator[Dict[str, str], None, None]:
+def read_base_data_csv(path: PathLike) -> Generator[dict[str, str], None, None]:
     with ZipFile(path, "r") as zip:
         for name in zip.namelist():
             with zip.open(name, "r") as fh:
@@ -127,7 +128,7 @@ def parse_base_data(context: Context) -> None:
         raise RuntimeError("Base data zip URL not found!")
     data_path = context.fetch_resource("base_data.zip", base_data_url)
 
-    context.log.info("Loading: %s" % data_path)
+    context.log.info(f"Loading: {data_path}")
     for idx, row in enumerate(read_base_data_csv(data_path)):
         if idx > 0 and idx % 100_000 == 0:
             context.log.info("Base data: %d..." % idx)
@@ -192,7 +193,7 @@ def get_psc_data_url(context: Context) -> str:
     raise RuntimeError("No PSC data URL found!")
 
 
-def read_psc_data(path: PathLike) -> Generator[Dict[str, Any], None, None]:
+def read_psc_data(path: PathLike) -> Generator[dict[str, Any], None, None]:
     with ZipFile(path, "r") as zip:
         for name in zip.namelist():
             with zip.open(name, "r") as fh:
@@ -207,7 +208,7 @@ def parse_psc_data(context: Context) -> None:
     if psc_data_url is None:
         raise RuntimeError("PSC data zip URL not found!")
     data_path = context.fetch_resource("psc_data.zip", psc_data_url)
-    context.log.info("Loading: %s" % data_path)
+    context.log.info(f"Loading: {data_path}")
     for idx, row in enumerate(read_psc_data(data_path)):
         if idx > 0 and idx % 100_000 == 0:
             context.log.info("PSC statements: %d..." % idx)
@@ -216,7 +217,7 @@ def parse_psc_data(context: Context) -> None:
         #     return
         company_nr = row.pop("company_number", None)
         if company_nr is None:
-            context.log.warning("No company number: %r" % row)
+            context.log.warning(f"No company number: {row!r}")
             continue
         data = row.pop("data")
         data.pop("etag", None)

--- a/datasets/gb/coh/psc_parse.py
+++ b/datasets/gb/coh/psc_parse.py
@@ -131,7 +131,7 @@ def parse_base_data(context: Context) -> None:
     context.log.info(f"Loading: {data_path}")
     for idx, row in enumerate(read_base_data_csv(data_path)):
         if idx > 0 and idx % 100_000 == 0:
-            context.log.info("Base data: %d..." % idx)
+            context.log.info(f"Base data: {idx}...")
             context.flush()
         company_nr = row.pop("CompanyNumber")
         entity = context.make("Company")
@@ -211,7 +211,7 @@ def parse_psc_data(context: Context) -> None:
     context.log.info(f"Loading: {data_path}")
     for idx, row in enumerate(read_psc_data(data_path)):
         if idx > 0 and idx % 100_000 == 0:
-            context.log.info("PSC statements: %d..." % idx)
+            context.log.info(f"PSC statements: {idx}...")
             context.flush()
         # if idx > 0 and idx % 1000000 == 0:
         #     return

--- a/datasets/gb/fca_firds/crawler.py
+++ b/datasets/gb/fca_firds/crawler.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
 from datetime import datetime, timedelta
-from typing import Iterator
+from collections.abc import Iterator
 
 from zavod import Context
 from zavod.shed.firds import latest_full_set, parse_xml_file
@@ -33,6 +33,6 @@ def get_recent_full_dump_urls(context: Context) -> Iterator[tuple[str, str]]:
 
 def crawl(context: Context) -> None:
     for file_name, url in latest_full_set(context, get_recent_full_dump_urls(context)):
-        context.log.info("Fetching %s" % file_name, url=url)
+        context.log.info(f"Fetching {file_name}", url=url)
         path = context.fetch_resource(file_name, url)
         parse_xml_file(context, path)

--- a/datasets/gb/fcdo_sanctions/crawler.py
+++ b/datasets/gb/fcdo_sanctions/crawler.py
@@ -1,7 +1,6 @@
 import re
 import csv
 import html
-from typing import Optional, List
 
 from rigour.mime.types import CSV
 from zavod.util import ElementOrTree
@@ -75,7 +74,7 @@ def apply_reg_number(context: Context, entity: Entity, reg_number: str) -> None:
         )
 
 
-def parse_company_names(context: Context, value: Optional[str]) -> List[str]:
+def parse_company_names(context: Context, value: str | None) -> list[str]:
     if not value:
         return []
     result = context.lookup("companies", value, warn_unmatched=True)
@@ -427,10 +426,10 @@ def csv_make_ship(context: Context, row: dict[str, str], entity: Entity) -> None
 def get_name_prop(
     context: Context,
     entity: Entity,
-    name: Optional[str],
+    name: str | None,
     name_type: str,
     alias_strength: str,
-) -> Optional[str]:
+) -> str | None:
     if name is None:
         return None
 
@@ -469,7 +468,7 @@ def crawl_csv(context: Context) -> None:
     path = context.fetch_resource("source.csv", csv_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
 
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         # Skip the first metadata row
         next(fh)
         for row in csv.DictReader(fh):

--- a/datasets/gb/nca_press_releases/crawler.py
+++ b/datasets/gb/nca_press_releases/crawler.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
 from zavod.extract.llm import DEFAULT_MODEL, run_typed_text_prompt
@@ -22,13 +22,13 @@ schema_field = Field(
 class Offender(BaseModel):
     entity_schema: Schema = schema_field
     name: str
-    aliases: List[str] = []
-    address: List[str] = []
-    country: List[str] = []
+    aliases: list[str] = []
+    address: list[str] = []
+    country: list[str] = []
 
 
 class Offenders(BaseModel):
-    offenders: List[Offender]
+    offenders: list[Offender]
 
 
 PROMPT = f"""
@@ -77,8 +77,8 @@ def crawl_enforcement_action(context: Context, url: str) -> None:
     article_element = article_content[0]
 
     # Extract topics and look them up
-    raw_topics: List[str] = article_doc.xpath("//li[@itemprop='keywords']/a/text()")
-    topics: List[str] = []
+    raw_topics: list[str] = article_doc.xpath("//li[@itemprop='keywords']/a/text()")
+    topics: list[str] = []
     for topic in raw_topics:
         res = context.lookup("topics", topic.strip(), warn_unmatched=True)
         if res is not None:

--- a/datasets/gb/proscribed_orgs/crawler.py
+++ b/datasets/gb/proscribed_orgs/crawler.py
@@ -4,7 +4,6 @@ proscribed terrorist groups and organizations.
 """
 
 import re
-from typing import Optional
 
 from zavod import Context
 from zavod import helpers as h
@@ -20,7 +19,7 @@ ALIAS_RE = re.compile(r"\s+\(([^)]+)\)")
 JUNK = " ,.;\t\r\n"
 
 
-def parse_comment(text: str) -> Optional[str | None]:
+def parse_comment(text: str) -> str | None:
     """
     Parse stack of  commentary from the act looking for the most
     recent date when groups were added.

--- a/datasets/ge/company_registry/crawler.py
+++ b/datasets/ge/company_registry/crawler.py
@@ -1,5 +1,5 @@
 import csv
-from typing import Any, Dict
+from typing import Any
 from normality.cleaning import collapse_spaces
 from followthemoney.types import registry
 
@@ -8,7 +8,7 @@ from zavod.entity import Entity
 from zavod.shed.internal_data import fetch_internal_data
 
 
-def crawl_row(context: Context, row: Dict[str, Any]) -> None:
+def crawl_row(context: Context, row: dict[str, Any]) -> None:
     id = row.pop("id")
     name = row.pop("name")
     legal_form = row.pop("legal_form")
@@ -80,7 +80,7 @@ def crawl_row(context: Context, row: Dict[str, Any]) -> None:
 def emit_rel(
     context: Context,
     schema_name: str,
-    row: Dict[str, Any],
+    row: dict[str, Any],
     name: str,
     entity: Entity,
     id: str,
@@ -123,7 +123,7 @@ def emit_rel(
 def crawl(context: Context) -> None:
     local_path = context.get_resource_path("companyinfo_v3.csv")
     fetch_internal_data("ge_ti_companies/companyinfo_v3.csv", local_path)
-    with open(local_path, "r", encoding="utf-8") as fh:
+    with open(local_path, encoding="utf-8") as fh:
         reader = csv.reader(fh, delimiter=";")
         original_headers = next(reader)
 

--- a/datasets/ge/declarations/crawler.py
+++ b/datasets/ge/declarations/crawler.py
@@ -2,7 +2,7 @@ from enum import Enum
 import re
 from copy import deepcopy
 from datetime import datetime, timedelta
-from typing import Any, Set, cast
+from typing import Any, cast
 from urllib.parse import urlencode
 
 from followthemoney.types import registry
@@ -179,7 +179,7 @@ def crawl_enterprise(
 def crawl_assets_for_family(
     context: Context,
     *,
-    minors: Set[tuple[str, str]],
+    minors: set[tuple[str, str]],
     item: dict[str, Any],
     key: str,
     pep: Entity,
@@ -351,7 +351,7 @@ def crawl_declaration(context: Context, *, item: dict[str, Any]) -> None:
     context.emit(occupancy)
     context.emit(person)
 
-    minor_family_member_names: Set[tuple[str, str]] = set()
+    minor_family_member_names: set[tuple[str, str]] = set()
     for rel in item.pop("FamilyMembers"):
         first_name, last_name, status = crawl_family_member(
             context, pep=person, relative=rel, declaration_url=declaration_url

--- a/datasets/ge/ot_list/crawler.py
+++ b/datasets/ge/ot_list/crawler.py
@@ -4,7 +4,6 @@ the individuals on the Otkhozoria–Tatunashvili List.
 """
 
 import re
-from typing import Dict
 from lxml.html import HtmlElement
 
 from zavod import Context, Entity
@@ -37,7 +36,7 @@ def apply_translit_name(context: Context, person: Entity, name: str) -> None:
     apply_translit_full_name(context, person, LangText(name, "kat"))
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     """Process a row of the table in the OT list."""
     name = row.pop(NAME_FIELD)
     birth_date = row.pop(DEMOGRAPHICS).split(maxsplit=1)[0]

--- a/datasets/gg/disqualified_directors/crawler.py
+++ b/datasets/gg/disqualified_directors/crawler.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Iterator
+from collections.abc import Iterator
 from lxml import etree
 import re
 from zavod import Context, helpers as h
@@ -85,7 +85,7 @@ def crawl_prohibition(context: Context, item: ProhibitionDetails) -> None:
     context.emit(person)
 
 
-def crawl_item(context: Context, item: Dict[str, str | None]) -> None:
+def crawl_item(context: Context, item: dict[str, str | None]) -> None:
     name = item.pop("name_of_disqualified_director")
 
     person = context.make("Person")

--- a/datasets/hk/legco/crawler.py
+++ b/datasets/hk/legco/crawler.py
@@ -3,7 +3,7 @@ Crawler for extracting names and constituencies of Hong Kong
 Legislative Council members.
 """
 
-from typing import Any, Dict, NamedTuple, Union
+from typing import Any, NamedTuple
 
 from banal import ensure_list
 from zavod import Context, Entity
@@ -17,9 +17,9 @@ MEMBER_URL_FORMAT = (
 class MemberPages(NamedTuple):
     """Member pages in English, Traditional and Simplified Chinese"""
 
-    en: Dict[str, Any]
-    hant: Dict[str, Any]
-    hans: Dict[str, Any]
+    en: dict[str, Any]
+    hant: dict[str, Any]
+    hans: dict[str, Any]
 
 
 def crawl_member_pages(context: Context, member_id: int) -> MemberPages:
@@ -34,7 +34,7 @@ def crawl_member_pages(context: Context, member_id: int) -> MemberPages:
 
 def crawl_person(
     context: Context,
-    member: Dict[str, Union[str, int]],
+    member: dict[str, str | int],
     pages: MemberPages,
 ) -> Entity:
     """Fetch personal information for a Legislative Council member and
@@ -45,33 +45,33 @@ def crawl_person(
     )
     # citizenship not required (Art 67): https://www.cmab.gov.hk/doc/en/documents/policy_responsibilities/Racial_Discrimination/AnnexI-Eng.pdf
     person.add("country", "hk")
-    context.log.debug("Unique ID {person_id}".format(person_id=person.id))
+    context.log.debug(f"Unique ID {person.id}")
     # Add names in English and both Chinese writing systems
     h.apply_name(person, full=pages.en.pop("name"), lang="eng")
     h.apply_name(person, full=pages.hant.pop("name"), lang="zho")
     h.apply_name(person, full=pages.hans.pop("name"), lang="zho")
     for email in ensure_list(pages.en.pop("email_address", [])):
-        context.log.debug("Email: {email}".format(email=email))
+        context.log.debug(f"Email: {email}")
         person.add("email", email)
     for url in ensure_list(pages.en.pop("homepage", [])):
         if url is not None:
-            context.log.debug("Web: {url}".format(url=url))
+            context.log.debug(f"Web: {url}")
             person.add("website", url)
     for phone in ("office_telephone", "mobile_phone"):
         for number in ensure_list(pages.en.pop(phone, [])):
             if number:
-                context.log.debug("Phone: {number}".format(number=number))
+                context.log.debug(f"Phone: {number}")
                 person.add("phone", number)
     title = pages.en.pop("title")
     if title and title != "-":
         person.add("title", title)
     for qual in ensure_list(pages.en.pop("qualification", [])):
         if qual:
-            context.log.debug("Education: {qual}".format(qual=qual))
+            context.log.debug(f"Education: {qual}")
             person.add("education", qual)
     for address in ensure_list(pages.en.pop("office_address", [])):
         if address:
-            context.log.debug("Address: {address}".format(address=address))
+            context.log.debug(f"Address: {address}")
             address_entity = h.make_address(context, address)
             h.copy_address(person, address_entity)
     return person
@@ -111,11 +111,11 @@ PAGE_FIELDS = [
 
 def crawl_member(
     context: Context,
-    member: Dict[str, Union[str, int]],
+    member: dict[str, str | int],
 ) -> None:
     """Emit entities for a member of the Legislative Council from JSON data."""
     salute_name = member.pop("salute_name")
-    context.log.debug("Adding {name}".format(name=salute_name))
+    context.log.debug(f"Adding {salute_name}")
     member_id = int(member["member_id"])
     pages = crawl_member_pages(context, member_id)
     person = crawl_person(context, member, pages)
@@ -143,7 +143,7 @@ def crawl_member(
         return
 
     for lang, page in zip(pages._fields, pages):
-        context.log.debug("Auditing data for {lang}".format(lang=lang))
+        context.log.debug(f"Auditing data for {lang}")
         assert int(page.pop("member_id")) == member_id
         if lang in ("hant", "hans"):
             lang = "zho"

--- a/datasets/hn/legislature/crawler.py
+++ b/datasets/hn/legislature/crawler.py
@@ -35,7 +35,7 @@ def crawl_deputy(
     if role == SUPLENTE_ROLE:
         return
     if role not in TITULAR_ROLES:
-        raise ValueError("Unknown deputy role: %r" % role)
+        raise ValueError(f"Unknown deputy role: {role!r}")
 
     record_id = row.pop("userDocument")
     party = row.pop("party")
@@ -44,7 +44,8 @@ def crawl_deputy(
     person.id = context.make_slug(str(record_id))
     # Each deputy has a public profile page keyed by their numeric site id.
     person.add(
-        "sourceUrl", "https://congresonacional.hn/congresistas/%s" % row.pop("userId")
+        "sourceUrl",
+        "https://congresonacional.hn/congresistas/{}".format(row.pop("userId")),
     )
     h.apply_name(
         person,

--- a/datasets/hr/public_officials/crawler.py
+++ b/datasets/hr/public_officials/crawler.py
@@ -1,5 +1,4 @@
 import csv
-from typing import Dict, List, Optional
 
 from rigour.mime.types import CSV
 
@@ -53,7 +52,7 @@ FIELDS = [
 ]
 
 
-def build_position_name(data: Dict[str, str]) -> Optional[str]:
+def build_position_name(data: dict[str, str]) -> str | None:
     """Builds the full Croatian position name from the title and legal entity name.
 
     When there's no title we fall back to the Croatian "Nepoznata dužnost" ("Unknown
@@ -83,9 +82,9 @@ def make_affiliation_entities(
     context: Context,
     person: Entity,
     *,
-    position_name: Optional[str],
-    position_data: Dict[str, str],
-) -> List[Entity]:
+    position_name: str | None,
+    position_data: dict[str, str],
+) -> list[Entity]:
     """Creates Position and Occupancy provided that the Occupancy meets OpenSanctions criteria.
     * A position's name include the title and optionally the name of the legal entity
     * A position with a legal entity but no title is titled 'Unknown position'
@@ -125,8 +124,8 @@ def make_person(
     *,
     first_name: str,
     last_name: str,
-    primary_position_name: Optional[str],
-    secondary_position_name: Optional[str],
+    primary_position_name: str | None,
+    secondary_position_name: str | None,
 ) -> Entity:
     positions = sorted(
         p for p in [primary_position_name, secondary_position_name] if p is not None
@@ -142,7 +141,7 @@ def make_person(
     return person
 
 
-def dict_keys_by_prefix(data: Dict[str, str], prefix: str) -> Dict[str, str]:
+def dict_keys_by_prefix(data: dict[str, str], prefix: str) -> dict[str, str]:
     """
     Returns a new dict with keys and values from the original matching the prefix.
     The prefix is removed from the keys in the new dict.
@@ -154,7 +153,7 @@ def dict_keys_by_prefix(data: Dict[str, str], prefix: str) -> Dict[str, str]:
     }
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     position_entities = []
 
     primary_position_data = dict_keys_by_prefix(row, "primary_")
@@ -199,8 +198,8 @@ def crawl_file(
     *,
     url: str,
     filename: str,
-    fields: List[str],
-    expected_headings: List[str],
+    fields: list[str],
+    expected_headings: list[str],
 ) -> None:
     path = context.fetch_resource(filename, url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)

--- a/datasets/id/dttot/crawler.py
+++ b/datasets/id/dttot/crawler.py
@@ -1,6 +1,5 @@
 import re
 import openpyxl
-from typing import Dict
 from normality import squash_spaces
 from rigour.mime.types import XLSX
 
@@ -27,7 +26,7 @@ def clean_addresses(raw_addresses: str) -> list[str]:
     return cleaned
 
 
-def crawl_row(context: Context, row: Dict[str, str | None]) -> None:
+def crawl_row(context: Context, row: dict[str, str | None]) -> None:
     item_id = row.pop("id")
     res = context.lookup("type", row.pop("type"), warn_unmatched=True)
     assert res and res.value

--- a/datasets/ie/parliament/crawler.py
+++ b/datasets/ie/parliament/crawler.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from zavod import Context, helpers as h
 from zavod.stateful.positions import categorise
@@ -15,7 +15,7 @@ POSITIONS = {
 }
 
 
-def crawl_member(context: Context, member: Dict[str, Any]) -> None:
+def crawl_member(context: Context, member: dict[str, Any]) -> None:
     person = context.make("Person")
     person.id = context.make_id(member.pop("memberCode"))
     h.apply_name(

--- a/datasets/ie/unlawful_organizations/crawler.py
+++ b/datasets/ie/unlawful_organizations/crawler.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, List
+from typing import Any
 import requests
 from zavod import Context, helpers as h
 
 QUERY_URL = " https://www.irishstatutebook.ie/solr/all_leg_title/select?q=unlawful+organisation&rows=10&hl.maxAnalyzedChars=-1&sort=year+desc&facet=true&facet.field=year&facet.field=type&facet.limit=300&facet.mincount=1&json.nl=map&wt=json"
 
-HARD_CODED_DATA: List[Dict[str, Any]] = [
+HARD_CODED_DATA: list[dict[str, Any]] = [
     {
         "url": "https://www.irishstatutebook.ie/eli/1983/si/7/made/en/print?q=unlawful+organisation&search_type=all",
         "title": "S.I. No. 7/1983 - Unlawful Organisation (Suppression) Order, 1983.",

--- a/datasets/il/mod_crypto/crawler.py
+++ b/datasets/il/mod_crypto/crawler.py
@@ -1,6 +1,6 @@
 import csv
 from pathlib import Path
-from typing import Dict, cast
+from typing import cast
 from lxml.html import HtmlElement
 
 from normality import squash_spaces
@@ -67,7 +67,7 @@ ID_FIELDS = [("id_no", "id_country"), ("residency_no", "residency_country")]
 LOCAL_PATH = Path(__file__).parent
 
 
-def remove_zero_width_space(row: Dict[str, str]) -> Dict[str, str]:
+def remove_zero_width_space(row: dict[str, str]) -> dict[str, str]:
     return {
         k: (v.replace("\u200b", "") if isinstance(v, str) else v)
         for k, v in row.items()
@@ -89,7 +89,7 @@ def write_csv_for_manual_diff(table: HtmlElement, path: Path) -> None:
             writer.writerow(cells)
 
 
-def crawl_csv_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_csv_row(context: Context, row: dict[str, str]) -> None:
     person = None
     entity = None
     country = None
@@ -220,7 +220,7 @@ def crawl(context: Context) -> None:
     # so we maintain the data manually in a google sheet, but dump the table to csv
     # to be able to see what changed quickly.
     src = context.fetch_resource("source.csv", context.data_url)
-    with open(src, "r") as f:
+    with open(src) as f:
         reader = csv.DictReader(f)
         for row in reader:
             row = remove_zero_width_space(row)

--- a/datasets/il/mod_terrorists/crawler.py
+++ b/datasets/il/mod_terrorists/crawler.py
@@ -2,7 +2,8 @@ import re
 from datetime import datetime
 from itertools import zip_longest
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any
+from collections.abc import Iterator
 
 from normality import slugify, squash_spaces, stringify
 from openpyxl import load_workbook
@@ -60,7 +61,7 @@ def apply_addresses(
         h.apply_address(context, entity, address)
 
 
-def parse_interval(sanction: Entity, date: Optional[str]) -> None:
+def parse_interval(sanction: Entity, date: str | None) -> None:
     if date is None:
         return
     date = date.strip()
@@ -82,7 +83,7 @@ def clean_numbered_name(raw_name: str) -> str:
     return cleaned
 
 
-def lang_pick(record: dict[str, str], field: str) -> Optional[str]:
+def lang_pick(record: dict[str, str], field: str) -> str | None:
     hebrew = record.pop(f"{field}_hebrew", None)
     english = record.pop(f"{field}_english", None)
     if english is not None:

--- a/datasets/il/wmd_sanctions/crawler.py
+++ b/datasets/il/wmd_sanctions/crawler.py
@@ -1,5 +1,5 @@
 from rigour.mime.types import XLSX
-from typing import Any, Optional
+from typing import Any
 from zavod import helpers as h
 import openpyxl
 import re
@@ -52,7 +52,7 @@ def apply_identifiers(entity: Entity, text: str, *, default_prop: str) -> None:
         entity.add(default_prop, item.strip())
 
 
-def extract_n_pop_address(text: str) -> tuple[Optional[str], Optional[str]]:
+def extract_n_pop_address(text: str) -> tuple[str | None, str | None]:
     """
     Extract address and update the text by removing the extracted address.
     """

--- a/datasets/im/disqualified_directors/crawler.py
+++ b/datasets/im/disqualified_directors/crawler.py
@@ -1,11 +1,10 @@
-from typing import Dict, Tuple
 from lxml.etree import _Element as Element
 
 from zavod import Context, helpers as h
 
 
-def extract_data(el: Element) -> Dict[str, str]:
-    data_dict: Dict[str, str] = {}
+def extract_data(el: Element) -> dict[str, str]:
+    data_dict: dict[str, str] = {}
 
     # Iterate through each p element
     for p in el:
@@ -29,14 +28,14 @@ def extract_data(el: Element) -> Dict[str, str]:
     return data_dict
 
 
-def parse_period(period: str) -> Tuple[str, str]:
+def parse_period(period: str) -> tuple[str, str]:
     period = period.replace("\xa0", " ").replace("From ", "").replace(" To ", " to ")
     start_date_str, end_date_str = period.split(" to ", 1)
 
     return start_date_str.strip(), end_date_str.strip()
 
 
-def crawl_item(context: Context, item: Dict[str, str]) -> None:
+def crawl_item(context: Context, item: dict[str, str]) -> None:
     name = item.pop("Name")
     birth_date = item.pop("Date of Birth")
     address = item.pop("Address (at date of disqualification)")

--- a/datasets/in/nse_debarred/crawler.py
+++ b/datasets/in/nse_debarred/crawler.py
@@ -1,7 +1,8 @@
 import shutil
 import zipfile
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
+from collections.abc import Iterator
 
 import xlrd
 

--- a/datasets/in/sansad/crawler.py
+++ b/datasets/in/sansad/crawler.py
@@ -1,5 +1,5 @@
 from itertools import count
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any
 
 from lxml.html import fromstring
 from prefixdate import parse_formats
@@ -11,7 +11,7 @@ from zavod import helpers as h
 CACHE = 7
 
 
-def decode_email(encoded: str | None) -> List[str]:
+def decode_email(encoded: str | None) -> list[str]:
     if not encoded or not isinstance(encoded, str):
         return []
     # Decode the email address
@@ -57,8 +57,8 @@ def emit_rca(context: Context, person: Entity, raw_name: str | None, role: str) 
 def crawl_ls_member(
     context: Context,
     position: Entity,
-    periods: Dict[str, Tuple[str, str]],
-    member: Dict[str, Any],
+    periods: dict[str, tuple[str, str]],
+    member: dict[str, Any],
 ) -> None:
     person = context.make("Person")
     mpsno = member.pop("mpsno", None)
@@ -135,13 +135,13 @@ def crawl_ls(context: Context) -> None:
     )
     context.emit(position)
 
-    periods: Dict[str, Tuple[str, str]] = {}
+    periods: dict[str, tuple[str, str]] = {}
     dates_resp = context.fetch_json(
         "https://sansad.in/api_ls/business/AllLoksabhaAndSessionDates", cache_days=1
     )
     for ls in dates_resp:
         num = str(ls.get("loksabha", ""))
-        dates: Set[str] = set()
+        dates: set[str] = set()
         for session in ls.get("sessions", []):
             for date in session.get("dates", []):
                 parsed = parse_formats(date, ["%d/%m/%Y"])
@@ -155,7 +155,7 @@ def crawl_ls(context: Context) -> None:
         crawl_ls_member(context, position, periods, member)
 
 
-def crawl_rs_member(context: Context, position: Entity, member: Dict[str, Any]) -> None:
+def crawl_rs_member(context: Context, position: Entity, member: dict[str, Any]) -> None:
     person = context.make("Person")
     mpsno = member.pop("mpsno", None)
     person.id = context.make_slug("rs", mpsno)

--- a/datasets/iq/aml_list/crawler.py
+++ b/datasets/iq/aml_list/crawler.py
@@ -109,7 +109,7 @@ def crawl(context: Context) -> None:
         "source.json", f"{context.data_url}?pageSize={PAGE_SIZE}"
     )
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         payload = json.load(fh)
     data = payload["data"]
     items = data["data"]

--- a/datasets/ir/sanctions/crawler.py
+++ b/datasets/ir/sanctions/crawler.py
@@ -40,6 +40,6 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/it/deputies/crawler.py
+++ b/datasets/it/deputies/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from zavod.stateful.positions import categorise
 
@@ -60,7 +60,7 @@ WHERE {{
 """
 
 
-def build_request_query(legislature: int) -> Dict[str, str]:
+def build_request_query(legislature: int) -> dict[str, str]:
     return {"query": QUERY.format(legislature=legislature), "format": "json"}
 
 

--- a/datasets/it/senate/crawler.py
+++ b/datasets/it/senate/crawler.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 from rigour.mime.types import JSON
 from zavod.stateful.positions import categorise
@@ -8,7 +8,7 @@ from zavod import Context
 from zavod import helpers as h
 
 
-def build_request_data(legislature: int) -> Dict[str, str]:
+def build_request_data(legislature: int) -> dict[str, str]:
     return {
         "alias": "senatori-legislatura",
         "id": "2",
@@ -19,7 +19,7 @@ def build_request_data(legislature: int) -> Dict[str, str]:
     }
 
 
-def crawl_item(context: Context, item: Dict[str, Any]) -> None:
+def crawl_item(context: Context, item: dict[str, Any]) -> None:
     first_name = item.pop("nome").get("value")
     last_name = item.pop("cognome").get("value")
     dob = item.pop("dataNascita").get("value")
@@ -110,7 +110,7 @@ def crawl(context: Context) -> None:
             data=build_request_data(leg),
         )
         context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-        with open(path, "r") as fh:
+        with open(path) as fh:
             data = json.load(fh)
         for item in data["results"]["bindings"]:
             crawl_item(context, item)

--- a/datasets/jo/sanctions/crawler.py
+++ b/datasets/jo/sanctions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from zavod import Context
 from zavod import helpers as h
 from lxml.html import HtmlElement
@@ -16,7 +15,7 @@ class MissingDataFile(Exception):
     pass
 
 
-def xlsx_url(doc: HtmlElement) -> Optional[str]:
+def xlsx_url(doc: HtmlElement) -> str | None:
     for link in doc.iterlinks():
         ext = link[2].split(".")[-1]
         if "xlsx" in ext:

--- a/datasets/jp/meti_eul/crawler.py
+++ b/datasets/jp/meti_eul/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict, Optional
 from urllib.parse import urljoin
 
 from normality import squash_spaces
@@ -47,7 +46,7 @@ def crawl_pdf_url(context: Context) -> str:
     raise ValueError("No PDF found")
 
 
-def transform_headers(row: Dict[str, Optional[str]]) -> Dict[str, Optional[str]]:
+def transform_headers(row: dict[str, str | None]) -> dict[str, str | None]:
     if HEADERS.keys() != row.keys():
         raise Exception(f"Unexpected headers {row.keys()} in row {row!r}")
     return {HEADERS[key]: value for key, value in row.items()}

--- a/datasets/jp/meti_ru/crawler.py
+++ b/datasets/jp/meti_ru/crawler.py
@@ -2,7 +2,7 @@ import csv
 import re
 from pathlib import Path
 from urllib.parse import urlparse
-from typing import Any, Optional
+from typing import Any
 
 import pdfplumber
 from lxml import html
@@ -34,7 +34,7 @@ EXPECTED_HASHES = {
 }
 
 
-def detect_script(context: Context, text: str) -> Optional[str]:
+def detect_script(context: Context, text: str) -> str | None:
     """
     Detect script in a string. Return 'jpn' or 'eng' if confident, else None.
     Used primarily not to misclassify Chinese names as Japanese.
@@ -232,6 +232,6 @@ def crawl(context: Context) -> None:
     # Crawling the google sheet
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/jp/mof_sanctions/crawler.py
+++ b/datasets/jp/mof_sanctions/crawler.py
@@ -2,7 +2,6 @@ import re
 import string
 from datetime import date, datetime
 from itertools import chain
-from typing import Dict, List
 from urllib.parse import urljoin
 
 import xlrd
@@ -19,8 +18,8 @@ from zavod import helpers as h
 # Match non-brackets inside an opening and closing pair of brackets
 BRACKETED = re.compile(r"([(（][^\(\)]*[)）]|\[[^\[\]]*\])")
 
-SPLITS = ["(%s)" % char for char in string.ascii_lowercase]
-SPLITS = SPLITS + ["（%s）" % char for char in string.ascii_lowercase]
+SPLITS = [f"({char})" for char in string.ascii_lowercase]
+SPLITS = SPLITS + [f"（{char}）" for char in string.ascii_lowercase]
 # WTF full-width brackets!
 SPLITS = SPLITS + ["（a）", "（b）", "（c）", "\n"]
 SPLITS = SPLITS + ["(i)", "(ii)", "(iii)", "(iv)", "(v)", "(vi)", "(vii)", "(viii)"]
@@ -45,7 +44,7 @@ DATE_SPLITS = SPLITS + [
 DATE_CLEAN = re.compile(r"(\(|\)|（|）| |改訂日|改訂|まれ)")
 
 
-def note_long_ids(entity: Entity, identifiers: List[str]) -> None:
+def note_long_ids(entity: Entity, identifiers: list[str]) -> None:
     for identifier in identifiers:
         if len(identifier) > IdentifierType.max_length:
             entity.add("notes", identifier)
@@ -69,8 +68,8 @@ def str_cell(cell: Cell | MergedCell) -> str | None:
     return text.replace("_x000D_", "\n")
 
 
-def parse_date(text: List[str]) -> List[str]:
-    dates: List[str] = []
+def parse_date(text: list[str]) -> list[str]:
+    dates: list[str] = []
     for date_ in h.multi_split(text, DATE_SPLITS):
         parsed = h.convert_excel_date(date_)
         if parsed is not None:
@@ -84,7 +83,7 @@ def parse_date(text: List[str]) -> List[str]:
     return dates
 
 
-def parse_names(names: List[str]) -> List[str]:
+def parse_names(names: list[str]) -> list[str]:
     cleaned = []
     # We split on numbering e.g. (a), (b) when reading the rows of the excel file
     # so we might have split a cell-wide opening and closing parenthesis
@@ -120,7 +119,7 @@ def parse_names(names: List[str]) -> List[str]:
     return cleaned
 
 
-def parse_notes(context: Context, entity: Entity, notes: List[str]) -> None:
+def parse_notes(context: Context, entity: Entity, notes: list[str]) -> None:
     for note in notes:
         cryptos = h.extract_cryptos(note)
         for key, curr in cryptos.items():
@@ -148,7 +147,7 @@ def fetch_excel_url(context: Context) -> str:
 
 
 def emit_row(
-    context: Context, sheet: str, section: str, row: Dict[str, List[str]]
+    context: Context, sheet: str, section: str, row: dict[str, list[str]]
 ) -> None:
     schema = context.lookup_value("schema", section, warn_unmatched=True)
     if schema is None:
@@ -287,7 +286,7 @@ def emit_row(
     context.audit_data(row)
 
 
-def trim_rightmost_blank(values: List[str | None], keep: int = 0) -> List[str | None]:
+def trim_rightmost_blank(values: list[str | None], keep: int = 0) -> list[str | None]:
     """
     Remove rightmost contiguous falsy values from a list, keeping at least `keep` values.
 
@@ -371,7 +370,7 @@ def crawl_sheets(
             # after a header is found, read normal data:
             if headers is not None:
                 assert len(row) == len(headers), (len(row), len(headers), row)
-                data: Dict[str, List[str]] = {}
+                data: dict[str, list[str]] = {}
                 for header, cell in zip(headers, row):
                     if header is None:
                         continue
@@ -410,5 +409,5 @@ def crawl(context: Context) -> None:
     elif url.endswith(".xls"):
         sheets = read_xls_sheets(context, url)
     else:
-        raise ValueError("Unknown file type: %s" % url)
+        raise ValueError(f"Unknown file type: {url}")
     crawl_sheets(context, sheets)

--- a/datasets/jp/sangiin/crawler.py
+++ b/datasets/jp/sangiin/crawler.py
@@ -76,7 +76,7 @@ def fetch_doc(context: Context, url: str, cache_days: int) -> Element:
     """
     text = context.fetch_text(url, cache_days=cache_days)
     if text is None or len(text) == 0:
-        raise ValueError("Empty document: %s" % url)
+        raise ValueError(f"Empty document: {url}")
     return html.fromstring(text.encode("latin-1"))
 
 

--- a/datasets/ke/frc_sanctions/crawler.py
+++ b/datasets/ke/frc_sanctions/crawler.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from normality import stringify
 from openpyxl import load_workbook
 from rigour.mime.types import XLSX
@@ -25,7 +23,7 @@ def parse_aliases(raw: str | None) -> list[str]:
     return results
 
 
-def crawl_row(context: Context, row: Dict[str, str | None]) -> None:
+def crawl_row(context: Context, row: dict[str, str | None]) -> None:
     # parse_xlsx_sheet slugifies headers: "Full Name" -> "full_name"
     # Pre-clean n/a placeholders so entity.add() receives None rather than the string
     row = {

--- a/datasets/kp/rusi_reports/crawler.py
+++ b/datasets/kp/rusi_reports/crawler.py
@@ -103,7 +103,7 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("data.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
 
-    with open(path, "r") as fh:
+    with open(path) as fh:
         data = json.load(fh)
 
     for item in data["entities"]:

--- a/datasets/ky/parliament/crawler.py
+++ b/datasets/ky/parliament/crawler.py
@@ -1,6 +1,5 @@
 import csv
 import re
-from typing import Dict, Optional
 from rigour.mime.types import CSV
 
 from zavod import Context
@@ -48,9 +47,7 @@ def clean_name(context: Context, name: str) -> str:
     return name.strip()
 
 
-def crawl_card_2025(
-    context: Context, position_str: str, el: Element
-) -> Optional[Entity]:
+def crawl_card_2025(context: Context, position_str: str, el: Element) -> Entity | None:
     content_el = h.xpath_element(el, ".//div[@class='member-select-content']")
     links_el = h.xpath_element(el, ".//div[@class='member-select-links']")
     name = clean_name(context, h.xpath_string(content_el, "./h1/text()"))
@@ -102,7 +99,7 @@ def crawl_card_2025(
     return None
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     start_date = row.pop("Start date", None)
     if start_date and start_date < h.earliest_term_start(TOPICS):
         context.log.info(
@@ -188,6 +185,6 @@ def crawl(context: Context) -> None:
     # i.e. 2025 is assumed as the `end_date`.
     path = context.fetch_resource("historical_data.csv", HISTORICAL_DATA_CSV)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/li/posting_sanctions/crawler.py
+++ b/datasets/li/posting_sanctions/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Optional
+from typing import Any
 from pdfplumber.page import Page
 
 from zavod import Context, Entity
@@ -31,7 +31,7 @@ TITLE_GENDER = {
 PROGRAM_KEY = "LI-ENTSG"
 
 
-def parse_address(context: Context, addr: str) -> Optional[Entity]:
+def parse_address(context: Context, addr: str) -> Entity | None:
     addr = addr.replace("‐", "-")
     addr = context.lookup_value("address_override", addr) or addr
     parts = [p.strip() for p in addr.split(",")]
@@ -55,11 +55,11 @@ def parse_address(context: Context, addr: str) -> Optional[Entity]:
 def crawl_named(
     context: Context,
     name: str,
-    address: Optional[Entity],
+    address: Entity | None,
     date: str,
     url: str,
     type: str,
-) -> Optional[Entity]:
+) -> Entity | None:
     """
     Parses the subjects named in the list. If a company name is split from a
     persons, we emit the person and their relationship, and return the company.

--- a/datasets/lt/illegal_gambling/crawler.py
+++ b/datasets/lt/illegal_gambling/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterator
+from collections.abc import Iterator
 
 from zavod import Context
 from zavod import helpers as h

--- a/datasets/lt/illegal_websites/crawler.py
+++ b/datasets/lt/illegal_websites/crawler.py
@@ -31,6 +31,6 @@ def crawl(context: Context) -> None:
         expected_charset="utf-8",
     )
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh, delimiter=";"):
             crawl_row(context, row)

--- a/datasets/lt/magnitsky_amendments/crawler.py
+++ b/datasets/lt/magnitsky_amendments/crawler.py
@@ -53,7 +53,7 @@ def crawl(context: Context) -> None:
         context.export_resource(
             path, mime_type="application/json", title=f"page_{page}"
         )
-        with open(path, "r", encoding="utf-8") as fh:
+        with open(path, encoding="utf-8") as fh:
             data = json.load(fh)
             if data.get("list") == []:
                 break

--- a/datasets/lt/pep_declarations/crawler.py
+++ b/datasets/lt/pep_declarations/crawler.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Optional
 
 from zavod import Context, Entity
 from zavod import helpers as h
@@ -29,7 +28,7 @@ class PinregSession:
         self.context = context
         self._guest_token = f"c{GUEST_ID}"
 
-    def get_deklaracija_by_id(self, id: int) -> Optional[dict[any]]:
+    def get_deklaracija_by_id(self, id: int) -> dict[any] | None:
         id_str = f"{id:06d}"
         self.context.log.info(f"fetching declaration {id_str}")
         r = self.context.http.get(
@@ -101,7 +100,7 @@ def parse_affiliations(
             if not role.pop("privaluDeklaruoti"):  # role must be declared
                 continue
 
-            position_name: Optional[str] = role.pop("pareigos")
+            position_name: str | None = role.pop("pareigos")
             assert position_name, (person, position_name)
             if not entity_is_lithuanian:
                 context.log.info(

--- a/datasets/lu/administrative_sanctions/crawler.py
+++ b/datasets/lu/administrative_sanctions/crawler.py
@@ -1,4 +1,4 @@
-from typing import List, cast
+from typing import cast
 import re
 
 from zavod import Context
@@ -47,13 +47,13 @@ def crawl_item(card: Element, context: Context) -> None:
     else:
         res = context.lookup("subtitle_to_names", subtitle)
         if res:
-            names = cast("List[str]", res.names)
+            names = cast("list[str]", res.names)
         else:
             # Try to look up based on the detail URL
             url_to_name_res = context.lookup("url_to_names", detail_url)
 
             if url_to_name_res:
-                names = cast("List[str]", url_to_name_res.names)
+                names = cast("list[str]", url_to_name_res.names)
             else:
                 context.log.warning(
                     "Can't find the name of the company in subtitle, skipping",

--- a/datasets/lu/chamber/crawler.py
+++ b/datasets/lu/chamber/crawler.py
@@ -82,7 +82,7 @@ def crawl(context: Context) -> None:
     # The source exports as Windows-1252, not UTF-8. Automatic detection is unreliable
     # here: byte 0xe8 is valid in several single-byte codepages, so a detector mistakes
     # the French/Luxembourgish text for cp1250 and yields mojibake.
-    with open(path, "r", encoding="cp1252") as fh:
+    with open(path, encoding="cp1252") as fh:
         rows = list(csv.DictReader(fh))
         # The Chamber has 60 seats.
         assert len(rows) >= 55, len(rows)

--- a/datasets/lv/business_register/crawler.py
+++ b/datasets/lv/business_register/crawler.py
@@ -1,10 +1,10 @@
 import csv
-from typing import Iterator, Optional, Dict
+from collections.abc import Iterator
 
 from zavod import Context, Entity
 from zavod import helpers as h
 
-Item = Dict[str, str]
+Item = dict[str, str]
 
 TYPES = {
     "FOREIGN_ENTITY": "LegalEntity",
@@ -15,9 +15,7 @@ TYPES = {
 }
 
 
-def company_id(
-    context: Context, reg_nr: str, name: Optional[str] = None
-) -> Optional[str]:
+def company_id(context: Context, reg_nr: str, name: str | None = None) -> str | None:
     if reg_nr:
         return f"oc-companies-lv-{reg_nr}".lower()
     if name is not None:
@@ -26,7 +24,7 @@ def company_id(
     return None
 
 
-def person_id(context: Context, row: Item) -> Optional[str]:
+def person_id(context: Context, row: Item) -> str | None:
     name = h.make_name(
         full=row.get("name"),
         first_name=row.get("forename"),
@@ -190,8 +188,7 @@ def parse_csv(context: Context, path: str) -> Iterator[Item]:
     data_path = context.fetch_resource(file_name, url)
     with open(data_path) as fh:
         reader = csv.DictReader(fh, delimiter=";")
-        for row in reader:
-            yield row
+        yield from reader
 
 
 def crawl(context: Context) -> None:

--- a/datasets/lv/fiu_sanctions/crawler.py
+++ b/datasets/lv/fiu_sanctions/crawler.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from lxml.etree import _Element
 from normality import slugify
 from openpyxl import load_workbook
@@ -13,7 +11,7 @@ from zavod.helpers import dates
 FROZEN_ASSETS_URL = "https://sankcijas.fid.gov.lv/uploads/sankciju_subjekti_tabula.xlsx"
 
 
-def crawl_person(context: Context, node: _Element) -> Optional[Entity]:
+def crawl_person(context: Context, node: _Element) -> Entity | None:
     entity = context.make("Person")
     entity.id = context.make_slug("person", node.findtext(".//Id"))
 
@@ -92,7 +90,7 @@ def crawl_person(context: Context, node: _Element) -> Optional[Entity]:
     return entity
 
 
-def crawl_organization(context: Context, node: _Element) -> Optional[Entity]:
+def crawl_organization(context: Context, node: _Element) -> Entity | None:
     entity = context.make("Organization")
     entity.id = context.make_slug("org", node.findtext(".//Id"))
 

--- a/datasets/lv/magnitsky_list/crawler.py
+++ b/datasets/lv/magnitsky_list/crawler.py
@@ -1,10 +1,9 @@
 import csv
-from typing import Dict
 import zavod.helpers as h
 from zavod import Context
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     original_name = row.get("Original Name")
     name_in_brackets = row.get("Name in Brackets")
     country = row.get("Country")
@@ -34,7 +33,7 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/mc/fund_freezes/crawler.py
+++ b/datasets/mc/fund_freezes/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict
+from typing import Any
 
 from zavod import Context
 from zavod import helpers as h
@@ -47,7 +47,7 @@ def extract_passport_no(text: str | None) -> list[str] | None:
     return matches
 
 
-def crawl_entity(context: Context, data: Dict[str, Any]) -> None:
+def crawl_entity(context: Context, data: dict[str, Any]) -> None:
     entity_id = data.pop("mesureId")
     status = data.pop("state")
     if status == "withdrawal":

--- a/datasets/md/companies/parse.py
+++ b/datasets/md/companies/parse.py
@@ -1,6 +1,6 @@
 from openpyxl import Workbook, load_workbook
 from rigour.mime.types import XLSX
-from typing import Optional, Dict, Any, List
+from typing import Any
 from urllib.parse import urljoin
 import re
 
@@ -44,9 +44,7 @@ def read_ckan(context: Context, source_url: str, label: str) -> str:
     raise RuntimeError("No data URL on data resource page!")
 
 
-def parse_directors(
-    context: Context, company: Entity, directors: Optional[str]
-) -> None:
+def parse_directors(context: Context, company: Entity, directors: str | None) -> None:
     if directors is None:
         return
     for director in directors.split("],"):
@@ -80,11 +78,11 @@ def parse_directors(
         context.emit(dship)
 
 
-def parse_founders(context: Context, company: Entity, founders: Optional[str]) -> None:
+def parse_founders(context: Context, company: Entity, founders: str | None) -> None:
     if founders is None:
         return
     if isinstance(founders, int):
-        context.log.info("last line: %r" % founders)
+        context.log.info(f"last line: {founders!r}")
         return
     for founder in founders.split("),"):
         founder = founder.replace(")", "")
@@ -108,7 +106,7 @@ def parse_founders(context: Context, company: Entity, founders: Optional[str]) -
         context.emit(own)
 
 
-def parse_owners(context: Context, company: Entity, owners: Optional[str]) -> None:
+def parse_owners(context: Context, company: Entity, owners: str | None) -> None:
     if owners is None:
         return
     for owner in owners.split("),"):
@@ -136,7 +134,7 @@ def parse_owners(context: Context, company: Entity, owners: Optional[str]) -> No
         context.emit(own)
 
 
-def parse_company(context: Context, data: Dict[str, Any]) -> None:
+def parse_company(context: Context, data: dict[str, Any]) -> None:
     idno = data.pop("IDNO/ Cod fiscal")
     name = data.pop("Denumirea completă")
     address = data.pop("Adresa")
@@ -169,7 +167,7 @@ def parse_company(context: Context, data: Dict[str, Any]) -> None:
 
 
 def parse_companies(context: Context, book: Workbook) -> None:
-    headers: Optional[List[str]] = None
+    headers: list[str] | None = None
     for idx, row in enumerate(book["Company"].iter_rows()):
         cells = [c.value for c in row]
         if headers is None:

--- a/datasets/md/companies/parse.py
+++ b/datasets/md/companies/parse.py
@@ -180,7 +180,7 @@ def parse_companies(context: Context, book: Workbook) -> None:
         data = dict(zip(headers, cells))
         parse_company(context, data)
         if idx > 0 and idx % 10000 == 0:
-            context.log.info("Read %d companies..." % idx)
+            context.log.info(f"Read {idx} companies...")
 
 
 def parse_nonprofits(context: Context, wb: Workbook) -> None:

--- a/datasets/md/interdictie/crawler.py
+++ b/datasets/md/interdictie/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterator, List
+from collections.abc import Iterator
 from lxml import html
 from rigour.mime.types import HTML
 
@@ -40,7 +40,7 @@ ROLES = {
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(path, HTML, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         doc = html.parse(fh)
 
     table = doc.find(".//table")
@@ -170,7 +170,7 @@ def crawl_control(
 
 
 def make_ownerships(
-    context: Context, company: Entity, date: str | None, owners: List[str]
+    context: Context, company: Entity, date: str | None, owners: list[str]
 ) -> Iterator[Entity]:
     for name in owners:
         name = name.strip()
@@ -196,7 +196,7 @@ def make_ownerships(
 
 
 def make_members(
-    context: Context, company: Entity, date: str | None, members: List[str]
+    context: Context, company: Entity, date: str | None, members: list[str]
 ) -> Iterator[Entity]:
     for name in members:
         name = name.strip()

--- a/datasets/md/terror_sanctions/crawler.py
+++ b/datasets/md/terror_sanctions/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import List, Tuple
 from lxml import html
 from rigour.mime.types import HTML
 
@@ -30,7 +29,7 @@ def clean_name(string: str) -> str:
     return name
 
 
-def parse_names(string: str) -> Tuple[str, List[str]]:
+def parse_names(string: str) -> tuple[str, list[str]]:
     parts = string.split("alias")
     name = clean_name(parts[0])
     aliases = parts[1:] if len(parts) > 1 else []
@@ -41,7 +40,7 @@ def parse_names(string: str) -> Tuple[str, List[str]]:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(path, HTML, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         doc = html.parse(fh)
 
     table = doc.find(".//table")

--- a/datasets/me/acp_peps/crawler.py
+++ b/datasets/me/acp_peps/crawler.py
@@ -2,7 +2,7 @@ import io
 import re
 from csv import DictReader
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 from zipfile import BadZipFile, ZipFile
 
 from zavod.stateful.positions import OccupancyStatus, categorise
@@ -13,8 +13,8 @@ from zavod import helpers as h
 
 def fetch_latest_filing(
     context: Context,
-    dates: List[Dict[str, Any]],
-) -> Tuple[Optional[str], Optional[Path]]:
+    dates: list[dict[str, Any]],
+) -> tuple[str | None, Path | None]:
     if not dates:
         return None, None
 
@@ -120,7 +120,7 @@ def emit_affiliated_position(
     *,
     person: Entity,
     function: str,
-    affiliation_data: Dict[str, str],
+    affiliation_data: dict[str, str],
     filing_date: str,
 ) -> None:
     """Creates Position and Occupancy after categorization.
@@ -181,7 +181,7 @@ def emit_affiliated_position(
 # and FUNKCIONER_PREZIME roughly equals PREZIME_CLANA_PORODICE (last name)
 def split_official_and_relatives(
     rows: list[dict[str, Any]],
-) -> Tuple[Optional[Dict[str, str]], List[Dict[str, str]]]:
+) -> tuple[dict[str, str] | None, list[dict[str, str]]]:
     """Split family rows into the relatives and the official."""
     # SRODSTVO contains Funkcioner for the official, else the family relationship.
     officials = [row for row in rows if row.get("SRODSTVO") == "Funkcioner"]
@@ -196,7 +196,7 @@ def crawl_person(context: Context, person_data: dict[str, Any]) -> bool:
     Returns true if a ZIP was read."""
     full_name = person_data.pop("imeIPrezime")
     dates = person_data.pop("izvjestajImovine")
-    function_labels: List[str] = person_data.pop("nazivFunkcije")
+    function_labels: list[str] = person_data.pop("nazivFunkcije")
     filing_date, zip_path = fetch_latest_filing(context, dates)
 
     family_rows = []

--- a/datasets/mo/legislature/crawler.py
+++ b/datasets/mo/legislature/crawler.py
@@ -94,13 +94,13 @@ def crawl(context: Context) -> None:
     heading = h.element_text(h.xpath_element(doc, ".//h3[contains(., 'Legislatura')]"))
     match = LEGISLATURE_RE.search(heading)
     if match is None:
-        raise ValueError("Could not parse legislature from heading: %r" % heading)
+        raise ValueError(f"Could not parse legislature from heading: {heading!r}")
     legislature = match.group(1)
     term_start = LEGISLATURE_START.get(legislature)
     if term_start is None:
         raise ValueError(
-            "Unknown legislature %r — a new term has been seated; add its start date "
-            "to LEGISLATURE_START." % legislature
+            f"Unknown legislature {legislature!r} — a new term has been seated; add its start date "
+            "to LEGISLATURE_START."
         )
 
     position = h.make_position(

--- a/datasets/mx/tax_offenders/crawler.py
+++ b/datasets/mx/tax_offenders/crawler.py
@@ -1,5 +1,6 @@
 import csv
-from typing import Any, Iterator
+from typing import Any
+from collections.abc import Iterator
 from rigour.mime.types import CSV
 
 from zavod import Context, helpers as h
@@ -103,7 +104,7 @@ def crawl(context: Context) -> None:
         source_file = context.fetch_resource(fname, url)
         context.export_resource(source_file, CSV, context.SOURCE_TITLE)
 
-        with open(source_file, "r", encoding="latin-1") as f:
+        with open(source_file, encoding="latin-1") as f:
             reader = csv.DictReader(f)
             for item in reader:
                 # Each csv has a slightly different name for each attribute

--- a/datasets/my/consumer_alert_list/crawler.py
+++ b/datasets/my/consumer_alert_list/crawler.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterator
+from typing import Any
+from collections.abc import Iterator
 from lxml import html
 import re
 import json

--- a/datasets/my/moha_sanctions/crawler.py
+++ b/datasets/my/moha_sanctions/crawler.py
@@ -4,7 +4,7 @@ from datapatch import Lookup
 from normality import squash_spaces
 from pdfplumber.page import Page
 from rigour.mime.types import PDF
-from typing import Tuple, Dict, Any
+from typing import Any
 
 from zavod import Context, helpers as h
 from zavod.extract.zyte_api import fetch_html
@@ -76,7 +76,7 @@ def crawl_row(
     context.audit_data(row, ignore=["internal_no"])
 
 
-def page_settings(page: Page) -> Tuple[Page, Dict[str, Any]]:
+def page_settings(page: Page) -> tuple[Page, dict[str, Any]]:
     # Crop top/bottom margins to focus on table area
     cropped = page.crop((0, 75, page.width, page.height - 10))
     settings = {

--- a/datasets/my/parliament/crawler.py
+++ b/datasets/my/parliament/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterator
+from collections.abc import Iterator
 
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
@@ -245,7 +245,7 @@ def iter_member_links(context: Context, roster_url: str) -> Iterator[tuple[str, 
     for link in links:
         match = re.search(r"[?&]id=(\d+)", link)
         if match is None:
-            raise ValueError("Member link without id: %s" % link)
+            raise ValueError(f"Member link without id: {link}")
         yield match.group(1), link
 
 

--- a/datasets/ng/chipper_peps/crawler.py
+++ b/datasets/ng/chipper_peps/crawler.py
@@ -2,7 +2,6 @@ import re
 import csv
 from normality import squash_spaces
 from rigour.mime.types import CSV
-from typing import Dict, Optional
 
 from zavod import Context
 from zavod import helpers as h
@@ -34,7 +33,7 @@ REGEX_HOUSE_REP = re.compile(
 # House of Representatives Deputy Chairman Army
 
 
-def has_length(name: Optional[str], length: int) -> bool:
+def has_length(name: str | None, length: int) -> bool:
     if name is None:
         return False
     return len(name.strip().strip(".")) >= length
@@ -79,7 +78,7 @@ def crawl_position(context: Context, entity: Entity, name: str) -> None:
         entity.add("topics", "poi")
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     entity = context.make("Person")
     identifier = row.pop("Unique Identifier")
     if not identifier:
@@ -138,6 +137,6 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/ng/join_dots/crawler.py
+++ b/datasets/ng/join_dots/crawler.py
@@ -203,7 +203,7 @@ def crawl(context: Context) -> None:
         if name_slug in pep_ids:
             context.log.info("Dropping name with duplicate entry", name=name_slug)
             dupes.add(name_slug)
-            pep_ids.pop((name_slug))
+            pep_ids.pop(name_slug)
         else:
             if name_slug not in dupes:
                 pep_ids[name_slug] = entity_id

--- a/datasets/ng/nigsac_sanctions/crawler.py
+++ b/datasets/ng/nigsac_sanctions/crawler.py
@@ -123,7 +123,7 @@ def crawl_entity(context: Context, url: str, data: dict[str, str | None]) -> Non
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(path, HTML, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         doc = html.fromstring(fh.read())
     doc.make_links_absolute(context.data_url)  # type: ignore[attr-defined]  # lxml-stubs omits HtmlMixin methods
 

--- a/datasets/nl/senate/crawler.py
+++ b/datasets/nl/senate/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional, Tuple
 from urllib.parse import urljoin
 
 from lxml.etree import _Element
@@ -15,7 +14,7 @@ DOB_REGEX = re.compile(r"Geboortedatum:\s*([\d-]+)")
 def get_residency_dob(
     context: Context,
     member_el: _Element,
-) -> Tuple[Optional[str], Optional[str]]:
+) -> tuple[str | None, str | None]:
     """
     Extracts residency and date of birth from a member element.
     Tries regex on the combined text of child nodes. Falls back to context.lookup if missing.
@@ -43,7 +42,7 @@ def get_residency_dob(
 
 def get_name_date_party(
     context: Context, doc: _Element
-) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+) -> tuple[str | None, str | None, str | None]:
     wrapper = doc.find(".//div[@id='main_content_wrapper']")
     # Get first sentence of first paragraph
     description = h.element_text(wrapper)

--- a/datasets/nl/terrorism_list/crawler.py
+++ b/datasets/nl/terrorism_list/crawler.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import IO, Dict, Generator, List, Tuple
+from typing import IO
+from collections.abc import Generator
 from lxml import etree
 from zipfile import ZipFile
 
@@ -7,19 +8,19 @@ from zavod import Context
 from zavod import helpers as h
 
 ODS = "application/vnd.oasis.opendocument.spreadsheet"
-CellValue = Tuple[str, str, str]
+CellValue = tuple[str, str, str]
 PROGRAM_KEY = "NL-UNSC1373"
 
 
 def read_table(
     fh: IO[bytes], sheet_name: str
-) -> Generator[List[CellValue], None, None]:
+) -> Generator[list[CellValue], None, None]:
     doc = etree.parse(fh)
     doc = h.remove_namespace(doc)
     for sheet in doc.findall(f"/body/spreadsheet/table[@name='{sheet_name}']"):
         for row in sheet.findall(".//table-row"):
             # print(inspect(row))
-            cells: List[CellValue] = []
+            cells: list[CellValue] = []
             for cell in row.findall("./table-cell"):
                 value = text = str(cell.xpath("string()")) or ""
                 type_ = cell.get("value-type") or "empty"
@@ -37,7 +38,7 @@ def read_table(
             yield cells
 
 
-def parse_sheet(path: Path) -> Generator[Dict[str, CellValue], None, None]:
+def parse_sheet(path: Path) -> Generator[dict[str, CellValue], None, None]:
     # ods is a bunch of xmls in a zip
     with ZipFile(path, "r") as zipfh:
         for name in zipfh.namelist():
@@ -80,7 +81,7 @@ def crawl(context: Context) -> None:
         sanction.add("sourceUrl", link_offical_notification[1])
         sanction.add("authorityId", link_offical_notification[2])
 
-        name = "%s %s" % (first_name, surname)
+        name = f"{first_name} {surname}"
         name = name.strip()
         if not len(name):
             context.log.warning("No name", entity=entity, name=name)

--- a/datasets/no/brreg/crawler.py
+++ b/datasets/no/brreg/crawler.py
@@ -2,7 +2,7 @@ import gzip
 import csv
 
 from rigour.mime.types import GZIP
-from typing import Any, List, Dict
+from typing import Any
 
 from zavod import Context, helpers as h, Entity
 from zavod.stateful.positions import categorise, OccupancyStatus
@@ -83,7 +83,7 @@ IGNORE = [
 ]
 
 
-def get_oldest_date(row: Dict[str, Any], keys_to_check: List[str]) -> str | None:
+def get_oldest_date(row: dict[str, Any], keys_to_check: list[str]) -> str | None:
     """
     Get the oldest date value from keys to check, delete the rest.
     """
@@ -96,7 +96,7 @@ def get_oldest_date(row: Dict[str, Any], keys_to_check: List[str]) -> str | None
 
 def crawl_company(
     context: Context,
-    row: Dict[Any, Any],
+    row: dict[Any, Any],
     company_name: str,
     org_number: str,
 ) -> Entity:

--- a/datasets/np/mha_sanctions/crawler.py
+++ b/datasets/np/mha_sanctions/crawler.py
@@ -106,7 +106,7 @@ def crawl(context: Context) -> None:
     # STATE TRADING COMPANY FOR CONSTRUCTION MATERIALS
 
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/ph/amlc_sanctions/crawler.py
+++ b/datasets/ph/amlc_sanctions/crawler.py
@@ -64,7 +64,7 @@ def crawl(context: Context) -> None:
     # AMLC Resolution TF -34
     # AMLC Resolution TF -33
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/ph/house_representatives/crawler.py
+++ b/datasets/ph/house_representatives/crawler.py
@@ -54,13 +54,14 @@ def fetch_page(context: Context, page: int) -> dict[str, Any]:
     status = response.get("status")
     if status == 401:
         raise RuntimeError(
-            "API rejected the authorization token (HTTP body status 401: %r). The "
+            "API rejected the authorization token (HTTP body status 401: {!r}). The "
             "site likely rotated x-hrep-website-backend; refresh WEBSITE_BACKEND_TOKEN "
-            "from the current value in the congress.gov.ph house-members JS bundle."
-            % response.get("message")
+            "from the current value in the congress.gov.ph house-members JS bundle.".format(
+                response.get("message")
+            )
         )
     if status != 200 or not response.get("success") or "data" not in response:
-        raise RuntimeError("Unexpected API response: %r" % response)
+        raise RuntimeError(f"Unexpected API response: {response!r}")
     data: dict[str, Any] = response["data"]
     return data
 

--- a/datasets/ph/most_wanted/crawler.py
+++ b/datasets/ph/most_wanted/crawler.py
@@ -1,9 +1,8 @@
 import csv
-from typing import Dict
 from zavod import Context
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     full_name = row.get("name")
     offense = row.get("offense")
     case_number = row.get("case number")
@@ -21,7 +20,7 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/ph/sec_advisories/crawler.py
+++ b/datasets/ph/sec_advisories/crawler.py
@@ -26,8 +26,8 @@ def crawl_item(li_tag: Element, context: Context) -> None:
             description = None
             import json
 
-            print("- match: %s" % json.dumps(long_name))
-            print("  name: %s" % json.dumps(long_name))
+            print(f"- match: {json.dumps(long_name)}")
+            print(f"  name: {json.dumps(long_name)}")
             return
 
         if res.ignore is True:
@@ -40,7 +40,7 @@ def crawl_item(li_tag: Element, context: Context) -> None:
         description = cast("str", res.description) or long_name
 
     if any(context.lookup("urgent_skip", name) for name in names):
-        context.log.info("Skipping %s" % name)
+        context.log.info(f"Skipping {name}")
         return
 
     source_url = li_link.get("href")

--- a/datasets/pk/na_members/crawler.py
+++ b/datasets/pk/na_members/crawler.py
@@ -102,7 +102,7 @@ def crawl(context: Context) -> None:
     hrefs = h.xpath_strings(doc, '//a[contains(@href, "profile.php?uid=")]/@href')
     uids = {match.group(1) for href in hrefs if (match := UID_RE.search(href))}
     if not uids:
-        raise ValueError("No member profile links found on %s" % context.data_url)
+        raise ValueError(f"No member profile links found on {context.data_url}")
 
     for uid in sorted(uids, key=int):
         crawl_member(context, position, categorisation, uid)

--- a/datasets/ps/local_freezing/crawler.py
+++ b/datasets/ps/local_freezing/crawler.py
@@ -1,8 +1,7 @@
-from typing import Dict
 from zavod import Context, helpers as h
 
 
-def crawl_item(context: Context, row: Dict[str, str | None]) -> None:
+def crawl_item(context: Context, row: dict[str, str | None]) -> None:
     entity = context.make("Person")
 
     # The last row of the table is empty

--- a/datasets/ps/ohchr_settlement/crawler.py
+++ b/datasets/ps/ohchr_settlement/crawler.py
@@ -1,6 +1,5 @@
 import csv
 from pathlib import Path
-from typing import Dict
 
 from zavod.extract import zyte_api
 
@@ -10,7 +9,7 @@ from zavod import helpers as h
 PROGRAM_KEY = "OHCHR-BHR"
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     name = row.pop("Business enterprise").strip()
     activities = row.pop("Sub-paragraph of listed activity (2020 report)").strip()
     country = row.pop("State concerned").strip()
@@ -77,7 +76,7 @@ def crawl(context: Context) -> None:
 
     # Crawl the CSV version of the database
     path = context.fetch_resource("ohchr_database.csv", context.data_url)
-    with open(path, "rt") as infh:
+    with open(path) as infh:
         reader = csv.DictReader(infh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/qa/nctc_sanctions/crawler.py
+++ b/datasets/qa/nctc_sanctions/crawler.py
@@ -17,7 +17,7 @@ def crawl(context: Context) -> None:
         context, "source.json", context.data_url, expected_media_type=HTML
     )
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         response = fh.read()
         try:
             data = json.loads(response)

--- a/datasets/ro/onpcsb_sanctions/crawler.py
+++ b/datasets/ro/onpcsb_sanctions/crawler.py
@@ -105,7 +105,7 @@ def crawl(context: Context) -> None:
     # AL AKHTAR TRUST
 
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/rs/apml_domestic/crawler.py
+++ b/datasets/rs/apml_domestic/crawler.py
@@ -1,5 +1,4 @@
 import csv
-from typing import Optional
 from urllib.parse import urljoin
 from rigour.mime.types import CSV
 
@@ -11,7 +10,7 @@ SHEET_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vTnxl3-xyO-9BBqM-rw
 
 def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url)
-    url: Optional[str] = None
+    url: str | None = None
     for link in doc.findall(".//div[@class='text-editor']//a"):
         url = urljoin(context.data_url, link.get("href"))
         url = url.replace("http://", "https://")
@@ -34,7 +33,7 @@ def crawl(context: Context) -> None:
 
     path = context.fetch_resource("source.csv", SHEET_URL)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             entity = context.make("Person")
             name = row.pop("name_srp")

--- a/datasets/ru/acf_bribetakers/crawler.py
+++ b/datasets/ru/acf_bribetakers/crawler.py
@@ -68,7 +68,7 @@ def parse_result(context: Context, row: dict[str, Any]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as file:
+    with open(path) as file:
         data = json.load(file)
         for result in data:
             parse_result(context, result)

--- a/datasets/ru/billionaires/crawler.py
+++ b/datasets/ru/billionaires/crawler.py
@@ -28,6 +28,6 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/ru/dossier_center_poi/crawler.py
+++ b/datasets/ru/dossier_center_poi/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable
+from collections.abc import Callable
 
 from zavod import Context, helpers as h
 from zavod.util import Element

--- a/datasets/ru/egrul/crawler.py
+++ b/datasets/ru/egrul/crawler.py
@@ -1,6 +1,7 @@
 import os
 import csv
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 from normality import squash_spaces
 from rigour.names import replace_org_types_display
 from followthemoney.types import registry
@@ -170,7 +171,7 @@ def emit_csv(context: Context, emit_fn: Callable[..., None], blob_name: str) -> 
     local_path = context.get_resource_path(blob_name)
     fetch_internal_data(blob_name, local_path)
 
-    with open(local_path, "r", newline="") as fh:
+    with open(local_path, newline="") as fh:
         for row in csv.DictReader(fh):
             emit_fn(context, row)
 

--- a/datasets/ru/fedsfm/crawler_terror.py
+++ b/datasets/ru/fedsfm/crawler_terror.py
@@ -86,11 +86,11 @@ def parse_foreign_persons(context: Context, entity: Entity, text: str) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(path, HTML, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         doc = html.parse(fh)
 
     for sec_id, (section, schema) in SECTIONS.items():
-        el = doc.find(".//div[@id='%s']" % sec_id)
+        el = doc.find(f".//div[@id='{sec_id}']")
         for item in el.findall(".//li"):
             text = item.text_content().strip()
             index, text = text.split(".", 1)

--- a/datasets/ru/fedsfm/crawler_wmd.py
+++ b/datasets/ru/fedsfm/crawler_wmd.py
@@ -8,7 +8,7 @@ from followthemoney.types import registry
 from zavod import Context
 from zavod import helpers as h
 
-SPLITS = ["%s)" % c for c in string.ascii_lowercase]
+SPLITS = [f"{c})" for c in string.ascii_lowercase]
 SPLITS = SPLITS + ["; ", " и "]
 
 
@@ -30,7 +30,7 @@ def maybe_rsplit(text: str | None, splitter: str) -> tuple[str | None, str | Non
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.html", context.data_url)
     context.export_resource(path, HTML, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         doc = html.parse(fh)
     tables = doc.findall(".//table")
     assert len(tables) == 1

--- a/datasets/ru/mfa_sanctions/crawler.py
+++ b/datasets/ru/mfa_sanctions/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterator
+from collections.abc import Iterator
 from lxml.html import HtmlElement
 
 from zavod import Context, helpers as h

--- a/datasets/ru/myrotvorets_wagner/crawler.py
+++ b/datasets/ru/myrotvorets_wagner/crawler.py
@@ -2,7 +2,8 @@ import csv
 from pathlib import Path
 from zipfile import ZipFile
 from io import TextIOWrapper
-from typing import Any, Dict, Generator
+from typing import Any
+from collections.abc import Generator
 
 from zavod import Context
 from zavod import helpers as h
@@ -18,10 +19,10 @@ HEADERS = [
 ]
 
 
-def read_zip_csv(context: Context, path: Path) -> Generator[Dict[str, Any], None, None]:
+def read_zip_csv(context: Context, path: Path) -> Generator[dict[str, Any], None, None]:
     with ZipFile(path, "r") as zipfh:
         for name in zipfh.namelist():
-            context.log.info("Reading: %s in %s" % (name, path))
+            context.log.info(f"Reading: {name} in {path}")
             with zipfh.open(name, "r") as fhb:
                 fh = TextIOWrapper(fhb, encoding="utf-8")
                 reader = csv.reader(fh, delimiter=",")

--- a/datasets/ru/navalny35/crawler.py
+++ b/datasets/ru/navalny35/crawler.py
@@ -25,6 +25,6 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/ru/nsd_isin/crawler.py
+++ b/datasets/ru/nsd_isin/crawler.py
@@ -23,7 +23,7 @@ def crawl_item(context: Context, url: str) -> None:
         html = context.fetch_html(url, cache_days=60)
     except RequestException as re:
         time.sleep(10)
-        context.log.error("HTTP error: %r" % re, url=url)
+        context.log.error(f"HTTP error: {re!r}", url=url)
         return
     table = html.findall('.//td[@class="content"]//table')
     if len(table) != 1:

--- a/datasets/se/riksdag/crawler.py
+++ b/datasets/se/riksdag/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from zavod import Context, helpers as h
 from zavod.entity import Entity
@@ -30,7 +30,7 @@ def translate_keys(context: Context, member_dict: dict[str, Any]) -> dict[str, A
     return {context.lookup_value("keys", k) or k: v for k, v in member_dict.items()}
 
 
-def extract_biography(person_info: Any) -> Optional[str]:
+def extract_biography(person_info: Any) -> str | None:
     """Join the source's biographical text blocks into a single narrative.
 
     The `personuppgift` payload mixes biography with images, contact details and
@@ -52,7 +52,7 @@ def extract_biography(person_info: Any) -> Optional[str]:
     return "\n".join(lines) if lines else None
 
 
-def position_for_mandate(context: Context, role: dict[str, Any]) -> Optional[Entity]:
+def position_for_mandate(context: Context, role: dict[str, Any]) -> Entity | None:
     """Build the Position a single mandate entry corresponds to, or None to skip it.
 
     The source lists every assignment a person has ever held. Only a few of them

--- a/datasets/se/soe/crawler.py
+++ b/datasets/se/soe/crawler.py
@@ -39,7 +39,7 @@ def crawl(context: Context) -> None:
     check_updates(context)
 
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             company_name = row.pop("company")
             pep_name = row.pop("name")

--- a/datasets/sg/gov_dir/crawler.py
+++ b/datasets/sg/gov_dir/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 from followthemoney.types import registry
 from lxml import etree
@@ -80,7 +79,7 @@ POSITION_REPLACEMENTS = [
 ]
 
 
-class CrawlState(object):
+class CrawlState:
     """Track what's seen and categorised to help validate the crawl"""
 
     seen_urls = set()
@@ -113,7 +112,7 @@ def is_pep(context: Context, rank: str) -> bool | None:
     return None
 
 
-def make_hierarchy(breadcrumbs: HtmlElement) -> Optional[str]:
+def make_hierarchy(breadcrumbs: HtmlElement) -> str | None:
     """
     A string like "PEC, IPOS, MINLAW" if the depth is > 1
 
@@ -171,7 +170,7 @@ def crawl_person(
     public_body: str,
     agency: str,
     section_name: str,
-    hierarchy: Optional[str],
+    hierarchy: str | None,
 ) -> bool:
     """Returns true if the crawled person is a PEP based on the provided position info"""
 

--- a/datasets/sg/mas_enforcement_actions/crawler.py
+++ b/datasets/sg/mas_enforcement_actions/crawler.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, Field
 from zavod.extract.llm import DEFAULT_MODEL, run_typed_text_prompt
@@ -26,14 +26,14 @@ schema_field = Field(
 class Defendant(BaseModel):
     name: str
     entity_schema: Schema = schema_field
-    aliases: List[str] = []
-    nationality: List[str] = []
-    country: List[str] = []
-    related_url: List[str] = []
+    aliases: list[str] = []
+    nationality: list[str] = []
+    country: list[str] = []
+    related_url: list[str] = []
 
 
 class Defendants(BaseModel):
-    defendants: List[Defendant]
+    defendants: list[Defendant]
 
 
 PROMPT = f"""
@@ -100,8 +100,8 @@ def crawl_item(
     date: str,
     url: str,
     article_name: str,
-    action_type: Optional[str],
-    origin: Optional[str],
+    action_type: str | None,
+    origin: str | None,
 ) -> None:
     entity = context.make(item.entity_schema)
     entity.id = context.make_id(item.name, item.country)  # type: ignore[arg-type]
@@ -129,7 +129,7 @@ def crawl_item(
 
 
 def crawl_enforcement_action(
-    context: Context, url: str, date: str, action_type: Optional[str]
+    context: Context, url: str, date: str, action_type: str | None
 ) -> None:
     article = context.fetch_html(url, cache_days=7, absolute_links=True)
     article_el = h.xpath_elements(

--- a/datasets/sg/mas_investor_alert/crawler.py
+++ b/datasets/sg/mas_investor_alert/crawler.py
@@ -136,7 +136,7 @@ def crawl_item(context: Context, item: dict[str, Any]) -> CrawlItemResult:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         data = json.load(fh)
 
     check_num_found(context, data)

--- a/datasets/sg/terrorists/crawler.py
+++ b/datasets/sg/terrorists/crawler.py
@@ -128,7 +128,7 @@ def crawl_additional_lists(context: Context) -> None:
     assert len(OTHER_MEASURES_HASHES) == 0, OTHER_MEASURES_HASHES.keys()
 
     path = context.fetch_resource("source.csv", ADDITIONAL_LISTS_DATA_URL)
-    with open(path, "r") as f:
+    with open(path) as f:
         for row in DictReader(f):
             name = row.pop("name")
             country = row.pop("country")

--- a/datasets/si/conflicts/crawler.py
+++ b/datasets/si/conflicts/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from zavod import Context
 
@@ -26,7 +26,7 @@ RESTRICTION_NOTE = (
 )
 
 
-def rename_record(context: Context, entry: Dict[str, Any]) -> Dict[str, Any]:
+def rename_record(context: Context, entry: dict[str, Any]) -> dict[str, Any]:
     result = {}
     for old_key, value in entry.items():
         new_key = context.lookup_value("columns", old_key)
@@ -37,7 +37,7 @@ def rename_record(context: Context, entry: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def crawl_entity(context: Context, record: Dict[str, Any]) -> None:
+def crawl_entity(context: Context, record: dict[str, Any]) -> None:
     subject_name = record.pop("entity_name")
     registration_number = record.pop("entity_reg_number")
     country = record.pop("country")

--- a/datasets/si/zvezoskop/crawler.py
+++ b/datasets/si/zvezoskop/crawler.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from normality import slugify, stringify
 from openpyxl import load_workbook
 from pathlib import Path
-from typing import Dict, Generator
+from collections.abc import Generator
 
 from zavod import Context
 from zavod import helpers as h
@@ -14,7 +14,7 @@ def make_person_id(context: Context, id: str) -> str:
     return context.make_slug("person", id)
 
 
-def crawl_person(context: Context, row: Dict[str, str]) -> str:
+def crawl_person(context: Context, row: dict[str, str]) -> str:
     person = context.make("Person")
     zvezo_id = row.pop("id_gni_live")
     if not zvezo_id:
@@ -99,7 +99,7 @@ def si_label(institution_si: str, department_si: str, position_si: str) -> str:
 
 
 def crawl_cv_entry(
-    context: Context, entities: Dict[str, Entity], row: Dict[str, str]
+    context: Context, entities: dict[str, Entity], row: dict[str, str]
 ) -> bool | None:
     svezo_id = row.pop("id_gni_live")
     person = entities[svezo_id]
@@ -222,7 +222,7 @@ def header_names(cells: list[str | None], expected_columns: int) -> list[str | N
 
 def excel_records(
     path: Path, sheet_name: str, expected_columns: int
-) -> Generator[Dict[str, str], None, None]:
+) -> Generator[dict[str, str], None, None]:
     wb = load_workbook(filename=path, read_only=True)
     sheet = wb[sheet_name]
     headers = None

--- a/datasets/sk/public_officials/crawler.py
+++ b/datasets/sk/public_officials/crawler.py
@@ -1,7 +1,7 @@
 import re
 from lxml import etree
 from lxml.etree import _Element as Element
-from typing import Any, Dict, List
+from typing import Any
 
 from zavod.stateful.positions import OccupancyStatus, categorise
 
@@ -28,7 +28,7 @@ def parse_details(context: Context, link_el: Element) -> None:
         context.log.info(f"Table not found for {name_raw}")
         return
 
-    data: Dict[str, str | List[str]] = {}
+    data: dict[str, str | list[str]] = {}
 
     label: str | None = None
     for row in table.findall(".//tr"):
@@ -58,10 +58,10 @@ def parse_details(context: Context, link_el: Element) -> None:
 
 
 def crawl_person(
-    context: Context, data: Dict[str, Any], href: str, name_raw: str
+    context: Context, data: dict[str, Any], href: str, name_raw: str
 ) -> None:
     year = data.pop("oznámenie za rok")
-    position_slk: List[str] = data.pop(
+    position_slk: list[str] = data.pop(
         "vykonávaná verejná funkcia"
     )  # "Public office held"
     int_id = data.pop("Interné číslo")

--- a/datasets/sv/legislature/crawler.py
+++ b/datasets/sv/legislature/crawler.py
@@ -12,7 +12,7 @@ def parse_party_names(doc: Element) -> dict[str, str]:
         guid = checkbox.get("value")
         if guid is None:
             continue
-        label = h.xpath_element(doc, ".//label[@for='%s']" % guid)
+        label = h.xpath_element(doc, f".//label[@for='{guid}']")
         names[guid] = h.element_text(label)
     return names
 

--- a/datasets/th/cabinet/crawler.py
+++ b/datasets/th/cabinet/crawler.py
@@ -70,7 +70,7 @@ def crawl(context: Context) -> None:
         page_links = h.xpath_strings(
             doc, "//ul[contains(@class,'pagination')]//a[@class='page-link']/text()"
         )
-        max_page = max((int(p) for p in page_links if p.strip().isdigit()))
+        max_page = max(int(p) for p in page_links if p.strip().isdigit())
         assert max_page is not None
         if page >= max_page:
             break

--- a/datasets/tj/companies/crawler.py
+++ b/datasets/tj/companies/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 import re
 from lxml import html
 from time import sleep
@@ -32,7 +32,7 @@ def get_callback_pagination_params(page: int) -> str:
     return f"c0:KV|2;[];GB|20;12|PAGERONCLICK3|PN{page};"
 
 
-def fetch_form_params(context: Context, section: str) -> Dict[str, Any]:
+def fetch_form_params(context: Context, section: str) -> dict[str, Any]:
     """
     This is a helper function to make the first request and get the form params
     for ASP.NET form.
@@ -42,7 +42,7 @@ def fetch_form_params(context: Context, section: str) -> Dict[str, Any]:
     Returns:
         The form params as a dict.
     """
-    params: Dict[str, str] = {}
+    params: dict[str, str] = {}
 
     response = context.fetch_html(
         BASE_URL.format(section=section), cache_days=CACHE_DAYS
@@ -106,7 +106,7 @@ def fetch_form_params(context: Context, section: str) -> Dict[str, Any]:
 def crawl_page(
     context: Context,
     section: str,
-    params: Dict[str, str],
+    params: dict[str, str],
     page_number: int,
     retries: int,
 ) -> int:
@@ -194,7 +194,7 @@ def crawl_page(
         value = re.sub(r"\\[rnt]", "", value)
         headers.append(context.lookup_value("headers", value))
     if not all(headers):
-        raise ValueError("Failed to translate some header: %s" % headers)
+        raise ValueError(f"Failed to translate some header: {headers}")
     data_rows = h.xpath_elements(
         dom,
         "descendant-or-self::*[@id = 'ASPxGridView1_DXMainTable']/"

--- a/datasets/tr/cmb_banned/crawler.py
+++ b/datasets/tr/cmb_banned/crawler.py
@@ -1,5 +1,4 @@
 import json
-from typing import Dict
 import re
 
 from rigour.mime.types import JSON
@@ -9,7 +8,7 @@ from zavod import Context, helpers as h
 REGEX_MASK = re.compile(r"(\d+)\*+")
 
 
-def crawl_item(row: Dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str], context: Context) -> None:
     name = row.pop("unvan")
     if not name:
         return
@@ -56,7 +55,7 @@ def crawl_item(row: Dict[str, str], context: Context) -> None:
     context.emit(sanction)
 
     if row.get("davaBilgisi") and row.get("davaBilgisi") not in ["Yok", "Var"]:
-        context.log.warning("Dava bilgisi var: %s" % row)
+        context.log.warning(f"Dava bilgisi var: {row}")
     context.audit_data(
         row,
         ignore=[
@@ -71,7 +70,7 @@ def crawl_item(row: Dict[str, str], context: Context) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as file:
+    with open(path) as file:
         data = json.load(file)
     for item in data:
         crawl_item(item, context)

--- a/datasets/tw/legislature/crawler.py
+++ b/datasets/tw/legislature/crawler.py
@@ -44,11 +44,11 @@ def crawl_member(
     leave_flag = row.pop("leaveFlag")
     leave_date = row.pop("leaveDate") or None
     if leave_flag not in ("否", "是"):
-        raise ValueError("Unexpected leaveFlag: %r" % leave_flag)
+        raise ValueError(f"Unexpected leaveFlag: {leave_flag!r}")
     end_date: str | None
     if leave_flag == "是":
         if leave_date is None:
-            raise ValueError("Departed member without leaveDate: %r" % name)
+            raise ValueError(f"Departed member without leaveDate: {name!r}")
         end_date = leave_date
     else:
         end_date = next_start[term]

--- a/datasets/tw/shtc/crawler.py
+++ b/datasets/tw/shtc/crawler.py
@@ -143,7 +143,7 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("shtc_list.csv", context.data_url)
     context.export_resource(path, mime_type=CSV, title=context.SOURCE_TITLE)
     # utf-8-sig filters out weird Microsoft BOM artifacts
-    with open(path, "rt", encoding="utf-8-sig") as infh:
+    with open(path, encoding="utf-8-sig") as infh:
         for row in csv.DictReader(infh):
             crawl_row(context, row)
 

--- a/datasets/ua/edr/parse.py
+++ b/datasets/ua/edr/parse.py
@@ -143,7 +143,7 @@ def parse_uo(context: Context, fh: IO[bytes]) -> None:
 def crawl(context: Context) -> None:
     path = context.get_resource_path("source.zip")
     fetch_internal_data("ua_edr/23022022.zip", path)
-    context.log.info("Parsing: %s" % path)
+    context.log.info(f"Parsing: {path}")
     with ZipFile(path, "r") as zip:
         for name in zip.namelist():
             if not name.lower().endswith(".xml"):

--- a/datasets/ua/edr/parse.py
+++ b/datasets/ua/edr/parse.py
@@ -67,7 +67,7 @@ def parse_owner(context: Context, company_id: str, unique_id: str, el: Element) 
 def parse_uo(context: Context, fh: IO[bytes]) -> None:
     for idx, (_, el) in enumerate(etree.iterparse(fh, tag="RECORD")):
         if idx > 0 and idx % 10000 == 0:
-            context.log.info("Parse UO records: %d..." % idx)
+            context.log.info(f"Parse UO records: {idx}...")
         # print(tag_text(el))
 
         company = context.make("Company")

--- a/datasets/ua/sfms_blacklist/crawler.py
+++ b/datasets/ua/sfms_blacklist/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Generator, Optional
+from collections.abc import Generator
 from datetime import datetime
 from followthemoney.types.identifier import IdentifierType
 
@@ -31,7 +31,7 @@ DATES_SPLITS = [
 ]
 
 
-def clean_id(entity: Entity, text: Optional[str]) -> Generator[str, None, None]:
+def clean_id(entity: Entity, text: str | None) -> Generator[str, None, None]:
     if text is None:
         return
     for substring in text.split(";"):

--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -8,7 +8,6 @@ ship-management orgs) so they don't depend on the source's internal numeric ids.
 
 import re
 from collections.abc import Iterator
-from typing import Optional
 from urllib.parse import urljoin
 
 from normality import squash_spaces
@@ -124,7 +123,7 @@ def resource_links(doc: Element) -> list[str]:
     )
 
 
-def parse_party(raw: Optional[str]) -> Optional[dict[str, str]]:
+def parse_party(raw: str | None) -> dict[str, str] | None:
     """Parse a 'Name (IMO / Country / Date)' owner/manager row."""
     if raw is None:
         return None
@@ -137,7 +136,7 @@ def parse_party(raw: Optional[str]) -> Optional[dict[str, str]]:
 def emit_party(
     context: Context,
     vessel: Entity,
-    raw: Optional[str],
+    raw: str | None,
     *,
     role: str,
     schema: str,
@@ -170,7 +169,7 @@ def url_id_of(url: str) -> str:
     return url.rstrip("/").rsplit("/", 1)[-1]
 
 
-def value_lines(el: Optional[Element]) -> list[str]:
+def value_lines(el: Element | None) -> list[str]:
     """Text runs of a value cell, split on <br> (one per text node), whitespace-squashed."""
     if el is None:
         return []
@@ -178,15 +177,13 @@ def value_lines(el: Optional[Element]) -> list[str]:
     return [s for s in (squash_spaces(t) for t in texts) if s]
 
 
-def pop_text(pairs: dict[str, Element], label: str) -> Optional[str]:
+def pop_text(pairs: dict[str, Element], label: str) -> str | None:
     """Remove a label's value cell from the map and return its squashed text, if any."""
     el = pairs.pop(label, None)
     return h.element_text(el) or None if el is not None else None
 
 
-def pop_prefixed(
-    pairs: dict[str, Element], prefix: str
-) -> tuple[Optional[Element], str]:
+def pop_prefixed(pairs: dict[str, Element], prefix: str) -> tuple[Element | None, str]:
     """Remove the first label that starts with `prefix`; return its value cell and full label.
 
     Used where a label carries an appended status badge (e.g. a liquidation date) so its text
@@ -246,8 +243,8 @@ def crawl_entity_page(
     context: Context,
     url: str,
     *,
-    program_key: Optional[str],
-    topic: Optional[str],
+    program_key: str | None,
+    topic: str | None,
 ) -> str:
     """Emit a LegalEntity from any company-type page (col-sm-8 layout); return its id.
 
@@ -508,8 +505,8 @@ def crawl_person_page(
     context: Context,
     url: str,
     *,
-    program_key: Optional[str],
-    topic: Optional[str],
+    program_key: str | None,
+    topic: str | None,
 ) -> None:
     """Emit a Person from a persons-listing detail page (col-md-4 layout).
 

--- a/datasets/us/ak/med_exclusions/crawler.py
+++ b/datasets/us/ak/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import PDF
 
 from zavod import Context, helpers as h
@@ -16,7 +15,7 @@ Return an empty string for unset fields.
 """
 
 
-def crawl_item(row: Dict[str, str], context: Context) -> None:
+def crawl_item(row: dict[str, str], context: Context) -> None:
     if not row.get("last_name"):
         return
 

--- a/datasets/us/al/med_exclusions/crawler.py
+++ b/datasets/us/al/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 import re
-from typing import List
 
 from openpyxl import load_workbook
 from pydantic import BaseModel, Field
@@ -61,8 +60,8 @@ POSITIONS_DESCRIPTION = (
 class Entity(BaseModel):
     name: str
     name_suffix: str | None = None
-    aliases: List[str] = []
-    positions: List[str] = Field(default=[], description=POSITIONS_DESCRIPTION)
+    aliases: list[str] = []
+    positions: list[str] = Field(default=[], description=POSITIONS_DESCRIPTION)
     address: str | None = None
 
 
@@ -84,7 +83,7 @@ RELATED_ENTITIES_DESCRIPTION = (
 
 
 class RootEntity(Entity):
-    related_entities: List[RelatedEntity] = Field(
+    related_entities: list[RelatedEntity] = Field(
         default=[], description=RELATED_ENTITIES_DESCRIPTION
     )
 

--- a/datasets/us/bis_denied/crawler.py
+++ b/datasets/us/bis_denied/crawler.py
@@ -73,7 +73,7 @@ def crawl(context: Context) -> None:
     elif ".csv" in url:
         context.log.info("Reading as CSV", url=url)
         path = path.rename(path.with_suffix(".csv"))
-        with open(path, "rt", encoding="utf-8-sig") as infh:
+        with open(path, encoding="utf-8-sig") as infh:
             reader = csv.DictReader(infh)
             fieldnames = reader.fieldnames
         norm_fieldnames = []
@@ -81,7 +81,7 @@ def crawl(context: Context) -> None:
             field = field.lower().replace(" ", "_")
             field = context.lookup_value("columns", field, field)
             norm_fieldnames.append(field)
-        with open(path, "rt", encoding="utf-8-sig") as infh:
+        with open(path, encoding="utf-8-sig") as infh:
             reader = csv.DictReader(infh, fieldnames=norm_fieldnames)
             next(reader)  # Skip header row
             rows = list(reader)

--- a/datasets/us/ca/med_exclusions/crawler.py
+++ b/datasets/us/ca/med_exclusions/crawler.py
@@ -106,7 +106,7 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", excel_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
 
-    with open(path, "r", encoding="utf-8-sig") as f:
+    with open(path, encoding="utf-8-sig") as f:
         reader = csv.DictReader(f)
         assert reader.fieldnames is not None
         reader.fieldnames = [slugify(key, sep="_") or "" for key in reader.fieldnames]

--- a/datasets/us/cbp_forced_labor/crawler.py
+++ b/datasets/us/cbp_forced_labor/crawler.py
@@ -59,6 +59,6 @@ def crawl(context: Context) -> None:
     _, _, _, path = fetch_resource(context, "source.csv", csv_url, CSV)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
 
-    with open(path, "r", encoding="latin-1") as fh:
+    with open(path, encoding="latin-1") as fh:
         for row in csv.DictReader(fh):
             crawl_row(context, row)

--- a/datasets/us/cftc_enforcement_actions/crawler.py
+++ b/datasets/us/cftc_enforcement_actions/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Literal, Optional
+from typing import Literal
 
 from lxml.html import HtmlElement
 from pydantic import BaseModel, Field
@@ -46,20 +46,20 @@ class RelatedCompany(BaseModel):
 class Defendant(BaseModel):
     entity_schema: Schema = schema_field
     name: str
-    aliases: List[str] | None = []
-    address: str | List[str] | None = address_field
-    country: str | List[str] | None = []
+    aliases: list[str] | None = []
+    address: str | list[str] | None = address_field
+    country: str | list[str] | None = []
     # status - was removed because it isn't consistently present in the source
     #          text in a way we can extract as a meaningful self-standing value.
     #          It remains in the json of old accepted values but is unused and
     #          not added for new entries.
     # notes - was just additional context to 'status'. Same fate.
-    original_press_release_number: Optional[str] = original_press_release_number_field
-    related_companies: List[RelatedCompany] = []
+    original_press_release_number: str | None = original_press_release_number_field
+    related_companies: list[RelatedCompany] = []
 
 
 class Defendants(BaseModel):
-    defendants: List[Defendant]
+    defendants: list[Defendant]
 
 
 PROMPT = f"""
@@ -229,7 +229,7 @@ def crawl_index_page(context: Context, doc: HtmlElement) -> bool:
 
 
 def crawl(context: Context) -> None:
-    next_url: Optional[str] = context.data_url
+    next_url: str | None = context.data_url
     while next_url:
         doc = context.fetch_html(next_url, absolute_links=True)
         next_urls = doc.xpath(".//a[@rel='next']/@href")

--- a/datasets/us/cia_world_leaders/crawler.py
+++ b/datasets/us/cia_world_leaders/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from normality import slugify, squash_spaces
 from zavod.stateful.positions import categorise
@@ -33,8 +33,8 @@ def crawl_leader(
     context: Context,
     country: str,
     source_url: str,
-    section: Optional[str],
-    leader: Dict[str, Any],
+    section: str | None,
+    leader: dict[str, Any],
 ) -> None:
     name = squash_spaces(leader["name"])
     name = name.replace("(Acting)", "")
@@ -96,7 +96,7 @@ def crawl_leader(
 
 
 def crawl_country(context: Context, country: str) -> None:
-    context.log.debug("Crawling country: %s" % country)
+    context.log.debug(f"Crawling country: {country}")
     country_slug = slugify(country.replace("'", ""), sep="-")
     data_url = DATA_URL % country_slug
     source_url = WEB_URL % country_slug

--- a/datasets/us/cms_npi/crawler.py
+++ b/datasets/us/cms_npi/crawler.py
@@ -1,7 +1,7 @@
 import csv
 import html
 from io import TextIOWrapper
-from typing import Any, Optional, TextIO
+from typing import Any, TextIO
 from urllib.parse import urljoin
 import zipfile
 from rigour.mime.types import ZIP
@@ -19,7 +19,7 @@ def unescape_row(row: dict[str, Any]) -> dict[str, Any]:
     return {k: html.unescape(v) if isinstance(v, str) else v for k, v in row.items()}
 
 
-def clean_name(value: Optional[str]) -> Optional[str]:
+def clean_name(value: str | None) -> str | None:
     """Return ``value`` only if it plausibly contains a name.
 
     The source frequently misuses name fields for placeholders (``-----``,
@@ -35,7 +35,7 @@ def clean_name(value: Optional[str]) -> Optional[str]:
     return value
 
 
-def npi_id(npi: Any) -> Optional[str]:
+def npi_id(npi: Any) -> str | None:
     """Format NPI as a zero-padded 10-digit string."""
     if npi is None or len(npi) != 10:
         return None

--- a/datasets/us/corpwatch/crawler.py
+++ b/datasets/us/corpwatch/crawler.py
@@ -3,15 +3,15 @@ import tarfile
 from io import TextIOWrapper
 from pathlib import Path
 from normality import slugify
-from typing import Callable, Optional, Dict
+from collections.abc import Callable
 
 from zavod import Context, Entity
 from zavod import helpers as h
 
-Row = Dict[str, str]
+Row = dict[str, str]
 
 
-def clean(value: Optional[str] = None) -> Optional[str]:
+def clean(value: str | None = None) -> str | None:
     if value is None:
         return None
     if value.lower().strip() == "null":
@@ -19,7 +19,7 @@ def clean(value: Optional[str] = None) -> Optional[str]:
     return value
 
 
-def make_proxy(context: Context, cw_id: str, row: Row) -> Optional[Entity]:
+def make_proxy(context: Context, cw_id: str, row: Row) -> Entity | None:
     """
     The cases detected where we don't find a suitable id are unusual data, so
     it's ok to not return any proxy then.
@@ -136,7 +136,7 @@ def parse_csv(
     with tarfile.open(data_path, "r:*") as tf:
         member = tf.extractfile(f"corpwatch_api_tables_csv/{name}")
         if member is None:
-            raise RuntimeError("Missing file in archive: %s" % name)
+            raise RuntimeError(f"Missing file in archive: {name}")
         wrapper = TextIOWrapper(member, encoding="utf-8-sig")
         reader = csv.DictReader(wrapper, delimiter="\t")
         idx = 0

--- a/datasets/us/cuba_sanctions/crawler.py
+++ b/datasets/us/cuba_sanctions/crawler.py
@@ -37,7 +37,7 @@ def crawl_accommodations(context: Context) -> None:
 
     path = context.fetch_resource("accommodations.csv", ACCOMMODATIONS_URL)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             proxy = context.make("Company")
             name = row.pop("Name").strip()
@@ -65,7 +65,7 @@ def crawl_restricted_entities(context: Context) -> None:
 
     path = context.fetch_resource("restricted_entities.csv", RESTRICTED_ENTITIES_URL)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             proxy = context.make("Company")
             name = row.pop("Company").strip()

--- a/datasets/us/dc/exclusions/crawler.py
+++ b/datasets/us/dc/exclusions/crawler.py
@@ -80,7 +80,7 @@ def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url, cache_days=1)
     tables = h.xpath_elements(doc, ".//table")
     # We expect 2 current and 2 historical tables
-    assert len(tables) == 4, "Expected 4 tables, found %d" % len(tables)
+    assert len(tables) == 4, f"Expected 4 tables, found {len(tables)}"
 
     for table in tables:
         for row in h.parse_html_table(table, header_tag="td"):

--- a/datasets/us/dea_fugitives/crawler.py
+++ b/datasets/us/dea_fugitives/crawler.py
@@ -77,7 +77,7 @@ def crawl(context: Context) -> None:
 
     while True:
         url = base_url + "?page=" + str(page_num)
-        context.log.info("Fetching page: %s" % page_num, url=url)
+        context.log.info(f"Fetching page: {page_num}", url=url)
         response = context.fetch_html(
             url, cache_days=1, headers=HEADERS, absolute_links=True
         )

--- a/datasets/us/dhs_uflpa/crawler.py
+++ b/datasets/us/dhs_uflpa/crawler.py
@@ -21,14 +21,12 @@ from zavod.extract.zyte_api import fetch_html
 # NAME, and Subsidiaries
 
 REGEX_NAME_STRUCTURE = re.compile(
-    (
-        r"^"
-        r"(?P<main>[\w.,/&\(\) -]+?) ?"
-        r"(\(((and|including) [a-z]+ alias(es)? ?:|(formerly|also) known as) (?P<alias_list>.+)\))? ?"
-        r"(?P<subordinate_note>, and Subsidiaries| and (subsidiaries|its subordinate and affiliated entities))? ?"
-        r"(and its ([a-z]+ [a-zA-Z]+-based subsidiaries, which include|subsidiary) (?P<subsidiary_list>.+))?"
-        r"$"
-    )
+    r"^"
+    r"(?P<main>[\w.,/&\(\) -]+?) ?"
+    r"(\(((and|including) [a-z]+ alias(es)? ?:|(formerly|also) known as) (?P<alias_list>.+)\))? ?"
+    r"(?P<subordinate_note>, and Subsidiaries| and (subsidiaries|its subordinate and affiliated entities))? ?"
+    r"(and its ([a-z]+ [a-zA-Z]+-based subsidiaries, which include|subsidiary) (?P<subsidiary_list>.+))?"
+    r"$"
 )
 SPLITTERS = [" and formerly known as ", ", and ", "; and ", ", ", "; "]
 

--- a/datasets/us/dod_chinese_milcorps/crawler.py
+++ b/datasets/us/dod_chinese_milcorps/crawler.py
@@ -36,7 +36,7 @@ def crawl(context: Context) -> None:
     # DOD Releases List of Chinese Military Companies in Accordance With Section 1260H of the National Defense Authorization Act for Fiscal Year 2021
 
     source_file = context.fetch_resource("source.csv", context.data_url)
-    with open(source_file, "r") as f:
+    with open(source_file) as f:
         reader = csv.DictReader(f)
         for row in reader:
             entity = context.make("Company")

--- a/datasets/us/fara_filings/crawler.py
+++ b/datasets/us/fara_filings/crawler.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from lxml import etree
 from rigour.mime.types import ZIP
 from pathlib import Path
-from typing import Iterator
+from collections.abc import Iterator
 from zipfile import ZipFile
 
 from zavod import Context, helpers as h

--- a/datasets/us/fbi_lazarus_crypto/crawler.py
+++ b/datasets/us/fbi_lazarus_crypto/crawler.py
@@ -1,9 +1,8 @@
 import csv
-from typing import Dict
 from zavod import Context
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     publicKey = row.pop("Address")
     network = row.pop("Network")
     linked_to = row.pop("Linked to")
@@ -32,7 +31,7 @@ def crawl_row(context: Context, row: Dict[str, str]) -> None:
 
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/us/fbi_most_wanted/crawler.py
+++ b/datasets/us/fbi_most_wanted/crawler.py
@@ -1,7 +1,6 @@
 import re
 import math
 from itertools import count
-from typing import Optional
 
 from zavod import Context
 from zavod import helpers as h
@@ -86,7 +85,7 @@ def crawl_person(context: Context, url: str) -> None:
                 if len(date) > 1:
                     h.apply_date(person, "birthDate", date)
         elif key in IGNORE_FIELDS:
-            note = "%s: %s" % (key, value)
+            note = f"{key}: {value}"
             person.add("notes", note)
         else:
             context.log.warn("Unknown field in table", key=key, value=value)
@@ -111,14 +110,14 @@ def crawl_person(context: Context, url: str) -> None:
 
 
 def crawl_type(context: Context, *, query_type: str, query_id: str) -> None:
-    total_pages: Optional[int] = None
+    total_pages: int | None = None
     total_xpath = './/div[@class="row top-total"]//p'
     for page in count(1):
         if total_pages is not None and page > total_pages:
             break
         url = FBI_URL % (query_type, query_id, page)
         # print(url)
-        context.log.info("Fetching %s" % url)
+        context.log.info(f"Fetching {url}")
         doc = fetch_html(context, url, total_xpath)
 
         if total_pages is None:

--- a/datasets/us/fcc_covered_list/crawler.py
+++ b/datasets/us/fcc_covered_list/crawler.py
@@ -1,6 +1,5 @@
 import csv
 from rigour.mime.types import CSV
-from typing import Dict
 from pathlib import Path
 
 from zavod import Context, helpers as h
@@ -9,7 +8,7 @@ from zavod.extract import zyte_api
 PROGRAM_KEY = "US-FCC"
 
 
-def crawl_item(context: Context, input_dict: Dict[str, str]) -> None:
+def crawl_item(context: Context, input_dict: dict[str, str]) -> None:
     name = input_dict.pop("Entity Name")
     description = input_dict.pop("Covered Equipment or Services")
 

--- a/datasets/us/fdic_failed_banks/crawler.py
+++ b/datasets/us/fdic_failed_banks/crawler.py
@@ -3,10 +3,9 @@ from rigour.mime.types import CSV
 
 from zavod import Context
 from zavod import helpers as h
-from typing import Dict
 
 
-def clean_row(row: Dict[str, str]) -> Dict[str, str]:
+def clean_row(row: dict[str, str]) -> dict[str, str]:
     """Clean non-standard spaces from row keys and values."""
     return {
         k.replace("\xa0", " ").strip(): v.replace("\xa0", " ").strip()
@@ -14,7 +13,7 @@ def clean_row(row: Dict[str, str]) -> Dict[str, str]:
     }
 
 
-def crawl_row(context: Context, row: Dict[str, str]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     row = clean_row(row)  # Clean the row before processing
 
     # Ensure the row contains necessary data
@@ -81,7 +80,7 @@ def crawl(context: Context) -> None:
 
     # Attempt to open the CSV file with different encodings
 
-    with open(source_path, "r", encoding="latin-1") as csvfile:
+    with open(source_path, encoding="latin-1") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/us/fed_enforcements/crawler.py
+++ b/datasets/us/fed_enforcements/crawler.py
@@ -1,5 +1,4 @@
 import csv
-from typing import Optional
 from urllib.parse import urljoin, urlparse
 
 from pydantic import BaseModel, Field
@@ -49,7 +48,7 @@ Instructions for specific fields:
 """
 
 
-def crawl_article(context: Context, url: str | None) -> Optional[Entity]:
+def crawl_article(context: Context, url: str | None) -> Entity | None:
     if not url or not url.strip():
         return None
     title: str | None = None
@@ -158,7 +157,7 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
 
-    with open(path, "r", encoding="utf-8-sig") as fh:
+    with open(path, encoding="utf-8-sig") as fh:
         for item in csv.DictReader(fh):
             url = item.pop("URL")
             if url != "DNE":

--- a/datasets/us/fincen_msb/crawler.py
+++ b/datasets/us/fincen_msb/crawler.py
@@ -1,5 +1,4 @@
 from csv import DictReader
-from typing import Dict, List
 from rigour.mime.types import CSV
 
 from zavod import Context
@@ -34,7 +33,7 @@ IGNORE_COLUMNS = [
 ]
 
 
-def crawl_row(context: Context, row: Dict[str, List[str]]) -> None:
+def crawl_row(context: Context, row: dict[str, list[str]]) -> None:
     name = h.multi_split(row.pop("LEGAL NAME"), NAME_SPLITS)
     street = row.pop("STREET ADDRESS")
     city = row.pop("CITY")

--- a/datasets/us/fincen_special_measures/crawler.py
+++ b/datasets/us/fincen_special_measures/crawler.py
@@ -2,21 +2,21 @@ from lxml import html
 import re
 from zavod import Context, helpers as h
 from normality import slugify, squash_spaces
-from typing import Dict, Generator, cast
-from typing import List
+from typing import cast
+from collections.abc import Generator
 from normality import collapse_spaces
 
 
 REGEX_DATE = re.compile(r"(\d{1,2}/\d{1,2}/\d{4})")
 
 
-def convert_date(date_str: str) -> List[str]:
+def convert_date(date_str: str) -> list[str]:
     """Convert various date formats to 'YYYY-MM-DD'."""
     dates = REGEX_DATE.findall(date_str)
     return dates
 
 
-def crawl_item(context: Context, row: Dict[str, str]) -> None:
+def crawl_item(context: Context, row: dict[str, str]) -> None:
     # Create the entity based on the schema
     name = row.pop("name").text_content()
     schema = context.lookup_value("target_type", name)
@@ -73,7 +73,7 @@ def crawl_item(context: Context, row: Dict[str, str]) -> None:
 
 
 # Parse the table and yield rows as dictionaries.
-def parse_table(table: html.HtmlElement) -> Generator[Dict[str, str], None, None]:
+def parse_table(table: html.HtmlElement) -> Generator[dict[str, str], None, None]:
     headers = None
     for row in table.findall(".//tr"):
         if headers is None:

--- a/datasets/us/finra_actions/crawler.py
+++ b/datasets/us/finra_actions/crawler.py
@@ -20,7 +20,6 @@ Mitigations:
 
 from lxml.etree import _Element
 from secrets import token_urlsafe
-from typing import Dict, Optional
 from urllib.parse import parse_qs, urljoin, urlparse
 
 from zavod import Context, helpers as h
@@ -32,7 +31,7 @@ RESULT_ROW_VALIDATOR = (
 )
 
 
-def crawl_item(context: Context, row: Dict[str, _Element]) -> None:
+def crawl_item(context: Context, row: dict[str, _Element]) -> None:
     names = []
     name_els = row.pop("firms_individuals")
     for div_row in h.xpath_elements(name_els, ".//div[@class='row']"):
@@ -82,7 +81,7 @@ def crawl_item(context: Context, row: Dict[str, _Element]) -> None:
     context.audit_data(row, ignore=["document_type"])
 
 
-def get_max_page(response: _Element) -> Optional[int]:
+def get_max_page(response: _Element) -> int | None:
     links = h.xpath_elements(response, ".//a[contains(@title, 'Go to last page')]")
     if len(links) == 0:
         # Intermediate result pages incorrectly showing "No Results Found" have

--- a/datasets/us/ga/med_exclusions/crawler.py
+++ b/datasets/us/ga/med_exclusions/crawler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, Optional, NamedTuple
+from typing import NamedTuple
 
 from openpyxl import load_workbook
 
@@ -8,9 +8,9 @@ from zavod import Context, helpers as h
 
 
 class SplitName(NamedTuple):
-    middle_name: Optional[str]
-    aliases: List[str]
-    first_names: List[str]
+    middle_name: str | None
+    aliases: list[str]
+    first_names: list[str]
 
 
 def split_middle_name(context: Context, middle_name: str) -> SplitName:
@@ -30,12 +30,12 @@ def split_middle_name(context: Context, middle_name: str) -> SplitName:
     return SplitName(name, aliases, [])
 
 
-def crawl_item(row: Dict[str, str | None], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     first_name = row.pop("first_name")
     last_name = row.pop("last_name")
     middle_name = row.pop("middle_name")
-    first_names: List[str] = []
-    aliases: List[str] = []
+    first_names: list[str] = []
+    aliases: list[str] = []
     if middle_name and "aka" in middle_name.lower():
         split = split_middle_name(context, middle_name)
         middle_name, aliases, first_names = split

--- a/datasets/us/hhs_exclusions/crawler.py
+++ b/datasets/us/hhs_exclusions/crawler.py
@@ -1,5 +1,5 @@
 import csv
-from typing import Dict, Any
+from typing import Any
 
 from zavod import helpers as h
 from zavod import Context
@@ -12,7 +12,7 @@ def is_zero(value: str) -> bool:
     return all(c == "0" for c in value)
 
 
-def crawl_item(context: Context, row: Dict[str, Any]) -> None:
+def crawl_item(context: Context, row: dict[str, Any]) -> None:
     city = row.pop("CITY")
     zip_code = row.pop("ZIP")
     first_name = row.pop("FIRSTNAME")
@@ -105,7 +105,7 @@ def crawl_item(context: Context, row: Dict[str, Any]) -> None:
 
 def crawl(context: Context) -> None:
     source_file = context.fetch_resource("source.csv", context.data_url)
-    with open(source_file, "r") as f:
+    with open(source_file) as f:
         reader = csv.DictReader(f)
         for row in reader:
             for key, value in row.items():

--- a/datasets/us/in/med_exclusions/crawler.py
+++ b/datasets/us/in/med_exclusions/crawler.py
@@ -1,11 +1,10 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
 from zavod import Context, helpers as h
 
 
-def crawl_item(context: Context, row: Dict[str, str | None]) -> None:
+def crawl_item(context: Context, row: dict[str, str | None]) -> None:
     name = row.pop("provider_name")
 
     if not name:

--- a/datasets/us/irs_ffi/crawler.py
+++ b/datasets/us/irs_ffi/crawler.py
@@ -7,7 +7,7 @@ from zavod import Context
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for row in csv.DictReader(fh):
             giin = row.pop("GIIN")
             name = row.pop("FINm")

--- a/datasets/us/me/med_exclusions/crawler.py
+++ b/datasets/us/me/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 import json
-from typing import Dict
 
 from openpyxl import load_workbook
 from rigour.mime.types import XLSX
@@ -13,7 +12,7 @@ EXCEL_FILENAME = "PI0008-PM%20Monthly%20Exclusion%20Report.xlsx"
 BASE_URL = "https://mainecare.maine.gov/PrvExclRpt"
 
 
-def crawl_item(row: Dict[str, str | None], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     if first_name := row.pop("provider_first_name"):
         last_name = row.pop("provider_last_name")
         middle_initial = row.pop("provider_mi")

--- a/datasets/us/mo/med_exclusions/crawler.py
+++ b/datasets/us/mo/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
@@ -7,7 +6,7 @@ from zavod.extract import zyte_api
 from zavod import helpers as h
 
 
-def crawl_item(row: Dict[str, str | None], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     entity = context.make("LegalEntity")
     entity.id = context.make_id(row.get("provider_name"), row.get("npi"))
     entity.add("name", row.pop("provider_name"))

--- a/datasets/us/navy/crawler.py
+++ b/datasets/us/navy/crawler.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
-from typing import Any, Mapping, Optional
+from typing import Any
+from collections.abc import Mapping
 from lxml import html, etree
 from urllib.parse import urljoin
 import orjson
@@ -77,7 +78,7 @@ def crawl_person(context: Context, item_html: str) -> None:
 
 def parse_json_or_xml(
     context: Context, url: str, data: str
-) -> Optional[Mapping[str, Any]]:
+) -> Mapping[str, Any] | None:
     try:
         root = etree.fromstring(data)
         html_data = h.xpath_string(root, ".//*[local-name() = 'data']/text()")

--- a/datasets/us/ne/med_exclusions/crawler.py
+++ b/datasets/us/ne/med_exclusions/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import PDF
 
 from zavod import Context, helpers as h
@@ -7,13 +6,13 @@ from zavod.extract.zyte_api import fetch_resource
 PAGE_SETTINGS = {"join_y_tolerance": 2}
 
 
-def key_from_prefix(row: Dict[str, str | None], prefix: str) -> str:
+def key_from_prefix(row: dict[str, str | None], prefix: str) -> str:
     key = [k for k in row.keys() if k.startswith(prefix)]
     assert len(key) == 1, ("Cannot find key.", key, row)
     return key[0]
 
 
-def crawl_item(row: Dict[str, str | None], context: Context) -> None:
+def crawl_item(row: dict[str, str | None], context: Context) -> None:
     name = row.pop(key_from_prefix(row, "provider_name"))
     listing_date = row.pop(key_from_prefix(row, "date_added_to_nmep"))
     npi = row.pop("provider_npi")

--- a/datasets/us/nk_jointventures/crawler.py
+++ b/datasets/us/nk_jointventures/crawler.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from rigour.mime.types import CSV, PDF
 import csv
 
@@ -6,7 +5,7 @@ from zavod import Context, helpers as h
 from zavod.extract.zyte_api import fetch_html, fetch_resource
 
 
-def crawl_item(context: Context, row: Dict[str, str]) -> None:
+def crawl_item(context: Context, row: dict[str, str]) -> None:
     name = row.pop("Joint Venture Name")
     sector = row.pop("Sector")
 
@@ -40,6 +39,6 @@ def crawl(context: Context) -> None:
 
     csv_path = context.fetch_resource("source.csv", context.data_url)
     context.export_resource(csv_path, CSV, title=context.SOURCE_TITLE)
-    with open(csv_path, "r") as fh:
+    with open(csv_path) as fh:
         for row in csv.DictReader(fh):
             crawl_item(context, row)

--- a/datasets/us/occ_enfact/crawler.py
+++ b/datasets/us/occ_enfact/crawler.py
@@ -18,7 +18,7 @@ IGNORE = [
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         data = json.load(fh)
     for record in data:
         # orig_record = dict(record)

--- a/datasets/us/ofac/enforcement_actions/crawler.py
+++ b/datasets/us/ofac/enforcement_actions/crawler.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, Field
 from zavod.entity import Entity
@@ -65,17 +65,17 @@ class RelatedCompany(BaseModel):
 class Defendant(BaseModel):
     entity_schema: Schema = schema_field
     name: str
-    aliases: List[str] = []
-    address: List[str] = address_field
-    country: List[str] = []
+    aliases: list[str] = []
+    address: list[str] = address_field
+    country: list[str] = []
     status: Status = status_field
-    notes: Optional[str] = notes_field
-    related_companies: List[RelatedCompany] = []
-    pdf_url: List[str] = []
+    notes: str | None = notes_field
+    related_companies: list[RelatedCompany] = []
+    pdf_url: list[str] = []
 
 
 class Defendants(BaseModel):
-    defendants: List[Defendant]
+    defendants: list[Defendant]
 
 
 PROMPT = f"""

--- a/datasets/us/ofac/ofac_advanced.py
+++ b/datasets/us/ofac/ofac_advanced.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from functools import cache, lru_cache
 from banal import first, as_bool
 from collections import defaultdict
-from typing import Union
 from datapatch import Result
 from lxml.etree import tostring, _Element as Element
 from os.path import commonprefix
@@ -20,7 +19,7 @@ from zavod.meta import load_dataset_from_path
 from zavod import helpers as h
 from zavod.util import ElementOrTree
 
-FeatureValue = Union[str, Entity, None]
+FeatureValue = str | Entity | None
 FeatureValues = list[FeatureValue]
 
 

--- a/datasets/us/ofac/ofac_advanced.py
+++ b/datasets/us/ofac/ofac_advanced.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from functools import cache, lru_cache
 from banal import first, as_bool
 from collections import defaultdict
-from typing import Optional, Dict, Union, List, Tuple, Set
+from typing import Union
 from datapatch import Result
 from lxml.etree import tostring, _Element as Element
 from os.path import commonprefix
@@ -21,7 +21,7 @@ from zavod import helpers as h
 from zavod.util import ElementOrTree
 
 FeatureValue = Union[str, Entity, None]
-FeatureValues = List[FeatureValue]
+FeatureValues = list[FeatureValue]
 
 
 @cache
@@ -32,7 +32,7 @@ def load_sdn() -> Dataset:
     return dataset
 
 
-def lookup(name: str, value: Optional[str]) -> Optional[Result]:
+def lookup(name: str, value: str | None) -> Result | None:
     # We don't want to duplicate the lookup configs in both YAML files,
     # so we're hard-coding that lookups go against the SDN config.
     lookup = load_sdn().lookups.get(name)
@@ -86,9 +86,7 @@ SANCTION_FEATURES = {
 IMO_RE = re.compile(r"IMO \d{6,9}")
 
 
-def get_relation_schema(
-    party_schema: Optional[Schema], range: Optional[Schema]
-) -> Schema:
+def get_relation_schema(party_schema: Schema | None, range: Schema | None) -> Schema:
     assert party_schema is not None
     assert range is not None
     if range.is_a("Asset") and party_schema.is_a("Organization"):
@@ -102,28 +100,28 @@ def get_relation_schema(
         raise
 
 
-def get_ref_element(refs: Element, type_: str, id: Optional[str]) -> Element:
+def get_ref_element(refs: Element, type_: str, id: str | None) -> Element:
     if id is None:
-        raise ValueError("Reference ID is None for type: %s" % type_)
+        raise ValueError(f"Reference ID is None for type: {type_}")
     element = refs.find(f"./{type_}Values/{type_}[@ID='{id}']")
     if element is None:
-        raise ValueError("Cannot find reference value [%s]: %s" % (type_, id))
+        raise ValueError(f"Cannot find reference value [{type_}]: {id}")
     return element
 
 
 @cache
-def get_ref_text(refs: Element, type_: str, id: str) -> Optional[str]:
+def get_ref_text(refs: Element, type_: str, id: str) -> str | None:
     element = get_ref_element(refs, type_, id)
     return element.text
 
 
 @cache
-def get_ref_country(refs: Element, id: str) -> Optional[str]:
+def get_ref_country(refs: Element, id: str) -> str | None:
     element = get_ref_element(refs, "Country", id)
     return element.text or element.get("ISO2")
 
 
-def parse_date(el: Optional[Element]) -> Optional[str]:
+def parse_date(el: Element | None) -> str | None:
     if el is None:
         return None
     pf = parse_parts(
@@ -134,9 +132,9 @@ def parse_date(el: Optional[Element]) -> Optional[str]:
     return pf.text
 
 
-def date_prefix(*dates: Optional[str]) -> Optional[str]:
+def date_prefix(*dates: str | None) -> str | None:
     dates_ = [d for d in dates if d is not None]
-    prefix: Optional[str] = commonprefix(dates_)[:10]
+    prefix: str | None = commonprefix(dates_)[:10]
     if prefix is not None and len(prefix) < 10:
         prefix = prefix[:7]
     if prefix is not None and len(prefix) < 7:
@@ -146,14 +144,14 @@ def date_prefix(*dates: Optional[str]) -> Optional[str]:
     return prefix
 
 
-def parse_date_period(date: Element) -> Tuple[str, ...]:
-    start: Optional[str] = None
+def parse_date_period(date: Element) -> tuple[str, ...]:
+    start: str | None = None
     start_el = date.find("./Start")
     if start_el is not None:
         start_from = parse_date(start_el.find("./From"))
         start_to = parse_date(start_el.find("./To"))
         start = date_prefix(start_from, start_to)
-    end: Optional[str] = None
+    end: str | None = None
     end_el = date.find("./End")
     if end_el is not None:
         end_from = parse_date(end_el.find("./From"))
@@ -171,7 +169,7 @@ def parse_date_period(date: Element) -> Tuple[str, ...]:
 
 @lru_cache(maxsize=2000)
 def parse_location(context: Context, refs: Element, location: Element) -> FeatureValue:
-    countries: Set[Optional[str]] = set()
+    countries: set[str | None] = set()
     for area in location.findall("./LocationAreaCode"):
         area_code = get_ref_element(refs, "AreaCode", area.get("AreaCodeID"))
         countries.add(area_code.get("Description"))
@@ -185,7 +183,7 @@ def parse_location(context: Context, refs: Element, location: Element) -> Featur
         context.log.warn("Multiple countries", countries=country_names)
     country_name = first(country_names)
 
-    parts: Dict[Optional[str], Optional[str]] = {}
+    parts: dict[str | None, str | None] = {}
     for part in location.findall("./LocationPart"):
         part_type = get_ref_text(refs, "LocPartType", part.get("LocPartTypeID"))
         parts[part_type] = part.findtext("./LocationPartValue/Value")
@@ -225,7 +223,7 @@ def parse_location(context: Context, refs: Element, location: Element) -> Featur
 
 
 def parse_relation(
-    context: Context, refs: Element, el: Element, parties: Dict[str, Schema]
+    context: Context, refs: Element, el: Element, parties: dict[str, Schema]
 ) -> None:
     type_id = el.get("RelationTypeID")
     type_ = get_ref_text(refs, "RelationType", type_id)
@@ -306,7 +304,7 @@ def parse_relation(
     # pprint(entity.to_dict())
 
 
-def parse_schema(refs: Element, sub_type_id: Optional[str]) -> str:
+def parse_schema(refs: Element, sub_type_id: str | None) -> str:
     sub_type = get_ref_element(refs, "PartySubType", sub_type_id)
 
     type_text = sub_type.text
@@ -314,7 +312,7 @@ def parse_schema(refs: Element, sub_type_id: Optional[str]) -> str:
         type_text = get_ref_text(refs, "PartyType", sub_type.get("PartyTypeID"))
 
     if type_text not in TYPES:
-        raise ValueError("Unknown party type: %s" % type_text)
+        raise ValueError(f"Unknown party type: {type_text}")
 
     return TYPES[type_text]
 
@@ -339,7 +337,7 @@ def parse_distinct_party(
     identity = identities[0]
 
     # Name parts (not clear why this cannot be in aliases...)
-    parts: Dict[str, str] = {}
+    parts: dict[str, str] = {}
     for group in identity.findall("NamePartGroups/MasterNamePartGroup/NamePartGroup"):
         part = get_ref_text(refs, "NamePartType", group.get("NamePartTypeID"))
         group_id = group.get("ID")
@@ -359,7 +357,7 @@ def parse_distinct_party(
     for reg_doc in doc.findall(reg_doc_path):
         parse_id_reg_document(context, proxy, refs, reg_doc)
 
-    features: Dict[str, FeatureValues] = {}
+    features: dict[str, FeatureValues] = {}
     for feature in profile.findall("./Feature"):
         feat_label, values = parse_feature(context, refs, doc, feature)
         if feat_label not in features:
@@ -390,17 +388,17 @@ def parse_alias(
     context: Context,
     proxy: Entity,
     refs: Element,
-    parts: Dict[str, str],
+    parts: dict[str, str],
     alias: Element,
 ) -> None:
     # primary = as_bool(alias.get("Primary"))
     is_weak = as_bool(alias.get("LowQuality"))
     alias_type = get_ref_element(refs, "AliasType", alias.get("AliasTypeID"))
     if alias_type.text not in ALIAS_TYPES:
-        raise ValueError("Unknown alias type: %s" % alias_type.text)
+        raise ValueError(f"Unknown alias type: {alias_type.text}")
     name_prop = ALIAS_TYPES[alias_type.text]
     for name in alias.findall("DocumentedName"):
-        names: Dict[str, str] = defaultdict(lambda: "")
+        names: dict[str, str] = defaultdict(lambda: "")
         lang = "eng"
         for value in name.findall("DocumentedNamePart/NamePartValue"):
             script_id = value.get("ScriptID")
@@ -497,8 +495,8 @@ def parse_id_reg_document(
             proxy.add(conf.prop, number)
 
     if proxy.schema.is_a("Person") and (conf.identification or conf.passport):
-        issue_date: Optional[str] = None
-        expire_date: Optional[str] = None
+        issue_date: str | None = None
+        expire_date: str | None = None
         for date in reg_doc.findall("./DocumentDate"):
             period_el = date.find("./DatePeriod")
             assert period_el is not None
@@ -543,7 +541,7 @@ def parse_id_reg_document(
         context.emit(identification)
 
 
-def extract_sanctions_measure_name(entry: Element, refs: Element) -> Optional[str]:
+def extract_sanctions_measure_name(entry: Element, refs: Element) -> str | None:
     """Extract the source program tag from a sanctions entry."""
     for measure in entry.findall("./SanctionsMeasure"):
         sanctions_type_id = measure.get("SanctionsTypeID")
@@ -561,9 +559,9 @@ def emit_sanctions_entry(
     context: Context,
     proxy: Entity,
     refs: Element,
-    features: Dict[str, FeatureValues],
+    features: dict[str, FeatureValues],
     entry: Element,
-) -> Optional[Entity]:
+) -> Entity | None:
     # context.inspect(entry)
     proxy.add("topics", "sanction")
 
@@ -642,12 +640,12 @@ def emit_sanctions_entry(
 
 def parse_feature(
     context: Context, refs: Element, doc: ElementOrTree, feature: Element
-) -> Tuple[str, FeatureValues]:
+) -> tuple[str, FeatureValues]:
     """Extract the value of typed features linked to entities."""
     feature_id = feature.get("FeatureTypeID")
     feature_label = get_ref_text(refs, "FeatureType", feature_id)
     if feature_label is None:
-        raise ValueError("Unknown feature type ID: %s" % feature_id)
+        raise ValueError(f"Unknown feature type ID: {feature_id}")
     feature_label = feature_label.strip()
     values: FeatureValues = []
 
@@ -745,7 +743,7 @@ def apply_feature(
 
         if prop is None:
             context.log.warn(
-                "Property not found: %s" % result.prop,
+                f"Property not found: {result.prop}",
                 entity=proxy,
                 schema=proxy.schema,
                 feature=feature,
@@ -761,7 +759,7 @@ def apply_feature(
 
         proxy.add(prop, values)
 
-    nested: Optional[Dict[str, str]] = result.nested
+    nested: dict[str, str] | None = result.nested
     if nested is not None:
         # So this is deeply funky: basically, nested entities are
         # mapped from
@@ -785,7 +783,7 @@ def apply_feature(
         if backref is not None:
             backref_prop = adj.schema.get(backref)
             if backref_prop is None:
-                raise ValueError("Backref prop not found: %s" % backref)
+                raise ValueError(f"Backref prop not found: {backref}")
             assert proxy.schema.is_a(backref_prop.range), (
                 proxy.schema,
                 backref_prop.range,
@@ -824,7 +822,7 @@ def crawl(context: Context) -> None:
     # with open(clean_path, "wb") as fh:
     #     fh.write(tostring(doc, pretty_print=True, encoding="utf-8"))
 
-    parties: Dict[str, Schema] = {}
+    parties: dict[str, Schema] = {}
     for distinct_party in doc.findall("./DistinctParties/DistinctParty"):
         proxy = parse_distinct_party(context, doc, refs, distinct_party)
         if proxy.id is not None:

--- a/datasets/us/ofac/press_releases/crawler.py
+++ b/datasets/us/ofac/press_releases/crawler.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional
+from typing import Literal
 
 from lxml.html import tostring
 from pydantic import BaseModel, Field
@@ -34,15 +34,15 @@ schema_field = Field(
 class Designee(BaseModel):
     entity_schema: Schema = schema_field
     name: str
-    aliases: List[str] = []
-    nationality: List[str] = []
-    imo: List[str] = []
-    country: List[str] = []
-    related_url: List[str] = []
+    aliases: list[str] = []
+    nationality: list[str] = []
+    imo: list[str] = []
+    country: list[str] = []
+    related_url: list[str] = []
 
 
 class Designees(BaseModel):
-    designees: List[Designee]
+    designees: list[Designee]
 
 
 PROMPT = f"""
@@ -129,7 +129,7 @@ def crawl_item(
     date: str,
     url: str,
     article_name: str,
-    origin: Optional[str],
+    origin: str | None,
 ) -> None:
     entity = context.make(item.entity_schema)
     entity.id = context.make_id(item.name, *item.country)

--- a/datasets/us/pa/med_exclusions/crawler.py
+++ b/datasets/us/pa/med_exclusions/crawler.py
@@ -103,6 +103,6 @@ def crawl(context: Context) -> None:
     path = context.fetch_resource("list.csv", context.data_url)
     context.export_resource(path, CSV, title=context.SOURCE_TITLE)
 
-    with open(path, "r") as fh:
+    with open(path) as fh:
         for item in csv.DictReader(fh):
             crawl_item(item, context)

--- a/datasets/us/plum_book/crawler.py
+++ b/datasets/us/plum_book/crawler.py
@@ -15,7 +15,7 @@ IGNORE = [
 
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r", encoding="utf-8-sig") as fh:
+    with open(path, encoding="utf-8-sig") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             agency_name = row.pop("AgencyName")

--- a/datasets/us/plural_legislators/crawler.py
+++ b/datasets/us/plural_legislators/crawler.py
@@ -1,6 +1,6 @@
 import re
 import os
-from typing import Any, Dict
+from typing import Any
 from zipfile import ZipFile
 from rigour.mime.types import ZIP
 from yaml import safe_load
@@ -150,7 +150,7 @@ def crawl_jurisdictions(
     jurisdictions = {}
     house_positions = {}
     headers = {"x-api-key": API_KEY}
-    query: Dict[str, Any] = {
+    query: dict[str, Any] = {
         "page": 1,
         "classification": "state",
         "include": "organizations",

--- a/datasets/us/sam_exclusions/crawler.py
+++ b/datasets/us/sam_exclusions/crawler.py
@@ -14,7 +14,8 @@ import io
 import csv
 import time
 from pathlib import Path
-from typing import Optional, Dict, Any, Generator, Tuple
+from typing import Any
+from collections.abc import Generator
 from zipfile import ZipFile
 from urllib.parse import urljoin
 from rigour.mime.types import ZIP
@@ -26,13 +27,13 @@ DOWNLOAD_URL = "https://sam.gov/api/prod/fileextractservices/v1/api/download/"
 IGNORE_COLUMNS = ["CT Code", "Open Data Flag", "SAM Number"]
 
 
-def parse_date(date: Optional[str]) -> str | None:
+def parse_date(date: str | None) -> str | None:
     if date in ("", "Indefinite", None):
         return None
     return date
 
 
-def clean_address_part(part: Any) -> Optional[str]:
+def clean_address_part(part: Any) -> str | None:
     if part is None:
         return None
     cleaned: str = str(part).strip()
@@ -41,7 +42,7 @@ def clean_address_part(part: Any) -> Optional[str]:
     return cleaned
 
 
-def read_rows(zip_path: Path) -> Generator[Tuple[str, Dict[str, str]], None, None]:
+def read_rows(zip_path: Path) -> Generator[tuple[str, dict[str, str]], None, None]:
     with ZipFile(zip_path, "r") as zip:
         for file_name in zip.namelist():
             with zip.open(file_name) as zfh:
@@ -65,13 +66,13 @@ def crawl_data_url(context: Context) -> str:
 
 def us_fed_excl_id(
     context: Context,
-    full_name: Optional[str],
-    first_name: Optional[str],
-    middle_name: Optional[str],
-    last_name: Optional[str],
-    zip_code: Optional[str],
-    city: Optional[str],
-) -> Optional[str]:
+    full_name: str | None,
+    first_name: str | None,
+    middle_name: str | None,
+    last_name: str | None,
+    zip_code: str | None,
+    city: str | None,
+) -> str | None:
     id_name = h.make_name(
         full=full_name,
         first_name=first_name,
@@ -92,15 +93,15 @@ def us_fed_excl_id(
 
 def usgsa_id(
     context: Context,
-    uei: Optional[str],
-    full_name: Optional[str],
-    first_name: Optional[str],
-    middle_name: Optional[str],
-    last_name: Optional[str],
-    zip_code: Optional[str],
-    city: Optional[str],
-    country: Optional[str],
-) -> Optional[str]:
+    uei: str | None,
+    full_name: str | None,
+    first_name: str | None,
+    middle_name: str | None,
+    last_name: str | None,
+    zip_code: str | None,
+    city: str | None,
+    country: str | None,
+) -> str | None:
     id_name = h.make_name(
         full=full_name,
         first_name=first_name,
@@ -131,7 +132,7 @@ def crawl(context: Context) -> None:
     data_url = crawl_data_url(context)
     path = context.fetch_resource("source.zip", data_url)
     context.export_resource(path, ZIP, title=context.SOURCE_TITLE)
-    schemata: Dict[str, str] = {}
+    schemata: dict[str, str] = {}
     for row_number, (filename, row) in enumerate(read_rows(path)):
         classification = row.pop("Classification")
         schema = context.lookup_value("classifications", classification)

--- a/datasets/us/sec/litigation/crawler.py
+++ b/datasets/us/sec/litigation/crawler.py
@@ -1,6 +1,6 @@
 import re
 from time import sleep
-from typing import List, Literal, Optional
+from typing import Literal
 
 from lxml.html import HtmlElement
 from pydantic import BaseModel, Field
@@ -90,15 +90,15 @@ aliases_field = Field(
 class Defendant(BaseModel):
     entity_schema: Schema = schema_field
     name: str
-    aliases: List[str] = aliases_field
-    address: List[str] = address_field
-    country: List[str] = []
+    aliases: list[str] = aliases_field
+    address: list[str] = address_field
+    country: list[str] = []
     status: Status = status_field
-    notes: Optional[str] = notes_field
+    notes: str | None = notes_field
 
 
 class Defendants(BaseModel):
-    defendants: List[Defendant]
+    defendants: list[Defendant]
 
 
 PROMPT = f"""
@@ -130,7 +130,7 @@ def get_title(url: str, article_element: HtmlElement) -> str:
     return titles[0].text_content()
 
 
-def get_case_numbers(article_element: HtmlElement) -> List[str]:
+def get_case_numbers(article_element: HtmlElement) -> list[str]:
     case_numbers = []
     for h3 in article_element.xpath(".//h3"):
         h3_text = h3.text_content().strip()
@@ -147,7 +147,7 @@ def get_release_id(url: str) -> str:
 
 
 def crawl_release(
-    context: Context, date: str, url: str, see_also_urls: List[str]
+    context: Context, date: str, url: str, see_also_urls: list[str]
 ) -> None:
     sleep(SLEEP)
     doc = context.fetch_html(url, headers=HEADERS, cache_days=15, absolute_links=True)
@@ -239,7 +239,7 @@ def crawl_index_page(context: Context, doc: HtmlElement) -> bool:
 
 
 def crawl(context: Context) -> None:
-    next_url: Optional[str] = context.data_url
+    next_url: str | None = context.data_url
     while next_url:
         context.log.info("Crawling index page", url=next_url)
         sleep(SLEEP)

--- a/datasets/us/sec/pause/crawler.py
+++ b/datasets/us/sec/pause/crawler.py
@@ -116,7 +116,7 @@ def crawl(context: Context) -> None:
             sleep(SLEEP)
             name_a_el = h.xpath_element(row.pop("name"), ".//a")
             name, url = h.element_text(name_a_el), name_a_el.get("href")
-            assert url is not None, "No URL found for name: %s" % name
+            assert url is not None, f"No URL found for name: {name}"
             category = h.element_text(row.pop("category"))
 
             crawl_entity(context, url=url, name=name, category=category)

--- a/datasets/us/special_leg/crawler.py
+++ b/datasets/us/special_leg/crawler.py
@@ -77,7 +77,7 @@ def crawl_fr_notices(context: Context) -> None:
 
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.csv", context.data_url)
-    with open(path, "r") as fh:
+    with open(path) as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             crawl_row(context, row)

--- a/datasets/us/trade_csl/crawler.py
+++ b/datasets/us/trade_csl/crawler.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Dict, List, Optional, Generator
+from typing import Any
+from collections.abc import Generator
 from banal import ensure_list
 from rigour.mime.types import JSON
 from followthemoney.types import registry
@@ -34,7 +35,7 @@ from zavod import helpers as h
 REGEX_AUTHORITY_ID_SEP = re.compile(r"(\d+ F\.?R\.?)")
 
 
-def lookup_topic(context: Context, program_name: Optional[str]) -> Optional[str]:
+def lookup_topic(context: Context, program_name: str | None) -> str | None:
     """Lookup the topic based on the sanction program."""
     res = context.lookup("sanction.program", program_name)
     if res is None:
@@ -50,7 +51,7 @@ def emit_relationship(
     entity_id: str,
     *,
     related_name: str,
-    list_entry: Dict[str, Any],
+    list_entry: dict[str, Any],
     source_program: str,
 ) -> None:
     related_entity = context.make("LegalEntity")
@@ -73,7 +74,7 @@ def emit_relationship(
 
 
 def make_and_emit_sanction(
-    context: Context, entity: Entity, *, source_program: str, list_entry: Dict[str, Any]
+    context: Context, entity: Entity, *, source_program: str, list_entry: dict[str, Any]
 ) -> None:
     sanction = h.make_sanction(
         context,
@@ -103,7 +104,7 @@ def make_and_emit_sanction(
 
 
 def parse_addresses(
-    context: Context, addresses: List[Dict[str, str]]
+    context: Context, addresses: list[dict[str, str]]
 ) -> Generator[Entity, None, None]:
     for address in addresses:
         country_code = registry.country.clean(address.get("country"))
@@ -149,14 +150,14 @@ def parse_addresses(
                 yield addr
 
 
-def clean_authority(value: Optional[str]) -> Optional[List[str]]:
+def clean_authority(value: str | None) -> list[str] | None:
     if value is None:
         return None
     value = REGEX_AUTHORITY_ID_SEP.sub(r", \1", value)
     return h.multi_split(value, [";", ", "])
 
 
-def parse_list_entry(context: Context, list_entry: Dict[str, Any]) -> None:
+def parse_list_entry(context: Context, list_entry: dict[str, Any]) -> None:
     for k, v in list(list_entry.items()):
         if isinstance(v, str) and len(v.strip()) == 0:
             list_entry.pop(k)
@@ -300,7 +301,7 @@ def parse_list_entry(context: Context, list_entry: Dict[str, Any]) -> None:
 def crawl(context: Context) -> None:
     path = context.fetch_resource("source.json", context.data_url)
     context.export_resource(path, JSON, title=context.SOURCE_TITLE)
-    with open(path, "r") as file:
+    with open(path) as file:
         data = json.load(file)
         for list_entry in data.get("results"):
             parse_list_entry(context, list_entry)

--- a/datasets/us/tx/med_exclusions/crawler.py
+++ b/datasets/us/tx/med_exclusions/crawler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import urlencode
 
 import xlrd
@@ -9,7 +9,7 @@ from rigour.mime.types import XLS
 from rigour.names.split_phrases import contains_split_phrase
 
 
-def crawl_row(drow: Dict[str, Any], context: Context, wb: xlrd.book.Book) -> None:
+def crawl_row(drow: dict[str, Any], context: Context, wb: xlrd.book.Book) -> None:
     for k, v in drow.items():
         if isinstance(v, str) and v.lower() in ["n/a"]:  # normalize NAs in values
             drow[k] = None

--- a/datasets/uy/pep/crawler.py
+++ b/datasets/uy/pep/crawler.py
@@ -1,5 +1,6 @@
 from zavod import Context
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any
+from collections.abc import Iterator
 from rigour.mime.types import XLSX
 import openpyxl
 from normality import slugify
@@ -8,7 +9,7 @@ from zavod.stateful.positions import OccupancyStatus, categorise
 
 
 def sheet_to_dicts(sheet: Any) -> Iterator[dict[str, Any]]:
-    headers: Optional[List[str]] = None
+    headers: list[str] | None = None
     for row in sheet.rows:
         cells = [c.value for c in row]
 
@@ -21,7 +22,7 @@ def sheet_to_dicts(sheet: Any) -> Iterator[dict[str, Any]]:
             yield row
 
 
-def parse_sheet_row(context: Context, row: Dict[str, str]) -> None:
+def parse_sheet_row(context: Context, row: dict[str, str]) -> None:
     person = context.make("Person")
 
     id_number = row.pop("c-i")

--- a/datasets/ve/asamblea_nacional/crawler.py
+++ b/datasets/ve/asamblea_nacional/crawler.py
@@ -4,7 +4,7 @@ PEP entities for its members.
 """
 
 import re
-from typing import Iterator
+from collections.abc import Iterator
 from urllib.parse import parse_qs, urlparse
 
 from zavod import Context, Entity

--- a/datasets/za/pmg_legislators/crawler.py
+++ b/datasets/za/pmg_legislators/crawler.py
@@ -1,6 +1,5 @@
 from followthemoney.helpers import post_summary
 from rigour.ids.wikidata import is_qid
-from typing import Dict, Optional
 from urllib.parse import unquote
 import re
 from rigour.mime.types import JSON
@@ -111,8 +110,8 @@ def crawl_person(
 
 
 def crawl_membership(
-    context: Context, entity: Entity, membership: dict, organizations: Dict[str, str]
-) -> Optional[str]:
+    context: Context, entity: Entity, membership: dict, organizations: dict[str, str]
+) -> str | None:
     org_id = membership.get("organization_id")
     if org_id is None:
         context.log.info("Membership without organization", membership=membership)
@@ -181,7 +180,7 @@ def crawl_membership(
 def crawl(context: Context) -> None:
     path = context.fetch_resource("pombola.json", context.data_url)
     context.export_resource(path, JSON, context.SOURCE_TITLE)
-    with open(path, "r") as f:
+    with open(path) as f:
         data = loads(f.read())
 
     # Extract and prepare organizations


### PR DESCRIPTION
Companion to #5091 (same migration, `zavod/` core). Independent — touches only `datasets/`.

## What

Runs ruff's pyupgrade (`UP`) rules across all 452 crawler files and clears every finding (1068 → 0).

**Commit 1 — autofixes** (`ruff check datasets/ --select UP --fix --unsafe-fixes` + F401 cleanup + `ruff format`, ~1046 fixes across 233 files):
- PEP 585 builtin generics (`List`→`list`, …), PEP 604 unions (`Optional[X]`→`X | None`, `Union`→`|`)
- dropped deprecated `typing` imports and the now-unused imports the rewrite left behind
- `%`→f-string where autofixable, redundant open modes, useless `object` inheritance, etc.

**Commit 2 — manual** (24 edits, 13 files — the cases ruff would not autofix):
- remaining `%`-format strings (mostly progress-log lines) → f-strings
- `Union`/`Optional` type aliases → PEP 604 (`seco_sanctions.MayStr`, `ofac_advanced.FeatureValue`)

## Verification

- `ruff check datasets/ --select UP` → **All checks passed**
- `ruff check datasets/ --config zavod/pyproject.toml` (E/F, as `lint_crawlers` runs it) + `ruff format --check` → clean
- `mypy-datasets` pre-commit hook → **Passed**

## Note

Like #5091, this does not enable `UP` enforcement. Once both this and #5091 land, the whole tree is `UP`-clean and enforcement (`extend-select = ["UP"]` in `zavod/pyproject.toml`) becomes a safe one-line follow-up.