### PR TITLE
Add /dataset-metadata skill and rework metadata docs

### DIFF
--- a/.claude/docs/crawler-guide.md
+++ b/.claude/docs/crawler-guide.md
@@ -23,11 +23,9 @@ title: Full Human-Readable Title
 prefix: xx-short        # unique, ≤ 10 chars, used for entity IDs
 entry_point: crawler.py
 coverage:
-  frequency: daily      # daily | weekly | monthly | never
-  schedule: "0 */2 * * *"  # cron, only for daily
+  frequency: daily      # house defaults per dataset type: see metadata.md
   start: 2024-01-01
 load_statements: true   # always true for production datasets
-ci_test: false          # true only for fast, small datasets
 
 summary: >-
   One sentence description.
@@ -73,9 +71,6 @@ Key rules:
 - Set assertions to ~80% min / ~150% max of expected counts. Checked by
   `zavod validate`, not by `zavod crawl`. See the "Data assertions" section of
   `zavod/docs/metadata.md` for the metrics and comparison semantics.
-- Write `summary` and `description` to be **time-agnostic** — describe the source's
-  purpose and update cadence, not the current snapshot (e.g. "Members of parliament,
-  updated after each election" not "Members since the 2023 elections").
 
 ## The crawler module
 

--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -62,7 +62,7 @@ assertions:
 ```
 
 - Include `Position` counts in assertions when the crawler creates multiple position types.
-- `frequency` matches source update cadence (daily/weekly/monthly). PEP crawlers do not have to be monthly.
+- `coverage.frequency`: house default for PEP sources is `monthly` — see the frequency defaults in `zavod/docs/metadata.md`.
 - Lookups rarely go past `type.*` for PEP crawlers. (Non-English role labels are handled by `translate_name=True` in `make_position`; a `position` translation lookup is only worth it when the source has very few distinct labels.)
 
 ## Step 3: Write the crawler module

--- a/.claude/skills/crawler-sanctions/SKILL.md
+++ b/.claude/skills/crawler-sanctions/SKILL.md
@@ -54,7 +54,7 @@ assertions:
       Organization: 1000
 ```
 
-- Sanctions lists typically use `frequency: daily` with a cron `schedule:`.
+- `coverage.frequency: daily` (house default for sanctions — see `zavod/docs/metadata.md`). Don't add a cron `schedule:` unless the run must follow the source's own publication time.
 - Assert Sanction entity counts alongside Person/Organization counts.
 
 ### Sanctions-specific lookups

--- a/.claude/skills/dataset-metadata/SKILL.md
+++ b/.claude/skills/dataset-metadata/SKILL.md
@@ -23,18 +23,13 @@ lookups and what they do.
 
 ## 2. Check each field against the doc
 
-- `title` — starts with the country's short English name (or the international issuer's
-  name/acronym); never possessive; established acronyms kept.
-- `summary` — one plain fragment just above 50 chars, no trailing period, no title-word
-  repetition, no humor.
-- `description` — scope and institutional context only; no per-record field lists, no
-  ETL mechanics, no sourcing narration.
-- `coverage.frequency` — matches the house default for the dataset type (sanctions
-  `daily`, PEP `monthly`, registries `weekly`, frozen dumps `never` + schedule).
+- `title` — the doc's Title rules.
+- `summary` — length and style per the doc's Summary rules.
+- `description` — the doc's Description rules, including its keep-out list.
+- `coverage.frequency` — the doc's house default for the dataset type.
 - `tags` — present and plausible for list type and target countries.
-- `publisher` — `name`/`name_en` language split, `acronym`, `country`, `official` set
-  correctly; description explains the publisher to a foreign reader.
-- `data` — `url` fetchable, `format` set, `lang` set for single-language sources.
+- `publisher` — all subfields per the doc's Publisher section.
+- `data` — `url` fetchable; `format` and `lang` per the doc's Source data section.
 
 ## 3. Maintainer comments
 

--- a/.claude/skills/dataset-metadata/SKILL.md
+++ b/.claude/skills/dataset-metadata/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: dataset-metadata
+description: Bring a dataset .yml's metadata in line with house conventions (title, summary, description, coverage, publisher, maintainer comments). Use when the user asks to fix, improve or standardise a dataset's metadata.
+argument-hint: "[dataset .yml path]"
+allowed-tools: Read, Edit, Glob, Grep, Bash
+---
+
+# Dataset metadata
+
+Standardise the metadata of the dataset at $ARGUMENTS.
+
+**The rules live in [`zavod/docs/metadata.md`](../../../zavod/docs/metadata.md) — read it
+first and follow it.** This skill is only the procedure for applying it; when a rule is
+unclear, read the doc, do not invent a convention. For a legislature/parliament PEP
+dataset, take the `title`, `description` and `coverage.frequency` patterns from the
+`/legislature-metadata` skill; the rest of this checklist applies as written.
+
+## 1. Read
+
+The `.yml`, then the crawler (`entry_point`, usually `crawler.py`) for scope facts:
+what the source covers, what is deliberately skipped, which lookups are not plain type
+lookups and what they do.
+
+## 2. Check each field against the doc
+
+- `title` — starts with the country's short English name (or the international issuer's
+  name/acronym); never possessive; established acronyms kept.
+- `summary` — one plain fragment just above 50 chars, no trailing period, no title-word
+  repetition, no humor.
+- `description` — scope and institutional context only; no per-record field lists, no
+  ETL mechanics, no sourcing narration.
+- `coverage.frequency` — matches the house default for the dataset type (sanctions
+  `daily`, PEP `monthly`, registries `weekly`, frozen dumps `never` + schedule).
+- `tags` — present and plausible for list type and target countries.
+- `publisher` — `name`/`name_en` language split, `acronym`, `country`, `official` set
+  correctly; description explains the publisher to a foreign reader.
+- `data` — `url` fetchable, `format` set, `lang` set for single-language sources.
+
+## 3. Maintainer comments
+
+- Top-of-file `#` block: known failure modes, source quirks, recurring-warning runbooks.
+- One short `#` comment above each non-type lookup: what it matches, why it exists.
+
+Only write down evidence: things observed in the code, the source data, `issues.log`,
+git history, or stated by the user. Never speculate, and never delete existing comments
+that still hold. Keep user-facing prose (description) and maintainer notes (comments)
+strictly apart.
+
+## Verify
+
+```bash
+python -c "from pathlib import Path; from zavod.meta import load_dataset_from_path; d = load_dataset_from_path(Path('<yml path>')); print(d.name, '-', d.model.title)"
+```
+
+Re-read the edited fields: every factual claim in title/description traces to the
+source or crawler, the summary length is in range, and no sourcing or mechanics
+language remains in the description.

--- a/.claude/skills/legislature-metadata/SKILL.md
+++ b/.claude/skills/legislature-metadata/SKILL.md
@@ -38,11 +38,11 @@ For one chamber of a bicameral body, name the chamber
 (`Romania Members of the Chamber of Deputies`). Keep any established acronym the file
 already uses only if it reads naturally; prefer the plain form.
 
-## 3. Description — scope and context, not field lists
+## 3. Description — the legislature pattern
 
 Follow the `description` guidance in
-[`zavod/docs/metadata.md`](../../../zavod/docs/metadata.md). One short paragraph,
-optionally two:
+[`zavod/docs/metadata.md`](../../../zavod/docs/metadata.md), including its
+"Keep out of the description" rules. One short paragraph, optionally two:
 
 **Paragraph 1 — who the members are + institutional context.** Scope-prefixed
 ("Current members of …" / "Current and historical members of …"), naming the body
@@ -54,14 +54,7 @@ country's".
 
 **Optional paragraph 2 — scope notes.** Only when there is something substantive to
 say: deliberate exclusions ("alternates are not included"), current-only vs historical
-coverage, a bounded period. Do **not** enumerate per-member attributes (name, gender,
-date of birth, …) — that is visible from the data itself and drifts as the crawler
-changes.
-
-**Strip** — provenance and mechanics belong in `publisher` / `data.url`, not here:
-- "sourced from / as published on the official website / member API";
-- anti-bot, browser-proxy, pagination, join-key or rolling-window details;
-- PEP after-office cutoffs and other internal plumbing.
+coverage, a bounded period.
 
 ### Worked example
 

--- a/.claude/skills/legislature-metadata/SKILL.md
+++ b/.claude/skills/legislature-metadata/SKILL.md
@@ -10,23 +10,22 @@ allowed-tools: Read, Edit, Glob, Grep
 Standardise the `title`, `description` and `coverage.frequency` of a PEP dataset that
 covers members of a national (or subnational) legislature. Target file: $ARGUMENTS
 
-Change **only** these three fields. Leave `summary`, `publisher`, `data`, `assertions`,
-`lookups` etc. untouched unless the user asks.
+General metadata rules live in [`zavod/docs/metadata.md`](../../../zavod/docs/metadata.md).
+This skill defines the legislature-specific pattern for `title`, `description` and
+`coverage.frequency` only. For every other field — `summary`, `publisher`, `data`,
+tags, maintainer comments — follow the `/dataset-metadata` skill; don't touch them
+here unless the user asked for a full metadata pass.
 
 ## 1. Read the crawler first
 
-Open the dataset's `entry_point` (usually `crawler.py` next to the `.yml`). The
-description's field list must match what the crawler *actually emits* — read the
-`person.add(...)`, `h.apply_name(...)`, `occupancy.add(...)` calls, not the source's
-raw columns. Emitting `constituency`, `politicalGroup`, `birthPlace` etc. only counts
-if it reaches an emitted entity.
-
-Also note from the crawler / `.yml`:
+Open the dataset's `entry_point` (usually `crawler.py` next to the `.yml`) and note the
+scope facts the description depends on:
 - unicameral vs bicameral, and (for a bicameral body) which chamber this is;
 - seat count, term length, and how members are elected (e.g. proportional
   representation, by district, appointed);
 - whether the dataset is current-only or also historical (look for
-  `earliest_term_start` / a PEP look-back cutoff → "Current and historical").
+  `earliest_term_start` / a PEP look-back cutoff → "Current and historical");
+- deliberate exclusions (e.g. alternates or substitutes skipped).
 
 ## 2. Title → `<Country> Members of <Parliament name>`
 
@@ -39,12 +38,11 @@ For one chamber of a bicameral body, name the chamber
 (`Romania Members of the Chamber of Deputies`). Keep any established acronym the file
 already uses only if it reads naturally; prefer the plain form.
 
-## 3. Description — two short paragraphs, content only
+## 3. Description — scope and context, not field lists
 
 Follow the `description` guidance in
-[`zavod/docs/metadata.md`](../../../zavod/docs/metadata.md) and the house pattern
-below. Describe **what is in the dataset** — the people and their data — not how it
-was fetched.
+[`zavod/docs/metadata.md`](../../../zavod/docs/metadata.md). One short paragraph,
+optionally two:
 
 **Paragraph 1 — who the members are + institutional context.** Scope-prefixed
 ("Current members of …" / "Current and historical members of …"), naming the body
@@ -54,12 +52,11 @@ role ("… and hold the country's legislative power, including passing laws and 
 the budget."). For an SAR or subnational body say "the region's" rather than "the
 country's".
 
-**Paragraph 2 — the per-member data.** "This dataset records each [member] with their
-…" then list exactly the attributes the crawler emits (name, gender, date/place of
-birth, party, parliamentary group, constituency, …). Keep genuinely substantive scope
-notes (e.g. "alternates are not included", "not every profile carries the full set of
-fields", "membership is treated as current on each run"). Give the original-language
-term in parentheses where the source uses one (e.g. parliamentary group (bancada)).
+**Optional paragraph 2 — scope notes.** Only when there is something substantive to
+say: deliberate exclusions ("alternates are not included"), current-only vs historical
+coverage, a bounded period. Do **not** enumerate per-member attributes (name, gender,
+date of birth, …) — that is visible from the data itself and drifts as the crawler
+changes.
 
 **Strip** — provenance and mechanics belong in `publisher` / `data.url`, not here:
 - "sourced from / as published on the official website / member API";
@@ -75,9 +72,6 @@ description: |
   legislature. Its 150 members are elected under proportional representation for a
   four-year term and hold the country's legislative power, including passing laws,
   approving the budget, and overseeing the government.
-
-  This dataset records each seated member with their name, gender, and date and place
-  of birth.
 ```
 
 ## 4. `coverage.frequency: monthly`
@@ -87,6 +81,9 @@ unchanged). If it is already `monthly`, leave it.
 
 ## Verify
 
-Re-read the edited fields. Confirm every attribute named in paragraph 2 is actually
-emitted by the crawler, the seat count / term / election method match the source, and
-no sourcing or mechanics language remains.
+Re-read the edited fields. Confirm the seat count / term / election method match the
+source, any scope note reflects what the crawler actually does, and no sourcing,
+mechanics, or per-field language remains.
+
+If the user asked for a full metadata pass, continue with the `/dataset-metadata`
+checklist for the remaining fields.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Use search (grep/glob/find) to find the most relevant starting document. Once yo
 * Writing a PEP crawler: use the `/crawler-pep` skill
 * Writing a sanctions crawler: use the `/crawler-sanctions` skill
 * Debugging a failing crawler: use the `/debug-crawler` skill
+* Standardising a dataset's metadata: use the `/dataset-metadata` skill
 * General crawler patterns (helpers, lookups, FTM schemata, qsv analysis): `.claude/docs/crawler-guide.md`
 * Filing a dataset issue or marking a source outage — only when a human asks for it in an interactive session, never in an automated run: `.claude/docs/issue-filing.md`
 

--- a/datasets/de/bundestag/de_bundestag.yml
+++ b/datasets/de/bundestag/de_bundestag.yml
@@ -7,27 +7,25 @@ load_statements: true
 entry_point: crawler.py
 ci_test: false
 summary: >-
-  Current and recent Members of the German Federal Parliament; mostly teachers and lawyers
+  Current and recently serving lawmakers in the federal parliament
 description: |
-  Members of the German Bundestag (German: Deutscher Bundestag), the legislative body
-  of the Federal Republic of Germany.
+  Current and recent members of the German Bundestag (Deutscher Bundestag), the
+  federal parliament of Germany. Its 630 members are elected for four-year terms
+  under a mixed-member proportional system and hold the country's legislative
+  power, including passing laws, electing the Chancellor, approving the budget,
+  and overseeing the government.
 
-  Parties must receive at least 5% of the second votes nationwide or win 
-  three direct constituency seats to enter the Bundestag, with exceptions for parties
-  representing recognized national minorities. 
-
-  The data is sourced from the official open data provided by the German Bundestag
-  administration, containing comprehensive biographical and mandate information for
-  all current members.
+  Deceased members are not included.
 url: https://www.bundestag.de/abgeordnete/biografien
 tags:
   - list.pep
 publisher:
-  name: German Bundestag
+  name: Deutscher Bundestag
+  name_en: German Bundestag
   description: |
-    The German Bundestag provides open data about its members on its official
-    website. The Bundestag exercises legislative power, elects the Chancellor, approves
-    the budget, and oversees the government.
+    The Bundestag is the federal parliament of the Federal Republic of Germany,
+    elected directly by the German people. It exercises legislative power, elects
+    the Chancellor, approves the budget, and oversees the government.
   country: de
   url: https://www.bundestag.de/en/
   official: true

--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -32,6 +32,7 @@ One to three short paragraphs describing the scope of the dataset. Write for a c
 - Open with what the dataset covers, and the institutional or legal context a reader from another country needs: what kind of body issues it, under what mandate, what inclusion on the list means.
 - Describe scope boundaries: what is included and excluded, current-only vs. historical coverage, any period the dataset is limited to.
 - Note significant limitations that affect how a reader should trust or interpret the data — for example a dataset maintained manually because the source is a PDF or behind an access block, or coverage that updates irregularly.
+- Write time-agnostic prose (in the `summary` too): describe the source's ongoing purpose ("Members of parliament, updated after each election"), not the current snapshot ("Members since the 2023 elections").
 
 Keep out of the description:
 

--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -4,56 +4,75 @@ Excellent dataset metadata is a relatively low-effort way to demonstrate the tra
 
 Remember to give the context that people from different countries need to make sense of systems they are not entirely familiar with. Share what you learned when figuring out what a source dataset represents.
 
+Metadata fields are user-facing prose. Knowledge addressed to future maintainers of the crawler — failure modes, source quirks, the purpose of a lookup — belongs in [YAML comments](#maintainer-notes-yaml-comments) instead.
+
 Use the `.yml` extension.
 
-## Properties:
+## Title
+
+As close as possible to an official title for what this dataset contains, starting with the name readers use to find it in a sorted list:
+
+- Start with the short English name of the issuing country, never possessive: `Canada Members of Parliament`, not "Members of the Canadian Parliament" or "Canada's Members of Parliament".
+- Datasets issued by international bodies start with the issuer's name or established acronym instead: `EU Financial Sanctions Files (FSF)`, `UN Security Council Consolidated Sanctions`, `INTERPOL Red Notices`.
+- Keep the agency acronym directly after the country when it identifies the list (`US OFAC Specially Designated Nationals (SDN) List`, `US SEC Litigation Releases`), and keep established list acronyms or original-language names in parentheses (`Mongolia Members of the State Great Khural`, `Slovakia Public Sector Partners Register (Register partnerov verejného sektora)`).
+- If the dataset is a subset of its source data, try to capture that: e.g. `Plural Legislators` if the Plural portal includes committees but the dataset only captures the legislators.
+
+## Summary
+
+A short line (50–90 characters — aim just above the lower bound) shown with the title in search results and listings.
+
+- One plain sentence or fragment, no trailing period.
+- Complement the title: add what it doesn't already convey (kind of measure, scope, legal basis) rather than repeating title words.
+- No humor, no editorializing.
+
+## Description
+
+One to three short paragraphs describing the scope of the dataset. Write for a compliance or domain-expert reader, not an engineer.
+
+- Open with what the dataset covers, and the institutional or legal context a reader from another country needs: what kind of body issues it, under what mandate, what inclusion on the list means.
+- Describe scope boundaries: what is included and excluded, current-only vs. historical coverage, any period the dataset is limited to.
+- Note significant limitations that affect how a reader should trust or interpret the data — for example a dataset maintained manually because the source is a PDF or behind an access block, or coverage that updates irregularly.
+
+Keep out of the description:
+
+- Per-record field listings ("records each person with their name, gender and date of birth") — that is visible from the data and its statistics, and drifts as the crawler changes.
+- Routine ETL mechanics: fetching, parsing, pagination, lookups.
+- Sourcing narration ("the data is sourced from the official website") — that is what `publisher` and `data.url` convey.
+
+## Maintainer notes (YAML comments)
+
+Document technical knowledge about the crawler as `#` comments in the `.yml`, adjacent to the thing they explain:
+
+- A top-of-file comment block for crawler-level notes: known failure modes and how to handle them, source publication quirks, runbooks for recurring warnings.
+- A short comment above each lookup that is not a plain type lookup (`type.country`, `type.date`, …), explaining its structure and purpose: what raw values it matches, and what the crawler does with the result.
+
+Comments record known facts — observed failures, documented source behaviour, decisions that were made — never speculation. Good examples: `datasets/cn/sanctions/cn_sanctions.yml` (a runbook for handling designation-notice warnings), `datasets/fr/tresor/fr_tresor_gels_avoir.yml` (one-line annotations on the groups within a large lookup).
+
+## Properties
 
 ### Basics
 
-- `title` - As close as possible to an official title for what this dataset contains. If it is a subset of its source data, try to capture that. e.g. `Plural Legislators` - if the Plural portal includes committees but the dataset only captures the legislators. Prefix the dataset's name with the country name as `Country` (and not `Country's`).
 - `entry_point` e.g. `crawler.py:crawl_peps` - the file name, optionally followed by a method name called by the zavod `crawl` command. Defaults to the `crawler.py:crawl` calling an entry point in the dataset directory.
 - `prefix` - The prefix used by entity id helpers, e.g. `gb-coh` or `ofac` - try to make this short but unique across datasets, unless you would like different datasets to intentionally generate overlapping keys. See the [entity ID guide](best_practices/entity_id.md) for the shape and stability rules that apply to IDs.
-- `summary` - A short (50-90 char) line that complements the title to identify the source. Add detail the title doesn't already convey rather than repeating it. Shown in search results, so keep it to one clear line.
-- `description` - One to three paragraphs describing the characteristics of the source and the dataset: what it contains, what it includes or excludes, and the context a reader needs to make sense of it. Write for a compliance or domain-expert reader, not an engineer. Describe the source, not the routine ETL mechanics; don't narrate fetching, parsing, or lookups. Note significant limitations that affect how a reader should trust or interpret the data, such as a dataset maintained manually because the source is a PDF or behind an access block, or coverage that updates irregularly. Skip minor field-level gaps such as missing dates of birth; those belong in the data itself, not the prose.
 - `url` - the home page or most authoritative place where someone can read about this particular dataset at its source. E.g If a source publishes 5 different datasets, try to link to the page describing the data actually contained in this dataset.
+- `disabled` - boolean, default `false`. Set to `true` for sources that are not available any more or should not be crawled at the moment: no crawl job is deployed and the coverage frequency is forced to `never`, but the metadata still gets published.
+- `hidden` - boolean, default `false`. Set to `true` to keep the dataset out of the website and other user interfaces while still running and publishing it.
 
 ### Data Coverage
 
 - `coverage`
-    - `frequency` - e.g. `daily`, `weekly`, `monthly`, `never`. This represents how often it is expected that this dataset will be updated. It conveys to users how often to expect updates, and will also be used to generate a crawling schedule unless a specific schedule is defined.
+    - `frequency` - e.g. `daily`, `weekly`, `monthly`, `never`. This represents how often it is expected that this dataset will be updated. It conveys to users how often to expect updates, and is used to derive a crawling schedule unless one is defined explicitly. House defaults by dataset type:
+        - sanctions and wanted lists: `daily`
+        - PEP sources (legislatures, governments): `monthly`
+        - company registries and other bulk sources: `weekly`
+        - frozen one-off dumps: `never`, with an explicit `schedule` (usually `@monthly`) so exports stay consistent with FollowTheMoney updates.
     - `start` - The date the dataset was first included in the `default` collection — i.e. the date the crawler was added to OpenSanctions. Use today's date when scaffolding a new crawler. A string in the format `YYYY-MM-DD`. Do **not** set this to the date the source data begins covering (e.g. an election date or the start of a parliamentary term).
     - `end` - The end date of a dataset which covers only a specific period in time, e.g. for a dataset specific to a data dump or parliamentary term. A string in the format `YYYY-MM-DD`. Future dates imply an expected end to the maintenance and coverage period of the dataset. Past end dates result in the datasets last_change date being fixed to that date, while its last_exported date remains unchanged.
-    - `schedule` - `string` - a cron style schedule defining what time and frequency a crawler should run, e.g `30 */6 * * *`
-    - Data sources that don't receive updates are marked `never` and must have their schedule defined otherwise (e.g. usually `coverage.schedule: @monthly` just to keep consistent with FTM updates). You may want to set `disabled: true` for sources that are not available any more so that the metadata can get published without attempting to crawl the source.
-
-### Deployment
-
-- `deploy`
-    - `premium` - `boolean` - whether its compute instance may be evicted, restarting the job. Set to `true` for jobs running for several hours.
-
-### Continuous Integration
-
-- `ci_test` - boolean, default `true`. If true, the crawler is run when its python or yaml is modified in CI. Set to false for extremely slow crawlers, or those that require credentials, and then take extra care when modifying them.
-
-### Exports
-
-- `exports` - An array of strings matching the [export formats](https://www.opensanctions.org/docs/bulk/), e.g. `"targets.nested.json"`. The default is best for most cases.
-- `load_statements` - Whether the statements should be loaded to a SQL table after the run. Usually `false` for collections and enrichment targets like company registries, and true for normal datasets and enrichers.
-
-### Tags
-
-`tags` are a controlled vocabulary used to categorize datasets by shared attributes such as legal basis, list type, target country, or sector. They support cross-referencing within specific scopes, such as distinguishing between sanctions, PEPs, and regulatory actions, and enable users to select the most relevant datasets for a given country, sector, or risk category.
-
-Currently, tags cover the following dimensions:
-- list type (e.g. `list.sanction`, `list.pep`);
-- issuer and jurisdiction (e.g. `issuer.west`, `juris.eu`);
-- target countries (e.g. `target.ru`, `target.us`)
-- sectors (e.g. `sector.financial`, `sector.maritime`)
-- risk themes (e.g. `risk.klepto`).
-
-Tag matching is by exact string, not by prefix: a dataset tagged only `list.pep.bulk` does not match `list.pep`. Sub-tags qualify a base tag and should be applied alongside it — `list.pep.bulk` marks PEP datasets (also tagged `list.pep`) that are excluded from broad PEP cross-referencing, such as declaration registries and sub-national officeholder lists.
-
-You can find a full overview of available tags [here](https://www.opensanctions.org/docs/metadata/).
+    - `schedule` - a cron style schedule defining what time and frequency a crawler should run, e.g `30 */6 * * *`. The deployed schedule is resolved as `coverage.schedule`, then `deploy.schedule`, then the mapping of `frequency` (falling back to daily); the minute is randomized per dataset to spread load, so only pin an exact time when it matters (e.g. right after the source's own publication time).
+- `manual_check` - for datasets that need periodic human re-verification, e.g. manually maintained data or a source that changes without machine-readable signals. A maintenance script reports datasets whose check is due and bumps `last_checked`.
+    - `last_checked` - quoted string `"YYYY-MM-DD"` (the exact format is required for the automatic update).
+    - `interval` - number of days between checks.
+    - `message` - what the reviewer should verify.
 
 ### Publisher
 
@@ -71,6 +90,44 @@ You can find a full overview of available tags [here](https://www.opensanctions.
 - `data`
     - `url`- The link to a bulk download or API base URL or endpoint - ideally something you can use within the crawler via `context.data_url` to request the data, and which ideally returns a useful response when followed by dataset users. It's not the end of the world if you make other requests to expand the data available to the crawler.
     - `format` a string defining the format of the data at that URL, e.g. `JSON`, `HTML`, `XML`. A Zip file containing thousands of YAML files might be more usefully annoted with `YAML` than `ZIP` because it conveys the structural syntax of the data.
+    - `lang` - ISO 639-3 code (e.g. `deu`, `slk`) of the source's primary language. It is applied as the default language of every statement the crawler emits, so set it when the source is predominantly in one non-English language.
+
+### Tags
+
+`tags` are a controlled vocabulary used to categorize datasets by shared attributes such as legal basis, list type, target country, or sector. They support cross-referencing within specific scopes, such as distinguishing between sanctions, PEPs, and regulatory actions, and enable users to select the most relevant datasets for a given country, sector, or risk category.
+
+Currently, tags cover the following dimensions:
+- list type (e.g. `list.sanction`, `list.pep`);
+- issuer and jurisdiction (e.g. `issuer.west`, `juris.eu`);
+- target countries (e.g. `target.ru`, `target.us`)
+- sectors (e.g. `sector.financial`, `sector.maritime`)
+- risk themes (e.g. `risk.klepto`).
+
+Tag matching is by exact string, not by prefix: a dataset tagged only `list.pep.bulk` does not match `list.pep`. Sub-tags qualify a base tag and should be applied alongside it — `list.pep.bulk` marks PEP datasets (also tagged `list.pep`) that are excluded from broad PEP cross-referencing, such as declaration registries and sub-national officeholder lists.
+
+You can find a full overview of available tags [here](https://www.opensanctions.org/docs/metadata/).
+
+### Deployment
+
+The `deploy` section configures the Kubernetes job that runs the crawler in production. It is consumed by the deployment tooling, not by zavod itself. Override the defaults only when a crawler demonstrably needs it:
+
+- `deploy`
+    - `memory` / `memory_limit` - memory request and limit (defaults `700Mi` / `1600Mi`), e.g. `2000Mi` for crawlers that hold large source files in memory.
+    - `cpu` / `cpu_limit` - CPU request and limit (defaults `200m` / `1600m`).
+    - `disk` / `disk_limit` - scratch disk (default `9Gi`) for crawlers that download large source archives.
+    - `premium` - `boolean` - whether its compute instance may be evicted, restarting the job. Set to `true` for jobs running for several hours.
+    - `schedule` - cron schedule; only consulted when `coverage.schedule` is not set.
+
+### Continuous Integration
+
+- `ci_test` - boolean, default `true`. If true, the crawler is run when its python or yaml is modified in CI. Set to false for extremely slow crawlers, or those that require credentials, and then take extra care when modifying them.
+
+### Exports
+
+- `exports` - An array of strings matching the [export formats](https://www.opensanctions.org/docs/bulk/), e.g. `"targets.nested.json"`. The default is best for most cases.
+- `load_statements` - Whether the statements should be loaded to a SQL table after the run. Usually `false` for collections and enrichment targets like company registries, and true for normal datasets and enrichers.
+- `resolve` - boolean, default `true`. Whether entities are resolved to canonical (deduplicated) IDs. Set to `false` only for special-purpose datasets that must retain their local IDs.
+- `full_dataset` - the name of the complete dataset a subset is derived from; required for datasets used as local enrichment targets, so that matches can be expanded from the full data.
 
 ### Date formatting
 

--- a/zavod/docs/tutorial.md
+++ b/zavod/docs/tutorial.md
@@ -39,14 +39,14 @@ The contents of the new metadata file should look something like this. This is a
 
 ```yaml
 name: eu_fsf_demo
-title: "Financial Sanctions Files (FSF)"
+title: "EU Financial Sanctions Files (FSF)"
 url: https://eeas.europa.eu/
 load_statements: true
 coverage:
     frequency: daily
     start: 2024-03-19
 
-# The description should be extensive, and can use markdown for formatting:
+# See the Description guidance in metadata.md:
 description: >
     As part of the Common Foreign Security Policy thr European Union publishes
     a sanctions list that is implemented by all member states.


### PR DESCRIPTION
Reworks `zavod/docs/metadata.md` into the authoritative reference for dataset metadata conventions and adds a terse `/dataset-metadata` skill that applies it.

## Docs (`zavod/docs/metadata.md`)

- `title`, `summary`, `description` promoted to their own sections with concrete conventions:
  - titles start with the issuing country's short English name (or the international issuer's name/acronym), never possessive; established acronyms kept;
  - summaries are one plain fragment just above 50 chars, no title repetition, no humor;
  - descriptions cover scope and institutional context only — no per-record field lists, ETL mechanics, or sourcing narration.
- New **Maintainer notes (YAML comments)** section: crawler-level notes (failure modes, source quirks, runbooks) go in a top-of-file `#` block, and each non-type lookup gets a short purpose comment. Comments record evidence, never speculation.
- Frequency house defaults by dataset type (sanctions `daily`, PEP `monthly`, registries `weekly`, frozen dumps `never` + schedule), and the actual schedule resolution order (`coverage.schedule` → `deploy.schedule` → frequency mapping, minute randomized per dataset — verified against the deploy tooling).
- Curated documentation for previously undocumented fields: `hidden`, `disabled`, `data.lang`, `resolve`, `full_dataset`, `manual_check`, and the `deploy.*` keys with their deployed defaults.

## Skills

- New `.claude/skills/dataset-metadata/SKILL.md`: procedure-only checklist deferring every rule to the doc, with a no-speculation guard for comments and a metadata-load verify step.
- `.claude/skills/legislature-metadata/SKILL.md` slimmed to the legislature-specific title/description/frequency pattern; per-member attribute enumeration dropped from descriptions (derivable from data statistics, drifts with the crawler). All other fields delegate to `/dataset-metadata`; the two skills cross-reference so either entry point works.

## Trial application

`[de_bundestag]` metadata updated with the new conventions as a worked example (second commit): scope-focused description, plain summary, publisher `name`/`name_en` split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)