### PR TITLE
Clean up position names and add missing QIDs across PEP crawlers

### DIFF
--- a/datasets/ad/consell_general/crawler.py
+++ b/datasets/ad/consell_general/crawler.py
@@ -73,6 +73,7 @@ def crawl(context: Context) -> None:
         country="ad",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q20177831",
+        lang="eng",
     )
     context.emit(position)
     categorisation = categorise(context, position, default_is_pep=True)

--- a/datasets/al/kuvendi/crawler.py
+++ b/datasets/al/kuvendi/crawler.py
@@ -89,6 +89,7 @@ def crawl(context: Context) -> None:
         country="al",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q20177772",
+        lang="eng",
     )
     context.emit(position)
 

--- a/datasets/au/act_parliament/crawler.py
+++ b/datasets/au/act_parliament/crawler.py
@@ -90,6 +90,7 @@ def crawl(context: Context) -> None:
         country="au",
         subnational_area="Australian Capital Territory",
         wikidata_id="Q6814365",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)

--- a/datasets/au/nsw_parliament/crawler.py
+++ b/datasets/au/nsw_parliament/crawler.py
@@ -161,6 +161,7 @@ def crawl(context: Context) -> None:
             country="au",
             wikidata_id=config["wikidata_id"],
             topics=["gov.state", "gov.legislative"],
+            lang="eng",
         )
         categorisation = categorise(context, position)
         context.emit(position)

--- a/datasets/au/nt_parliament/crawler.py
+++ b/datasets/au/nt_parliament/crawler.py
@@ -79,6 +79,7 @@ def crawl(context: Context) -> None:
         country="au",
         subnational_area="Northern Territory",
         wikidata_id="Q26998278",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)

--- a/datasets/au/parliament/crawler.py
+++ b/datasets/au/parliament/crawler.py
@@ -178,6 +178,7 @@ def crawl(context: Context) -> None:
         country="au",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q18912794",
+        lang="eng",
     )
     senate = h.make_position(
         context,
@@ -185,6 +186,7 @@ def crawl(context: Context) -> None:
         country="au",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q6814428",
+        lang="eng",
     )
     positions: dict[str, tuple[Entity, PositionCategorisation]] = {}
     for chamber, position in (("Member", house), ("Senator", senate)):

--- a/datasets/au/qld_parliament/crawler.py
+++ b/datasets/au/qld_parliament/crawler.py
@@ -101,6 +101,7 @@ def crawl(context: Context) -> None:
         country="au",
         subnational_area="Queensland",
         wikidata_id="Q18526194",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)

--- a/datasets/au/sa_parliament/crawler.py
+++ b/datasets/au/sa_parliament/crawler.py
@@ -135,6 +135,7 @@ def crawl(context: Context) -> None:
         subnational_area="South Australia",
         wikidata_id="Q18220900",
         topics=["gov.state", "gov.legislative"],
+        lang="eng",
     )
     legislative_council = h.make_position(
         context,
@@ -143,6 +144,7 @@ def crawl(context: Context) -> None:
         subnational_area="South Australia",
         wikidata_id="Q18662245",
         topics=["gov.state", "gov.legislative"],
+        lang="eng",
     )
     context.emit(house_assembly)
     context.emit(legislative_council)

--- a/datasets/au/tas_parliament/crawler.py
+++ b/datasets/au/tas_parliament/crawler.py
@@ -117,6 +117,7 @@ def crawl(context: Context) -> None:
         subnational_area="Tasmania",
         topics=["gov.state", "gov.legislative"],
         wikidata_id="Q19007285",
+        lang="eng",
     )
     ha_categorisation = categorise(context, ha_position, default_is_pep=True)
     context.emit(ha_position)
@@ -128,6 +129,7 @@ def crawl(context: Context) -> None:
         subnational_area="Tasmania",
         topics=["gov.state", "gov.legislative"],
         wikidata_id="Q19299542",
+        lang="eng",
     )
     lc_categorisation = categorise(context, lc_position, default_is_pep=True)
     context.emit(lc_position)

--- a/datasets/au/vic_parliament/crawler.py
+++ b/datasets/au/vic_parliament/crawler.py
@@ -67,6 +67,7 @@ def crawl(context: Context) -> None:
             country="au",
             topics=["gov.state", "gov.legislative"],
             wikidata_id=config["wikidata_id"],
+            lang="eng",
         )
         categorisation = categorise(context, position, default_is_pep=True)
         context.emit(position)

--- a/datasets/au/wa_parliament/crawler.py
+++ b/datasets/au/wa_parliament/crawler.py
@@ -106,6 +106,7 @@ def crawl(context: Context) -> None:
             country="au",
             subnational_area="Western Australia",
             wikidata_id=config["wikidata_id"],
+            lang="eng",
         )
         categorisation = categorise(context, position, default_is_pep=True)
         context.emit(position)

--- a/datasets/az/parliament/crawler.py
+++ b/datasets/az/parliament/crawler.py
@@ -150,6 +150,7 @@ def crawl_member(context: Context, url: str, name: str) -> None:
         name="Member of the National Assembly of Azerbaijan",
         country="az",
         wikidata_id="Q21269547",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     occupancy = h.make_occupancy(

--- a/datasets/ba/parliament/crawler.py
+++ b/datasets/ba/parliament/crawler.py
@@ -180,12 +180,14 @@ def crawl(context: Context) -> None:
         name="Member of the House of Representatives of Bosnia and Herzegovina",
         country="ba",
         wikidata_id="Q21290855",
+        lang="eng",
     )
     hop = h.make_position(
         context,
         name="Member of the House of Peoples of Bosnia and Herzegovina",
         country="ba",
         wikidata_id="Q21328613",
+        lang="eng",
     )
     hor_cat = categorise(context, hor, default_is_pep=True)
     hop_cat = categorise(context, hop, default_is_pep=True)

--- a/datasets/bg/parliament/crawler.py
+++ b/datasets/bg/parliament/crawler.py
@@ -197,6 +197,8 @@ def crawl(context: Context) -> None:
         name="Member of the National Assembly of Bulgaria",
         country="bg",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q18924508",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -123,6 +123,7 @@ def crawl(context: Context) -> None:
         country="bh",
         wikidata_id="Q21328582",
         topics=["gov.national", "gov.legislative"],
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/bh/nuwab/crawler.py
+++ b/datasets/bh/nuwab/crawler.py
@@ -119,7 +119,7 @@ def crawl_member(
 def crawl(context: Context) -> None:
     position = h.make_position(
         context,
-        name="Member of the Council of Representatives",
+        name="Member of the Council of Representatives of Bahrain",
         country="bh",
         wikidata_id="Q21328582",
         topics=["gov.national", "gov.legislative"],

--- a/datasets/bh/shura_council/crawler.py
+++ b/datasets/bh/shura_council/crawler.py
@@ -238,6 +238,7 @@ def crawl(context: Context) -> None:
         country="bh",
         wikidata_id="Q21328598",
         topics=["gov.national", "gov.legislative"],
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/bt/parliament/crawler.py
+++ b/datasets/bt/parliament/crawler.py
@@ -92,6 +92,7 @@ def crawl_chamber(context: Context, chamber: Chamber) -> None:
         country="bt",
         topics=["gov.national", "gov.legislative"],
         wikidata_id=chamber.wikidata_id,
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/ca/commons/crawler.py
+++ b/datasets/ca/commons/crawler.py
@@ -42,6 +42,7 @@ def crawl_member(context: Context, el: etree._Element) -> None:
         wikidata_id="Q15964890",
         country="ca",
         topics=["gov.legislative", "gov.national"],
+        lang="eng",
     )
     context.emit(position)
     # <FromDateTime>2025-04-28T00:00:00</FromDateTime>

--- a/datasets/ca/senate/crawler.py
+++ b/datasets/ca/senate/crawler.py
@@ -11,6 +11,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q18524027",
         country="ca",
         topics=["gov.legislative", "gov.national"],
+        lang="eng",
     )
     context.emit(position)
     doc = context.fetch_html(context.data_url)

--- a/datasets/ch/parlament/crawler.py
+++ b/datasets/ch/parlament/crawler.py
@@ -109,6 +109,7 @@ def crawl_councillor(context: Context, councillor_id: int) -> None:
             country="ch",
             topics=["gov.legislative", "gov.national"],
             wikidata_id=wikidata_id,
+            lang="eng",
         )
         categorisation = categorise(context, position, default_is_pep=True)
         if not categorisation.is_pep:

--- a/datasets/cm/senate/crawler.py
+++ b/datasets/cm/senate/crawler.py
@@ -9,6 +9,7 @@ def crawl(context: Context) -> None:
         name="Senator of Cameroon",
         country="cm",
         wikidata_id="Q21295128",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/cn/npc/crawler.py
+++ b/datasets/cn/npc/crawler.py
@@ -106,7 +106,7 @@ def crawl_delegation(
 def crawl(context: Context) -> None:
     position = h.make_position(
         context,
-        "Member of the National People's Congress",
+        "Member of the National People's Congress of China",
         country="cn",
         wikidata_id="Q10891456",
         lang="eng",

--- a/datasets/cn/peoples_congress_wikipedia/crawler.py
+++ b/datasets/cn/peoples_congress_wikipedia/crawler.py
@@ -108,7 +108,11 @@ def crawl_item(
         entity.add("position", positions.text_content().split("\n"), lang="chi")
 
     position = h.make_position(
-        context, "Member of the National People’s Congress", country="cn"
+        context,
+        "Member of the National People's Congress",
+        country="cn",
+        wikidata_id="Q10891456",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
 

--- a/datasets/cn/peoples_congress_wikipedia/crawler.py
+++ b/datasets/cn/peoples_congress_wikipedia/crawler.py
@@ -109,7 +109,7 @@ def crawl_item(
 
     position = h.make_position(
         context,
-        "Member of the National People's Congress",
+        "Member of the National People's Congress of China",
         country="cn",
         wikidata_id="Q10891456",
         lang="eng",

--- a/datasets/cu/inventario_legislatura/crawler.py
+++ b/datasets/cu/inventario_legislatura/crawler.py
@@ -32,7 +32,7 @@ def crawl(context: Context) -> None:
     term_start = "2023"
     position = h.make_position(
         context,
-        "Member of the National Assembly of People's Power",
+        "Member of the National Assembly of People's Power of Cuba",
         country="cu",
         wikidata_id="Q21272829",
         lang="eng",

--- a/datasets/cu/inventario_legislatura/crawler.py
+++ b/datasets/cu/inventario_legislatura/crawler.py
@@ -35,6 +35,7 @@ def crawl(context: Context) -> None:
         "Member of the National Assembly of People's Power",
         country="cu",
         wikidata_id="Q21272829",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)

--- a/datasets/cy/parliament/crawler.py
+++ b/datasets/cy/parliament/crawler.py
@@ -53,6 +53,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q19801674",
         country="cy",
         topics=["gov.legislative", "gov.national"],
+        lang="eng",
     )
     context.emit(position)
 

--- a/datasets/de/bundesrat/crawler.py
+++ b/datasets/de/bundesrat/crawler.py
@@ -85,10 +85,10 @@ def crawl_item(context: Context, item: HtmlElement) -> None:
 
     position = h.make_position(
         context,
-        name="Mitglied des Bundesrates",
+        name="Member of the Bundesrat of Germany",
         country="de",
         topics=["gov.legislative", "gov.national"],
-        lang="deu",
+        lang="eng",
         wikidata_id="Q15835370",
     )
     categorisation = categorise(context, position, default_is_pep=True)

--- a/datasets/de/bundestag/crawler.py
+++ b/datasets/de/bundestag/crawler.py
@@ -14,6 +14,7 @@ def create_emit_position(context: Context) -> Entity:
         country="de",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q1939555",
+        lang="eng",
     )
     context.emit(position)
     return position

--- a/datasets/ee/riigikogu/crawler.py
+++ b/datasets/ee/riigikogu/crawler.py
@@ -39,9 +39,11 @@ def crawl_item(member_url: str, context: Context) -> None:
 
     position = h.make_position(
         context,
-        "Member of the Riigikogu",
+        "Member of the Riigikogu of Estonia",
         country="ee",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21100241",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/fr/assemblee/crawler.py
+++ b/datasets/fr/assemblee/crawler.py
@@ -139,6 +139,8 @@ def crawl_acteur(context: Context, data: dict[str, Any]) -> None:
         "Member of the French National Assembly",
         country="fr",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q3044918",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/fr/senat/crawler.py
+++ b/datasets/fr/senat/crawler.py
@@ -83,6 +83,8 @@ def crawl_row(
         name="Senator of the French Fifth Republic",
         country="fr",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q14828018",
+        lang="eng",
     )
     # is_pep=True because we expect all senators to be PEPs
     categorisation = categorise(context, position, default_is_pep=True)

--- a/datasets/gb/commons/crawler.py
+++ b/datasets/gb/commons/crawler.py
@@ -60,6 +60,7 @@ def crawl_member(
         country="gb",
         topics=TOPICS,
         wikidata_id="Q16707842",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     if not categorisation.is_pep:

--- a/datasets/gb/commons/crawler.py
+++ b/datasets/gb/commons/crawler.py
@@ -56,7 +56,7 @@ def crawl_member(
 
     position = h.make_position(
         context,
-        name="Member of the House of Commons",
+        name="Member of the House of Commons of the United Kingdom",
         country="gb",
         topics=TOPICS,
         wikidata_id="Q16707842",

--- a/datasets/gb/lords/crawler.py
+++ b/datasets/gb/lords/crawler.py
@@ -43,6 +43,7 @@ def crawl_member(
         name="Member of the House of Lords",
         country="gb",
         wikidata_id="Q18952564",
+        lang="eng",
     )
     # hereditary, life peer, etc:
     position.add("notes", membership["membershipFrom"])

--- a/datasets/gh/parliament/crawler.py
+++ b/datasets/gh/parliament/crawler.py
@@ -60,6 +60,7 @@ def crawl(context: Context) -> None:
         country="gh",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21290881",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)

--- a/datasets/hk/legco/crawler.py
+++ b/datasets/hk/legco/crawler.py
@@ -125,6 +125,8 @@ def crawl_member(
         name="Member of the Legislative Council of Hong Kong",
         country="hk",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q27908372",
+        lang="eng",
     )
     if member.pop("is_president", "N") == "Y":
         position = h.make_position(
@@ -132,6 +134,8 @@ def crawl_member(
             name="President of the Legislative Council of Hong Kong",
             country="hk",
             topics=["gov.national", "gov.legislative"],
+            wikidata_id="Q3068969",
+            lang="eng",
         )
 
     occupancy = h.make_occupancy(

--- a/datasets/ie/parliament/crawler.py
+++ b/datasets/ie/parliament/crawler.py
@@ -9,7 +9,7 @@ POSITIONS = {
         "wikidata_id": "Q18043391",
     },
     "dail": {
-        "title": "Teachta Dála",
+        "title": "Member of the Dáil",
         "wikidata_id": "Q654291",
     },
 }
@@ -43,6 +43,7 @@ def crawl_member(context: Context, member: dict[str, Any]) -> None:
             topics=["gov.national", "gov.legislative"],
             country=["ie"],
             wikidata_id=wikidata_id,
+            lang="eng",
         )
 
         categorisation = categorise(context, position, default_is_pep=True)

--- a/datasets/ie/parliament/crawler.py
+++ b/datasets/ie/parliament/crawler.py
@@ -9,7 +9,7 @@ POSITIONS = {
         "wikidata_id": "Q18043391",
     },
     "dail": {
-        "title": "Member of the Dáil",
+        "title": "Member of the Dáil of Ireland",
         "wikidata_id": "Q654291",
     },
 }

--- a/datasets/il/knesset_members/crawler.py
+++ b/datasets/il/knesset_members/crawler.py
@@ -11,7 +11,7 @@ from zavod.stateful.positions import OccupancyStatus, categorise
 
 CACHE_SHORT = 1
 CACHE_LONG = 30
-PEPS = set()
+PEPS: set[str] = set()
 
 
 def fetch_json_with_retry(context: Context, url: str, *, cache_days: int) -> Any:
@@ -53,6 +53,7 @@ def crawl_position(
         return
     context.emit(person)
     context.emit(occupancy)
+    assert person.id is not None
     PEPS.add(person.id)
 
 
@@ -92,6 +93,7 @@ def crawl_position_no_tenure(
     occupancy.add("description", f"Knesset {knesset['KnessetNumber']}")
     context.emit(person)
     context.emit(occupancy)
+    assert person.id is not None
     PEPS.add(person.id)
 
 
@@ -100,7 +102,7 @@ def crawl_positions(
 ) -> None:
     position = h.make_position(
         context,
-        "Knesset Member",
+        "Member of the Knesset of Israel",
         country="il",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q4047513",

--- a/datasets/il/knesset_members/crawler.py
+++ b/datasets/il/knesset_members/crawler.py
@@ -104,6 +104,7 @@ def crawl_positions(
         country="il",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q4047513",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/in/sansad/crawler.py
+++ b/datasets/in/sansad/crawler.py
@@ -132,6 +132,7 @@ def crawl_ls(context: Context) -> None:
         wikidata_id="Q16556694",
         country="in",
         topics=["gov.legislative", "gov.national"],
+        lang="eng",
     )
     context.emit(position)
 
@@ -230,6 +231,7 @@ def crawl_rs(context: Context) -> None:
         wikidata_id="Q17324844",
         country="in",
         topics=["gov.legislative", "gov.national"],
+        lang="eng",
     )
     context.emit(position)
 

--- a/datasets/in/sansad/crawler.py
+++ b/datasets/in/sansad/crawler.py
@@ -128,7 +128,7 @@ def crawl_ls_member(
 def crawl_ls(context: Context) -> None:
     position = h.make_position(
         context,
-        name="Member of the Lok Sabha",
+        name="Member of the Lok Sabha of India",
         wikidata_id="Q16556694",
         country="in",
         topics=["gov.legislative", "gov.national"],
@@ -227,7 +227,7 @@ def crawl_rs_member(context: Context, position: Entity, member: dict[str, Any]) 
 def crawl_rs(context: Context) -> None:
     position = h.make_position(
         context,
-        name="Member of the Rajya Sabha",
+        name="Member of the Rajya Sabha of India",
         wikidata_id="Q17324844",
         country="in",
         topics=["gov.legislative", "gov.national"],

--- a/datasets/is/althingi/crawler.py
+++ b/datasets/is/althingi/crawler.py
@@ -77,6 +77,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q21272959",
         topics=["gov.legislative", "gov.national"],
         country="is",
+        lang="eng",
     )
     context.emit(position)
 

--- a/datasets/is/althingi/crawler.py
+++ b/datasets/is/althingi/crawler.py
@@ -73,7 +73,7 @@ def crawl_item(
 def crawl(context: Context) -> None:
     position = h.make_position(
         context,
-        "Member of the Althing",
+        "Member of the Althing of Iceland",
         wikidata_id="Q21272959",
         topics=["gov.legislative", "gov.national"],
         country="is",

--- a/datasets/it/deputies/crawler.py
+++ b/datasets/it/deputies/crawler.py
@@ -87,7 +87,7 @@ def crawl_item(context: Context, item: dict[str, Any]) -> None:
 
     position = h.make_position(
         context,
-        name="Member of the Chamber of Deputies",
+        name="Member of the Chamber of Deputies of the Italian Republic",
         wikidata_id="Q18558478",
         country="it",
         topics=["gov.legislative", "gov.national"],

--- a/datasets/it/senate/crawler.py
+++ b/datasets/it/senate/crawler.py
@@ -36,7 +36,7 @@ def crawl_item(context: Context, item: dict[str, Any]) -> None:
 
     position = h.make_position(
         context,
-        name="Member of the Senate",
+        name="Member of the Senate of the Italian Republic",
         wikidata_id="Q13653224",
         country="it",
         topics=["gov.legislative", "gov.national"],

--- a/datasets/jp/sangiin/crawler.py
+++ b/datasets/jp/sangiin/crawler.py
@@ -163,6 +163,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q14552828",
         country="jp",
         topics=["gov.legislative", "gov.national"],
+        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)

--- a/datasets/jp/shugiin/crawler.py
+++ b/datasets/jp/shugiin/crawler.py
@@ -36,6 +36,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q17506823",
         country="jp",
         topics=["gov.legislative", "gov.national"],
+        lang="eng",
     )
     context.emit(position)
 

--- a/datasets/kg/jogorku_kenesh/crawler.py
+++ b/datasets/kg/jogorku_kenesh/crawler.py
@@ -56,6 +56,7 @@ def crawl(context: Context) -> None:
         name="Member of the Jogorku Kenesh of the Kyrgyz Republic",
         country="kg",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21091853",
         lang="eng",
     )
     categorisation = categorise(context, position)

--- a/datasets/kr/assembly/crawler.py
+++ b/datasets/kr/assembly/crawler.py
@@ -66,6 +66,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q14850694",
         country="kr",
         topics=["gov.legislative", "gov.national"],
+        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)

--- a/datasets/li/landtag/crawler.py
+++ b/datasets/li/landtag/crawler.py
@@ -26,6 +26,7 @@ def make_member_position(context: Context, substitute: bool) -> Entity:
         topics=["gov.national", "gov.legislative"],
         # Only the full member position has a dedicated Wikidata item.
         wikidata_id=None if substitute else "Q21328607",
+        lang="eng",
     )
 
 

--- a/datasets/lt/seimas/crawler.py
+++ b/datasets/lt/seimas/crawler.py
@@ -19,7 +19,7 @@ def make_seimas_position(context: Context) -> Entity:
     # split into two entities for the same role.
     return h.make_position(
         context,
-        name="Member of the Seimas",
+        name="Member of the Seimas of Lithuania",
         wikidata_id="Q18507240",
         country="lt",
         topics=POSITION_TOPICS,

--- a/datasets/lv/saeima/crawler.py
+++ b/datasets/lv/saeima/crawler.py
@@ -43,7 +43,13 @@ def crawl_item(context: Context, unid: str) -> None:
     )
     entity.add("email", h.element_text(email_el))
 
-    position = h.make_position(context, "deputy of Saeima", country="lv")
+    position = h.make_position(
+        context,
+        "Member of the Saeima of Latvia",
+        country="lv",
+        wikidata_id="Q21191589",
+        lang="eng",
+    )
     categorisation = categorise(context, position, default_is_pep=True)
 
     occupancy = h.make_occupancy(

--- a/datasets/me/skupstina/crawler.py
+++ b/datasets/me/skupstina/crawler.py
@@ -53,6 +53,7 @@ def make_member_position(context: Context) -> Entity:
         country="me",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21328576",
+        lang="eng",
     )
 
 

--- a/datasets/mn/parliament/crawler.py
+++ b/datasets/mn/parliament/crawler.py
@@ -129,9 +129,11 @@ def crawl_member(
 
     position = h.make_position(
         context,
-        "Member of the State Great Khural",
+        "Member of the State Great Khural of Mongolia",
         country="mn",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21328637",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     if not categorisation.is_pep:

--- a/datasets/mt/parlament/crawler.py
+++ b/datasets/mt/parlament/crawler.py
@@ -62,6 +62,7 @@ def crawl(context: Context) -> None:
         wikidata_id="Q19367406",
         topics=["gov.legislative", "gov.national"],
         country="mt",
+        lang="eng",
     )
     context.emit(position)
 

--- a/datasets/mx/deputies/crawler.py
+++ b/datasets/mx/deputies/crawler.py
@@ -37,7 +37,11 @@ def crawl_item(context: Context, input_dict: dict[str, Any]) -> None:
     entity.add("political", input_dict.pop("Partido"))
 
     position = h.make_position(
-        context, "Member of the Chamber of Deputies of Mexico", country="mx"
+        context,
+        "Member of the Chamber of Deputies of Mexico",
+        country="mx",
+        wikidata_id="Q18534310",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
 

--- a/datasets/mx/senators/crawler.py
+++ b/datasets/mx/senators/crawler.py
@@ -131,7 +131,13 @@ def crawl(context: Context) -> None:
     senators = fetch_json(context, senators_url, cache_days=1, geolocation="MX")
 
     # We first define the Mexico Senator Position
-    position = h.make_position(context, "Member of the Senate of Mexico", country="mx")
+    position = h.make_position(
+        context,
+        "Member of the Senate of Mexico",
+        country="mx",
+        wikidata_id="Q19971999",
+        lang="eng",
+    )
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)
 

--- a/datasets/my/parliament/crawler.py
+++ b/datasets/my/parliament/crawler.py
@@ -252,7 +252,7 @@ def iter_member_links(context: Context, roster_url: str) -> Iterator[tuple[str, 
 def crawl_rakyat(context: Context) -> None:
     rakyat_position = h.make_position(
         context,
-        name="Member of the Dewan Rakyat",
+        name="Member of the Dewan Rakyat of Malaysia",
         country="my",
         topics=DEFAULT_PARLIAMENT_TOPICS,
         wikidata_id="Q21290861",
@@ -271,7 +271,7 @@ def crawl_rakyat(context: Context) -> None:
 def crawl_negara(context: Context) -> None:
     negara_position = h.make_position(
         context,
-        name="Member of the Dewan Negara",
+        name="Member of the Dewan Negara of Malaysia",
         country="my",
         topics=DEFAULT_PARLIAMENT_TOPICS,
         wikidata_id="Q21328606",

--- a/datasets/my/parliament/my_parliament.yml
+++ b/datasets/my/parliament/my_parliament.yml
@@ -107,11 +107,11 @@ lookups:
     lowercase: true
     options:
       - match: Yang di-Pertua Dewan Rakyat
-        name: Speaker of the Dewan Rakyat
+        name: Speaker of the Dewan Rakyat of Malaysia
         topics: [gov.legislative, gov.national]
         wikidata_id: Q7574262
       - match: Timbalan Yang di-Pertua Dewan Rakyat
-        name: Deputy Speaker of the Dewan Rakyat
+        name: Deputy Speaker of the Dewan Rakyat of Malaysia
         topics: [gov.legislative, gov.national]
         wikidata_id: Q126361900
       - match: Ketua Majlis
@@ -124,11 +124,11 @@ lookups:
         name: Secretary of the Dewan Rakyat
         topics: [gov.admin, gov.national]
       - match: Yang di-Pertua Dewan Negara
-        name: President of the Dewan Negara
+        name: President of the Dewan Negara of Malaysia
         topics: [gov.legislative, gov.national]
         wikidata_id: Q7241319
       - match: Timbalan Yang di-Pertua Dewan Negara
-        name: Deputy President of the Dewan Negara
+        name: Deputy President of the Dewan Negara of Malaysia
         topics: [gov.legislative, gov.national]
         wikidata_id: Q134572656
       # Ordinary members and blanks — not a presiding office.

--- a/datasets/nl/house_of_representatives/crawler.py
+++ b/datasets/nl/house_of_representatives/crawler.py
@@ -72,7 +72,7 @@ def crawl_person(context: Context, element: _Element, position: Entity) -> None:
 def crawl(context: Context) -> None:
     position = make_position(
         context,
-        name="Member of the House of Representatives",
+        name="Member of the House of Representatives of the Netherlands",
         country="nl",
         summary="Member of the lower house of the bicameral parliament of the Netherlands, the States General",
         wikidata_id="Q18887908",

--- a/datasets/nl/house_of_representatives/crawler.py
+++ b/datasets/nl/house_of_representatives/crawler.py
@@ -76,6 +76,7 @@ def crawl(context: Context) -> None:
         country="nl",
         summary="Member of the lower house of the bicameral parliament of the Netherlands, the States General",
         wikidata_id="Q18887908",
+        lang="eng",
     )
     categorise(context, position, default_is_pep=True)
     context.emit(position)

--- a/datasets/nl/senate/crawler.py
+++ b/datasets/nl/senate/crawler.py
@@ -85,7 +85,7 @@ def crawl_member(context: Context, member_el: _Element) -> None:
 
     position = h.make_position(
         context,
-        name="Member of the Senate",
+        name="Member of the Senate of the Netherlands",
         country="nl",
         topics=["gov.legislative", "gov.national"],
         lang="eng",

--- a/datasets/nz/parliament/crawler.py
+++ b/datasets/nz/parliament/crawler.py
@@ -140,6 +140,7 @@ def crawl(context: Context) -> None:
         country="nz",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q19899675",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     context.emit(position)

--- a/datasets/om/parliament/crawler.py
+++ b/datasets/om/parliament/crawler.py
@@ -265,6 +265,7 @@ def get_position(
             country="om",
             topics=["gov.national", "gov.legislative"],
             wikidata_id=chamber.position_qids.get(kind),
+            lang="eng",
         )
         categorisation = categorise(context, position, default_is_pep=True)
         context.emit(position)

--- a/datasets/pg/parliament/crawler.py
+++ b/datasets/pg/parliament/crawler.py
@@ -110,6 +110,7 @@ def crawl_member(
             country="pg",
             subnational_area=province_name,
             wikidata_id=wikidata_id,
+            lang="eng",
         )
         cat = categorise(context, position, default_is_pep=True)
         context.emit(position)
@@ -153,6 +154,7 @@ def crawl(context: Context) -> None:
         name="Member of the National Parliament of Papua New Guinea",
         country="pg",
         wikidata_id="Q21294916",
+        lang="eng",
     )
     mp_categorisation = categorise(context, mp_position, default_is_pep=True)
     context.emit(mp_position)

--- a/datasets/ph/house_representatives/crawler.py
+++ b/datasets/ph/house_representatives/crawler.py
@@ -134,6 +134,7 @@ def crawl(context: Context) -> None:
         country="ph",
         topics=TOPICS,
         wikidata_id="Q18002923",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     if not categorisation.is_pep:

--- a/datasets/ph/senate/crawler.py
+++ b/datasets/ph/senate/crawler.py
@@ -122,6 +122,7 @@ def crawl(context: Context) -> None:
         country="ph",
         topics=TOPICS,
         wikidata_id="Q18579098",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)

--- a/datasets/pk/na_members/crawler.py
+++ b/datasets/pk/na_members/crawler.py
@@ -94,6 +94,7 @@ def crawl(context: Context) -> None:
         name="Member of the National Assembly of Pakistan",
         country="pk",
         wikidata_id="Q20760546",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)

--- a/datasets/pk/senate_members/crawler.py
+++ b/datasets/pk/senate_members/crawler.py
@@ -97,6 +97,7 @@ def crawl(context: Context) -> None:
         name="Member of the Senate of Pakistan",
         country="pk",
         wikidata_id="Q20081441",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)

--- a/datasets/pl/sejm/crawler.py
+++ b/datasets/pl/sejm/crawler.py
@@ -57,7 +57,7 @@ def crawl_person(context: Context, url: str) -> None:
 
     position = h.make_position(
         context,
-        name="Member of the Sejm",
+        name="Member of the Sejm of Poland",
         wikidata_id="Q19269361",
         country="pl",
         topics=["gov.legislative", "gov.national"],

--- a/datasets/pl/senate/crawler.py
+++ b/datasets/pl/senate/crawler.py
@@ -79,7 +79,7 @@ def crawl(context: Context) -> None:
 
         position = h.make_position(
             context,
-            name="Member of the Senate",
+            name="Member of the Senate of the Republic of Poland",
             wikidata_id="Q81747225",
             country="pl",
             topics=["gov.legislative", "gov.national"],

--- a/datasets/pt/parliament/crawler.py
+++ b/datasets/pt/parliament/crawler.py
@@ -46,6 +46,7 @@ def crawl_parliament(context: Context, parl_name: str, url: str) -> None:
             topics=["gov.national", "gov.legislative"],
             country=["pt"],
             wikidata_id="Q19953703",
+            lang="eng",
         )
         categorisation = categorise(context, position, default_is_pep=True)
 

--- a/datasets/rs/national_assembly/crawler.py
+++ b/datasets/rs/national_assembly/crawler.py
@@ -224,6 +224,7 @@ def crawl(context: Context) -> None:
         country="rs",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21295999",
+        lang="eng",
     )
     context.emit(position)
     categorisation = categorise(context, position, default_is_pep=True)

--- a/datasets/ru/duma_deputies/crawler.py
+++ b/datasets/ru/duma_deputies/crawler.py
@@ -126,6 +126,7 @@ def crawl(context: Context) -> None:
         country="ru",
         wikidata_id="Q17276321",
         topics=["gov.national", "gov.legislative"],
+        lang="eng",
     )
 
     for record in data["persons"]:

--- a/datasets/ru/duma_deputies/crawler.py
+++ b/datasets/ru/duma_deputies/crawler.py
@@ -122,7 +122,7 @@ def crawl(context: Context) -> None:
     # Assembly of Russia.
     position = h.make_position(
         context,
-        name="Member of the State Duma",
+        name="Member of the State Duma of Russia",
         country="ru",
         wikidata_id="Q17276321",
         topics=["gov.national", "gov.legislative"],

--- a/datasets/ru/federation_council/crawler.py
+++ b/datasets/ru/federation_council/crawler.py
@@ -86,6 +86,7 @@ def crawl(context: Context) -> None:
         country="ru",
         wikidata_id="Q4516946",
         topics=["gov.national", "gov.legislative"],
+        lang="eng",
     )
     context.emit(position)
 

--- a/datasets/si/dz_rs/crawler.py
+++ b/datasets/si/dz_rs/crawler.py
@@ -120,6 +120,7 @@ def crawl(context: Context) -> None:
         country="si",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21296001",
+        lang="eng",
     )
     context.emit(position)
 

--- a/datasets/tm/mejlis/crawler.py
+++ b/datasets/tm/mejlis/crawler.py
@@ -89,6 +89,7 @@ def crawl(context: Context) -> None:
         name="Member of the Mejlis of Turkmenistan",
         country="tm",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21328577",
         lang="eng",
     )
     categorisation = categorise(context, position)

--- a/datasets/tr/parliament/crawler.py
+++ b/datasets/tr/parliament/crawler.py
@@ -98,7 +98,11 @@ def crawl_item(context: Context, item: Element) -> None:
     entity.add("political", party)
 
     position = h.make_position(
-        context, "Member of the Grand National Assembly", country="tr"
+        context,
+        "Member of the Grand National Assembly of Turkey",
+        country="tr",
+        wikidata_id="Q21030356",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
 

--- a/datasets/tw/legislature/crawler.py
+++ b/datasets/tw/legislature/crawler.py
@@ -146,6 +146,7 @@ def crawl(context: Context) -> None:
         country="tw",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q6310593",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)

--- a/datasets/tw/legislature/crawler.py
+++ b/datasets/tw/legislature/crawler.py
@@ -142,7 +142,7 @@ def crawl(context: Context) -> None:
     }
     position = h.make_position(
         context,
-        name="Member of the Legislative Yuan",
+        name="Member of the Legislative Yuan of Taiwan",
         country="tw",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q6310593",

--- a/datasets/ua/rada/crawler.py
+++ b/datasets/ua/rada/crawler.py
@@ -52,6 +52,7 @@ def crawl_member(
         country="ua",
         topics=TOPICS,
         wikidata_id="Q12132454",
+        lang="eng",
     )
     position.add("subnationalArea", row.pop("region_name", None))
     categorisation = categorise(context, position)

--- a/datasets/us/congress/crawler.py
+++ b/datasets/us/congress/crawler.py
@@ -49,6 +49,7 @@ def crawl_positions(
             country="us",
             topics=res.topics,
             wikidata_id=res.wikidata_id,
+            lang="eng",
         )
         categorisation = categorise(context, position)
         if categorisation.is_pep:

--- a/datasets/uz/legislative_chamber/crawler.py
+++ b/datasets/uz/legislative_chamber/crawler.py
@@ -56,6 +56,7 @@ def crawl(context: Context) -> None:
         name="Member of the Legislative Chamber of the Oliy Majlis of Uzbekistan",
         country="uz",
         topics=["gov.national", "gov.legislative"],
+        wikidata_id="Q21328622",
         lang="eng",
     )
     categorisation = categorise(context, position)

--- a/datasets/ve/asamblea_nacional/crawler.py
+++ b/datasets/ve/asamblea_nacional/crawler.py
@@ -120,6 +120,7 @@ def crawl_member(
         country="Venezuela",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q20011182",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     if not categorisation.is_pep:

--- a/datasets/vn/national_assembly/crawler.py
+++ b/datasets/vn/national_assembly/crawler.py
@@ -143,6 +143,7 @@ def crawl_deputy(context: Context, url: str, province: str, deputy: str) -> None
         country="vn",
         topics=["gov.national"],
         wikidata_id="Q10841192",
+        lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
     occupancy = h.make_occupancy(

--- a/datasets/xk/assembly/crawler.py
+++ b/datasets/xk/assembly/crawler.py
@@ -151,6 +151,7 @@ def crawl(context: Context) -> None:
         country="xk",
         topics=["gov.national", "gov.legislative"],
         wikidata_id="Q22262242",
+        lang="eng",
     )
     categorisation = categorise(context, position)
     context.emit(position)


### PR DESCRIPTION
Went through all `make_position` calls that pass a `wikidata_id` (116 of them) plus the ones that arguably should, and fixed three things.

## Tag the position name as English

56 files.

- 61 calls had an English title but no `lang` at all, so the name got emitted untagged — added `lang="eng"`.
- `de/bundesrat`: "Mitglied des Bundesrates" (`lang="deu"`) → "Member of the Bundesrat of Germany", the English label on https://www.wikidata.org/wiki/Q15835370.
- `ie/parliament`: "Teachta Dála" → "Member of the Dáil of Ireland".
- Special cases:
  - Checked no call passes a non-English `summary`/`description`/`subnational_area`, since `make_position` applies the same `lang` to those. Only `nl/house_of_representatives` and the `au/*` + `pg` subnational areas have any, all English.
  - `es/parliament` threads `lang=lang` through a helper — both QID-passing callers already pass `"eng"`, the `"spa"` one passes `wikidata_id=None`. Left alone.

## Add the QID where one exists

15 positions that were `make_id`-keyed even though Wikidata has an item for them. Keying on the QID lets them line up with the same position from other sources.

- `bg/parliament`, `ee/riigikogu`, `fr/assemblee`, `fr/senat`, `hk/legco` (member + president), `kg/jogorku_kenesh`, `lv/saeima`, `mn/parliament`, `mx/deputies`, `mx/senators`, `tm/mejlis`, `tr/parliament`, `uz/legislative_chamber`.
- `cn/peoples_congress_wikipedia` used a typographic apostrophe and no QID, so it emitted a *second* Position for the job `cn/npc` already covers via https://www.wikidata.org/wiki/Q10891456. Both now emit the same entity.
- Verified each item is `instance of: position`, subclasses the right legislator type, and its jurisdiction matches the dataset's country.
- Special cases:
  - Every one of these re-keys its Position from a hash to the QID, so expect churn in the next run's diff.
  - Four had no country in the name ("deputy of Saeima", Riigikogu, State Great Khural, Grand National Assembly) — renamed in the same commit, since the id changes either way.
  - `ci/senate` looks like it belongs here but no Wikidata position item seems to exist for the Ivorian Senate.

## Name the country in the position name

25 names, 19 datasets.

Real collisions, where the bare name was ambiguous:

- "Member of the Senate" was emitted identically by `it/senate`, `nl/senate` and `pl/senate` — now "…of the Italian Republic" / "…of the Netherlands" / "…of the Republic of Poland".
- `nl/house_of_representatives` "Member of the House of Representatives", while 7 other datasets already said "…of {Cyprus, Japan, Malta, …}".
- `gb/commons` "Member of the House of Commons" vs `ca/commons` "…of Canada".
- Also `it/deputies` and `bh/nuwab` (Iraq's chamber shares the English name).

Bare but not yet ambiguous, normalised for consistency:

- `il` ("Knesset Member" → "Member of the Knesset of Israel" — also had the word order backwards), `is`, `tw`, `in` (Lok Sabha + Rajya Sabha), `lt`, `pl/sejm`, `ru`, `my` (2 in the crawler + 4 lookup entries in the yml), `cu`, `cn`.

Deliberately excluded:

- `eu/meps` and `se/riksdag` MEP — supranational, no country belongs there.
- Subnational positions disambiguated by region: `au/*` (8 datasets), `be/flemish_parliament`, `be/walloon_parliament`.
- Names already carrying a nationality adjective: `hr` ("Croatian"), `gr` ("Hellenic"), `de/bundestag` ("German"), `ch` ("Swiss"), `ar` ("Argentine"), `us/congress` ("United States senator").
- `_wikidata/categories` has its own "Member of the Sejm" spec, but those positions are `make_id`-keyed by design, so renaming would re-key them. Out of scope.

---

Nothing enforces any of this, so it'll drift again. Possible followup: have `make_position` assert that `wikidata_id is not None` implies `lang == "eng"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
