### PR TITLE
Add Cameroon Senate PEP crawler

### DIFF
--- a/datasets/cm/senate/cm_senate.yml
+++ b/datasets/cm/senate/cm_senate.yml
@@ -1,0 +1,45 @@
+title: Cameroon Senate
+name: cm_senate
+prefix: cm-sen
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-24
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Senate of Cameroon, the upper house of Parliament.
+description: |
+  The Senate (Sénat) is the upper house of the Parliament of Cameroon. It has 100 members:
+  seven per region elected by regional and municipal councillors, plus 30 appointed by the
+  President, serving five-year terms.
+
+  This dataset records each senator with their name and role from the Senate's official
+  website.
+url: https://senat.cm/
+publisher:
+  name: Sénat du Cameroun
+  description: >
+    The Senate is the upper house of the Parliament of Cameroon.
+  url: https://senat.cm/
+  country: cm
+  official: true
+data:
+  url: https://senat.cm/?page_id=869
+  format: HTML
+  lang: fra
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 80
+      Position: 1
+    country_entities:
+      cm: 80
+  max:
+    schema_entities:
+      Person: 120
+      Position: 1

--- a/datasets/cm/senate/crawler.py
+++ b/datasets/cm/senate/crawler.py
@@ -1,0 +1,50 @@
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Senator of Cameroon",
+        country="cm",
+        wikidata_id="Q21295128",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, cache_days=1)
+    cards = h.xpath_elements(
+        doc, '//div[contains(@class, "sptp-member") and contains(@class, "border-bg")]'
+    )
+    if not cards:
+        raise ValueError("No senator cards found on the Senate page")
+
+    seen: set[str] = set()
+    for card in cards:
+        names = h.xpath_elements(card, './/div[@class="sptp-member-name"]')
+        name = h.element_text(names[0]) if names else ""
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        roles = h.xpath_elements(card, './/div[@class="sptp-member-profession"]')
+        role = h.element_text(roles[0]) if roles else None
+
+        person = context.make("Person")
+        person.id = context.make_id(name)
+        person.add("name", name, lang="fra")
+        # Senators must be Cameroonian citizens (Electoral Code, Law No. 2012/001,
+        # Section 220(2)). https://aceproject.org/electoral-advice/archive/questions/replies/7798903/986792279/ELECTORAL-CODE-OF-CAMEROON.pdf
+        person.add("citizenship", "cm")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        if role:
+            occupancy.add("description", role, lang="fra")
+        context.emit(occupancy)
+        context.emit(person)


### PR DESCRIPTION
Adds a PEP crawler for the **Senate of Cameroon** (upper house, 100 seats).

**Source:** official site `senat.cm` (WordPress sptp_member cards).

**Output:** Position *Senator of Cameroon* (`Q21295128`); 100 senators with name + role. Citizenship `cm` per Electoral Code (Law 2012/001) Sec. 220(2).

Together with the National Assembly crawler, closes opensanctions/crawler-planning#838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)