### PR TITLE
[zavod] Touch empty statements file at end of crawl, not in flush()

### DIFF
--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -174,11 +174,21 @@ class Context:
         """Flush the context to ensure all data is written to disk."""
         if self._db is not None:
             self._db.checkpoint()
-        # The statement writer is only opened on the first emit, so a crawl
-        # that emitted nothing would leave no statements file behind - and
-        # downstream stages would silently fall back to streaming a previous
-        # version's statements from the archive, republishing old data as a
-        # new successful run. Record the empty output explicitly instead.
+
+    def finalize_statements(self) -> None:
+        """Ensure a statements file exists even if the crawl emitted nothing.
+
+        The statement writer is only opened on the first emit, so a crawl
+        that emitted nothing would leave no statements file behind - and
+        downstream stages would silently fall back to streaming a previous
+        version's statements from the archive, republishing old data as a
+        new successful run. Record the empty output explicitly instead.
+
+        Only called once the crawl has completed successfully so that statements
+        file is never created earlier than it would by emitting entities.
+        This can be important while e.g. enrichers backfill from the most recent
+        statements file.
+        """
         if not self.dry_run and self._writer is None:
             self._writer_path.touch()
 

--- a/zavod/zavod/crawl.py
+++ b/zavod/zavod/crawl.py
@@ -35,6 +35,7 @@ def crawl_dataset(dataset: Dataset, dry_run: bool = False) -> ContextStats:
         entry_point = load_entry_point(dataset)
         entry_point(context)
         context.flush()
+        context.finalize_statements()
         context.log.info(
             "Run completed",
             entities=context.stats.entities,


### PR DESCRIPTION
so. many. words.

Just read the Files changed and https://github.com/opensanctions/opensanctions/issues/5157#issuecomment-5104959843



## Summary

Since ce3b579ab (#4799), `Context.flush()` touched an empty `statements.pack` whenever nothing had been emitted yet. But `flush()` runs mid-crawl — notably in the local enricher right before it syncs its subject store. For a dataset that lists **itself** as an input (`ext_icij_offshoreleaks`), the store sync then read the just-created empty file instead of falling back to the archived previous version: the local-file read succeeds with zero statements, so the `FileNotFoundError`-gated archive fallback never fires.

That starved the self-referential feedback input which sustains previously confirmed matches and their expansion context, dropping the published Company count from 912 to 406 and failing the `schema_entities` min assertion on every run since 2026-07-26 (deterministically — failed runs publish no pack, so nothing changes between retries).

## Fix

Move the touch out of `flush()` into a new `Context.finalize_statements()`, called from `crawl_dataset()` once the entry point has completed successfully — the point the original change assumed `flush()` represented. The empty-crawl protection from #4782 is preserved: a completed crawl that emitted nothing still records an explicitly empty output, but the file is never created earlier than the first emit would create it.

No data bootstrap is needed on deploy: the failed runs never published, so the archive fallback will stream the last successful (2026-07-18) pack on the next run and the feedback stratum rebuilds in one pass.

Fixes https://github.com/opensanctions/opensanctions/issues/5157

## Testing

- `pytest zavod/tests/test_context.py zavod/tests/test_publish.py` — 16 passed, including the two #4799 regression tests (`test_crawl_dataset_empty`, `test_empty_crawl_does_not_resurrect_archived_statements`), which exercise `crawl_dataset` end-to-end and confirm the empty-crawl protection still holds
- `mypy --strict` and `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)