### PR TITLE
Add Qatar Shura Council PEP crawler

### DIFF
--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -1,0 +1,60 @@
+from zavod import Context
+from zavod import helpers as h
+from zavod.stateful.positions import categorise
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    )
+}
+
+
+def clean_name(raw: str) -> str:
+    # Names are prefixed with an honorific and a slash, e.g.
+    # "سعادة السيد / حسن بن عبدالله الغانم"; keep the part after the slash.
+    name = " ".join(raw.split())
+    if "/" in name:
+        name = name.split("/")[-1]
+    return name.strip()
+
+
+def crawl(context: Context) -> None:
+    position = h.make_position(
+        context,
+        name="Member of the Shura Council of Qatar",
+        country="qa",
+        wikidata_id="Q21328600",
+    )
+    categorisation = categorise(context, position, default_is_pep=True)
+    if not categorisation.is_pep:
+        return
+    context.emit(position)
+
+    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
+    cards = h.xpath_elements(doc, '//div[contains(@class, "card")][.//h3]')
+    if not cards:
+        raise ValueError("No member cards found on the Shura Council page")
+
+    seen: set[str] = set()
+    for card in cards:
+        headings = h.xpath_elements(card, ".//h3")
+        name = clean_name(h.element_text(headings[0])) if headings else ""
+        if not name or name in seen:
+            continue
+        seen.add(name)
+
+        person = context.make("Person")
+        person.id = context.make_id(name)
+        person.add("name", name, lang="ara")
+        # Shura Council members must hold original Qatari nationality (Constitution of
+        # Qatar, Article 80(1)). https://www.constituteproject.org/constitution/Qatar_2003
+        person.add("citizenship", "qa")
+
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is None:
+            continue
+        context.emit(occupancy)
+        context.emit(person)

--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -3,9 +3,6 @@ from zavod import helpers as h
 from zavod.stateful.positions import categorise
 from zavod.util import Element
 
-# No Wikidata item covers either leadership office.
-POSITION_QIDS = {"Member of the Shura Council of Qatar": "Q21328600"}
-
 
 def crawl_member(context: Context, card: Element) -> None:
     link = h.xpath_element(card, './/h3//a[contains(@href, "/Members/")]')
@@ -36,7 +33,8 @@ def crawl_member(context: Context, card: Element) -> None:
             name=title,
             country="qa",
             topics=["gov.national", "gov.legislative"],
-            wikidata_id=POSITION_QIDS.get(title),
+            # No Wikidata item covers either leadership office.
+            wikidata_id="Q21328600" if "Member of the Shura Council" in title else None,
             lang="eng",
         )
         categorisation = categorise(context, position)

--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -1,60 +1,138 @@
+from normality import squash_spaces
+
 from zavod import Context
 from zavod import helpers as h
-from zavod.stateful.positions import categorise
+from zavod.entity import Entity
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
 
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-    )
-}
+# Every member is rendered in a div.card. The class must be matched exactly:
+# contains(@class, "card") also matches the nested div.card-body and returns each
+# member twice.
+CARD = '//div[@class="card"]'
 
-
-def clean_name(raw: str) -> str:
-    # Names are prefixed with an honorific and a slash, e.g.
-    # "سعادة السيد / حسن بن عبدالله الغانم"; keep the part after the slash.
-    name = " ".join(raw.split())
-    if "/" in name:
-        name = name.split("/")[-1]
-    return name.strip()
+# The roster's own name for plain membership, as opposed to the two leadership
+# offices its holders occupy in addition to their seat.
+MEMBER = "Member of the Shura Council of Qatar"
 
 
-def crawl(context: Context) -> None:
-    position = h.make_position(
-        context,
-        name="Member of the Shura Council of Qatar",
-        country="qa",
-        wikidata_id="Q21328600",
-    )
-    categorisation = categorise(context, position, default_is_pep=True)
-    if not categorisation.is_pep:
-        return
-    context.emit(position)
+def member_cards(doc: Element) -> dict[str, Element]:
+    """Map each member's profile path to their card on a roster page.
 
-    doc = context.fetch_html(context.data_url, headers=HEADERS, cache_days=1)
-    cards = h.xpath_elements(doc, '//div[contains(@class, "card")][.//h3]')
-    if not cards:
-        raise ValueError("No member cards found on the Shura Council page")
-
-    seen: set[str] = set()
-    for card in cards:
-        headings = h.xpath_elements(card, ".//h3")
-        name = clean_name(h.element_text(headings[0])) if headings else ""
-        if not name or name in seen:
+    The roster ends with an empty card carrying no member link, so cards are keyed
+    off the link rather than counted. The path is the same in both locales, which
+    is what lets the Arabic and English rosters be joined.
+    """
+    cards: dict[str, Element] = {}
+    for card in h.xpath_elements(doc, CARD):
+        hrefs = h.xpath_strings(card, './/h3//a[contains(@href, "/Members/")]/@href')
+        if len(hrefs) == 0:
             continue
-        seen.add(name)
+        cards[hrefs[0].split("/Members/")[-1]] = card
+    return cards
 
-        person = context.make("Person")
-        person.id = context.make_id(name)
-        person.add("name", name, lang="ara")
-        # Shura Council members must hold original Qatari nationality (Constitution of
-        # Qatar, Article 80(1)). https://www.constituteproject.org/constitution/Qatar_2003
-        person.add("citizenship", "qa")
 
+def card_name(card: Element) -> str:
+    """Read the member name out of a card's heading.
+
+    The name sits either inside the leading ``span.h5`` (English roster, with the
+    honorific, e.g. ``H.E. Mr. Hassan bin Abdullah Al-Ghanim/``) or as that span's
+    tail text (Arabic roster, where the span holds only the honorific). A trailing
+    slash separates the two in the source markup and is not part of the name.
+    """
+    span = h.xpath_element(card, ".//h3//a/span[@class='h5']")
+    tail = squash_spaces(span.tail or "")
+    name = tail if tail else h.element_text(span)
+    return squash_spaces(name.strip("/"))
+
+
+def crawl_member(
+    context: Context,
+    positions: dict[str, tuple[Entity, PositionCategorisation]],
+    slug: str,
+    en_card: Element,
+    ar_card: Element | None,
+) -> None:
+    role = h.element_text(h.xpath_element(en_card, ".//h4"))
+    # required: true on the lookup, so a new role halts the crawl rather than being
+    # emitted as a plain membership.
+    title = context.lookup_value("position", role)
+    assert title is not None, role
+
+    raw_name = card_name(en_card)
+    name = h.strip_name_titles(context, raw_name)
+    if name is None:
+        return
+
+    person = context.make("Person")
+    # The profile path carries the member's name, so hash it rather than slugging it.
+    person.id = context.make_id(slug)
+    person.add(
+        "name", name, lang="eng", original_value=raw_name if name != raw_name else None
+    )
+    if ar_card is not None:
+        person.add("name", card_name(ar_card), lang="ara")
+    person.add(
+        "sourceUrl",
+        f"https://www.shura.qa/en/Pages/About-Council/President-and-Members/Members/{slug}",
+    )
+    # Shura Council members must hold original Qatari nationality (Constitution of
+    # Qatar, Article 80(1)). https://www.constituteproject.org/constitution/Qatar_2003
+    person.add("citizenship", "qa")
+
+    # The Speaker and Deputy Speaker are elected from among the members and hold
+    # their seat as well, so they get an occupancy for each office.
+    held = [MEMBER] if title == MEMBER else [MEMBER, title]
+    emitted = False
+    for held_title in held:
+        position, categorisation = positions[held_title]
         occupancy = h.make_occupancy(
             context, person, position, categorisation=categorisation
         )
         if occupancy is None:
             continue
         context.emit(occupancy)
+        emitted = True
+    if emitted:
         context.emit(person)
+
+
+def crawl(context: Context) -> None:
+    positions: dict[str, tuple[Entity, PositionCategorisation]] = {}
+    for title, wikidata_id in (
+        (MEMBER, "Q21328600"),
+        # No Wikidata item covers either leadership office, so these are keyed on
+        # their name instead.
+        ("Speaker of the Shura Council of Qatar", None),
+        ("Deputy Speaker of the Shura Council of Qatar", None),
+    ):
+        position = h.make_position(
+            context,
+            name=title,
+            country="qa",
+            topics=["gov.national", "gov.legislative"],
+            wikidata_id=wikidata_id,
+            lang="eng",
+        )
+        categorisation = categorise(context, position)
+        if not categorisation.is_pep:
+            continue
+        context.emit(position)
+        positions[title] = (position, categorisation)
+
+    if MEMBER not in positions:
+        return
+
+    # The English roster carries the official English names and role labels; the
+    # Arabic one carries the native-script names. Both are keyed on the same
+    # profile path.
+    en_cards = member_cards(context.fetch_html(context.data_url, cache_days=1))
+    assert len(en_cards) > 1, len(en_cards)
+    ar_cards = member_cards(
+        context.fetch_html(
+            context.data_url.replace("/en/", "/ar-QA/"),
+            cache_days=1,
+        )
+    )
+    for slug, en_card in en_cards.items():
+        crawl_member(context, positions, slug, en_card, ar_cards.get(slug))

--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -2,13 +2,13 @@ from normality import squash_spaces
 
 from zavod import Context
 from zavod import helpers as h
-from zavod.entity import Entity
-from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.stateful.positions import categorise
 from zavod.util import Element
 
-# The roster's own name for plain membership, as opposed to the two leadership
-# offices its holders occupy in addition to their seat.
-MEMBER = "Member of the Shura Council of Qatar"
+# No Wikidata item covers either leadership office.
+POSITION_QIDS = {"Member of the Shura Council of Qatar": "Q21328600"}
+
+MEMBER_HREF = './/h3//a[contains(@href, "/Members/")]/@href'
 
 
 def member_cards(doc: Element) -> dict[str, Element]:
@@ -20,7 +20,7 @@ def member_cards(doc: Element) -> dict[str, Element]:
     """
     cards: dict[str, Element] = {}
     for card in h.xpath_elements(doc, '//div[@class="card"]'):
-        hrefs = h.xpath_strings(card, './/h3//a[contains(@href, "/Members/")]/@href')
+        hrefs = h.xpath_strings(card, MEMBER_HREF)
         if len(hrefs) == 0:
             continue
         cards[hrefs[0].split("/Members/")[-1]] = card
@@ -43,14 +43,13 @@ def card_name(card: Element) -> str:
 
 def crawl_member(
     context: Context,
-    positions: dict[str, tuple[Entity, PositionCategorisation]],
     slug: str,
     en_card: Element,
     ar_card: Element | None,
 ) -> None:
     role = h.element_text(h.xpath_element(en_card, ".//h4"))
-    title = context.lookup_value("position", role)
-    assert title is not None, role
+    res = context.lookup("position", role)
+    assert res is not None, role
 
     raw_name = card_name(en_card)
     name = h.strip_name_titles(context, raw_name)
@@ -65,67 +64,46 @@ def crawl_member(
     )
     if ar_card is not None:
         person.add("name", card_name(ar_card), lang="ara")
-    person.add(
-        "sourceUrl",
-        f"https://www.shura.qa/en/Pages/About-Council/President-and-Members/Members/{slug}",
-    )
+    person.add("sourceUrl", h.xpath_string(en_card, MEMBER_HREF))
     # Shura Council members must hold original Qatari nationality (Constitution of
     # Qatar, Article 80(1)). https://www.constituteproject.org/constitution/Qatar_2003
     person.add("citizenship", "qa")
 
-    # The Speaker and Deputy Speaker are elected from among the members and hold
-    # their seat as well, so they get an occupancy for each office.
-    held = [MEMBER] if title == MEMBER else [MEMBER, title]
-    emitted = False
-    for held_title in held:
-        position, categorisation = positions[held_title]
-        occupancy = h.make_occupancy(
-            context, person, position, categorisation=categorisation
-        )
-        if occupancy is None:
-            continue
-        context.emit(occupancy)
-        emitted = True
-    if emitted:
-        context.emit(person)
-
-
-def crawl(context: Context) -> None:
-    positions: dict[str, tuple[Entity, PositionCategorisation]] = {}
-    for title, wikidata_id in (
-        (MEMBER, "Q21328600"),
-        # No Wikidata item covers either leadership office, so these are keyed on
-        # their name instead.
-        ("Speaker of the Shura Council of Qatar", None),
-        ("Deputy Speaker of the Shura Council of Qatar", None),
-    ):
+    for title in res.values:
         position = h.make_position(
             context,
             name=title,
             country="qa",
             topics=["gov.national", "gov.legislative"],
-            wikidata_id=wikidata_id,
+            wikidata_id=POSITION_QIDS.get(title),
             lang="eng",
         )
         categorisation = categorise(context, position)
         if not categorisation.is_pep:
             continue
-        context.emit(position)
-        positions[title] = (position, categorisation)
+        occupancy = h.make_occupancy(
+            context, person, position, categorisation=categorisation
+        )
+        if occupancy is not None:
+            context.emit(occupancy)
+            context.emit(position)
+            context.emit(person)
 
-    if MEMBER not in positions:
-        return
 
+def crawl(context: Context) -> None:
     # The English roster carries the official English names and role labels; the
     # Arabic one carries the native-script names. Both are keyed on the same
     # profile path.
-    en_cards = member_cards(context.fetch_html(context.data_url, cache_days=1))
+    en_cards = member_cards(
+        context.fetch_html(context.data_url, cache_days=1, absolute_links=True)
+    )
     assert len(en_cards) > 1, len(en_cards)
     ar_cards = member_cards(
         context.fetch_html(
             context.data_url.replace("/en/", "/ar-QA/"),
             cache_days=1,
+            absolute_links=True,
         )
     )
     for slug, en_card in en_cards.items():
-        crawl_member(context, positions, slug, en_card, ar_cards.get(slug))
+        crawl_member(context, slug, en_card, ar_cards.get(slug))

--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -6,11 +6,6 @@ from zavod.entity import Entity
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import Element
 
-# Every member is rendered in a div.card. The class must be matched exactly:
-# contains(@class, "card") also matches the nested div.card-body and returns each
-# member twice.
-CARD = '//div[@class="card"]'
-
 # The roster's own name for plain membership, as opposed to the two leadership
 # offices its holders occupy in addition to their seat.
 MEMBER = "Member of the Shura Council of Qatar"
@@ -24,7 +19,7 @@ def member_cards(doc: Element) -> dict[str, Element]:
     is what lets the Arabic and English rosters be joined.
     """
     cards: dict[str, Element] = {}
-    for card in h.xpath_elements(doc, CARD):
+    for card in h.xpath_elements(doc, '//div[@class="card"]'):
         hrefs = h.xpath_strings(card, './/h3//a[contains(@href, "/Members/")]/@href')
         if len(hrefs) == 0:
             continue
@@ -54,8 +49,6 @@ def crawl_member(
     ar_card: Element | None,
 ) -> None:
     role = h.element_text(h.xpath_element(en_card, ".//h4"))
-    # required: true on the lookup, so a new role halts the crawl rather than being
-    # emitted as a plain membership.
     title = context.lookup_value("position", role)
     assert title is not None, role
 

--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -1,5 +1,3 @@
-from normality import squash_spaces
-
 from zavod import Context
 from zavod import helpers as h
 from zavod.stateful.positions import categorise
@@ -8,63 +6,29 @@ from zavod.util import Element
 # No Wikidata item covers either leadership office.
 POSITION_QIDS = {"Member of the Shura Council of Qatar": "Q21328600"}
 
-MEMBER_HREF = './/h3//a[contains(@href, "/Members/")]/@href'
 
-
-def member_cards(doc: Element) -> dict[str, Element]:
-    """Map each member's profile path to their card on a roster page.
-
-    The roster ends with an empty card carrying no member link, so cards are keyed
-    off the link rather than counted. The path is the same in both locales, which
-    is what lets the Arabic and English rosters be joined.
-    """
-    cards: dict[str, Element] = {}
-    for card in h.xpath_elements(doc, '//div[@class="card"]'):
-        hrefs = h.xpath_strings(card, MEMBER_HREF)
-        if len(hrefs) == 0:
-            continue
-        cards[hrefs[0].split("/Members/")[-1]] = card
-    return cards
-
-
-def card_name(card: Element) -> str:
-    """Read the member name out of a card's heading.
-
-    The name sits either inside the leading ``span.h5`` (English roster, with the
-    honorific, e.g. ``H.E. Mr. Hassan bin Abdullah Al-Ghanim/``) or as that span's
-    tail text (Arabic roster, where the span holds only the honorific). A trailing
-    slash separates the two in the source markup and is not part of the name.
-    """
-    span = h.xpath_element(card, ".//h3//a/span[@class='h5']")
-    tail = squash_spaces(span.tail or "")
-    name = tail if tail else h.element_text(span)
-    return squash_spaces(name.strip("/"))
-
-
-def crawl_member(
-    context: Context,
-    slug: str,
-    en_card: Element,
-    ar_card: Element | None,
-) -> None:
-    role = h.element_text(h.xpath_element(en_card, ".//h4"))
-    res = context.lookup("position", role)
+def crawl_member(context: Context, member_card: Element) -> None:
+    role = h.element_text(h.xpath_element(member_card, ".//h4"))
+    res = context.lookup("position", role, warn_unmatched=True)
     assert res is not None, role
 
-    raw_name = card_name(en_card)
+    raw_name = h.element_text(h.xpath_element(member_card, ".//h3//a"))
     name = h.strip_name_titles(context, raw_name)
-    if name is None:
-        return
+    assert name is not None, raw_name
+    clean_name = name.rstrip("/")
 
     person = context.make("Person")
-    # The profile path carries the member's name, so hash it rather than slugging it.
-    person.id = context.make_id(slug)
+    person.id = context.make_id(raw_name)
     person.add(
-        "name", name, lang="eng", original_value=raw_name if name != raw_name else None
+        "name",
+        clean_name,
+        lang="eng",
+        original_value=raw_name if clean_name != raw_name else None,
     )
-    if ar_card is not None:
-        person.add("name", card_name(ar_card), lang="ara")
-    person.add("sourceUrl", h.xpath_string(en_card, MEMBER_HREF))
+    person.add(
+        "sourceUrl",
+        h.xpath_string(member_card, './/h3//a[contains(@href, "/Members/")]/@href'),
+    )
     # Shura Council members must hold original Qatari nationality (Constitution of
     # Qatar, Article 80(1)). https://www.constituteproject.org/constitution/Qatar_2003
     person.add("citizenship", "qa")
@@ -91,19 +55,8 @@ def crawl_member(
 
 
 def crawl(context: Context) -> None:
-    # The English roster carries the official English names and role labels; the
-    # Arabic one carries the native-script names. Both are keyed on the same
-    # profile path.
-    en_cards = member_cards(
-        context.fetch_html(context.data_url, cache_days=1, absolute_links=True)
-    )
-    assert len(en_cards) > 1, len(en_cards)
-    ar_cards = member_cards(
-        context.fetch_html(
-            context.data_url.replace("/en/", "/ar-QA/"),
-            cache_days=1,
-            absolute_links=True,
-        )
-    )
-    for slug, en_card in en_cards.items():
-        crawl_member(context, slug, en_card, ar_cards.get(slug))
+    doc = context.fetch_html(context.data_url, cache_days=1, absolute_links=True)
+    for member_card in h.xpath_elements(
+        doc, '//div[@class="content-block"]//div[@class="card"]', expect_exactly=49
+    ):
+        crawl_member(context, member_card)

--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -7,12 +7,9 @@ from zavod.util import Element
 POSITION_QIDS = {"Member of the Shura Council of Qatar": "Q21328600"}
 
 
-def crawl_member(context: Context, member_card: Element) -> None:
-    role = h.element_text(h.xpath_element(member_card, ".//h4"))
-    res = context.lookup("position", role, warn_unmatched=True)
-    assert res is not None, role
-
-    raw_name = h.element_text(h.xpath_element(member_card, ".//h3//a"))
+def crawl_member(context: Context, card: Element) -> None:
+    link = h.xpath_element(card, './/h3//a[contains(@href, "/Members/")]')
+    raw_name = h.element_text(link)
     name = h.strip_name_titles(context, raw_name)
     assert name is not None, raw_name
     clean_name = name.rstrip("/")
@@ -25,14 +22,14 @@ def crawl_member(context: Context, member_card: Element) -> None:
         lang="eng",
         original_value=raw_name if clean_name != raw_name else None,
     )
-    person.add(
-        "sourceUrl",
-        h.xpath_string(member_card, './/h3//a[contains(@href, "/Members/")]/@href'),
-    )
+    person.add("sourceUrl", h.xpath_string(link, "./@href"))
     # Shura Council members must hold original Qatari nationality (Constitution of
     # Qatar, Article 80(1)). https://www.constituteproject.org/constitution/Qatar_2003
     person.add("citizenship", "qa")
 
+    role = h.element_text(h.xpath_element(card, ".//h4"))
+    res = context.lookup("position", role)
+    assert res is not None, role
     for title in res.values:
         position = h.make_position(
             context,
@@ -48,15 +45,15 @@ def crawl_member(context: Context, member_card: Element) -> None:
         occupancy = h.make_occupancy(
             context, person, position, categorisation=categorisation
         )
-        if occupancy is not None:
-            context.emit(occupancy)
-            context.emit(position)
-            context.emit(person)
+        if occupancy is None:
+            continue
+        context.emit(position)
+        context.emit(occupancy)
+        context.emit(person)
 
 
 def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url, cache_days=1, absolute_links=True)
-    for member_card in h.xpath_elements(
-        doc, '//div[@class="content-block"]//div[@class="card"]', expect_exactly=49
-    ):
-        crawl_member(context, member_card)
+    cards = h.xpath_elements(doc, '//div[@class="content-block"]//div[@class="card"]')
+    for card in cards:
+        crawl_member(context, card)

--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -43,11 +43,10 @@ def crawl_member(context: Context, card: Element) -> None:
         occupancy = h.make_occupancy(
             context, person, position, categorisation=categorisation
         )
-        if occupancy is None:
-            continue
-        context.emit(position)
-        context.emit(occupancy)
-        context.emit(person)
+        if occupancy is not None:
+            context.emit(position)
+            context.emit(occupancy)
+            context.emit(person)
 
 
 def crawl(context: Context) -> None:

--- a/datasets/qa/shura_council/crawler.py
+++ b/datasets/qa/shura_council/crawler.py
@@ -51,6 +51,10 @@ def crawl_member(context: Context, card: Element) -> None:
 
 def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url, cache_days=1, absolute_links=True)
+    # The roster is requested per session, so fail when a newer one is published.
+    sessions = h.xpath_strings(doc, '//select[@id="sessionNumber"]/option/@value')
+    latest = max(int(s) for s in sessions if s)
+    assert context.data_url.endswith(f"SessionNumber={latest}"), latest
     cards = h.xpath_elements(doc, '//div[@class="content-block"]//div[@class="card"]')
     for card in cards:
         crawl_member(context, card)

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -1,0 +1,44 @@
+title: Qatar Shura Council
+name: qa_shura_council
+prefix: qa-shura
+entry_point: crawler.py
+coverage:
+  frequency: monthly
+  start: 2026-07-24
+load_statements: true
+ci_test: false
+summary: >-
+  Members of the Shura Council of Qatar, the country's legislative body.
+description: |
+  The Shura Council (Majlis al-Shura) is the legislative body of the State of Qatar. It has
+  45 members: 30 elected and 15 appointed by the Emir, serving four-year terms.
+
+  This dataset records each member with their name and role from the Council's official
+  website.
+url: https://www.shura.qa/
+publisher:
+  name: Shura Council of Qatar
+  description: >
+    The Shura Council is the legislative body of the State of Qatar.
+  url: https://www.shura.qa/
+  country: qa
+  official: true
+data:
+  url: https://www.shura.qa/Pages/About-Council/President-and-Members?SessionNumber=54
+  format: HTML
+  lang: ara
+
+tags:
+  - list.pep
+
+assertions:
+  min:
+    schema_entities:
+      Person: 35
+      Position: 1
+    country_entities:
+      qa: 35
+  max:
+    schema_entities:
+      Person: 60
+      Position: 1

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -28,7 +28,8 @@ publisher:
   country: qa
   official: true
 data:
-  url: https://www.shura.qa/en/Pages/About-Council/President-and-Members
+  # Requested with the session number because we assert the latest session is being used.
+  url: https://www.shura.qa/en/Pages/About-Council/President-and-Members?SessionNumber=54
   format: HTML
   lang: eng
 http:

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -61,10 +61,10 @@ lookups:
 assertions:
   min:
     schema_entities:
-      Person: 35
+      Person: 40
       Position: 3
     country_entities:
-      qa: 35
+      qa: 40
   max:
     schema_entities:
       Person: 80

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -11,9 +11,9 @@ summary: >-
   National legislative body, part elected and part appointed by the Emir
 description: |
   Current members of the Shura Council (Majlis al-Shura), the national legislative body of
-  the State of Qatar. Its members — elected and appointed by the Emir — serve four-year
-  terms and hold the country's legislative authority, including approving the general
-  budget and passing laws.
+  the State of Qatar. Of its 45 members, 30 are elected by direct ballot for a four-year
+  term and 15 are appointed by the Emir, and together they hold the country's legislative
+  authority, including passing laws and approving the general budget.
 
   Only the sitting session's roster is published in a form that carries dates, so earlier
   sessions are not included.

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -48,7 +48,8 @@ lookups:
     required: true
     options:
       - match: Member of the Shura Council
-        value: Member of the Shura Council of Qatar
+        values:
+          - Member of the Shura Council of Qatar
       - match: The Shura Speaker
         values:
           - Speaker of the Shura Council of Qatar

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -11,12 +11,8 @@ summary: >-
   National legislative body, part elected and part appointed by the Emir
 description: |
   Current members of the Shura Council (Majlis al-Shura), the national legislative body of
-  the State of Qatar. Of its 45 members, 30 are elected by direct ballot for a four-year
-  term and 15 are appointed by the Emir, and together they hold the country's legislative
+  the State of Qatar. As of November 2024, all 45 seats are appointed by Emir. Members hold the country's legislative
   authority, including passing laws and approving the general budget.
-
-  Only the sitting session's roster is published in a form that carries dates, so earlier
-  sessions are not included.
 url: https://www.shura.qa/
 publisher:
   name: Shura Council of Qatar
@@ -27,9 +23,7 @@ publisher:
   official: true
 data:
   # The English roster; the crawler also reads the /ar-QA/ locale for Arabic names.
-  # SessionNumber selects the annual sitting — the site exposes sessions 1-54, but
-  # only the current one can be dated, so the crawler reads the latest.
-  url: https://www.shura.qa/en/Pages/About-Council/President-and-Members?SessionNumber=54
+  url: https://www.shura.qa/en/Pages/About-Council/President-and-Members
   format: HTML
   lang: eng
 http:
@@ -56,9 +50,13 @@ lookups:
       - match: Member of the Shura Council
         value: Member of the Shura Council of Qatar
       - match: The Shura Speaker
-        value: Speaker of the Shura Council of Qatar
+        values:
+          - Speaker of the Shura Council of Qatar
+          - Member of the Shura Council of Qatar
       - match: The Deputy Speaker
-        value: Deputy Speaker of the Shura Council of Qatar
+        values:
+          - Deputy Speaker of the Shura Council of Qatar
+          - Member of the Shura Council of Qatar
 
 assertions:
   min:

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -6,7 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-24
 load_statements: true
-ci_test: false  # The site returns 403 to non-browser user agents.
+ci_test: true
 summary: >-
   National legislative body, part elected and part appointed by the Emir
 description: |

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -8,17 +8,15 @@ coverage:
 load_statements: true
 ci_test: false  # The site returns 403 to non-browser user agents.
 summary: >-
-  Members of the Shura Council of Qatar, the country's legislative body.
+  National legislative body, part elected and part appointed by the Emir
 description: |
   Current members of the Shura Council (Majlis al-Shura), the national legislative body of
   the State of Qatar. Its members — elected and appointed by the Emir — serve four-year
   terms and hold the country's legislative authority, including approving the general
   budget and passing laws.
 
-  This dataset records each member with their name in Arabic and English, a link to their
-  profile, and whether they hold the office of Speaker or Deputy Speaker alongside their
-  seat. Only the sitting session's roster is published in a form that carries dates, so
-  earlier sessions are not included.
+  Only the sitting session's roster is published in a form that carries dates, so earlier
+  sessions are not included.
 url: https://www.shura.qa/
 publisher:
   name: Shura Council of Qatar

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -6,16 +6,19 @@ coverage:
   frequency: monthly
   start: 2026-07-24
 load_statements: true
-ci_test: false
+ci_test: false  # The site returns 403 to non-browser user agents.
 summary: >-
   Members of the Shura Council of Qatar, the country's legislative body.
 description: |
   Current members of the Shura Council (Majlis al-Shura), the national legislative body of
-  the State of Qatar. Its 45 members — 30 elected and 15 appointed by the Emir — serve
-  four-year terms and hold the country's legislative authority, including approving the
-  general budget and passing laws.
+  the State of Qatar. Its members — elected and appointed by the Emir — serve four-year
+  terms and hold the country's legislative authority, including approving the general
+  budget and passing laws.
 
-  This dataset records each member with their name.
+  This dataset records each member with their name in Arabic and English, a link to their
+  profile, and whether they hold the office of Speaker or Deputy Speaker alongside their
+  seat. Only the sitting session's roster is published in a form that carries dates, so
+  earlier sessions are not included.
 url: https://www.shura.qa/
 publisher:
   name: Shura Council of Qatar
@@ -25,21 +28,48 @@ publisher:
   country: qa
   official: true
 data:
-  url: https://www.shura.qa/Pages/About-Council/President-and-Members?SessionNumber=54
+  # The English roster; the crawler also reads the /ar-QA/ locale for Arabic names.
+  # SessionNumber selects the annual sitting — the site exposes sessions 1-54, but
+  # only the current one can be dated, so the crawler reads the latest.
+  url: https://www.shura.qa/en/Pages/About-Council/President-and-Members?SessionNumber=54
   format: HTML
-  lang: ara
+  lang: eng
+http:
+  # The site returns 403 without a browser user agent.
+  user_agent: >-
+    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
+    Chrome/124.0.0.0 Safari/537.36
+
+names:
+  prefixes_strip:
+    - H.E. Mr.
+    - H.E. Mrs.
+    - H.E. Ms.
+    - H.E. Dr.
+    - H.E.
 
 tags:
   - list.pep
+
+lookups:
+  position:
+    required: true
+    options:
+      - match: Member of the Shura Council
+        value: Member of the Shura Council of Qatar
+      - match: The Shura Speaker
+        value: Speaker of the Shura Council of Qatar
+      - match: The Deputy Speaker
+        value: Deputy Speaker of the Shura Council of Qatar
 
 assertions:
   min:
     schema_entities:
       Person: 35
-      Position: 1
+      Position: 3
     country_entities:
       qa: 35
   max:
     schema_entities:
-      Person: 60
-      Position: 1
+      Person: 80
+      Position: 3

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -1,4 +1,4 @@
-title: Qatar Shura Council
+title: Qatar Members of the Shura Council
 name: qa_shura_council
 prefix: qa-shura
 entry_point: crawler.py
@@ -10,11 +10,12 @@ ci_test: false
 summary: >-
   Members of the Shura Council of Qatar, the country's legislative body.
 description: |
-  The Shura Council (Majlis al-Shura) is the legislative body of the State of Qatar. It has
-  45 members: 30 elected and 15 appointed by the Emir, serving four-year terms.
+  Current members of the Shura Council (Majlis al-Shura), the national legislative body of
+  the State of Qatar. Its 45 members — 30 elected and 15 appointed by the Emir — serve
+  four-year terms and hold the country's legislative authority, including approving the
+  general budget and passing laws.
 
-  This dataset records each member with their name and role from the Council's official
-  website.
+  This dataset records each member with their name.
 url: https://www.shura.qa/
 publisher:
   name: Shura Council of Qatar

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -8,11 +8,17 @@ coverage:
 load_statements: true
 ci_test: true
 summary: >-
-  National legislative body, part elected and part appointed by the Emir
+  Members of the advisory legislative body of the State of Qatar.
 description: |
-  Current members of the Shura Council (Majlis al-Shura), the national legislative body of
-  the State of Qatar. As of November 2024, all 45 seats are appointed by Emir. Members hold the country's legislative
-  authority, including passing laws and approving the general budget.
+  Current members of the Shura Council (Majlis al-Shura), the unicameral national
+  legislature of the State of Qatar. All 45 members are appointed by the Emir, following
+  a November 2024 constitutional amendment that ended elections to the 30 seats
+  previously filled by vote, and they hold the country's legislative authority,
+  including passing laws and approving the general budget.
+
+  This dataset records each member with their name and their seat in the council, along
+  with any presiding office, Speaker or Deputy Speaker, held alongside that seat.
+  Only the current legislative session is covered.
 url: https://www.shura.qa/
 publisher:
   name: Shura Council of Qatar
@@ -22,7 +28,6 @@ publisher:
   country: qa
   official: true
 data:
-  # The English roster; the crawler also reads the /ar-QA/ locale for Arabic names.
   url: https://www.shura.qa/en/Pages/About-Council/President-and-Members
   format: HTML
   lang: eng
@@ -63,10 +68,10 @@ assertions:
   min:
     schema_entities:
       Person: 40
-      Position: 3
+      Position: 2
     country_entities:
       qa: 40
   max:
     schema_entities:
       Person: 80
-      Position: 3
+      Position: 5


### PR DESCRIPTION
Adds a PEP crawler for the **Shura Council of Qatar**.

**Source:** official council site `shura.qa`. The `/en` members URL redirects to a shell, so the crawler requests the members page directly with its `SessionNumber` (54 = current session).

**Output:** Position *Member of the Shura Council of Qatar* (`Q21328600`); 49 members with Arabic name (honorific prefix stripped). Citizenship `qa` per Constitution Art. 80(1).

Closes opensanctions/crawler-planning#805

🤖 Generated with [Claude Code](https://claude.com/claude-code)