### PR TITLE
lint: enforce ruff UP + bump nomenklatura 4.12.4 + fix enricher topics

### DIFF
--- a/datasets/_global/black_sea_mou/detention/crawler.py
+++ b/datasets/_global/black_sea_mou/detention/crawler.py
@@ -1,7 +1,7 @@
 import random
 import time
 from datetime import datetime
-from datetime import timezone
+from datetime import UTC
 from typing import Any
 from urllib.parse import urlencode
 
@@ -115,7 +115,7 @@ def crawl(context: Context) -> None:
         "Referer": context.data_url,
         "Origin": context.data_url,
     }
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     year = START_YEAR
     month = START_MONTH
     while (year, month) <= (now.year, now.month):

--- a/datasets/al/kuvendi/crawler.py
+++ b/datasets/al/kuvendi/crawler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -28,7 +28,7 @@ def clean_birth_date(raw: str | None) -> str | None:
     year = int(raw[:4])
     if year < 1925 or year > 2007:
         return None
-    parsed = datetime.fromisoformat(raw).replace(tzinfo=timezone.utc)
+    parsed = datetime.fromisoformat(raw).replace(tzinfo=UTC)
     return parsed.astimezone(TIRANE).date().isoformat()
 
 

--- a/datasets/ee/ariregister/crawler.py
+++ b/datasets/ee/ariregister/crawler.py
@@ -1,6 +1,6 @@
 import ijson  # type: ignore
 import zipfile
-from typing import Any, TypeVar
+from typing import Any
 from collections.abc import Generator
 from followthemoney.util import make_entity_id
 
@@ -8,7 +8,6 @@ from zavod import Context, Entity
 from zavod import helpers as h
 
 Item = dict[str, Any]
-Default = TypeVar("Default")
 
 SOURCES = {
     "officers1": "ettevotja_rekvisiidid__kaardile_kantud_isikud.json",
@@ -28,7 +27,7 @@ TYPES = {
 NULL_NAME = {"-", ".", "#", "##"}
 
 
-def get_value(
+def get_value[Default](
     data: Item, keys: tuple[str, ...], default: Default | None = None
 ) -> Default | Any:
     for key in keys:

--- a/datasets/no/storting/crawler.py
+++ b/datasets/no/storting/crawler.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta, date, timezone
+from datetime import datetime, timedelta, date, timezone, UTC
 from typing import Any
 
 from zavod import Context, helpers as h
@@ -50,7 +50,7 @@ def parse_ms_date(ms_date: str | None) -> date | None:
     ms = int(match.group(1))
     tz_str = match.group(2)
     # Parse the UTC timestamp
-    dt_utc = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+    dt_utc = datetime.fromtimestamp(ms / 1000, tz=UTC)
     # If there's an offset, convert to that local timezone to get the local date
     if tz_str:
         sign = 1 if tz_str[0] == "+" else -1

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 requires-python = ">= 3.12"
 dependencies = [
     "followthemoney == 4.10.0",
-    "nomenklatura == 4.12.2",
+    "nomenklatura == 4.12.4",
     "plyvel == 1.5.1", # Also update macOS install docs
     "rigour == 2.2.3",
     "datapatch >= 1.2.4, < 1.3",
@@ -110,6 +110,7 @@ src_paths = ["zavod"]
 
 [tool.ruff.lint]
 # Pin the enforced rule set explicitly so a ruff upgrade can't opt the whole
-# codebase into new default rules at once. This is the pre-0.16 default set;
-# adopt further rules deliberately via extend-select.
+# codebase into new default rules at once. E4/E7/E9/F is the pre-0.16 default;
+# UP (pyupgrade) is enabled deliberately now that the tree is clean.
 select = ["E4", "E7", "E9", "F"]
+extend-select = ["UP"]

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -212,7 +212,7 @@ def enrich(context: Context) -> None:
     config = dict(context.dataset.config)
     topic_gated: bool = bool(config.get("topic_gated", False))
     enricher = LocalEnricher(context.dataset, context.cache, config)
-    enrich_topics: frozenset[str] = frozenset(enricher._filter_topics)
+    enrich_topics: frozenset[str] = frozenset(enricher.filter_topics)
     if topic_gated and not enrich_topics:
         context.log.warning(
             "topic_gated=True but no topics configured; all expanded entities will be external"


### PR DESCRIPTION
Builds on #5091 (zavod migration) and #5092 (datasets migration) — this branch merges both, then flips enforcement on and fixes the enricher regression. **Merge #5091 and #5092 first**, then rebase this on main so its own diff reduces to the four changes below. (Or merge this one alone — it contains everything.)

## The four changes on top of the migrations

1. **Enable `UP` enforcement** — `extend-select = ["UP"]` in `zavod/pyproject.toml`. The shared config governs both `make lint` (zavod) and the crawler lint (`datasets/`, via `--config`), so the whole tree is now held to pyupgrade.
2. **Version-gated UP fixes** that only surface once UP runs under zavod's 3.12 target: `UP017` (`datetime.timezone.utc` → `datetime.UTC`, 3 crawlers) and `UP047` (PEP 695 generic in `ee/ariregister`), plus the F401/TypeVar cleanup they leave behind. (These weren't caught by the `--select UP` passes in #5091/#5092, which run without the target-version context.)
3. **Bump `nomenklatura` 4.12.2 → 4.12.4.**
4. **Fix `zavod/runner/local_enricher.py`** — read the enricher's public `filter_topics` instead of the removed private `_filter_topics`. nomenklatura 4.12.3 (commit 9174cd6) resolved enricher topics once and exposed them as a public, already-`all`-expanded `filter_topics: Set[str]`; zavod's side was never updated, so `make typecheck` failed and the line would `AttributeError` at runtime. The `"all"` expansion now applies automatically, so the `topic_gated` warning logic and downstream gating use the identical resolved set.

## Verification

- `ruff check zavod/ datasets/ --config zavod/pyproject.toml` (E/F + UP) → **All checks passed**
- `ruff format --check` → clean
- `mypy --strict` (zavod) → **Success, no issues** (the `filter_topics` fix clears the last error)