### PR TITLE
Add Chile Senate PEP crawler

### DIFF
--- a/datasets/cl/senate/cl_senate.yml
+++ b/datasets/cl/senate/cl_senate.yml
@@ -1,0 +1,45 @@
+title: Chile Senate
+name: cl_senate
+prefix: cl-sen
+entry_point: crawler.py
+coverage:
+  frequency: weekly
+  start: 2026-07-24
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Senate of Chile, the upper house of the National Congress.
+description: |
+  The Senate (Senado) is the upper house of the National Congress of Chile. Its senators
+  are elected by proportional representation from the country's regional constituencies for
+  an eight-year term.
+
+  This dataset records each sitting senator with their name, gender, party and region from
+  the Senate's open-data service.
+url: https://www.senado.cl/
+publisher:
+  name: Senado de la República de Chile
+  description: >
+    The Senate is the upper house of the National Congress of Chile.
+  url: https://www.senado.cl/
+  country: cl
+  official: true
+data:
+  url: https://web-back.senado.cl/api/hemicycle?vigentes=1&camara=S&limit=100
+  format: JSON
+  lang: spa
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 40
+      Position: 1
+    country_entities:
+      cl: 40
+  max:
+    schema_entities:
+      Person: 60
+      Position: 1

--- a/datasets/cl/senate/cl_senate.yml
+++ b/datasets/cl/senate/cl_senate.yml
@@ -1,21 +1,21 @@
-title: Chile Senate
+title: Chile Members of the Senate
 name: cl_senate
 prefix: cl-sen
 entry_point: crawler.py
 coverage:
-  frequency: weekly
+  frequency: monthly
   start: 2026-07-24
 load_statements: true
 ci_test: false
 summary: >-
   Members of the Senate of Chile, the upper house of the National Congress.
 description: |
-  The Senate (Senado) is the upper house of the National Congress of Chile. Its senators
-  are elected by proportional representation from the country's regional constituencies for
-  an eight-year term.
+  Current members of the Senate (Senado), the upper house of the National Congress of Chile.
+  Its 50 senators are elected by proportional representation from the country's regional
+  constituencies for an eight-year term and, together with the Chamber of Deputies, hold the
+  country's legislative power, including passing laws and approving the budget.
 
-  This dataset records each sitting senator with their name, gender, party and region from
-  the Senate's open-data service.
+  This dataset records each sitting senator with their name, gender, party, and region.
 url: https://www.senado.cl/
 publisher:
   name: Senado de la República de Chile

--- a/datasets/cl/senate/cl_senate.yml
+++ b/datasets/cl/senate/cl_senate.yml
@@ -8,18 +8,21 @@ coverage:
 load_statements: true
 ci_test: true
 summary: >-
-  Members of the Senate of Chile, the upper house of the National Congress.
+  Current and recent senators of the upper house of the National Congress of Chile.
 description: |
-  Current members of the Senate (Senado), the upper house of the National Congress of Chile.
-  Its 50 senators are elected by proportional representation from the country's regional
-  constituencies for an eight-year term and, together with the Chamber of Deputies, hold the
-  country's legislative power, including passing laws and approving the budget.
+  Current and historical members of the Senate (Senado), the upper house of the National
+  Congress of Chile. Its 50 senators are elected by proportional representation from the
+  country's regional constituencies for an eight-year term and, together with the Chamber
+  of Deputies, hold the country's legislative power, including passing laws and approving
+  the budget.
 
-  This dataset records senators of the current and recent terms with their name, gender, party,
-  email, and region, along with the term(s) each of them served.
+  This dataset records each senator with their name, gender, party, email, and region
+  (constituency), along with the term or terms they served. Senators whose terms all ended
+  long enough ago that they are no longer treated as politically exposed are not included.
 url: https://www.senado.cl/
 publisher:
   name: Senado de la República de Chile
+  name_en: Senate of the Republic of Chile
   description: >
     The Senate is the upper house of the National Congress of Chile.
   url: https://www.senado.cl/

--- a/datasets/cl/senate/cl_senate.yml
+++ b/datasets/cl/senate/cl_senate.yml
@@ -6,7 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-24
 load_statements: true
-ci_test: false
+ci_test: true
 summary: >-
   Members of the Senate of Chile, the upper house of the National Congress.
 description: |
@@ -15,7 +15,8 @@ description: |
   constituencies for an eight-year term and, together with the Chamber of Deputies, hold the
   country's legislative power, including passing laws and approving the budget.
 
-  This dataset records each sitting senator with their name, gender, party, and region.
+  This dataset records senators of the current and recent terms with their name, gender, party,
+  email, and region, along with the term(s) each of them served.
 url: https://www.senado.cl/
 publisher:
   name: Senado de la República de Chile
@@ -25,9 +26,17 @@ publisher:
   country: cl
   official: true
 data:
-  url: https://web-back.senado.cl/api/hemicycle?vigentes=1&camara=S&limit=100
+  url: https://web-back.senado.cl/api/hemicycle?camara=S&limit=1000
   format: JSON
   lang: spa
+
+lookups:
+  type.gender:
+    options:
+      - match: Hombre
+        value: male
+      - match: Mujer
+        value: female
 
 tags:
   - list.pep
@@ -35,11 +44,11 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 40
+      Person: 90
       Position: 1
     country_entities:
-      cl: 40
+      cl: 90
   max:
     schema_entities:
-      Person: 60
+      Person: 170
       Position: 1

--- a/datasets/cl/senate/crawler.py
+++ b/datasets/cl/senate/crawler.py
@@ -1,0 +1,42 @@
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+GENDERS = {"Hombre": "male", "Mujer": "female"}
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Senator of Chile",
+        country="cl",
+        wikidata_id="Q18882653",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    payload = context.fetch_json(context.data_url, cache_days=1)
+    senators = payload["data"]["parlamentarios"]["data"]
+    if not senators:
+        raise ValueError("Senate API returned no senators")
+
+    for senator in senators:
+        person = context.make("Person")
+        person.id = context.make_slug(str(senator["ID_PARLAMENTARIO"]))
+        person.add("name", senator.get("NOMBRE_COMPLETO"), lang="spa")
+        person.add("gender", GENDERS.get(senator.get("SEXO_ETIQUETA")))
+        person.add("political", senator.get("PARTIDO"), lang="spa")
+        # Senators must be citizens with the right to vote (Constitution of Chile,
+        # Article 50). https://www.constituteproject.org/constitution/Chile_2021
+        person.add("citizenship", "cl")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        occupancy.add("constituency", senator.get("REGION"), lang="spa")
+        context.emit(occupancy)
+        context.emit(person)

--- a/datasets/cl/senate/crawler.py
+++ b/datasets/cl/senate/crawler.py
@@ -55,7 +55,7 @@ def crawl_member(
         )
         if occupancy is None:
             continue
-        occupancy.add("constituency", senator.pop("REGION"), lang="spa")
+        occupancy.add("constituency", senator.pop("REGION", None), lang="spa")
         context.emit(occupancy)
         context.emit(person)
 

--- a/datasets/cl/senate/crawler.py
+++ b/datasets/cl/senate/crawler.py
@@ -1,8 +1,63 @@
+from typing import Any
+
 from zavod import Context
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
 
-GENDERS = {"Hombre": "male", "Mujer": "female"}
+
+POSITION_TOPICS = ["gov.national", "gov.legislative"]
+
+
+def crawl_member(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    senator: dict[str, Any],
+) -> None:
+    person = context.make("Person")
+    person.id = context.make_slug(str(senator["ID_PARLAMENTARIO"]))
+    first = senator.pop("NOMBRE")
+    last = " ".join(
+        p
+        for p in (senator.pop("APELLIDO_PATERNO"), senator.pop("APELLIDO_MATERNO"))
+        if p
+    )
+    h.apply_name(person, first_name=first, last_name=last, lang="spa")
+    person.add("gender", senator.pop("SEXO_ETIQUETA"))
+    person.add("political", senator.pop("PARTIDO"), lang="spa")
+    person.add("email", senator.pop("EMAIL"))
+    # Senators must be citizens with the right to vote (Constitution of Chile,
+    # Article 50). https://www.constituteproject.org/constitution/Chile_2021
+    person.add("citizenship", "cl")
+
+    for period in senator.get("PERIODOS") or []:
+        # A member's PERIODOS list covers their whole parliamentary career, so it also
+        # carries their Chamber of Deputies terms (CAMARA="D"), which belong to a different
+        # dataset. Only Senate terms are relevant here.
+        if period.get("CAMARA") != "S":
+            continue
+        start, end = period.pop("DESDE"), period.pop("HASTA")
+        if int(start) < int(h.earliest_term_start(POSITION_TOPICS)[:4]):
+            continue
+
+        occupancy = h.make_occupancy(
+            context,
+            person,
+            position,
+            # PERIODOS gives term boundaries as years only. The Chilean Congress is installed on
+            # 11 March, so we anchor the term to that date — otherwise a term ending in the
+            # current year (e.g. 2022-2026) is indistinguishable from an ongoing one and would be
+            # misclassified as current. https://www.constituteproject.org/constitution/Chile_2021
+            period_start=f"{start}{'-03-11'}",
+            period_end=f"{end}{'-03-11'}",
+            categorisation=categorisation,
+        )
+        if occupancy is None:
+            continue
+        occupancy.add("constituency", senator.pop("REGION"), lang="spa")
+        context.emit(occupancy)
+        context.emit(person)
 
 
 def crawl(context: Context) -> None:
@@ -10,33 +65,16 @@ def crawl(context: Context) -> None:
         context,
         name="Senator of Chile",
         country="cl",
+        topics=POSITION_TOPICS,
         wikidata_id="Q18882653",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    payload = context.fetch_json(context.data_url, cache_days=1)
+    payload = context.fetch_json(context.data_url, cache_days=14)
     senators = payload["data"]["parlamentarios"]["data"]
-    if not senators:
-        raise ValueError("Senate API returned no senators")
-
     for senator in senators:
-        person = context.make("Person")
-        person.id = context.make_slug(str(senator["ID_PARLAMENTARIO"]))
-        person.add("name", senator.get("NOMBRE_COMPLETO"), lang="spa")
-        person.add("gender", GENDERS.get(senator.get("SEXO_ETIQUETA")))
-        person.add("political", senator.get("PARTIDO"), lang="spa")
-        # Senators must be citizens with the right to vote (Constitution of Chile,
-        # Article 50). https://www.constituteproject.org/constitution/Chile_2021
-        person.add("citizenship", "cl")
-
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        occupancy.add("constituency", senator.get("REGION"), lang="spa")
-        context.emit(occupancy)
-        context.emit(person)
+        crawl_member(context, position, categorisation, senator)

--- a/datasets/cl/senate/crawler.py
+++ b/datasets/cl/senate/crawler.py
@@ -6,9 +6,6 @@ from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 
 
-POSITION_TOPICS = ["gov.national", "gov.legislative"]
-
-
 def crawl_member(
     context: Context,
     position: Entity,
@@ -30,6 +27,8 @@ def crawl_member(
     # Senators must be citizens with the right to vote (Constitution of Chile,
     # Article 50). https://www.constituteproject.org/constitution/Chile_2021
     person.add("citizenship", "cl")
+    # The source gives one region per senator, not one per term.
+    region = senator.pop("REGION", None)
 
     for period in senator.get("PERIODOS") or []:
         # A member's PERIODOS list covers their whole parliamentary career, so it also
@@ -37,25 +36,26 @@ def crawl_member(
         # dataset. Only Senate terms are relevant here.
         if period.get("CAMARA") != "S":
             continue
+        # PERIODOS gives term boundaries as years only.
         start, end = period.pop("DESDE"), period.pop("HASTA")
-        if int(start) < int(h.earliest_term_start(POSITION_TOPICS)[:4]):
+        if int(start) < int(h.earliest_term_start(position.get("topics"))[:4]):
             continue
 
         occupancy = h.make_occupancy(
             context,
             person,
             position,
-            # PERIODOS gives term boundaries as years only. The Chilean Congress is installed on
-            # 11 March, so we anchor the term to that date — otherwise a term ending in the
-            # current year (e.g. 2022-2026) is indistinguishable from an ongoing one and would be
-            # misclassified as current. https://www.constituteproject.org/constitution/Chile_2021
-            period_start=f"{start}{'-03-11'}",
-            period_end=f"{end}{'-03-11'}",
+            period_start=start,
+            # The Chilean Congress is installed on 11 March, so the end year is anchored to
+            # that date: a bare year only counts as elapsed once it is over, which would
+            # leave a term ending in the current year (e.g. 2022-2026) indistinguishable
+            # from an ongoing one. https://www.constituteproject.org/constitution/Chile_2021
+            period_end=f"{end}-03-11",
             categorisation=categorisation,
         )
         if occupancy is None:
             continue
-        occupancy.add("constituency", senator.pop("REGION", None), lang="spa")
+        occupancy.add("constituency", region, lang="spa")
         context.emit(occupancy)
         context.emit(person)
 
@@ -65,7 +65,7 @@ def crawl(context: Context) -> None:
         context,
         name="Senator of Chile",
         country="cl",
-        topics=POSITION_TOPICS,
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q18882653",
         lang="eng",
     )


### PR DESCRIPTION
Adds a PEP crawler for the **Senate of Chile** (upper house).

**Source:** Senate open-data JSON API (`web-back.senado.cl/api/hemicycle`).

**Output:** Position *Senator of Chile* (`Q18882653`); 50 senators with name, gender, party and region (constituency). Citizenship `cl` per Constitution Art. 50.

Closes opensanctions/crawler-planning#793

🤖 Generated with [Claude Code](https://claude.com/claude-code)