### PR TITLE
[us_fincen_msb] Fix mypy --strict type errors

### DIFF
--- a/datasets/us/fincen_msb/crawler.py
+++ b/datasets/us/fincen_msb/crawler.py
@@ -33,7 +33,7 @@ IGNORE_COLUMNS = [
 ]
 
 
-def crawl_row(context: Context, row: dict[str, list[str]]) -> None:
+def crawl_row(context: Context, row: dict[str, str]) -> None:
     name = h.multi_split(row.pop("LEGAL NAME"), NAME_SPLITS)
     street = row.pop("STREET ADDRESS")
     city = row.pop("CITY")
@@ -47,7 +47,8 @@ def crawl_row(context: Context, row: dict[str, list[str]]) -> None:
     country = country or "USA"
 
     entity = context.make("LegalEntity")
-    entity.id = context.make_id(name, street, listing_date, city, state)
+    # `name` is a list[str] here; keep it as-is to preserve existing entity IDs.
+    entity.id = context.make_id(name, street, listing_date, city, state)  # type: ignore[arg-type]
     entity.add("name", name)
     entity.add(
         "alias",


### PR DESCRIPTION
The `crawl_row` `row` param was annotated `dict[str, list[str]]`, but `csv.DictReader` yields `str` values — corrected to `dict[str, str]`, which clears 11 cascading errors. `make_id` gets a `# type: ignore[arg-type]` (its `list[str]` arg is hashed into published entity IDs, so leaving it untouched avoids re-keying).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
