### PR TITLE
[issues-agent] Switch agents to Sonnet 5 and Opus 5

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,6 +58,6 @@ jobs:
           # embedded quotes are literal. --append-system-prompt (not
           # --system-prompt) keeps Claude Code's default behavior and adds to it.
           claude_args: >-
-            --model claude-opus-4-8 --max-turns 30
+            --model claude-opus-5 --max-turns 30
             --append-system-prompt "On autofix/* PRs you are tuning datapatch lookups and small crawler fixes. Key references: zavod/docs/best_practices/datapatch_lookups.md (lookups) and .claude/docs/crawler-guide.md. The repo CLAUDE.md maps the rest of the documentation."
             --allowed-tools "Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,Skill"

--- a/contrib/maintenance/issues_agent.py
+++ b/contrib/maintenance/issues_agent.py
@@ -39,8 +39,8 @@ from .issues import is_issue_ignored, issues_checksum
 # Match compute to task difficulty. Lookup/assertion edits on YAML are mechanical,
 # so a mid-tier model with few turns suffices. Datasets with a crawler may need an
 # actual code fix — stronger reasoning, plus turns to run mypy, crawl, and iterate.
-MODEL_LOOKUP = "claude-sonnet-4-6"
-MODEL_CODE = "claude-opus-4-8"
+MODEL_LOOKUP = "claude-sonnet-5"
+MODEL_CODE = "claude-opus-5"
 MAX_TURNS_LOOKUP = 30
 MAX_TURNS_CODE_VERIFIABLE = 100  # ci_test true: edit, then crawl-verify and iterate
 MAX_TURNS_CODE_BLIND = 60  # ci_test false: edit + mypy/ruff, no crawl loop


### PR DESCRIPTION
Bumps the Claude-driven agents to the current model generation.

**Issues agent** (`contrib/maintenance/issues_agent.py`):
- `MODEL_LOOKUP`: `claude-sonnet-4-6` → `claude-sonnet-5`
- `MODEL_CODE`: `claude-opus-4-8` → `claude-opus-5`

The split stays the same — mid-tier model for mechanical YAML lookup/assertion edits, stronger model for datasets with a crawler that may need an actual code fix. Turn budgets are unchanged.

**`@claude` mention bot** (`.github/workflows/claude.yml`):
- `--model claude-opus-4-8` → `claude-opus-5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)