### PR TITLE
[us_fincen_special_measures] Clean footnote markers and annotations from names

### DIFF
--- a/datasets/us/fincen_special_measures/crawler.py
+++ b/datasets/us/fincen_special_measures/crawler.py
@@ -15,6 +15,9 @@ from zavod import helpers as h
 
 LOCAL_PATH = Path(__file__).parent
 REGEX_DATE = re.compile(r"(\d{1,2}/\d{1,2}/\d{4})")
+# Trailing asterisks in the name column are footnote markers, not part of the name.
+REGEX_FOOTNOTE = re.compile(r"[\s*]+$")
+REGEX_ANNOTATION = re.compile(r"\b(includes|renamed|formerly)\b", re.IGNORECASE)
 RELATIONSHIPS = {"self", "target", "subsidiary", "owner", "related"}
 
 
@@ -176,7 +179,20 @@ def crawl_item(
             schema = "Company"
         main = context.make(schema)
         main.id = context.make_id(name)
-        main.add("name", name)
+        # The raw name keys the entity ID, the lookups and the details.csv
+        # join, but footnote markers and inline annotations ("(Includes ...)",
+        # "renamed ...") must not end up in the name property.
+        override = context.lookup("clean_name", name)
+        if override is not None:
+            main.add("name", override.name, original_value=name)
+            main.add("alias", override.alias)
+            main.add("notes", override.notes)
+        else:
+            clean_name = REGEX_FOOTNOTE.sub("", name)
+            if REGEX_ANNOTATION.search(clean_name) is not None:
+                context.log.warning("Measure name needs a clean_name lookup", name=name)
+            original = name if clean_name != name else None
+            main.add("name", clean_name, original_value=original)
         # Adjust the topic based on the presence of "final rule"
         final_rule = collapse_spaces(final_rule_text.strip().lower())
         if (

--- a/datasets/us/fincen_special_measures/us_fincen_special_measures.yml
+++ b/datasets/us/fincen_special_measures/us_fincen_special_measures.yml
@@ -50,6 +50,19 @@ lookups:
           - "Nauru"
           - "Ukraine"
         value: PublicBody
+  clean_name:
+    # Names in the overview table that carry inline annotations. The raw
+    # string stays the entity ID and the details.csv join key; these
+    # overrides only clean up the emitted properties. Trailing asterisk
+    # footnote markers (e.g. "Burma****") are stripped in code.
+    options:
+      - match: "Commercial Bank of Syria (Includes Syrian Lebanese Commercial Bank)*****"
+        name: "Commercial Bank of Syria"
+        notes: "Includes Syrian Lebanese Commercial Bank"
+      - match: "Infobank (Includes Belmetalnergo); renamed Trustbank ***"
+        name: "Infobank"
+        alias: "Trustbank"
+        notes: "Includes Belmetalnergo"
   skip_entity:
     # Rows that name a class of transactions, not an entity we can represent.
     # The class itself is not emitted; only the members named in the linked


### PR DESCRIPTION
Follow-up to #5155. Users reported dirty names coming out of the special measures table:

* `Commercial Bank of Syria (Includes Syrian Lebanese Commercial Bank)*****`
* `Infobank (Includes Belmetalnergo); renamed Trustbank ***`
* `Burma****`

The trailing asterisks are footnote markers on the FinCEN page, and the inline annotations are not part of the name. This change:

* strips trailing asterisk footnote markers from all table names in code;
* adds a `clean_name` lookup for the two annotated names — "Includes ..." moves into `notes`, "renamed Trustbank" becomes an `alias`;
* logs a warning if a future table name carries an includes/renamed/formerly annotation without a lookup entry.

Entity IDs, the `target_type`/`skip_entity` lookups and the details.csv join all stay keyed on the raw table string, so no entity IDs change; the raw string is kept as `original_value` on the cleaned name statements. The entities referenced by the annotations were already modelled from details.csv (Syrian Lebanese Commercial Bank and Belmetalnergo as subsidiaries; Trustbank/PJSC Trustbank aliases on Infobank).

Verified with a local crawl: no asterisks remain in any emitted statement value, zero warnings, same entity count (921).

🤖 Generated with [Claude Code](https://claude.com/claude-code)