### PR TITLE
[wikidata] Skip rejected positions before classification

### DIFF
--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -12,10 +12,10 @@ from rigour.time import iso_datetime
 from zavod.shed.wikidata.client import WIKIDATA_QUERY_CACHE, create_wikidata_client
 from zavod.shed.wikidata.human import wikidata_basic_human
 from zavod.shed.wikidata.position import (
-    position_holders,
     wikidata_occupancy,
     wikidata_position,
 )
+from zavod.stateful.positions import categorised_position_qids
 
 from zavod import Context, Entity
 from zavod import helpers as h
@@ -38,7 +38,6 @@ ALWAYS_PERSONS = ["Q21258544"]
 @dataclass
 class FoundRecord:
     from_categories: set[str] = field(default_factory=set)
-    from_positions: set[str] = field(default_factory=set)
     from_declarator: bool = False
 
 
@@ -51,6 +50,12 @@ class CrawlState:
         # a usable PEP position. Positions recur across the whole person set,
         # so each distinct QID is fetched and categorised only once per run.
         self.positions: dict[str, Entity | None] = {}
+        blocked = 0
+        for qid, is_pep in categorised_position_qids(context):
+            if not is_pep:
+                self.positions[qid] = None
+                blocked += 1
+        self.log.info("Preloaded rejected positions", blocked=blocked)
 
         self.persons: dict[str, FoundRecord] = defaultdict(FoundRecord)
         self.persons.update({qid: FoundRecord() for qid in ALWAYS_PERSONS})
@@ -216,48 +221,6 @@ def crawl_category(state: CrawlState, category_crawl_spec: dict[str, Any]) -> No
     state.context.flush()
 
 
-def crawl_position_holder(state: CrawlState, position_qid: str) -> set[str]:
-    persons: set[str] = set()
-
-    position = get_position(state, position_qid)
-    if position is None:
-        return persons
-    # Cheap re-fetch: get_position just pulled this item into the client LRU.
-    item = state.client.fetch_item(position_qid)
-    if item is None:
-        return persons
-
-    # find person QIDs such that person --( P39 position held )--> position_qid
-    holders = position_holders(state.client, item)
-    persons.update(holders.keys())
-    for person_qid, modified_at in holders.items():
-        if modified_at is not None:
-            state.person_modified_at[person_qid] = modified_at
-
-    # Crawl direct officeholders only after their modification dates can
-    # invalidate stale person items from the cache.
-    crawl_officeholders(state, item, position)
-
-    # find person QIDs such that position_qid --( P1308 officeholder )--> person
-    for claim in item.claims:
-        if claim.property == "P1308" and claim.qid is not None:  # officeholder
-            persons.add(claim.qid)
-
-    state.log.info(f"Found {len(persons)} holders of {item.label} [{position_qid}]")
-    return persons
-
-
-def crawl_igo_positions(state: CrawlState) -> None:
-    """Crawl holders of explicitly curated international-organisation roles."""
-    position_qids: list[str] = state.context.dataset.config.get("igo_positions", [])
-    state.log.info(f"Crawling {len(position_qids)} IGO positions")
-    for position_qid in position_qids:
-        for holder_qid in crawl_position_holder(state, position_qid):
-            state.persons[holder_qid].from_positions.add(position_qid)
-
-        state.context.flush()
-
-
 def crawl_declarator(state: CrawlState) -> None:
     # Import all profiles which have a Declarator ID, a reference to a Russian PEP
     # site containing profiles of all elected officials in Russia.
@@ -316,7 +279,7 @@ def crawl_persons(state: CrawlState) -> None:
 
         state.log.info(
             f"Crawled person {entity.id} "
-            f"(found in categories {found_record.from_categories}, positions {found_record.from_positions}): "
+            f"(found in categories {found_record.from_categories}): "
             f"{entity.caption} {entity.get('topics')}"
         )
 
@@ -339,7 +302,6 @@ def crawl_persons(state: CrawlState) -> None:
 def crawl(context: Context) -> None:
     state = CrawlState(context)
     crawl_declarator(state)
-    crawl_igo_positions(state)
     category_crawl_specs: list[dict[str, Any]] = context.dataset.config.get(
         "categories", []
     )

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -1,7 +1,6 @@
-# This discovers entities in three ways:
+# This discovers entities in two ways:
 #
 # - wikidata items with a Declarator.org ID
-# - wikidata items holding one of the explicitly curated IGO positions defined below
 # - wikidata items in specific Wikipedia categories defined below, using https://petscan.wmcloud.org
 #
 # # Categories
@@ -175,25 +174,6 @@ lookups:
         value: 1942-02
 
 config:
-  # Heads of international organisations for which Wikidata Q codes were found.
-  # These are crawled directly, without expanding their Wikidata subclasses.
-  igo_positions:
-    - "Q24558593" # Administrator of the United Nations Development Programme
-    - "Q65782205" # Director General of the International Atomic Energy Agency
-    - "Q66566041" # Director-General of the Food and Agriculture Organization
-    - "Q111363853" # Director-General of the International Labour Organization
-    - "Q108603609" # Director-General of the World Intellectual Property Organization
-    - "Q28784183" # Director-General of UNESCO
-    - "Q67199671" # Executive Director of UNICEF
-    - "Q123171287" # Executive Director of United Nations Office for Project Services
-    - "Q19926443" # President of the International Court of Justice
-    - "Q29511440" # President of the United Nations Economic and Social Council
-    - "Q4352360" # President of the United Nations Security Council
-    - "Q110970831" # President of the World Meteorological Organization
-    - "Q42591216" # Secretary-General of the International Maritime Organization
-    - "Q17389566" # Secretary-General of the International Telecommunication Union
-    - "Q27832358" # United Nations High Commissioner for Refugees
-    - "Q112963010" # UNRWA Commissioner-General
   # These are person QIDs that shouldn't be found. If they are, we're probably including
   # categories that are by definition generally not PEPs.
   exclusion_checks:

--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -102,9 +102,20 @@ def query_occupation_positions(
 def discover_candidates(context: Context, client: WikidataClient) -> set[str]:
     """Enumerate candidate position QIDs. Positions already categorised as PEP
     in the review database are always included, so a failing discovery query
-    can delay new positions but never drop known ones."""
-    candidates: set[str] = set(categorised_position_qids(context))
-    context.log.info(f"Loaded {len(candidates)} positions from the review database")
+    can delay new positions but never drop known ones. Positions reviewed as
+    non-PEP are excluded so classification can skip them entirely."""
+    candidates: set[str] = set()
+    blocked: set[str] = set()
+    for qid, is_pep in categorised_position_qids(context):
+        if is_pep:
+            candidates.add(qid)
+        else:
+            blocked.add(qid)
+    context.log.info(
+        "Loaded position verdicts from the review database",
+        accepted=len(candidates),
+        blocked=len(blocked),
+    )
     for territory in all_territories():
         context.log.info(f"Crawling territory: {territory.qid} ({territory.name})")
         try:
@@ -121,6 +132,7 @@ def discover_candidates(context: Context, client: WikidataClient) -> set[str]:
                 error=str(exc),
             )
         context.flush()
+    candidates.difference_update(blocked)
     return candidates
 
 

--- a/zavod/zavod/stateful/positions.py
+++ b/zavod/zavod/stateful/positions.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from enum import Enum
 from functools import lru_cache
+from collections.abc import Iterator
 
 from rigour.dates import ended_before, starts_after
 from rigour.ids.wikidata import is_qid
@@ -127,18 +128,19 @@ def categorise_many(
     return categorisations
 
 
-def categorised_position_qids(context: Context) -> list[str]:
-    """Return a list of position QIDs that have been categorised."""
-    stmt = select(position_table.c.entity_id)
-    stmt = stmt.filter(position_table.c.is_pep.is_(True))
+def categorised_position_qids(context: Context) -> Iterator[tuple[str, bool]]:
+    """Yield reviewed Wikidata position QIDs and their PEP verdicts.
+
+    Use this to seed or exclude positions before doing expensive source-side
+    discovery and classification work.
+    """
+    stmt = select(position_table.c.entity_id, position_table.c.is_pep)
+    stmt = stmt.filter(position_table.c.is_pep.is_not(None))
     stmt = stmt.filter(position_table.c.deleted_at.is_(None))
     stmt = stmt.filter(position_table.c.entity_id.like("Q%"))
-    rows = context.db.execute(stmt).fetchall()
-    qids = []
-    for row in rows:
+    for row in context.db.execute(stmt):
         if is_qid(row.entity_id):
-            qids.append(row.entity_id)
-    return qids
+            yield row.entity_id, row.is_pep
 
 
 def get_after_office(topics: list[str]) -> timedelta:

--- a/zavod/zavod/tests/stateful/test_positions.py
+++ b/zavod/zavod/tests/stateful/test_positions.py
@@ -7,6 +7,7 @@ from zavod.stateful.positions import (
     occupancy_status,
     OccupancyStatus,
     categorise,
+    categorised_position_qids,
 )
 from zavod.stateful.model import position_table
 from zavod.meta import Dataset
@@ -229,6 +230,48 @@ def test_categorise_flow(testdataset1: Dataset):
     categorisation = categorise(context, position2, default_is_pep=True)
     assert categorisation.is_pep is True
     assert categorisation.topics == ["gov.igo"]
+    context.close()
+
+
+def test_categorised_position_qids_returns_reviewed_verdicts(
+    testdataset1: Dataset,
+):
+    context = Context(testdataset1)
+    values = [
+        {
+            "entity_id": "Q100",
+            "caption": "Accepted position",
+            "countries": ["de"],
+            "topics": [],
+            "is_pep": True,
+            "dataset": "test",
+            "created_at": settings.RUN_TIME,
+        },
+        {
+            "entity_id": "Q200",
+            "caption": "Rejected position",
+            "countries": ["fr"],
+            "topics": [],
+            "is_pep": False,
+            "dataset": "test",
+            "created_at": settings.RUN_TIME,
+        },
+        {
+            "entity_id": "Q300",
+            "caption": "Unreviewed position",
+            "countries": ["gb"],
+            "topics": [],
+            "is_pep": None,
+            "dataset": "test",
+            "created_at": settings.RUN_TIME,
+        },
+    ]
+    context.db.execute(position_table.insert().values(values))
+
+    assert dict(categorised_position_qids(context)) == {
+        "Q100": True,
+        "Q200": False,
+    }
     context.close()
 
 


### PR DESCRIPTION
Stacked on #5102.

## Summary
- stream recorded Wikidata position verdicts from the review database
- seed wd_peps discovery with accepted positions and remove rejected candidates before Wikidata fetching and classification
- preload rejected positions into the wd_categories position cache
- remove the redundant wd_categories IGO holder crawl now handled by wd_peps

## Tests
- /Users/pudo/.python/wrangle/bin/python -m pytest zavod/zavod/tests/stateful -q
- ruff check and format checks on changed Python files
- YAML parsing and lint checks
- git diff --check