### PR TITLE
Issues 2026-07-27

### DIFF
--- a/datasets/gb/coh/gb_coh_psc.yml
+++ b/datasets/gb/coh/gb_coh_psc.yml
@@ -46,6 +46,12 @@ assertions:
       Person: 12_000_000
       Organization: 17_000
       Company: 10_000
+    # ~42% of Company entities are only a registration-number stub, likely
+    # dissolved companies still referenced by a PSC statement but no longer
+    # in the base data file.
+    property_fill_rate:
+      Company:
+        name: 0.5
   max:
     schema_entities:
       Person: 24_000_000

--- a/zavod/zavod/helpers/excel.py
+++ b/zavod/zavod/helpers/excel.py
@@ -29,7 +29,8 @@ def convert_excel_cell(book: Book, cell: Cell) -> str | None:
     """
     # https://xlrd.readthedocs.io/en/latest/api.html#xlrd.sheet.Cell
     if cell.ctype == XL_CELL_NUMBER:
-        return str(int(cell.value))
+        # Excel stores all numbers as floats; stringify keeps the fractional part.
+        return stringify(cell.value)
     elif cell.ctype in (XL_CELL_EMPTY, XL_CELL_ERROR, XL_CELL_BLANK):
         return None
     if cell.ctype == XL_CELL_DATE:


### PR DESCRIPTION
- **[zavod] Keep fractional part of Excel number cells**
  convert_excel_cell ran every XL_CELL_NUMBER cell through int(), truncating
  anything with a fractional part. stringify() is what parse_xls_sheet and
  parse_xlsx_sheet already use for cell values, and returns identical output
  for whole numbers.
  
  Co-Authored-By: Claude <noreply@anthropic.com>
  

- **[gb_coh_psc] Lower the Company.name fill rate assertion to 0.5**
  The default `min.property_fill_rate.Company.name` of 0.95 (added in 0995712d3)
  doesn't fit this dataset: ~42% of the 11.8M Company entities are only a
  registration-number stub, with no name. Those are likely dissolved companies —
  `parse_psc_data` emits a stub Company per PSC statement so the Ownership has an
  asset to point at, and the base data file only covers companies still on the
  register — but I haven't verified that.
  
  Either way, it is not new drift. Company.name fill rate across the retained
  archive:
  
      2026-07-15  0.5781
      2026-07-08  0.5787
      2026-07-01  0.5795
      2026-06-24  0.5770
      2026-06-17  0.5781
      2026-06-10  0.5782
      2026-06-03  0.5789
      2026-05-27  0.5795
      2026-05-20  0.5802
      2026-05-13  0.5809
  
  Flat at 0.577-0.581, and the value that tripped the assertion (0.5773) sits
  right in that range. Artifacts older than 2026-05-13 are pruned, so the window
  is 10 weeks rather than the full year, but the default assertion landed
  2026-07-13 and the first failing run was 2026-07-22 — the assertion is new,
  the data isn't. The failed run's only error is this assertion; everything else
  is a warning.
  
  0.5 leaves years of headroom on the ~-0.0004/week drift. `ext_gb_coh_psc.yml`
  already carries a similar override.
  