### PR TITLE
Guard tabular parsers against silent column misattribution

### DIFF
--- a/zavod/zavod/helpers/excel.py
+++ b/zavod/zavod/helpers/excel.py
@@ -82,6 +82,7 @@ def parse_xls_sheet(
     Cells with links are included as keys with _url appended to the original key.
     """
     headers: list[str] | None = None
+    headers_validated = False
     for row_ix, row in enumerate(sheet):
         if row_ix < skiprows:
             continue
@@ -119,6 +120,15 @@ def parse_xls_sheet(
                         cell = f"column_{idx}"
                     headers.append(slugify_text(cell, "_") or "")
             continue
+
+        if not headers_validated:
+            # Headers are final once the first data row is reached (they may
+            # span several rows via join_header_rows). Records are built by
+            # zipping headers with cells, so a duplicate header would silently
+            # drop the earlier column's cell.
+            duplicates = {hdr for hdr in headers if headers.count(hdr) > 1}
+            assert not duplicates, f"Duplicate headers: {sorted(duplicates)}"
+            headers_validated = True
 
         for header, value in zip(headers, cells):
             record[header] = stringify(value)
@@ -170,6 +180,10 @@ def parse_xlsx_sheet(
                 if header_slug is None and header is not None:
                     header_slug = f"column_{idx}"
                 headers.append(header_slug)
+            duplicates = {hdr for hdr in headers if headers.count(hdr) > 1}
+            # Records are built by zipping headers with cells, so a duplicate
+            # header would silently drop the earlier column's cell.
+            assert not duplicates, f"Duplicate headers: {sorted(duplicates)}"
             continue
 
         record: dict[str, str | None] = {}

--- a/zavod/zavod/helpers/html.py
+++ b/zavod/zavod/helpers/html.py
@@ -81,7 +81,15 @@ def parse_html_table(
       - `zavod.helpers.links_to_dict`
     """
     headers = None
-    for rownum, row in enumerate(table.findall(".//tr")):
+    rows = [
+        row
+        for row in table.findall(".//tr")
+        # A descendant search also matches rows of tables nested inside a
+        # cell; only rows whose nearest <table> ancestor is the target table
+        # belong to it.
+        if next(row.iterancestors("table"), None) in (table, None)
+    ]
+    for rownum, row in enumerate(rows):
         if rownum < skiprows:
             continue
 
@@ -95,6 +103,10 @@ def parse_html_table(
                     header_text = f"column_{colnum}"
                 assert header_text is not None, "No table header text"
                 headers.append(header_text)
+            duplicates = {hdr for hdr in headers if headers.count(hdr) > 1}
+            # Rows are built with dict(zip(headers, cells)), so a duplicate
+            # header would silently drop the earlier column's cell.
+            assert not duplicates, f"Duplicate headers: {sorted(duplicates)}"
             continue
 
         cells = row.findall("./td")

--- a/zavod/zavod/helpers/pdf.py
+++ b/zavod/zavod/helpers/pdf.py
@@ -116,8 +116,23 @@ def parse_pdf_table(
                 headers = [
                     header_slug(cell or "", preserve_header_newlines) for cell in row
                 ]
+                duplicates = {hdr for hdr in headers if headers.count(hdr) > 1}
+                # Rows are built with dict(zip(headers, row)), so a duplicate
+                # header (e.g. two empty header cells, which both slugify to
+                # "") would silently drop the earlier column's cell.
+                assert not duplicates, f"Duplicate headers: {sorted(duplicates)}"
                 continue
             assert len(headers) == len(row), (headers, row)
+            row_slugs = [
+                header_slug(cell or "", preserve_header_newlines) for cell in row
+            ]
+            if row_slugs == headers:
+                # Tables that repeat their header row on every page would
+                # otherwise emit the repeated headers as a data row.
+                context.log.info(
+                    f"Skipping repeated header row on page {page.page_number}"
+                )
+                continue
             yield dict(zip(headers, row))
 
         page.close()

--- a/zavod/zavod/tests/helpers/test_excel.py
+++ b/zavod/zavod/tests/helpers/test_excel.py
@@ -1,5 +1,8 @@
+import pytest
 import xlrd  # type: ignore
-from openpyxl import load_workbook
+from xlrd import XL_CELL_TEXT  # type: ignore
+from xlrd.sheet import Cell  # type: ignore
+from openpyxl import Workbook, load_workbook
 from zavod.context import Context
 from zavod.helpers.excel import (
     convert_excel_cell,
@@ -80,3 +83,47 @@ def test_parse_xlsx_sheet(vcontext: Context):
         "text_url": "http://example.com/hello",
         "column_4": "blank_header_value",
     }
+
+
+class StubXlsSheet:
+    """Just enough of xlrd.sheet.Sheet for parse_xls_sheet — xlrd cannot
+    write files, so a duplicate-header .xls fixture cannot be generated."""
+
+    book = None
+    hyperlink_map: dict = {}
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+def test_parse_xls_sheet_duplicate_headers(vcontext: Context):
+    # Headers that collide after slugification would silently drop the
+    # earlier column's cell ({"name": "latin", "dob": "1970"}).
+    sheet = StubXlsSheet(
+        [
+            [
+                Cell(XL_CELL_TEXT, "Name"),
+                Cell(XL_CELL_TEXT, "Name"),
+                Cell(XL_CELL_TEXT, "DOB"),
+            ],
+            [
+                Cell(XL_CELL_TEXT, "original"),
+                Cell(XL_CELL_TEXT, "latin"),
+                Cell(XL_CELL_TEXT, "1970"),
+            ],
+        ]
+    )
+    with pytest.raises(AssertionError, match="Duplicate headers"):
+        list(parse_xls_sheet(vcontext, sheet))
+
+
+def test_parse_xlsx_sheet_duplicate_headers(vcontext: Context):
+    book = Workbook()
+    sheet = book.active
+    sheet.append(["Name", "Name", "DOB"])
+    sheet.append(["original", "latin", "1970"])
+    with pytest.raises(AssertionError, match="Duplicate headers"):
+        list(parse_xlsx_sheet(vcontext, sheet))

--- a/zavod/zavod/tests/helpers/test_html.py
+++ b/zavod/zavod/tests/helpers/test_html.py
@@ -1,3 +1,4 @@
+import pytest
 from lxml import html
 from rigour.text import text_hash
 
@@ -49,6 +50,50 @@ def test_parse_html_table(testdataset1: Dataset):
     links_dict = h.links_to_dict(rows[0]["read_more"])
     assert links_dict["read_more"] == "/james-bond", links_dict
     assert links_dict["extra"] == "/james-bond-extra", links_dict
+
+
+DUPLICATE_HEADERS_HTML = """
+<html>
+  <table>
+    <tr><th>Name</th><th>Name</th><th>DOB</th></tr>
+    <tr><td>original script</td><td>latin script</td><td>1970</td></tr>
+  </table>
+</html>
+"""
+
+NESTED_TABLE_HTML = """
+<html>
+  <table>
+    <tr><th>Name</th><th>Info</th></tr>
+    <tr>
+      <td>Alice</td>
+      <td>
+        <table><tr><td>inner1</td><td>inner2</td></tr></table>
+      </td>
+    </tr>
+  </table>
+</html>
+"""
+
+
+def test_parse_html_table_duplicate_headers():
+    # Headers that collide after slugification would silently drop the earlier
+    # column's cell ({"name": "latin script", "dob": "1970"}).
+    doc = html.fromstring(DUPLICATE_HEADERS_HTML)
+    table = doc.xpath(".//table")[0]
+    with pytest.raises(AssertionError, match="Duplicate headers"):
+        list(h.parse_html_table(table))
+
+
+def test_parse_html_table_nested_table():
+    # Rows of a table nested inside a cell must not be emitted as rows of the
+    # outer table.
+    doc = html.fromstring(NESTED_TABLE_HTML)
+    table = doc.xpath(".//table")[0]
+    rows = list(h.parse_html_table(table))
+    assert len(rows) == 1, rows
+    str_row = h.cells_to_str(rows[0])
+    assert str_row["name"] == "Alice", str_row
 
 
 def test_element_text():

--- a/zavod/zavod/tests/helpers/test_pdf.py
+++ b/zavod/zavod/tests/helpers/test_pdf.py
@@ -77,11 +77,13 @@ def test_parse_pdf_table_multiple_pages(vcontext):
             vcontext, PDF_PATH, skiprows=1, page_settings=basic_settings_func
         )
     )
-    assert len(list(rows)) == 6, rows
+    # Page 2 repeats the header row ("Forenames"/"Surname"); it is skipped
+    # rather than emitted as a data row.
+    assert len(list(rows)) == 5, rows
     assert rows[0]["forenames"] == "Jon"
     assert rows[2]["forenames"] == "First\nName"
-    assert rows[3]["forenames"] == "Forenames"
-    assert rows[5]["forenames"] == "Frederica"
+    assert rows[3]["forenames"] == "Jane"
+    assert rows[4]["forenames"] == "Frederica"
 
 
 def test_parse_pdf_table_headers_per_page(vcontext):


### PR DESCRIPTION
Closes #4933.

Three fixes, following the suggestions in the issue:

1. **Duplicate headers**: all four parsers (`parse_html_table`, `parse_pdf_table`, `parse_xls_sheet`, `parse_xlsx_sheet`) now assert that headers are unique after slugification. Rows are built with `dict(zip(headers, cells))`, so a duplicate header silently dropped the earlier column's cell. This also covers the two-empty-PDF-header-cells case, since both slugify to `""`.

2. **Nested tables**: `parse_html_table` used `table.findall(".//tr")`, a descendant search that also matched rows of tables nested inside a cell and emitted them as outer-table rows. It now only parses rows whose nearest `<table>` ancestor is the target table.

3. **Repeated page headers**: `parse_pdf_table` with the default `headers_per_page=False` emitted repeated per-page header rows as data. A row whose slugified cells equal the headers is now skipped and logged, independent of the flag.

A few notes:

- `test_parse_pdf_table_multiple_pages` previously asserted the repeated header row (`rows[3]["forenames"] == "Forenames"`); it now expects 5 rows with that row skipped. The page-2 `"First\nName"` row still comes through — it slugifies to `first_name`, not `forenames`, so it is a different header row rather than a repeat, and detecting that generically seemed out of scope here.
- `parse_xls_sheet` validates headers at the first data row rather than at header build, because `join_header_rows` can extend them across several rows.
- The xls duplicate-header test uses a small stub sheet with real `xlrd` cells, since xlrd cannot write files to produce a fixture.
- A crawler whose source legitimately serves duplicate headers will now fail loudly instead of dropping a column — as I read the issue, that is the intended behaviour, but happy to downgrade the assert to a warning if you'd rather roll this out gently.

Dev note: zavod doesn't install on Windows (pyicu/plyvel), so I couldn't run the test suite locally. I verified the changes by driving the three helper modules directly against the repo fixtures (`book.xls`, `book.xlsx`, `test_pdf.pdf`) with zavod internals stubbed: all existing expectations are unchanged before/after, and the updated PDF expectations above come from running the fixture PDF through pdfplumber. CI should be treated as authoritative.