### PR TITLE
[gb_nca_most_wanted] Fix mypy --strict type errors

### DIFF
--- a/datasets/gb/nca_most_wanted/crawler.py
+++ b/datasets/gb/nca_most_wanted/crawler.py
@@ -28,10 +28,10 @@ def crawl_person(context: Context, item: _Element, url: str) -> None:
 
     # Article
     article_body = doc.find('.//div[@itemprop="articleBody"]')
-    assert article_body is not None, person_url
+    assert article_body is not None
     article = article_body.find(".//p")
-    assert article is not None, person_url
-    assert article.text is not None, person_url
+    assert article is not None
+    assert article.text is not None
     person.add("notes", article.text.strip())
     # Fields
     for field_name in FIELD_NAMES:
@@ -45,22 +45,18 @@ def crawl_person(context: Context, item: _Element, url: str) -> None:
         values = column.findall('./span[@class="field-value "]')
 
         for label, value in dict(zip(labels, values)).items():
+            assert value.text is not None
             label_text = slugify(label.text)
             if label_text == "sex":
-                assert value.text is not None
                 person.add("gender", value.text.strip())
             elif label_text == "ethnic-appearance":
-                assert value.text is not None
                 person.add("ethnicity", value.text.strip())
             elif label_text == "additional-information":
-                assert value.text is not None
                 assert article.text is not None
                 person.add("notes", [article.text.strip(), value.text.strip()])
             elif label_text == "height":
-                assert value.text is not None
                 person.add("height", value.text.strip())
             elif label_text == "hair-colour":
-                assert value.text is not None
                 person.add("hairColor", value.text.strip())
 
     context.emit(person)

--- a/datasets/gb/nca_most_wanted/crawler.py
+++ b/datasets/gb/nca_most_wanted/crawler.py
@@ -27,7 +27,11 @@ def crawl_person(context: Context, item: _Element, url: str) -> None:
     doc = context.fetch_html(person_url, cache_days=7)
 
     # Article
-    article = doc.find('.//div[@itemprop="articleBody"]').find(".//p")
+    article_body = doc.find('.//div[@itemprop="articleBody"]')
+    assert article_body is not None, person_url
+    article = article_body.find(".//p")
+    assert article is not None, person_url
+    assert article.text is not None, person_url
     person.add("notes", article.text.strip())
     # Fields
     for field_name in FIELD_NAMES:
@@ -43,14 +47,20 @@ def crawl_person(context: Context, item: _Element, url: str) -> None:
         for label, value in dict(zip(labels, values)).items():
             label_text = slugify(label.text)
             if label_text == "sex":
+                assert value.text is not None
                 person.add("gender", value.text.strip())
             elif label_text == "ethnic-appearance":
+                assert value.text is not None
                 person.add("ethnicity", value.text.strip())
             elif label_text == "additional-information":
+                assert value.text is not None
+                assert article.text is not None
                 person.add("notes", [article.text.strip(), value.text.strip()])
             elif label_text == "height":
+                assert value.text is not None
                 person.add("height", value.text.strip())
             elif label_text == "hair-colour":
+                assert value.text is not None
                 person.add("hairColor", value.text.strip())
 
     context.emit(person)


### PR DESCRIPTION
All 10 errors were `None`-attribute access on lxml `.find()` results (`_Element | None`) and `.text` (`str | None`). Added `assert ... is not None` narrowing where the code already assumed the element/text was present (it would crash on `None` either way), rather than swapping to `h.element_text` which would change direct-text to full text-content semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
