### PR TITLE
Add Brazil Chamber of Deputies PEP crawler

### DIFF
--- a/datasets/br/chamber_deputies/br_chamber_deputies.yml
+++ b/datasets/br/chamber_deputies/br_chamber_deputies.yml
@@ -1,0 +1,46 @@
+title: Brazil Chamber of Deputies
+name: br_chamber_deputies
+prefix: br-cd
+entry_point: crawler.py
+coverage:
+  frequency: weekly
+  start: 2026-07-24
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Chamber of Deputies of Brazil, the lower house of the National
+  Congress.
+description: |
+  The Chamber of Deputies (Câmara dos Deputados) is the lower house of the National
+  Congress of Brazil. Its 513 federal deputies are elected by open-list proportional
+  representation from the states and the Federal District for a four-year term.
+
+  This dataset records each sitting deputy with their name, legal full name, party, state,
+  gender, date of birth and place of birth from the Chamber's open-data API.
+url: https://www.camara.leg.br/
+publisher:
+  name: Câmara dos Deputados
+  description: >
+    The Chamber of Deputies is the lower house of the National Congress of Brazil.
+  url: https://www.camara.leg.br/
+  country: br
+  official: true
+data:
+  url: https://dadosabertos.camara.leg.br/api/v2/deputados
+  format: JSON
+  lang: por
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 450
+      Position: 1
+    country_entities:
+      br: 450
+  max:
+    schema_entities:
+      Person: 560
+      Position: 1

--- a/datasets/br/chamber_deputies/br_chamber_deputies.yml
+++ b/datasets/br/chamber_deputies/br_chamber_deputies.yml
@@ -8,15 +8,19 @@ coverage:
 load_statements: true
 ci_test: false
 summary: >-
-  Members of the Chamber of Deputies of Brazil, the lower house of the National
-  Congress.
+  Current and recent members of the Chamber of Deputies of Brazil, the lower house
+  of the National Congress.
 description: |
   The Chamber of Deputies (Câmara dos Deputados) is the lower house of the National
   Congress of Brazil. Its 513 federal deputies are elected by open-list proportional
   representation from the states and the Federal District for a four-year term.
 
-  This dataset records each sitting deputy with their name, legal full name, party, state,
-  gender, date of birth and place of birth from the Chamber's open-data API.
+  This dataset records deputies from the Chamber's open-data API, covering each
+  legislative term they served.
+
+  Coverage is not limited to the deputies currently sitting: it spans the recent
+  legislative terms and so also includes former deputies, among them substitutes
+  (suplentes) who held a seat during the current legislature but have since left it.
 url: https://www.camara.leg.br/
 publisher:
   name: Câmara dos Deputados
@@ -26,7 +30,7 @@ publisher:
   country: br
   official: true
 data:
-  url: https://dadosabertos.camara.leg.br/api/v2/deputados
+  url: https://dadosabertos.camara.leg.br/api/v2
   format: JSON
   lang: por
 

--- a/datasets/br/chamber_deputies/br_chamber_deputies.yml
+++ b/datasets/br/chamber_deputies/br_chamber_deputies.yml
@@ -1,9 +1,9 @@
-title: Brazil Chamber of Deputies
+title: Brazil Members of the Chamber of Deputies
 name: br_chamber_deputies
 prefix: br-cd
 entry_point: crawler.py
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-07-24
 load_statements: true
 ci_test: false
@@ -11,16 +11,17 @@ summary: >-
   Current and recent members of the Chamber of Deputies of Brazil, the lower house
   of the National Congress.
 description: |
-  The Chamber of Deputies (Câmara dos Deputados) is the lower house of the National
-  Congress of Brazil. Its 513 federal deputies are elected by open-list proportional
-  representation from the states and the Federal District for a four-year term.
+  Current and historical members of the Chamber of Deputies (Câmara dos Deputados), the
+  lower house of the National Congress of Brazil. Its 513 federal deputies are elected by
+  open-list proportional representation from the states and the Federal District for a
+  four-year term and, together with the Federal Senate, hold the country's legislative
+  power, including passing laws and approving the budget.
 
-  This dataset records deputies from the Chamber's open-data API, covering each
-  legislative term they served.
-
-  Coverage is not limited to the deputies currently sitting: it spans the recent
-  legislative terms and so also includes former deputies, among them substitutes
-  (suplentes) who held a seat during the current legislature but have since left it.
+  This dataset records each deputy with their name, gender, date and place of birth, date
+  of death, tax number (CPF), website, and — for their most recent term — their party and
+  the state they represent. Coverage spans the recent legislative terms, so it also includes
+  former deputies, among them substitutes (suplentes) who held a seat during the current
+  legislature but have since left it.
 url: https://www.camara.leg.br/
 publisher:
   name: Câmara dos Deputados

--- a/datasets/br/chamber_deputies/br_chamber_deputies.yml
+++ b/datasets/br/chamber_deputies/br_chamber_deputies.yml
@@ -35,6 +35,14 @@ data:
   format: JSON
   lang: por
 
+lookups:
+  type.gender:
+    options:
+      - match: M
+        value: male
+      - match: F
+        value: female
+
 tags:
   - list.pep
 

--- a/datasets/br/chamber_deputies/crawler.py
+++ b/datasets/br/chamber_deputies/crawler.py
@@ -1,0 +1,79 @@
+from itertools import count
+from typing import Any
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+GENDERS = {"M": "male", "F": "female"}
+
+
+def crawl_deputy(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    summary: dict[str, Any],
+) -> None:
+    deputy_id = summary["id"]
+    detail = context.fetch_json(f"{context.data_url}/{deputy_id}", cache_days=14)[
+        "dados"
+    ]
+
+    person = context.make("Person")
+    person.id = context.make_slug(str(deputy_id))
+    person.add("name", summary.get("nome"), lang="por")
+    person.add("name", detail.get("nomeCivil"), lang="por")
+    person.add("gender", GENDERS.get(detail.get("sexo")))
+    h.apply_date(person, "birthDate", detail.get("dataNascimento"))
+    h.apply_date(person, "deathDate", detail.get("dataFalecimento"))
+    municipality = detail.get("municipioNascimento")
+    uf = detail.get("ufNascimento")
+    if municipality and uf:
+        person.add("birthPlace", f"{municipality}, {uf}", lang="por")
+    person.add("political", summary.get("siglaPartido"), lang="por")
+    person.add("taxNumber", detail.get("cpf"))
+    person.add("sourceUrl", summary.get("uri"))
+    # Federal deputies must be Brazilian nationals (Constitution of Brazil 1988,
+    # Article 14 §3 I). https://www.constituteproject.org/constitution/Brazil_2017
+    person.add("citizenship", "br")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    if summary.get("siglaUf"):
+        occupancy.add("constituency", summary["siglaUf"])
+    context.emit(occupancy)
+    context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Chamber of Deputies of Brazil",
+        country="br",
+        wikidata_id="Q20058725",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    seen = 0
+    for page in count(1):
+        data = context.fetch_json(
+            context.data_url,
+            params={"ordem": "ASC", "ordenarPor": "nome", "itens": 100, "pagina": page},
+            cache_days=1,
+        )
+        deputies = data["dados"]
+        if not deputies:
+            break
+        for summary in deputies:
+            crawl_deputy(context, position, categorisation, summary)
+            seen += 1
+
+    if seen == 0:
+        raise ValueError("No deputies returned by the Chamber API")

--- a/datasets/br/chamber_deputies/crawler.py
+++ b/datasets/br/chamber_deputies/crawler.py
@@ -1,4 +1,4 @@
-from itertools import count
+from collections.abc import Iterator
 from typing import Any
 
 from zavod import Context
@@ -7,44 +7,108 @@ from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
 GENDERS = {"M": "male", "F": "female"}
+TOPICS = ["gov.national", "gov.legislative"]
+
+
+def next_page_url(data: dict[str, Any]) -> str | None:
+    """Return the href of the API response's `next` page link, if there is one."""
+    return next((link["href"] for link in data["links"] if link["rel"] == "next"), None)
+
+
+def fetch_paginated(
+    context: Context, url: str, params: dict[str, Any]
+) -> Iterator[dict[str, Any]]:
+    """Yield every item across the API's result pages.
+
+    The API caps a page at 1000 items regardless of the requested `itens`, so a
+    larger result set has to be walked page by page by following the `next` link.
+    """
+    data = context.fetch_json(url, params={**params, "itens": 1000}, cache_days=1)
+    yield from data["dados"]
+    next_url = next_page_url(data)
+    while next_url is not None:
+        data = context.fetch_json(next_url, cache_days=1)
+        yield from data["dados"]
+        next_url = next_page_url(data)
 
 
 def crawl_deputy(
     context: Context,
     position: Entity,
     categorisation: PositionCategorisation,
-    summary: dict[str, Any],
+    deputy_id: int,
+    term_start: str,
+    term_end: str,
+    legislature_id: int,
 ) -> None:
-    deputy_id = summary["id"]
-    detail = context.fetch_json(f"{context.data_url}/{deputy_id}", cache_days=14)[
-        "dados"
-    ]
+    detail = context.fetch_json(
+        f"{context.data_url}/deputados/{deputy_id}", cache_days=14
+    )["dados"]
+    status = detail.pop("ultimoStatus")
 
     person = context.make("Person")
     person.id = context.make_slug(str(deputy_id))
-    person.add("name", summary.get("nome"), lang="por")
-    person.add("name", detail.get("nomeCivil"), lang="por")
-    person.add("gender", GENDERS.get(detail.get("sexo")))
-    h.apply_date(person, "birthDate", detail.get("dataNascimento"))
-    h.apply_date(person, "deathDate", detail.get("dataFalecimento"))
-    municipality = detail.get("municipioNascimento")
-    uf = detail.get("ufNascimento")
+    person.add("name", status.pop("nome"), lang="por")
+    person.add("name", detail.pop("nomeCivil"), lang="por")
+    person.add("gender", GENDERS.get(detail.pop("sexo")))
+    h.apply_date(person, "birthDate", detail.pop("dataNascimento"))
+    h.apply_date(person, "deathDate", detail.pop("dataFalecimento"))
+    municipality = detail.pop("municipioNascimento")
+    uf = detail.pop("ufNascimento")
     if municipality and uf:
         person.add("birthPlace", f"{municipality}, {uf}", lang="por")
-    person.add("political", summary.get("siglaPartido"), lang="por")
-    person.add("taxNumber", detail.get("cpf"))
-    person.add("sourceUrl", summary.get("uri"))
+    person.add("taxNumber", detail.pop("cpf"))
+    person.add("website", detail.pop("urlWebsite"))
+    person.add("sourceUrl", detail.pop("uri"))
     # Federal deputies must be Brazilian nationals (Constitution of Brazil 1988,
     # Article 14 §3 I). https://www.constituteproject.org/constitution/Brazil_2017
     person.add("citizenship", "br")
 
+    party = status.pop("siglaPartido")
+    constituency = status.pop("siglaUf")
+    situacao = status.pop("situacao")
+    status_date = status.pop("data")
+    # ultimoStatus only describes the deputy's most recent term.
+    is_most_recent = status.pop("idLegislatura") == legislature_id
+    context.audit_data(
+        detail,
+        ignore=["id", "redeSocial", "escolaridade"],
+    )
+    context.audit_data(
+        status,
+        ignore=[
+            "id",
+            "uri",
+            "uriPartido",
+            "urlFoto",
+            "email",
+            "nomeEleitoral",
+            "gabinete",
+            "condicaoEleitoral",
+            "descricaoStatus",
+        ],
+    )
+
+    # The legislature's term is the period we can always attribute to an occupancy.
+    # Only for the deputy's current term ("Exercício") do we also know a personal
+    # entry date and that the occupancy is still open; past terms keep just the
+    # period bounds, since we don't know when the deputy personally entered or left.
+    holds_now = is_most_recent and situacao == "Exercício"
     occupancy = h.make_occupancy(
-        context, person, position, categorisation=categorisation
+        context,
+        person,
+        position,
+        categorisation=categorisation,
+        start_date=status_date if holds_now else None,
+        period_start=term_start,
+        period_end=term_end,
+        no_end_implies_current=holds_now,
     )
     if occupancy is None:
         return
-    if summary.get("siglaUf"):
-        occupancy.add("constituency", summary["siglaUf"])
+    if is_most_recent:
+        occupancy.add("politicalGroup", party)
+        occupancy.add("constituency", constituency)
     context.emit(occupancy)
     context.emit(person)
 
@@ -55,25 +119,42 @@ def crawl(context: Context) -> None:
         name="Member of the Chamber of Deputies of Brazil",
         country="br",
         wikidata_id="Q20058725",
+        topics=TOPICS,
+        number_of_seats="513",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    seen = 0
-    for page in count(1):
-        data = context.fetch_json(
-            context.data_url,
-            params={"ordem": "ASC", "ordenarPor": "nome", "itens": 100, "pagina": page},
-            cache_days=1,
-        )
-        deputies = data["dados"]
-        if not deputies:
-            break
-        for summary in deputies:
-            crawl_deputy(context, position, categorisation, summary)
-            seen += 1
+    cutoff = h.earliest_term_start(TOPICS)
+    legislatures = sorted(
+        fetch_paginated(
+            context,
+            f"{context.data_url}/legislaturas",
+            {"ordenarPor": "id", "ordem": "DESC"},
+        ),
+        key=lambda legislature: int(legislature["id"]),
+        reverse=True,
+    )
 
-    if seen == 0:
-        raise ValueError("No deputies returned by the Chamber API")
+    for legislature in legislatures:
+        # Terms are processed newest-first; once one ended before the PEP cut-off,
+        # every older term is out of scope too.
+        if legislature["dataFim"] < cutoff:
+            break
+        deputies = fetch_paginated(
+            context,
+            f"{context.data_url}/deputados",
+            {"idLegislatura": legislature["id"], "ordenarPor": "nome", "ordem": "ASC"},
+        )
+        for deputy in deputies:
+            crawl_deputy(
+                context,
+                position,
+                categorisation,
+                deputy["id"],
+                legislature["dataInicio"],
+                legislature["dataFim"],
+                legislature["id"],
+            )

--- a/datasets/br/chamber_deputies/crawler.py
+++ b/datasets/br/chamber_deputies/crawler.py
@@ -6,7 +6,6 @@ from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-GENDERS = {"M": "male", "F": "female"}
 TOPICS = ["gov.national", "gov.legislative"]
 
 
@@ -23,7 +22,7 @@ def fetch_paginated(
     The API caps a page at 1000 items regardless of the requested `itens`, so a
     larger result set has to be walked page by page by following the `next` link.
     """
-    data = context.fetch_json(url, params={**params, "itens": 1000}, cache_days=1)
+    data = context.fetch_json(url, params={**params, "itens": 1000}, cache_days=14)
     yield from data["dados"]
     next_url = next_page_url(data)
     while next_url is not None:
@@ -50,7 +49,7 @@ def crawl_deputy(
     person.id = context.make_slug(str(deputy_id))
     person.add("name", status.pop("nome"), lang="por")
     person.add("name", detail.pop("nomeCivil"), lang="por")
-    person.add("gender", GENDERS.get(detail.pop("sexo")))
+    person.add("gender", detail.pop("sexo"))
     h.apply_date(person, "birthDate", detail.pop("dataNascimento"))
     h.apply_date(person, "deathDate", detail.pop("dataFalecimento"))
     municipality = detail.pop("municipioNascimento")
@@ -121,8 +120,9 @@ def crawl(context: Context) -> None:
         wikidata_id="Q20058725",
         topics=TOPICS,
         number_of_seats="513",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)


### PR DESCRIPTION
Adds a PEP crawler for the **Chamber of Deputies of Brazil** (lower house).

**Source:** official open-data REST API (`dadosabertos.camara.leg.br`) — paginated list + per-deputy detail.

**Output:** Position *Member of the Chamber of Deputies of Brazil* (`Q20058725`); 512 deputies with electoral + legal names, party, state, gender, DOB, birthplace, CPF (taxNumber). Citizenship `br` per Constitution Art. 14 §3 I.

Closes opensanctions/crawler-planning#789

🤖 Generated with [Claude Code](https://claude.com/claude-code)