### PR TITLE
[ext_gb_coh_psc] Revert bucket size change

### DIFF
--- a/datasets/_externals/ext_gb_coh_psc.yml
+++ b/datasets/_externals/ext_gb_coh_psc.yml
@@ -68,7 +68,6 @@ config:
     max_candidates: 100
     match_batch: 300
     memory: 4000
-    max_bucket_size: 120
   limit: 100
   max_bin: 14
   threshold: 0.5


### PR DESCRIPTION
Doesn't look like we're matching more entities, but run time increased a lot.

I don't think we learned much from this experiment - about 5 related things changed while we were trying to run this.

Also I think the root of the thing was that ofac press releases was failing, and that wasn't bucket-related.

So let's try again when we can chill a bit and just change one thing at a time

Closes https://github.com/opensanctions/operations/issues/2691