### PR TITLE
Discount analyzer statements when judging entity substance

### DIFF
--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -49,14 +49,17 @@ Requirements and invariants that make this correct:
   analyzer reads the store with ``external=True`` precisely so it can *see*
   those passengers and apply the rules to them; with an internal-only view it
   would be blind to exactly the entities it needs to evaluate.
-- **Patches inherit the related entity's external-ness.** A patch is emitted
-  internal iff the related entity already has at least one internal statement
-  (``Entity.external`` is true only when *every* statement is external),
-  otherwise external. So a derived topic on a genuinely published entity is
-  published, while a topic on a purely-external passenger stays external.
-  Either way the topic is visible in the ``external=True`` view and continues
-  to feed the next ownership hop — but tagging a passenger does not, on its
-  own, force it into the published export.
+- **Patch external-ness tracks published source data.** A patch is emitted
+  internal iff the related entity has at least one internal statement from a
+  non-analyzer dataset (``ANALYZER_DATASETS``), otherwise external. So a
+  derived topic on a genuinely published entity is published, while a topic
+  on a purely-external passenger stays external. Discounting the analyzers'
+  own statements is what keeps this from becoming self-sustaining: without
+  it, one internal patch would keep an entity "internal" forever — even
+  after its source data was demoted to external — publishing nameless,
+  topic-only stubs. Either way the topic is visible in the ``external=True``
+  view and continues to feed the next ownership hop — but tagging a
+  passenger does not, on its own, force it into the published export.
 - **Edge end dates terminate propagation.** Relationships carrying an
   ``endDate`` are skipped: a former director or ex-spouse does not propagate
   risk. Checked once in ``analyze_entity`` before rule dispatch.
@@ -70,11 +73,12 @@ from collections.abc import Iterator
 
 from followthemoney import registry
 from followthemoney.property import Property
+from followthemoney.statement import BASE_ID
 from nomenklatura.store.base import View as BaseView
 
 from zavod import Context, Entity
 from zavod.meta import Dataset, get_multi_dataset
-from zavod.constants import ORIGIN_INFERRED
+from zavod.constants import ANALYZER_DATASETS, ORIGIN_INFERRED
 from zavod.store import get_store
 from zavod.integration import get_dataset_linker
 
@@ -121,6 +125,23 @@ def non_graph_topics(context: Context, entity: Entity) -> set[str]:
     return {s.value for s in topic_stmts if s.dataset != context.dataset.name}
 
 
+def has_published_substance(entity: Entity) -> bool:
+    """Return whether the entity has published source data of its own.
+
+    Decides patch external-ness — see the ``Patch external-ness`` invariant
+    in the module docstring: analyzer statements are discounted so a prior
+    patch cannot keep an otherwise-unpublished entity internal. BASE_ID
+    checksum statements are skipped: they are synthesized at read time with
+    a meaningless external flag.
+    """
+    for stmt in entity.statements:
+        if stmt.prop == BASE_ID:
+            continue
+        if not stmt.external and stmt.dataset not in ANALYZER_DATASETS:
+            return True
+    return False
+
+
 def emit_patch(
     context: Context,
     risk_source: Entity,
@@ -143,7 +164,7 @@ def emit_patch(
     patch = context.make(schema_name)
     patch.id = related_entity.id
     patch.add("topics", topic, origin=ORIGIN_INFERRED)
-    context.emit(patch, external=related_entity.external)
+    context.emit(patch, external=not has_published_substance(related_entity))
 
 
 def walk_edge(

--- a/datasets/_analysis/ann_graph_topics/test_ann_graph_topics.py
+++ b/datasets/_analysis/ann_graph_topics/test_ann_graph_topics.py
@@ -45,11 +45,16 @@ def _entity(
     id: str,
     properties: dict[str, list[str]] | None = None,
     dataset: Dataset = SOURCE,
+    external: bool = False,
 ) -> Entity:
-    return Entity.from_data(
+    entity = Entity.from_data(
         dataset,
         {"schema": schema, "id": id, "properties": properties or {}},
     )
+    if external:
+        for stmt in entity.statements:
+            stmt._external = True
+    return entity
 
 
 def _store(
@@ -549,6 +554,59 @@ def test_emit_patch_preserves_non_legalentity_schema() -> None:
     )
     patches = {e.id: e for e, _ in ctx.emitted}
     assert patches["sec1"].schema.name == "Security"
+
+
+# ---- emit_patch external-ness --------------------------------------------
+
+
+def _patch_external(ctx: FakeContext, target_id: str) -> bool:
+    flags = {ext for entity, ext in ctx.emitted if entity.id == target_id}
+    assert len(flags) == 1, flags
+    return flags.pop()
+
+
+def test_patch_internal_for_published_target() -> None:
+    # The spouse has internal source statements, so the derived topic is
+    # published along with them.
+    ctx = _analyze(
+        [
+            _entity("Person", "pep", {"topics": ["role.pep"]}),
+            _entity("Family", "fam", {"person": ["pep"], "relative": ["spouse"]}),
+            _entity("Person", "spouse", {"name": ["Jane Doe"]}),
+        ],
+        source_id="pep",
+    )
+    assert _patch_external(ctx, "spouse") is False
+
+
+def test_patch_external_for_passenger_target() -> None:
+    # The spouse only exists as an external enrichment passenger; tagging it
+    # must not, on its own, pull it into the published export.
+    ctx = _analyze(
+        [
+            _entity("Person", "pep", {"topics": ["role.pep"]}),
+            _entity("Family", "fam", {"person": ["pep"], "relative": ["spouse"]}),
+            _entity("Person", "spouse", {"name": ["Jane Doe"]}, external=True),
+        ],
+        source_id="pep",
+    )
+    assert _patch_external(ctx, "spouse") is True
+
+
+def test_patch_external_despite_prior_own_patch() -> None:
+    # A previously emitted internal patch must not keep the target internal
+    # once its source data has been demoted to external: analyzer statements
+    # are discounted when judging published substance.
+    ctx = _analyze(
+        [
+            _entity("Person", "pep", {"topics": ["role.pep"]}),
+            _entity("Family", "fam", {"person": ["pep"], "relative": ["spouse"]}),
+            _entity("Person", "spouse", {"name": ["Jane Doe"]}, external=True),
+            _entity("Person", "spouse", {"topics": ["role.rca"]}, dataset=GRAPH),
+        ],
+        source_id="pep",
+    )
+    assert _patch_external(ctx, "spouse") is True
 
 
 # ---- non_graph_topics ---------------------------------------------------

--- a/datasets/_externals/brightquery.yml
+++ b/datasets/_externals/brightquery.yml
@@ -55,7 +55,7 @@ inputs:
   - eu_sanctions
   - ir_uani_business_registry
   - us_sanctions
-  - us_sam_exclusions
+  # - us_sam_exclusions
   - us_cftc_enforcement_actions
   - us_ddtc_debarred
   - us_ddtc_enforcements
@@ -63,10 +63,10 @@ inputs:
   - us_fed_enforcements
   - us_ofac_enforcement_actions
   - us_sec_pause
-  - regulatory
+  # - regulatory
   - enforcement
-  - debarment
-  - ext_us_cms_npi
+  # - debarment
+  # - ext_us_cms_npi
 
 config:
   type: nomenklatura.enrich.brightquery:BrightQueryEnricher

--- a/datasets/_externals/opencorporates.yml
+++ b/datasets/_externals/opencorporates.yml
@@ -36,7 +36,8 @@ publisher:
   url: https://opencorporates.com/info/about/
 
 inputs:
-  - ann_graph_topics
+  # if this ever emits adjacent entities:
+  # - ann_graph_topics
   - eu_sanctions
   - ir_uani_business_registry
   - us_sanctions

--- a/datasets/_externals/openfigi.yml
+++ b/datasets/_externals/openfigi.yml
@@ -49,7 +49,8 @@ http:
     - POST
 
 inputs:
-  - ann_graph_topics
+  # if this ever emits adjacent entities:
+  # - ann_graph_topics
   - sanctions
   - securities
   - ru_nsd_isin

--- a/datasets/_externals/permid.yml
+++ b/datasets/_externals/permid.yml
@@ -42,7 +42,8 @@ publisher:
   url: https://www.lseg.com/en/about-us/what-we-do
 
 inputs:
-  - ann_graph_topics
+  # if this ever emits adjacent entities:
+  # - ann_graph_topics
   - au_dfat_sanctions
   - ca_dfatd_sema_sanctions
   - ch_seco_sanctions

--- a/zavod/zavod/constants.py
+++ b/zavod/zavod/constants.py
@@ -6,3 +6,11 @@ ORIGIN_INFERRED = "inferred"
 
 # Coming from data patch lookups
 ORIGIN_LOOKUP = "patch"
+
+# Datasets that emit derived annotations (topic patches, PEP categorisation)
+# computed from the rest of the graph, rather than crawled source data. Their
+# statements don't count as substance when deciding whether an entity has
+# published source data, and entities consisting only of their statements are
+# skipped as enrichment subjects. Hard-coded for now; could become a dataset
+# metadata flag (`type: analyzer`) if the list grows.
+ANALYZER_DATASETS = frozenset({"ann_graph_topics", "ann_pep_positions"})

--- a/zavod/zavod/runner/enrich.py
+++ b/zavod/zavod/runner/enrich.py
@@ -6,7 +6,7 @@ from nomenklatura.enrich import Enricher, EnrichmentException, make_enricher
 from zavod.meta import Dataset, get_multi_dataset
 from zavod.entity import Entity
 from zavod.context import Context
-from zavod.runner.util import check_enrich_topics, should_promote
+from zavod.runner.util import check_enrich_topics, is_analyzer_stub, should_promote
 from zavod.store import get_store, View
 
 
@@ -69,6 +69,8 @@ def enrich(context: Context) -> None:
                 context.flush()
             if entity_idx > 0 and entity_idx % 10000 == 0:
                 context.log.info(f"Enriched {entity_idx} entities...")
+            if is_analyzer_stub(entity):
+                continue
             context.log.debug(f"Enrich query: {entity!r}")
             try:
                 for match in enricher.match_wrapped(entity):

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -18,7 +18,7 @@ from zavod.context import Context
 from zavod.integration.dedupe import get_dataset_linker
 from zavod.entity import Entity
 from zavod.meta import Dataset, get_multi_dataset, get_catalog
-from zavod.runner.util import check_enrich_topics, should_promote
+from zavod.runner.util import check_enrich_topics, is_analyzer_stub, should_promote
 from zavod.store import get_store, View
 from zavod.reset import reset_caches
 
@@ -93,7 +93,9 @@ class LocalEnricher(BaseEnricher[Dataset]):
     def candidates(
         self, subjects: Iterator[Entity]
     ) -> Generator[tuple[Identifier, BlockingMatches], None, None]:
-        entity_generator = (e for e in subjects if self._filter_entity(e))
+        entity_generator = (
+            e for e in subjects if self._filter_entity(e) and not is_analyzer_stub(e)
+        )
         yield from self._index.match_entities(entity_generator)
 
     def match_candidates(

--- a/zavod/zavod/runner/util.py
+++ b/zavod/zavod/runner/util.py
@@ -1,7 +1,18 @@
 from collections.abc import Iterable, Mapping
 
+from zavod.constants import ANALYZER_DATASETS
 from zavod.entity import Entity
 from zavod.store import View
+
+
+def is_analyzer_stub(entity: Entity) -> bool:
+    """Return whether the entity consists only of analyzer-emitted statements.
+
+    Such entities are derived annotations (e.g. a bare topic patch) with no
+    source data of their own — there is nothing to match on, so enrichers
+    skip them as subjects.
+    """
+    return entity.datasets.issubset(ANALYZER_DATASETS)
 
 
 def endpoint_ids(entity: Entity) -> set[str]:

--- a/zavod/zavod/tests/enrich/test_runner_util.py
+++ b/zavod/zavod/tests/enrich/test_runner_util.py
@@ -1,0 +1,30 @@
+from zavod.entity import Entity
+from zavod.meta import Dataset
+from zavod.runner.util import is_analyzer_stub
+
+GRAPH = Dataset({"name": "ann_graph_topics", "title": "Graph"})
+SOURCE = Dataset({"name": "src", "title": "Source"})
+
+
+def _entity(dataset: Dataset, properties: dict[str, list[str]]) -> Entity:
+    return Entity.from_data(
+        dataset,
+        {"schema": "Person", "id": "e", "properties": properties},
+    )
+
+
+def test_analyzer_only_entity_is_stub() -> None:
+    assert is_analyzer_stub(_entity(GRAPH, {"topics": ["role.rca"]}))
+
+
+def test_source_entity_is_not_stub() -> None:
+    assert not is_analyzer_stub(_entity(SOURCE, {"name": ["John Doe"]}))
+
+
+def test_mixed_entity_is_not_stub() -> None:
+    # An analyzer patch merged with source data has something to match on.
+    entity = _entity(GRAPH, {"topics": ["role.rca"]})
+    prop = entity.schema.get("name")
+    assert prop is not None
+    entity.unsafe_add(prop, "John Doe", dataset="src")
+    assert not is_analyzer_stub(entity)


### PR DESCRIPTION
Follow-up to #5105 / #5104, addressing the residual "nameless stub" problem.

`ann_graph_topics` patches inherit the related entity's external-ness — and the entity's own prior internal patch counts towards that. So a patch once emitted internal keeps the entity "internal" forever, even after its source data was demoted to external. That's how `default` ended up with published nameless `LegalEntity` profiles carrying only `role.rca` (e.g. Macron's parents, [Q28838264](https://www.opensanctions.org/entities/Q28838264/)).

This introduces a hard-coded `ANALYZER_DATASETS` list in `zavod.constants` (could become a `type: analyzer` dataset metadata flag later) and uses it in two places:

- **`emit_patch` externality**: a patch is emitted internal only when the related entity has an internal statement from a *non-analyzer* dataset. Patch external-ness now follows the source data instead of sustaining itself: the legacy Macron-family stubs flip to external on the next analyzer run, and flip back to internal once the enricher promotes the entities (per #5105). Synthesized `BASE_ID` checksum statements are ignored — they are generated at read time with a meaningless external flag.
- **Enricher subject skip**: both `zavod.runner.enrich` and `zavod.runner.local_enricher` now skip subjects whose statements all come from analyzer datasets. Bare topic patches have no names or identifiers to match on; this offsets #5105 adding `ann_graph_topics` (~100k stub entities) to enricher inputs, keeping them out of blocking, matching, and remote API queries. Entities where a patch merges with real source data are unaffected — the skip requires *every* contributing dataset to be an analyzer.

Expected effect: one analyzer cycle after deploy, the stub profiles drop out of `default`; combined with #5105, promoted RCA entities come back as full profiles with their patches internal again. There is a known ≤1-cycle gap where a freshly promoted entity is published before the analyzer re-attaches its `role.rca` topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)