### PR TITLE
Issues 2026-07-27

### DIFF
--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -176,7 +176,9 @@ lookups:
           - 269/2014
           - 208/2014
         value: EU-UKR
-      - match: 765/2006
+      - match:
+          - 765/2006
+          - 2012/642
         value: EU-BLR
       - match:
           - 2018/1542

--- a/datasets/ru/billionaires/ru_billionaires_2021.yml
+++ b/datasets/ru/billionaires/ru_billionaires_2021.yml
@@ -34,6 +34,11 @@ assertions:
   min:
     schema_entities:
       Person: 80
+    # This dataset emits Wikidata QID stubs; names come from Wikidata enrichment,
+    # so the default name fill-rate assertion does not apply here.
+    property_fill_rate:
+      Person:
+        name: 0
   max:
     schema_entities:
       Person: 120


### PR DESCRIPTION
- **[eu_journal_sanctions] Add program ID for more Belarus legislation**
  

- **[ru_billionaires_2021] Exempt from default name fill-rate assertion**
  This dataset emits Wikidata QID stubs with only wikidataId and topics;
  names come from Wikidata enrichment. The default property_fill_rate
  baseline added in 0995712d3 exempted the sibling stub datasets
  (ru_navalny35, wd_curated) but missed this one, so it's been failing
  since 2026-07-13.
  
  Co-Authored-By: Claude <noreply@anthropic.com>
  