### PR TITLE
Keep the decimal part of fractional Excel cells

### DIFF
--- a/zavod/zavod/helpers/excel.py
+++ b/zavod/zavod/helpers/excel.py
@@ -29,7 +29,15 @@ def convert_excel_cell(book: Book, cell: Cell) -> str | None:
     """
     # https://xlrd.readthedocs.io/en/latest/api.html#xlrd.sheet.Cell
     if cell.ctype == XL_CELL_NUMBER:
-        return str(int(cell.value))
+        # xlrd reports every number as a float, so integer identifiers arrive
+        # as e.g. 1234.0. Drop that artifact only when the value really is
+        # integral: int() truncates toward zero, which would silently turn a
+        # genuine 12.75 into "12". This matches parse_xls_sheet, which
+        # stringifies the same cells.
+        assert isinstance(cell.value, float)
+        if cell.value.is_integer():
+            return str(int(cell.value))
+        return stringify(cell.value)
     elif cell.ctype in (XL_CELL_EMPTY, XL_CELL_ERROR, XL_CELL_BLANK):
         return None
     if cell.ctype == XL_CELL_DATE:

--- a/zavod/zavod/tests/helpers/test_excel.py
+++ b/zavod/zavod/tests/helpers/test_excel.py
@@ -1,4 +1,6 @@
 import xlrd  # type: ignore
+from xlrd import XL_CELL_NUMBER  # type: ignore
+from xlrd.sheet import Cell  # type: ignore
 from openpyxl import load_workbook
 from zavod.context import Context
 from zavod.helpers.excel import (
@@ -25,6 +27,21 @@ def test_excel_cell():
     cells = [convert_excel_cell(book, cell) for cell in row]
     assert cells[0] == "1"
     assert cells[1] == "2023-07-26T00:00:00"
+
+
+def test_excel_cell_fractional_number():
+    """Fractional cells must keep their decimal part, not be truncated."""
+    book = xlrd.open_workbook(XLS_BOOK.as_posix())
+
+    # integral values still lose the float artifact xlrd adds
+    assert convert_excel_cell(book, Cell(XL_CELL_NUMBER, 1.0)) == "1"
+    assert convert_excel_cell(book, Cell(XL_CELL_NUMBER, 1234.0)) == "1234"
+    assert convert_excel_cell(book, Cell(XL_CELL_NUMBER, 0.0)) == "0"
+
+    # fractional values are preserved rather than truncated toward zero
+    assert convert_excel_cell(book, Cell(XL_CELL_NUMBER, 12.75)) == "12.75"
+    assert convert_excel_cell(book, Cell(XL_CELL_NUMBER, 0.75)) == "0.75"
+    assert convert_excel_cell(book, Cell(XL_CELL_NUMBER, -2.5)) == "-2.5"
 
 
 def test_excel_date():


### PR DESCRIPTION
Closes #4944.

`convert_excel_cell` converts every numeric cell with `str(int(cell.value))`. The `int()` is there for a good reason — xlrd hands back all numbers as floats, so an integer id arrives as `1234.0` — but it truncates toward zero, so any genuinely fractional cell is silently corrupted.

Driving the current numeric branch with real `xlrd` cells:

| cell value | current | expected |
|---|---|---|
| `1.0` | `"1"` | `"1"` |
| `1234.0` | `"1234"` | `"1234"` |
| `0.0` | `"0"` | `"0"` |
| `12.75` | **`"12"`** | `"12.75"` |
| `3.7` | **`"3"`** | `"3.7"` |
| `0.75` | **`"0"`** | `"0.75"` |
| `-2.5` | **`"-2"`** | `"-2.5"` |
| `0.004` | **`"0"`** | `"0.004"` |
| `99.999` | **`"99"`** | `"99.999"` |

Six of nine wrong, and `0.75 → "0"` is the shape that matters: a nonzero amount published as zero.

The fix strips the artifact only when `cell.value.is_integer()`, and stringifies otherwise — which is exactly what the sibling `parse_xls_sheet` already does with the same cells, so the two paths now agree instead of disagreeing about identical data. Integer ids are unaffected.

Both current callers apply this to every cell of the sheet (`datasets/ae/local_terrorists/crawler.py`, `datasets/jp/mof_sanctions/crawler.py`), so any fractional numeric in those sheets is affected today.

### On verification

I should be straight about what I could and could not run. **zavod does not install on Windows** — `pyicu` has no wheel and `plyvel` needs a C toolchain — so I could not execute your test suite locally.

What I did instead: mirrored the numeric branch exactly and drove it with real `xlrd.sheet.Cell` objects to produce the table above, then confirmed each of the six assertions in the new test passes against the patched logic and fails against the current one.

The test I added is a real repo test and runs in your CI. It constructs cells directly rather than touching the `book.xls` fixture, so nothing binary changes:

```python
assert convert_excel_cell(book, Cell(XL_CELL_NUMBER, 1.0)) == "1"
assert convert_excel_cell(book, Cell(XL_CELL_NUMBER, 12.75)) == "12.75"
```

Worth flagging: I deliberately left the two sibling issues alone. Both #4941 and #4945 note that a fix changes already-published entity ids or values, so they need a call from you rather than a drive-by PR. This one has no such consequence — it only stops data being destroyed.
