### PR TITLE
describe lang for make_position()

### DIFF
--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -89,12 +89,18 @@ capture".
 Build position names with `h.make_position`. Rules:
 
 - **Always pass `lang=`** (ISO 639-3, e.g. `lang="eng"`, `lang="fra"`) declaring the
-  language the position name is in. Two cases:
+  language the position name is in. If omitted, `make_position` falls back to the
+  dataset's `data.lang` (`lang or context.lang`) — so an English name over a
+  non-English source must set `lang="eng"` explicitly. Two cases:
     - **Crawler-supplied names** (the standard case — e.g. a parliament crawler where
       the name is always `Member of the ... Parliament`): write the name in English
       and pass `lang="eng"`. Use the standard English term for the role; keep
       native-language terminology only for proper nouns of specific institutions
-      (e.g. `Landtag of Mecklenburg-Vorpommern`).
+      (e.g. `Landtag of Mecklenburg-Vorpommern`). Pass `lang="eng"` even when the
+      dataset's `data.lang` is another language (e.g. a `data.lang: spa` source whose
+      crawler emits `Member of the Congress of the Republic` still passes
+      `lang="eng"`) — otherwise the English name is treated as being in the dataset
+      language and, with `translate_name=True`, wrongly sent to the translator.
     - **Source-supplied names** (role labels read from the data): pass them through
       as-is with the source language as `lang=` and `translate_name=True` —
       `make_position` translates the name to English via LLM and keys the entity ID

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -81,11 +81,19 @@ Do
   institutions where translation would obscure the reference
   (e.g. `Landtag of Mecklenburg-Vorpommern`, not `State Parliament of …`).
 - always pass `lang=` to `h.make_position` declaring the language of the name you
-  pass. When the position name comes from the source in a non-English language,
-  pass it unmodified with `translate_name=True` — the helper translates it to
-  English and derives the entity ID from the untranslated name, keeping IDs
-  stable. When the source has only very few distinct labels, a `position` lookup
-  in the YAML translating them to English is an acceptable alternative.
+  pass. `lang=` describes the position name specifically, and if you omit it the
+  helper falls back to the dataset's `data.lang` (`lang or context.lang`) — both to
+  label the stored name and to decide whether to translate. So when the crawler
+  supplies an English name (the standard case) over a source whose `data.lang` is
+  another language, pass `lang="eng"` explicitly, e.g. a `data.lang: spa` source
+  whose crawler emits `Member of the Congress of the Republic` must pass
+  `lang="eng"` — otherwise the English name is treated as Spanish (and, with
+  `translate_name=True`, wrongly sent to the translator). When the position name
+  comes from the source in a non-English language, pass it unmodified with
+  `translate_name=True` — the helper translates it to English and derives the
+  entity ID from the untranslated name, keeping IDs stable. When the source has
+  only very few distinct labels, a `position` lookup in the YAML translating them
+  to English is an acceptable alternative.
 - include the role
 - include the organizational body where needed
 - include the specific geographic jurisdiction where relevant


### PR DESCRIPTION
set `lang="eng"` whenever we have a non-eng dataset with eng position names generated. 