### PR TITLE
[eu_meps] Solve AWS WAF challenge via browser session cookie

### DIFF
--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -1,5 +1,5 @@
 from zavod.entity import Entity
-from zavod.extract import zyte_api
+from zavod.extract.zyte_api import ZyteAPIRequest, ZyteScrapeType, fetch as zyte_fetch
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import Element
 
@@ -78,11 +78,23 @@ def crawl_node(
 
 
 def crawl(context: Context) -> None:
-    # The European Parliament put the MEP list endpoint behind an AWS WAF challenge
-    # (HTTP 202 with an empty body and an x-amzn-waf-action: challenge header), so a
-    # direct fetch returns an empty document. Route the request through Zyte, which
-    # solves the challenge and returns the XML.
-    _, _, _, path = zyte_api.fetch_resource(context, "source.xml", context.data_url)
+    # The European Parliament put the MEP list endpoint behind an AWS WAF
+    # JavaScript challenge (HTTP 202 with an x-amzn-waf-action: challenge
+    # header), which neither a direct fetch nor Zyte's plain HTTP mode can
+    # pass. Solve the challenge in a Zyte browser session, then reuse the
+    # issued aws-waf-token cookie for the actual XML fetch.
+    page_result = zyte_fetch(
+        context,
+        ZyteAPIRequest(
+            url=context.data_url,
+            scrape_type=ZyteScrapeType.BROWSER_HTML,
+            response_cookies=True,
+        ),
+    )
+    for cookie in page_result.cookies or []:
+        context.http.cookies[cookie["name"]] = cookie["value"]
+
+    path = context.fetch_resource("source.xml", context.data_url)
     context.export_resource(path, "text/xml", title=context.SOURCE_TITLE)
     doc = context.parse_resource_xml(path)
 


### PR DESCRIPTION
## Summary

eu_meps has been failing for 6 consecutive runs. The previous fix (#5128) routed the fetch through `zyte_api.fetch_resource`, but that uses Zyte's plain `httpResponseBody` mode, which does not solve the AWS WAF JavaScript challenge on europarl.europa.eu — Zyte returns the challenge HTML page (status 202), which then fails XML parsing with `Opening and ending tag mismatch: meta line 5 and head` (the error seen in this morning's 07:13 run, after #5128 had merged).

This change solves the challenge in a Zyte browser session with `responseCookies` enabled, injects the issued `aws-waf-token` cookie (verified not IP-bound) into the session, and fetches the raw XML directly with `context.fetch_resource` — the same pattern as `nz_russia_sanctions`. The crawler's XML parsing and resource caching stay unchanged.

## Verification

- Local crawl completes: 719 Persons, 219 Organizations, 1 Position — identical to the last successful run (2026-07-18), `changed=0` at the statement level
- Empty `issues.log`, `mypy --strict` clean, export passes all assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)