### PR TITLE
[us_nk_jointventures] Fix mypy --strict type errors

### DIFF
--- a/datasets/us/nk_jointventures/crawler.py
+++ b/datasets/us/nk_jointventures/crawler.py
@@ -23,12 +23,13 @@ def crawl_item(context: Context, row: dict[str, str]) -> None:
 
 def crawl(context: Context) -> None:
     table_xpath = ".//table[@aria-label='Table of Files associated with page']"
+    dataset_url = context.dataset.url
+    assert dataset_url is not None
     doc = fetch_html(
-        context, context.dataset.url, table_xpath, cache_days=1, absolute_links=True
+        context, dataset_url, table_xpath, cache_days=1, absolute_links=True
     )
-    table = doc.xpath(table_xpath)
-    assert len(table) == 1, "Expected exactly one table in the document"
-    link = table[0].xpath(".//a/@href")
+    table = h.xpath_element(doc, table_xpath)
+    link = h.xpath_strings(table, ".//a/@href")
     assert len(link) == 1, "Expected exactly one link in the table"
 
     # Expect

--- a/datasets/us/nk_jointventures/crawler.py
+++ b/datasets/us/nk_jointventures/crawler.py
@@ -28,13 +28,12 @@ def crawl(context: Context) -> None:
         context, context.dataset.url, table_xpath, cache_days=1, absolute_links=True
     )
     table = h.xpath_element(doc, table_xpath)
-    link = h.xpath_strings(table, ".//a/@href")
-    assert len(link) == 1, "Expected exactly one link in the table"
+    link = h.xpath_string(table, ".//a/@href")
 
     # Expect
     # North Korea Sanctions & Enforcement Actions Advisory | 827.97 KB | 08/03/2018
     # Assert hash of linked PDF (hopefully less fickle than HTML)
-    _, _, _, pdf_path = fetch_resource(context, "source.pdf", link[0], PDF)
+    _, _, _, pdf_path = fetch_resource(context, "source.pdf", link, PDF)
     h.assert_file_hash(pdf_path, "cd9894479b1330bf0db3885ded3254e580af7acd")
 
     csv_path = context.fetch_resource("source.csv", context.data_url)

--- a/datasets/us/nk_jointventures/crawler.py
+++ b/datasets/us/nk_jointventures/crawler.py
@@ -23,10 +23,9 @@ def crawl_item(context: Context, row: dict[str, str]) -> None:
 
 def crawl(context: Context) -> None:
     table_xpath = ".//table[@aria-label='Table of Files associated with page']"
-    dataset_url = context.dataset.url
-    assert dataset_url is not None
+    assert context.dataset.url is not None
     doc = fetch_html(
-        context, dataset_url, table_xpath, cache_days=1, absolute_links=True
+        context, context.dataset.url, table_xpath, cache_days=1, absolute_links=True
     )
     table = h.xpath_element(doc, table_xpath)
     link = h.xpath_strings(table, ".//a/@href")


### PR DESCRIPTION
Narrow `context.dataset.url` (`str | None`) before `fetch_html`, and swap raw `.xpath()` for the typed `h.xpath_element` / `h.xpath_strings` helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
