### PR TITLE
[us_fincen_special_measures] Fix mypy --strict type errors

### DIFF
--- a/datasets/us/fincen_special_measures/crawler.py
+++ b/datasets/us/fincen_special_measures/crawler.py
@@ -1,10 +1,10 @@
-from lxml import html
 import re
+from collections.abc import Iterator
+
+from normality import slugify
+
 from zavod import Context, helpers as h
-from normality import slugify, squash_spaces
-from typing import cast
-from collections.abc import Generator
-from normality import collapse_spaces
+from zavod.util import Element
 
 
 REGEX_DATE = re.compile(r"(\d{1,2}/\d{1,2}/\d{4})")
@@ -16,9 +16,9 @@ def convert_date(date_str: str) -> list[str]:
     return dates
 
 
-def crawl_item(context: Context, row: dict[str, str]) -> None:
+def crawl_item(context: Context, row: dict[str, Element]) -> None:
     # Create the entity based on the schema
-    name = row.pop("name").text_content()
+    name = h.element_text(row.pop("name"))
     schema = context.lookup_value("target_type", name)
     if schema is None:
         schema = "Company"
@@ -26,10 +26,8 @@ def crawl_item(context: Context, row: dict[str, str]) -> None:
     entity.id = context.make_id(name)
     entity.add("name", name)
     # Adjust the topic based on the presence of "final rule"
-    final_rule = collapse_spaces(
-        row.get("final-rule", "").text_content().strip().lower()
-    )
-    rescinded_date = squash_spaces(row.get("rescinded").text_content())
+    final_rule = h.element_text(row["final-rule"]).lower()
+    rescinded_date = h.element_text(row["rescinded"])
     if (
         final_rule
         and final_rule != "---"
@@ -43,24 +41,25 @@ def crawl_item(context: Context, row: dict[str, str]) -> None:
     sanction = h.make_sanction(context, entity)
 
     # Extract PDF links
-    anchors = row.get("finding").findall(".//a")
-    anchors.extend(row.get("notice-of-proposed-rulemaking").findall(".//a"))
-    anchors.extend(row.get("rescinded").findall(".//a"))
-    anchors.extend(row.get("final-rule").findall(".//a"))
-    sanction.add("sourceUrl", [a.get("href") for a in anchors])
+    source_urls = h.xpath_strings(row["finding"], ".//a/@href")
+    source_urls.extend(
+        h.xpath_strings(row["notice-of-proposed-rulemaking"], ".//a/@href")
+    )
+    source_urls.extend(h.xpath_strings(row["rescinded"], ".//a/@href"))
+    source_urls.extend(h.xpath_strings(row["final-rule"], ".//a/@href"))
+    sanction.add("sourceUrl", source_urls)
 
-    finding_date = row.get("finding").text_content()
-    nprm_date = row.get("notice-of-proposed-rulemaking").text_content()
+    finding_date = h.element_text(row["finding"])
+    nprm_date = h.element_text(row["notice-of-proposed-rulemaking"])
     listing_date = finding_date if finding_date else nprm_date
     for date in convert_date(listing_date):
         h.apply_date(sanction, "listingDate", date)
 
-    final_rule_date = row.get("final-rule").text_content()
+    final_rule_date = h.element_text(row["final-rule"])
     if final_rule_date != "---":
         for date in convert_date(final_rule_date):
             h.apply_date(sanction, "startDate", date)
 
-    # rescinded_date = row.get("rescinded").text_content()
     if rescinded_date != "---" and rescinded_date != "":
         for date in convert_date(rescinded_date):
             h.apply_date(sanction, "endDate", date)
@@ -73,20 +72,21 @@ def crawl_item(context: Context, row: dict[str, str]) -> None:
 
 
 # Parse the table and yield rows as dictionaries.
-def parse_table(table: html.HtmlElement) -> Generator[dict[str, str], None, None]:
-    headers = None
+def parse_table(table: Element) -> Iterator[dict[str, Element]]:
+    headers: list[str] | None = None
     for row in table.findall(".//tr"):
         if headers is None:
             headers = []
-            for el in row.findall("./th"):
-                # Workaround because lxml-stubs doesn't yet support HtmlElement
-                # https://github.com/lxml/lxml-stubs/pull/71
-                eltree = cast(html.HtmlElement, el)
-                headers.append(slugify(eltree.text_content()))
-            assert headers[0] is None, headers
+            for idx, el in enumerate(row.findall("./th")):
+                slug = slugify(h.element_text(el))
+                if idx == 0:
+                    # The first column has no header in the source; it holds the name.
+                    assert slug is None, slug
+                    slug = "name"
+                assert slug is not None, h.element_text(el)
+                headers.append(slug)
             # no duplicate column headers
             assert len(set(headers)) == len(headers), headers
-            headers[0] = "name"
             continue
 
         cells = row.findall("./td")
@@ -99,7 +99,6 @@ def parse_table(table: html.HtmlElement) -> Generator[dict[str, str], None, None
 # Main crawl function to fetch and process data.
 def crawl(context: Context) -> None:
     doc = context.fetch_html(context.data_url, absolute_links=True)
-    table = doc.get_element_by_id("special-measures-table")
-    if table is not None:
+    for table in h.xpath_elements(doc, '//table[@id="special-measures-table"]'):
         for row in parse_table(table):
             crawl_item(context, row)


### PR DESCRIPTION
The row dicts actually hold HTML cell `Element`s, not `str` — retyped `crawl_item` / `parse_table` accordingly (was a false `dict[str, str]`). Swapped `.text_content()` for `h.element_text`, moved `@href` into the xpath via `h.xpath_strings`, and replaced the untyped `get_element_by_id` + None-guard with an `h.xpath_elements` loop.

`parse_table` now builds `headers` as `list[str]` in one pass, folding the "first column has no header, it holds the name" fix-up into the loop — so the row dict comprehension stays as it was. Side effect: the duplicate-header check now runs after the `name` substitution, so a real column slugifying to `name` gets caught instead of slipping through.

Also dropped now-unused imports and one dead commented-out line in the block I rewrote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
