### PR TITLE
Add Brazil Federal Senate PEP crawler

### DIFF
--- a/datasets/br/federal_senate/br_federal_senate.yml
+++ b/datasets/br/federal_senate/br_federal_senate.yml
@@ -1,0 +1,46 @@
+title: Brazil Federal Senate
+name: br_federal_senate
+prefix: br-sf
+entry_point: crawler.py
+coverage:
+  frequency: weekly
+  start: 2026-07-24
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Federal Senate of Brazil, the upper house of the National
+  Congress.
+description: |
+  The Federal Senate (Senado Federal) is the upper house of the National Congress of
+  Brazil. Its 81 senators — three per state and the Federal District — are elected by
+  majority vote for eight-year terms.
+
+  This dataset records each senator currently in office with their name, full name, party,
+  state and gender from the Senate's open-data service.
+url: https://www.senado.leg.br/
+publisher:
+  name: Senado Federal
+  description: >
+    The Federal Senate is the upper house of the National Congress of Brazil.
+  url: https://www.senado.leg.br/
+  country: br
+  official: true
+data:
+  url: https://legis.senado.leg.br/dadosabertos/senador/lista/atual
+  format: JSON
+  lang: por
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 70
+      Position: 1
+    country_entities:
+      br: 70
+  max:
+    schema_entities:
+      Person: 90
+      Position: 1

--- a/datasets/br/federal_senate/br_federal_senate.yml
+++ b/datasets/br/federal_senate/br_federal_senate.yml
@@ -16,8 +16,8 @@ description: |
   elected by majority vote for eight-year terms and, together with the Chamber of Deputies,
   hold the country's legislative power, including passing laws and approving the budget.
 
-  This dataset records each senator currently in office with their name, gender, party, and
-  state.
+  This dataset records each senator currently in office with their name, gender, party,
+  state, and the eight-year term they were elected to.
 url: https://www.senado.leg.br/
 publisher:
   name: Senado Federal

--- a/datasets/br/federal_senate/br_federal_senate.yml
+++ b/datasets/br/federal_senate/br_federal_senate.yml
@@ -1,9 +1,9 @@
-title: Brazil Federal Senate
+title: Brazil Members of the Federal Senate
 name: br_federal_senate
 prefix: br-sf
 entry_point: crawler.py
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-07-24
 load_statements: true
 ci_test: false
@@ -11,12 +11,13 @@ summary: >-
   Members of the Federal Senate of Brazil, the upper house of the National
   Congress.
 description: |
-  The Federal Senate (Senado Federal) is the upper house of the National Congress of
-  Brazil. Its 81 senators — three per state and the Federal District — are elected by
-  majority vote for eight-year terms.
+  Current members of the Federal Senate (Senado Federal), the upper house of the National
+  Congress of Brazil. Its 81 senators — three per state and the Federal District — are
+  elected by majority vote for eight-year terms and, together with the Chamber of Deputies,
+  hold the country's legislative power, including passing laws and approving the budget.
 
-  This dataset records each senator currently in office with their name, full name, party,
-  state and gender from the Senate's open-data service.
+  This dataset records each senator currently in office with their name, gender, party, and
+  state.
 url: https://www.senado.leg.br/
 publisher:
   name: Senado Federal

--- a/datasets/br/federal_senate/br_federal_senate.yml
+++ b/datasets/br/federal_senate/br_federal_senate.yml
@@ -27,12 +27,21 @@ publisher:
   country: br
   official: true
 data:
-  url: https://legis.senado.leg.br/dadosabertos/senador/lista/atual
+  # The endpoint serves XML by default; the .json suffix requests JSON.
+  url: https://legis.senado.leg.br/dadosabertos/senador/lista/atual.json
   format: JSON
   lang: por
 
 tags:
   - list.pep
+
+lookups:
+  type.gender:
+    options:
+      - match: Masculino
+        value: male
+      - match: Feminino
+        value: female
 
 assertions:
   min:

--- a/datasets/br/federal_senate/crawler.py
+++ b/datasets/br/federal_senate/crawler.py
@@ -1,0 +1,49 @@
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+GENDERS = {"Masculino": "male", "Feminino": "female"}
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Senator of Brazil",
+        country="br",
+        wikidata_id="Q18964326",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    # The endpoint serves XML by default; request JSON explicitly.
+    data = context.fetch_json(
+        context.data_url, headers={"Accept": "application/json"}, cache_days=1
+    )
+    senators = data["ListaParlamentarEmExercicio"]["Parlamentares"]["Parlamentar"]
+    if not senators:
+        raise ValueError("Senate API returned no senators")
+
+    for senator in senators:
+        info = senator["IdentificacaoParlamentar"]
+        person = context.make("Person")
+        person.id = context.make_slug(info["CodigoParlamentar"])
+        person.add("name", info.get("NomeParlamentar"), lang="por")
+        person.add("name", info.get("NomeCompletoParlamentar"), lang="por")
+        person.add("gender", GENDERS.get(info.get("SexoParlamentar")))
+        person.add("political", info.get("SiglaPartidoParlamentar"), lang="por")
+        person.add("sourceUrl", info.get("UrlPaginaParlamentar"))
+        # Senators must be Brazilian nationals (Constitution of Brazil 1988,
+        # Article 14 §3 I). https://www.constituteproject.org/constitution/Brazil_2017
+        person.add("citizenship", "br")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        if info.get("UfParlamentar"):
+            occupancy.add("constituency", info["UfParlamentar"])
+        context.emit(occupancy)
+        context.emit(person)

--- a/datasets/br/federal_senate/crawler.py
+++ b/datasets/br/federal_senate/crawler.py
@@ -33,8 +33,14 @@ def crawl(context: Context) -> None:
         # Article 14 §3 I). https://www.constituteproject.org/constitution/Brazil_2017
         person.add("citizenship", "br")
 
+        mandate = senator["Mandato"]
         occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
+            context,
+            person,
+            position,
+            categorisation=categorisation,
+            start_date=mandate["PrimeiraLegislaturaDoMandato"]["DataInicio"],
+            end_date=mandate["SegundaLegislaturaDoMandato"]["DataFim"],
         )
         if occupancy is None:
             continue

--- a/datasets/br/federal_senate/crawler.py
+++ b/datasets/br/federal_senate/crawler.py
@@ -2,8 +2,6 @@ from zavod import Context
 from zavod import helpers as h
 from zavod.stateful.positions import categorise
 
-GENDERS = {"Masculino": "male", "Feminino": "female"}
-
 
 def crawl(context: Context) -> None:
     position = h.make_position(
@@ -11,29 +9,26 @@ def crawl(context: Context) -> None:
         name="Senator of Brazil",
         country="br",
         wikidata_id="Q18964326",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    # The endpoint serves XML by default; request JSON explicitly.
-    data = context.fetch_json(
-        context.data_url, headers={"Accept": "application/json"}, cache_days=1
-    )
+    data = context.fetch_json(context.data_url, cache_days=7)
     senators = data["ListaParlamentarEmExercicio"]["Parlamentares"]["Parlamentar"]
-    if not senators:
-        raise ValueError("Senate API returned no senators")
 
     for senator in senators:
         info = senator["IdentificacaoParlamentar"]
         person = context.make("Person")
         person.id = context.make_slug(info["CodigoParlamentar"])
-        person.add("name", info.get("NomeParlamentar"), lang="por")
-        person.add("name", info.get("NomeCompletoParlamentar"), lang="por")
-        person.add("gender", GENDERS.get(info.get("SexoParlamentar")))
-        person.add("political", info.get("SiglaPartidoParlamentar"), lang="por")
-        person.add("sourceUrl", info.get("UrlPaginaParlamentar"))
+        person.add("name", info.pop("NomeParlamentar"), lang="por")
+        person.add("name", info.pop("NomeCompletoParlamentar"), lang="por")
+        person.add("gender", info.pop("SexoParlamentar"))
+        person.add("email", info.pop("EmailParlamentar"))
+        person.add("political", info.pop("SiglaPartidoParlamentar"), lang="por")
+        person.add("sourceUrl", info.pop("UrlPaginaParlamentar"))
         # Senators must be Brazilian nationals (Constitution of Brazil 1988,
         # Article 14 §3 I). https://www.constituteproject.org/constitution/Brazil_2017
         person.add("citizenship", "br")


### PR DESCRIPTION
Adds a PEP crawler for the **Federal Senate of Brazil** (upper house, 81 seats).

**Source:** Senate open-data service (`legis.senado.leg.br/dadosabertos`, JSON via Accept header).

**Output:** Position *Senator of Brazil* (`Q18964326`); 81 senators with name, full name, party, state (constituency), gender. Citizenship `br` per Constitution Art. 14 §3 I.

Closes opensanctions/crawler-planning#790

🤖 Generated with [Claude Code](https://claude.com/claude-code)