### PR TITLE
Release 14 datasets into peps and sanctions

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -55,8 +55,11 @@ children:
   - bg_jud_declarations
   - bg_parliament
   - bh_nuwab
+  - bh_shura_council
+  - bo_diputados
   - bo_senado
   - br_pep
+  - bt_parliament
   - bz_national_assembly
   - ca_commons
   - ca_foreign_reps
@@ -64,6 +67,8 @@ children:
   - ch_parlament
   - ci_senate
   - cl_info_probidad
+  - cm_senate
+  - cn_npc
   - cn_peoples_congress_wikipedia
   - co_funcion_publica
   - co_join_dots
@@ -108,6 +113,7 @@ children:
   - it_senate
   - jp_sangiin
   - jp_shugiin
+  - ke_judiciary
   - ke_national_assembly
   - ke_senate
   - kg_jogorku_kenesh
@@ -123,6 +129,7 @@ children:
   - lu_chamber
   - lv_saeima
   - ma_representatives
+  - mc_conseil_national
   - me_acp_peps
   - me_skupstina
   - mk_officials
@@ -132,6 +139,7 @@ children:
   - mx_deputies
   - mx_governors
   - mx_senators
+  - my_parliament
   - ng_chipper_peps
   - ng_join_dots
   - ni_legislature
@@ -146,6 +154,8 @@ children:
   - pg_parliament
   - ph_house_representatives
   - ph_senate
+  - pk_na_members
+  - pk_senate_members
   - pl_sejm
   - pl_senate
   - pt_parliament
@@ -156,6 +166,7 @@ children:
   - rs_national_assembly
   - ru_duma_deputies
   - ru_federation_council
+  - ru_kremlin_persons
   - rw_parliament
   - se_riksdag
   - se_soe
@@ -169,6 +180,7 @@ children:
   - sv_legislature
   - th_cabinet
   - tj_majlisi_milli
+  - tm_mejlis
   - tr_parliament
   - tw_legislature
   - tz_bunge

--- a/datasets/_collections/sanctions.yml
+++ b/datasets/_collections/sanctions.yml
@@ -106,6 +106,7 @@ children:
   - ro_onpcsb_sanctions
   - rs_apml_domestic
   - ru_mfa_sanctions
+  - sa_pcct_terrorism_list
   - sg_terrorists
   - th_designated_person
   - tn_cnlct
@@ -116,6 +117,7 @@ children:
   - un_1718_vessels
   - un_sc_sanctions
   - us_bis_denied
+  - us_bis_mieu
   - us_cbp_forced_labor
   - us_cuba_sanctions
   - us_dhs_uflpa

--- a/datasets/bh/shura_council/bh_shura_council.yml
+++ b/datasets/bh/shura_council/bh_shura_council.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: bh-shura
 coverage:
   frequency: weekly
-  start: 2026-06-25
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/bo/diputados/bo_diputados.yml
+++ b/datasets/bo/diputados/bo_diputados.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: bo-dip
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/bt/parliament/bt_parliament.yml
+++ b/datasets/bt/parliament/bt_parliament.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: bt-pa
 coverage:
   frequency: monthly
-  start: 2026-06-25
+  start: 2026-07-27
 load_statements: true
 summary: >-
   Current and former members of both chambers of Bhutan's Parliament.

--- a/datasets/cm/senate/cm_senate.yml
+++ b/datasets/cm/senate/cm_senate.yml
@@ -4,7 +4,7 @@ prefix: cm-sen
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-24
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/cn/npc/cn_npc.yml
+++ b/datasets/cn/npc/cn_npc.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: cn-npc
 coverage:
   frequency: monthly
-  start: 2026-07-12
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/ke/judiciary/ke_judiciary.yml
+++ b/datasets/ke/judiciary/ke_judiciary.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ke-jud
 coverage:
   frequency: monthly
-  start: 2026-07-05
+  start: 2026-07-27
 load_statements: true
 ci_test: true
 summary: Current judges of the superior courts listed by the Judiciary of Kenya

--- a/datasets/mc/conseil_national/mc_conseil_national.yml
+++ b/datasets/mc/conseil_national/mc_conseil_national.yml
@@ -4,7 +4,7 @@ prefix: mc-cn
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/my/parliament/my_parliament.yml
+++ b/datasets/my/parliament/my_parliament.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: my-parl
 coverage:
   frequency: monthly
-  start: 2026-07-17
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/pk/na_members/pk_na_members.yml
+++ b/datasets/pk/na_members/pk_na_members.yml
@@ -4,7 +4,7 @@ prefix: pk-na
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-02
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/pk/senate_members/pk_senate_members.yml
+++ b/datasets/pk/senate_members/pk_senate_members.yml
@@ -4,7 +4,7 @@ prefix: pk-sen
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-17
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/ru/kremlin_persons/ru_kremlin_persons.yml
+++ b/datasets/ru/kremlin_persons/ru_kremlin_persons.yml
@@ -4,7 +4,7 @@ prefix: ru-kremlin
 entry_point: crawler.py
 coverage:
   frequency: weekly
-  start: 2026-07-15
+  start: 2026-07-27
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/sa/pcct_terrorism_list/sa_pcct_terrorism_list.yml
+++ b/datasets/sa/pcct_terrorism_list/sa_pcct_terrorism_list.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: sa-pcct
 coverage:
   frequency: daily
-  start: "2026-07-14"
+  start: "2026-07-27"
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/tm/mejlis/tm_mejlis.yml
+++ b/datasets/tm/mejlis/tm_mejlis.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: tm-mejlis
 coverage:
   frequency: monthly
-  start: 2026-06-24
+  start: 2026-07-27
 load_statements: true
 ci_test: false # Live external government website needing a browser UA, not in CI
 summary: >-


### PR DESCRIPTION
Adds 14 merged crawlers to their topical collections and bumps `coverage.start` on each to the release date.

**Into `peps`:** `bh_shura_council`, `bo_diputados`, `bt_parliament`, `cm_senate`, `cn_npc`, `ke_judiciary`, `mc_conseil_national`, `my_parliament`, `pk_na_members`, `pk_senate_members`, `ru_kremlin_persons`, `tm_mejlis`

**Into `sanctions`:** `sa_pcct_terrorism_list`, `us_bis_mieu`

`contrib/check_hierarchy.py datasets` no longer reports any of these as having no collections; both collection lists remain alphabetically sorted and free of duplicates.

Note: `cn_npc` covers the same body as the existing `cn_peoples_congress_wikipedia` (which also includes former members). Both are now in `peps` under distinct prefixes, so they will need deduplication against each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)