### PR TITLE
Add Cameroon National Assembly PEP crawler

### DIFF
--- a/datasets/cm/national_assembly/cm_national_assembly.yml
+++ b/datasets/cm/national_assembly/cm_national_assembly.yml
@@ -1,0 +1,45 @@
+title: Cameroon National Assembly
+name: cm_national_assembly
+prefix: cm-na
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-24
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the National Assembly of Cameroon, the lower house of Parliament.
+description: |
+  The National Assembly (Assemblée nationale) is the lower house of the Parliament of
+  Cameroon. Its 180 members are directly elected from the country's divisions for a
+  five-year term.
+
+  This dataset records each member of the current (10th) legislature with their name,
+  political party and region from the National Assembly's website.
+url: https://www.assnat.cm/
+publisher:
+  name: Assemblée nationale du Cameroun
+  description: >
+    The National Assembly is the lower house of the Parliament of Cameroon.
+  url: https://www.assnat.cm/
+  country: cm
+  official: true
+data:
+  url: https://www.assnat.cm/index.php/en/members/10th-legislative
+  format: HTML
+  lang: eng
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 150
+      Position: 1
+    country_entities:
+      cm: 150
+  max:
+    schema_entities:
+      Person: 200
+      Position: 1

--- a/datasets/cm/national_assembly/cm_national_assembly.yml
+++ b/datasets/cm/national_assembly/cm_national_assembly.yml
@@ -1,4 +1,4 @@
-title: Cameroon National Assembly
+title: Cameroon Members of the National Assembly
 name: cm_national_assembly
 prefix: cm-na
 entry_point: crawler.py
@@ -6,16 +6,17 @@ coverage:
   frequency: monthly
   start: 2026-07-24
 load_statements: true
-ci_test: false
+ci_test: true
 summary: >-
   Members of the National Assembly of Cameroon, the lower house of Parliament.
 description: |
-  The National Assembly (Assemblée nationale) is the lower house of the Parliament of
-  Cameroon. Its 180 members are directly elected from the country's divisions for a
-  five-year term.
+  Current members of the National Assembly (Assemblée nationale), the lower house of
+  the bicameral Parliament of Cameroon. Its 180 members are directly elected from the
+  country's divisions for a five-year term and, together with the Senate, hold the
+  country's legislative power, including passing laws and approving the budget.
 
-  This dataset records each member of the current (10th) legislature with their name,
-  political party and region from the National Assembly's website.
+  This dataset records each sitting member with their name, political party, and the
+  region they represent.
 url: https://www.assnat.cm/
 publisher:
   name: Assemblée nationale du Cameroun

--- a/datasets/cm/national_assembly/crawler.py
+++ b/datasets/cm/national_assembly/crawler.py
@@ -1,0 +1,77 @@
+from itertools import count
+
+from zavod import Context
+from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+PAGE_SIZE = 15
+MAX_PAGES = 20
+
+
+def crawl_page(
+    context: Context,
+    position: Entity,
+    categorisation: PositionCategorisation,
+    start: int,
+) -> int:
+    doc = context.fetch_html(context.data_url, params={"start": start}, cache_days=1)
+    cards = h.xpath_elements(doc, '//div[@class="team-content"]')
+    for card in cards:
+        titles = h.xpath_elements(card, './/h3[@class="team-title"]')
+        name = h.element_text(titles[0]) if titles else ""
+        if not name:
+            continue
+        posts = h.xpath_elements(card, './/span[@class="post"]')
+        party_region = h.element_text(posts[0]) if posts else ""
+        # "PARTY-REGION", e.g. "UNDP-ADAMAWA"; the party abbreviation never contains a dash.
+        party: str | None = None
+        region: str | None = None
+        if "-" in party_region:
+            party, _, region = party_region.partition("-")
+            party, region = party.strip() or None, region.strip() or None
+        elif party_region:
+            party = party_region
+
+        person = context.make("Person")
+        person.id = context.make_id(name, party_region)
+        person.add("name", name)
+        person.add("political", party)
+        # National Assembly members must be Cameroonian citizens (Electoral Code,
+        # Law No. 2012/001, Section 156). https://aceproject.org/electoral-advice/archive/questions/replies/7798903/986792279/ELECTORAL-CODE-OF-CAMEROON.pdf
+        person.add("citizenship", "cm")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        occupancy.add("constituency", region)
+        context.emit(occupancy)
+        context.emit(person)
+    return len(cards)
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the National Assembly of Cameroon",
+        country="cm",
+        wikidata_id="Q21295975",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    total = 0
+    for page in count(0):
+        if page > MAX_PAGES:
+            raise ValueError("National Assembly member list exceeded the page cap")
+        count_on_page = crawl_page(context, position, categorisation, page * PAGE_SIZE)
+        if count_on_page == 0:
+            break
+        total += count_on_page
+
+    if total == 0:
+        raise ValueError("No members found on the National Assembly pages")

--- a/datasets/cm/national_assembly/crawler.py
+++ b/datasets/cm/national_assembly/crawler.py
@@ -1,55 +1,42 @@
-from itertools import count
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
 
 from zavod import Context
 from zavod import helpers as h
-from zavod.entity import Entity
-from zavod.stateful.positions import PositionCategorisation, categorise
-
-PAGE_SIZE = 15
-MAX_PAGES = 20
 
 
-def crawl_page(
+def crawl_member(
     context: Context,
+    card: Element,
     position: Entity,
     categorisation: PositionCategorisation,
-    start: int,
-) -> int:
-    doc = context.fetch_html(context.data_url, params={"start": start}, cache_days=1)
-    cards = h.xpath_elements(doc, '//div[@class="team-content"]')
-    for card in cards:
-        titles = h.xpath_elements(card, './/h3[@class="team-title"]')
-        name = h.element_text(titles[0]) if titles else ""
-        if not name:
-            continue
-        posts = h.xpath_elements(card, './/span[@class="post"]')
-        party_region = h.element_text(posts[0]) if posts else ""
-        # "PARTY-REGION", e.g. "UNDP-ADAMAWA"; the party abbreviation never contains a dash.
-        party: str | None = None
-        region: str | None = None
-        if "-" in party_region:
-            party, _, region = party_region.partition("-")
-            party, region = party.strip() or None, region.strip() or None
-        elif party_region:
-            party = party_region
+) -> None:
+    titles = h.xpath_elements(card, './/h3[@class="team-title"]')
+    name = h.element_text(titles[0])
 
-        person = context.make("Person")
-        person.id = context.make_id(name, party_region)
-        person.add("name", name)
-        person.add("political", party)
-        # National Assembly members must be Cameroonian citizens (Electoral Code,
-        # Law No. 2012/001, Section 156). https://aceproject.org/electoral-advice/archive/questions/replies/7798903/986792279/ELECTORAL-CODE-OF-CAMEROON.pdf
-        person.add("citizenship", "cm")
+    # The party/region label sits in a span.post, or - when that wrapper is
+    # missing - directly in the second title heading.
+    posts = h.xpath_elements(card, './/span[@class="post"]')
+    party_region = h.element_text(posts[0]) if posts else h.element_text(titles[1])
+    party, _, region = party_region.partition("-")
 
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        occupancy.add("constituency", region)
-        context.emit(occupancy)
-        context.emit(person)
-    return len(cards)
+    person = context.make("Person")
+    person.id = context.make_id(name, party_region)
+    person.add("name", name)
+    person.add("political", party.strip())
+    # National Assembly members must be Cameroonian citizens (Electoral Code,
+    # Law No. 2012/001, Section 156). https://aceproject.org/electoral-advice/archive/questions/replies/7798903/986792279/ELECTORAL-CODE-OF-CAMEROON.pdf
+    person.add("citizenship", "cm")
+
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is None:
+        return
+    occupancy.add("constituency", region.strip())
+    context.emit(occupancy)
+    context.emit(person)
 
 
 def crawl(context: Context) -> None:
@@ -58,20 +45,20 @@ def crawl(context: Context) -> None:
         name="Member of the National Assembly of Cameroon",
         country="cm",
         wikidata_id="Q21295975",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    total = 0
-    for page in count(0):
-        if page > MAX_PAGES:
-            raise ValueError("National Assembly member list exceeded the page cap")
-        count_on_page = crawl_page(context, position, categorisation, page * PAGE_SIZE)
-        if count_on_page == 0:
-            break
-        total += count_on_page
-
-    if total == 0:
-        raise ValueError("No members found on the National Assembly pages")
+    # Follow the "Next" pagination link until the last page, which has none.
+    url: str | None = context.data_url
+    while url is not None:
+        doc = context.fetch_html(url, cache_days=30, absolute_links=True)
+        for card in h.xpath_elements(doc, '//div[@class="team-content"]'):
+            crawl_member(context, card, position, categorisation)
+        next_urls = h.xpath_strings(
+            doc, '//a[contains(@class, "page-link next")]/@href'
+        )
+        url = next_urls[0] if next_urls else None

--- a/datasets/cm/senate/cm_senate.yml
+++ b/datasets/cm/senate/cm_senate.yml
@@ -1,4 +1,4 @@
-title: Cameroon Senate
+title: Cameroon Members of the Senate
 name: cm_senate
 prefix: cm-sen
 entry_point: crawler.py
@@ -10,12 +10,14 @@ ci_test: false
 summary: >-
   Members of the Senate of Cameroon, the upper house of Parliament.
 description: |
-  The Senate (Sénat) is the upper house of the Parliament of Cameroon. It has 100 members:
-  seven per region elected by regional and municipal councillors, plus 30 appointed by the
-  President, serving five-year terms.
+  Current members of the Senate (Sénat), the upper house of the bicameral Parliament of
+  Cameroon. Its 100 senators serve five-year terms — seven per region indirectly elected
+  by regional and municipal councillors, plus 30 appointed by the President — and,
+  together with the National Assembly, hold the country's legislative power, including
+  passing laws and approving the budget.
 
-  This dataset records each senator with their name and role from the Senate's official
-  website.
+  This dataset records each sitting senator with their name and their role within the
+  Senate.
 url: https://senat.cm/
 publisher:
   name: Sénat du Cameroun

--- a/datasets/cm/senate/cm_senate.yml
+++ b/datasets/cm/senate/cm_senate.yml
@@ -27,7 +27,7 @@ publisher:
   country: cm
   official: true
 data:
-  url: https://senat.cm/?page_id=869
+  url: https://senat.cm/
   format: HTML
   lang: fra
 

--- a/datasets/cm/senate/crawler.py
+++ b/datasets/cm/senate/crawler.py
@@ -9,18 +9,29 @@ def crawl(context: Context) -> None:
         name="Senator of Cameroon",
         country="cm",
         wikidata_id="Q21295128",
+        lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    categorisation = categorise(context, position)
     if not categorisation.is_pep:
         return
     context.emit(position)
 
-    doc = context.fetch_html(context.data_url, cache_days=1)
+    # fetch url from the "Les Sénateurs" menu link on the homepage, which is a stable anchor.
+    landing_page = context.fetch_html(context.data_url, cache_days=30)
+    # The label appears in more than one menu (e.g. desktop and mobile); they
+    # should all point to the same page.
+    senators_url = set(
+        h.xpath_strings(landing_page, '//a[normalize-space(.)="Les Sénateurs"]/@href')
+    )
+    if len(senators_url) != 1:
+        raise ValueError(
+            f"Expected one 'Les Sénateurs' link target, got {senators_url}"
+        )
+
+    doc = context.fetch_html(senators_url.pop(), cache_days=30)
     cards = h.xpath_elements(
         doc, '//div[contains(@class, "sptp-member") and contains(@class, "border-bg")]'
     )
-    if not cards:
-        raise ValueError("No senator cards found on the Senate page")
 
     seen: set[str] = set()
     for card in cards:


### PR DESCRIPTION
Adds a PEP crawler for the **National Assembly of Cameroon** (lower house, 180 seats, 10th Legislature).

**Source:** official site `assnat.cm` — paginated member cards (15/page via `?start=`).

**Output:** Position *Member of the National Assembly of Cameroon* (`Q21295975`); 178 members with party and region (parsed from the "PARTY-REGION" label). Citizenship `cm` per Electoral Code (Law 2012/001) Sec. 156.

Part of opensanctions/crawler-planning#838 (National Assembly; the Senate chamber is a separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)