### PR TITLE
[wd_peps] Retain position entities across crawl phases

### DIFF
--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -1,15 +1,13 @@
+from collections.abc import Generator
 from datetime import datetime
 from functools import lru_cache
-from collections.abc import Generator
 
+from nomenklatura.wikidata import WikidataClient
 from rigour.ids.wikidata import is_qid
 from rigour.territories import get_territories
 from rigour.territories.territory import Territory
-from nomenklatura.wikidata import WikidataClient
-
-from zavod import Context
 from zavod.entity import Entity
-from zavod.shed.wikidata.client import create_wikidata_client, WIKIDATA_QUERY_CACHE
+from zavod.shed.wikidata.client import WIKIDATA_QUERY_CACHE, create_wikidata_client
 from zavod.shed.wikidata.human import wikidata_basic_human
 from zavod.shed.wikidata.position import (
     POSITION_ABOLISHED_CUTOFF,
@@ -18,6 +16,8 @@ from zavod.shed.wikidata.position import (
     wikidata_position,
 )
 from zavod.stateful.positions import categorised_position_qids
+
+from zavod import Context
 
 # Positions are discovered by evidence of use — someone holds them via P39
 # (position held), or they name an officeholder via P1308 — rather than by
@@ -28,6 +28,7 @@ from zavod.stateful.positions import categorised_position_qids
 ABOLISHED_CLAUSE = """
     OPTIONAL { ?position p:P576|p:P582 [ a wikibase:BestRank ; psv:P576|psv:P582 [ wikibase:timeValue ?abolished ] ] }
 """
+POSITION_CACHE_SIZE = 250_000
 
 
 def all_territories() -> Generator[Territory, None, None]:
@@ -112,7 +113,7 @@ def discover_candidates(context: Context, client: WikidataClient) -> set[str]:
                 candidates.update(
                     query_occupation_positions(context, client, territory)
                 )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             context.log.warning(
                 "Position discovery query failed",
                 territory=territory.qid,
@@ -123,11 +124,9 @@ def discover_candidates(context: Context, client: WikidataClient) -> set[str]:
     return candidates
 
 
-@lru_cache(maxsize=5000)
+@lru_cache(maxsize=POSITION_CACHE_SIZE)
 def get_position(context: Context, client: WikidataClient, qid: str) -> Entity | None:
-    """Build (or rebuild) the Position entity for a QID. Bounded cache: evicted
-    entries are reconstructed from the SQL-cached item data, so run-level memory
-    does not grow with the number of accepted positions."""
+    """Retain evaluated FtM positions across every phase of a PEP crawl."""
     item = client.fetch_item(qid)
     if item is None:
         return None
@@ -239,4 +238,13 @@ def crawl(context: Context) -> None:
     context.flush()
     context.log.info(
         f"Emitted {len(has_holders)} positions and {len(done_persons)} candidate persons"
+    )
+    cache_info = get_position.cache_info()
+    context.log.info(
+        "Position entity cache",
+        hits=cache_info.hits,
+        misses=cache_info.misses,
+        evictions=max(0, cache_info.misses - cache_info.currsize),
+        size=cache_info.currsize,
+        maxsize=cache_info.maxsize,
     )

--- a/datasets/_wikidata/peps/wd_peps.yml
+++ b/datasets/_wikidata/peps/wd_peps.yml
@@ -7,7 +7,7 @@ coverage:
   start: 2022-12-27
 deploy:
   memory: "2000Mi"
-  memory_limit: "4000Mi"
+  memory_limit: "5000Mi"
   schedule: "0 0 * * 2,4,6"
   premium: true
 load_statements: true


### PR DESCRIPTION
## What

- increases the FtM Position entity LRU from 5k to 250k entries
- keeps rejected positions cached as None and reports final hit/miss/eviction counts
- raises the wd_peps memory limit from 4 GiB to 5 GiB

The Wikidata Item LRU is unchanged. The larger cache is specifically for already-evaluated FtM Position entities, avoiding repeated type, country, translation and review-database work across classification, holder, person and final-emission phases.

## Memory

A deliberately heavy synthetic Position sample used about 4.06 KiB per entry, or approximately 0.99 GiB for 250k entries. Combined with the observed production peak of roughly 2.8 GiB, the projected peak is about 3.8 GiB under the new 5 GiB limit. Rejected candidates are much cheaper because they cache as None.

## Estonia verification

Warm-cache runs were restricted to Estonia and used the same local PostgreSQL/Wikidata cache:

| FtM cache | runtime | peak RSS | hits | misses | evictions |
| --- | ---: | ---: | ---: | ---: | ---: |
| 5k | 72.63s | 578 MiB | 30,809 | 274 | 0 |
| 250k | 71.04s | 599 MiB | 30,809 | 274 | 0 |

Both emitted exactly 130 positions, 22,118 candidate people, 11,070 entities and 65,480 statements.

This slice does not demonstrate the expected full-run speedup: its complete 274-position working set fits in the existing 5k cache, so neither run evicted anything. The cache-stat log is retained so the first production run can show the actual global working set and eviction reduction.

- ruff check clean
- mypy --strict clean