### PR TITLE
Add ann_graph_topics to inputs of all enrichers

### DIFF
--- a/datasets/_analysis/ann_pep_positions/ann_pep_positions.yml
+++ b/datasets/_analysis/ann_pep_positions/ann_pep_positions.yml
@@ -36,6 +36,7 @@ publisher:
   official: false
 
 inputs:
+  - ann_graph_topics
   - peps
   - wd_curated
   - wd_categories

--- a/datasets/_externals/brightquery.yml
+++ b/datasets/_externals/brightquery.yml
@@ -51,6 +51,7 @@ assertions:
       Company: 1200
 
 inputs:
+  - ann_graph_topics
   - eu_sanctions
   - ir_uani_business_registry
   - us_sanctions

--- a/datasets/_externals/ext_us_cms_npi.yml
+++ b/datasets/_externals/ext_us_cms_npi.yml
@@ -54,6 +54,7 @@ assertions:
       Person: 100
 
 inputs:
+  - ann_graph_topics
   - debarment
 
 config:

--- a/datasets/_externals/ext_us_ofac_press_releases.yml
+++ b/datasets/_externals/ext_us_ofac_press_releases.yml
@@ -41,7 +41,7 @@ tags:
 url: https://ofac.treasury.gov/press-releases
 
 inputs:
-  # - ann_graph_topics
+  - ann_graph_topics
   - us_sanctions
   # - special_interest
   # - maritime

--- a/datasets/_externals/opencorporates.yml
+++ b/datasets/_externals/opencorporates.yml
@@ -36,6 +36,7 @@ publisher:
   url: https://opencorporates.com/info/about/
 
 inputs:
+  - ann_graph_topics
   - eu_sanctions
   - ir_uani_business_registry
   - us_sanctions

--- a/datasets/_externals/openfigi.yml
+++ b/datasets/_externals/openfigi.yml
@@ -49,6 +49,7 @@ http:
     - POST
 
 inputs:
+  - ann_graph_topics
   - sanctions
   - securities
   - ru_nsd_isin

--- a/datasets/_externals/permid.yml
+++ b/datasets/_externals/permid.yml
@@ -42,6 +42,7 @@ publisher:
   url: https://www.lseg.com/en/about-us/what-we-do
 
 inputs:
+  - ann_graph_topics
   - au_dfat_sanctions
   - ca_dfatd_sema_sanctions
   - ch_seco_sanctions

--- a/datasets/_externals/wikidata.yml
+++ b/datasets/_externals/wikidata.yml
@@ -56,6 +56,7 @@ http:
     - POST
 
 inputs:
+  - ann_graph_topics
   - interpol_red_notices
   - peps
   - sanctions


### PR DESCRIPTION
Since enrichment graph context became gated on risk topics (25b7b1449), promotion of expanded entities depends on the topic being visible in the subject view built from each enricher's `inputs`. The topics assigned by the graph analyzer (`role.rca`, `sanction.linked`, …) live in `ann_graph_topics` — an enricher without it as an input can never promote entities whose only risk topic is analyzer-assigned. Most visibly, Wikidata family members of PEPs stopped being published; see #5104 for the full diagnosis.

This adds `ann_graph_topics` to the `inputs` of the enrichers that were missing it (most `ext_*` local enrichers already had it):

- `wikidata` — restores the rca-promotion loop for PEP family members (wikidata run → analyzer tags `role.rca` → next wikidata run promotes the Person + Family edge)
- `brightquery`, `opencorporates`, `openfigi`, `permid` — same gating mechanics via `zavod.runner.enrich`
- `ext_us_cms_npi`, `ext_us_ofac_press_releases` — local enrichers that were missing it (for the latter it was already present but commented out)
- `ann_pep_positions` — so analyzer-tagged persons are in scope for position analysis

Notes:

- The subject view is opened with `external=True`, so even patches that the analyzer emits as external become visible to the gate. Convergence takes one extra cycle for new entities (enrich → analyzer → enrich).
- The input cycle (wikidata → ann_graph_topics → default → wikidata) is operationally fine: runs read the archived output of the previous run, and `ann_graph_topics` already reads its own output via `default`.
- Subject iteration is not meaningfully polluted: the analyzer's patch entities are schema `LegalEntity` without names, and schema-filtered enrichers (e.g. wikidata: `Person`) skip them.

Fixes #5104

🤖 Generated with [Claude Code](https://claude.com/claude-code)