### PR TITLE
Give the issues agent a single, CI-accurate verification command

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -105,7 +105,9 @@ jobs:
       - name: Install maintenance tool dependencies
         if: ${{ !matrix.task.needs_zavod }}
         run: |
-          pip install requests pyyaml
+          # prek + yamllint back contrib/lint_dataset.sh, which the agent runs to
+          # verify its edits; zavod[dev] supplies them on the crawler path.
+          pip install requests pyyaml prek yamllint
           # poppler-utils (pdftotext/pdftoppm) so the agent can read PDF source
           # documents even for datasets whose task doesn't install zavod.
           sudo apt-get install -y -qq poppler-utils

--- a/contrib/lint_dataset.sh
+++ b/contrib/lint_dataset.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Run every lint check CI applies to changed dataset files, in one command.
+#
+# Reach for this after editing anything under datasets/ — a crawler, a metadata
+# YAML, a static data file — to confirm the change will survive CI before
+# opening a PR. It mirrors the two lint steps in
+# .github/workflows/lint_crawlers.yml, so a pass here means a pass there.
+#
+# Usage: contrib/lint_dataset.sh <path> [<path> ...]
+#
+# Passing a dataset's YAML is enough: its crawler is looked up via the
+# entry_point and linted too. Enrichment datasets run an installed module rather
+# than dataset-local code, so for those only the YAML is checked. Paths are
+# otherwise dispatched by extension — .yml/.yaml to yamllint, .py to ruff and
+# mypy — and everything is passed to the pre-commit hooks, which own the
+# per-dataset mypy exclusions. Do not invoke ruff or mypy by hand instead of this
+# script, or you will chase findings CI does not enforce.
+
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: contrib/lint_dataset.sh <path> [<path> ...]" >&2
+  exit 2
+fi
+
+# The ruff invocations below name a config relative to the repository root, and
+# crawler_code is imported as a package module, so run from the root regardless
+# of where the caller sits.
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+PYTHON="${PYTHON:-$(command -v python3 || command -v python)}"
+
+status=0
+all=()
+yamls=()
+pythons=()
+
+# Arrays are expanded via ${arr[@]+"${arr[@]}"} throughout: under `set -u`,
+# bash 3.2 (still the system bash on macOS) errors on an empty array otherwise.
+# Returns non-zero when the path was already collected, so callers can avoid
+# queueing it twice.
+add_python() {
+  local candidate existing
+  candidate="$1"
+  for existing in ${pythons[@]+"${pythons[@]}"}; do
+    [ "$existing" = "$candidate" ] && return 1
+  done
+  pythons+=("$candidate")
+}
+
+for path in "$@"; do
+  if [ ! -e "$path" ]; then
+    echo "lint_dataset: no such file: $path" >&2
+    status=1
+    continue
+  fi
+  all+=("$path")
+  case "$path" in
+    *.yml | *.yaml) yamls+=("$path") ;;
+    *.py) add_python "$path" ;;
+  esac
+done
+
+# Resolve each YAML to its crawler, if it has one. Datasets whose entry_point
+# names an installed module contribute no line, so this stays empty for them.
+if [ "${#yamls[@]}" -gt 0 ]; then
+  while IFS= read -r resolved; do
+    [ -n "$resolved" ] || continue
+    if add_python "$resolved"; then
+      all+=("$resolved")
+    fi
+  done < <("$PYTHON" -m contrib.maintenance.crawler_code "${yamls[@]}")
+fi
+
+run() {
+  echo "+ $*"
+  "$@" || status=1
+}
+
+if [ "${#yamls[@]}" -gt 0 ] && command -v yamllint >/dev/null; then
+  run yamllint "${yamls[@]}"
+fi
+
+if [ "${#pythons[@]}" -gt 0 ]; then
+  run ruff check --config zavod/pyproject.toml "${pythons[@]}"
+  run ruff format --check --diff --config zavod/pyproject.toml "${pythons[@]}"
+fi
+
+# Covers check-yaml, yamllint, ruff and the mypy-datasets hook with its
+# exclusions applied. Note the ruff hook runs with --fix, so this may edit files.
+if [ "${#all[@]}" -gt 0 ]; then
+  run prek run --files ${all[@]+"${all[@]}"}
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "lint_dataset: OK"
+else
+  echo "lint_dataset: FAILED" >&2
+fi
+exit "$status"

--- a/contrib/maintenance/crawler_code.py
+++ b/contrib/maintenance/crawler_code.py
@@ -1,0 +1,49 @@
+"""Print the crawler source file belonging to each given dataset YAML.
+
+    python -m contrib.maintenance.crawler_code <dataset.yml> [<dataset.yml> ...]
+
+Use this from shell tooling that needs a dataset's code, not just its metadata —
+contrib/lint_dataset.sh, for instance, takes a YAML path and has to find the
+crawler to lint. Many datasets have no dataset-local code at all: the ~28
+enrichment datasets point their entry_point at an installed module such as
+`zavod.runner.local_enricher:enrich`. Those simply produce no output line, so a
+caller reading stdout gets an empty list rather than an error.
+
+Prints one resolved path per line, in argument order, omitting datasets without
+local code. Exits non-zero only if a YAML cannot be read.
+"""
+
+import argparse
+import sys
+
+from .datasets import get_code_path, read_dataset_meta
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Print the crawler source file for each dataset YAML, if it has one."
+    )
+    parser.add_argument(
+        "yaml_paths",
+        nargs="+",
+        metavar="dataset.yml",
+        help="path to a dataset metadata YAML, e.g. datasets/au/nsw_parliament/au_nsw_parliament.yml",
+    )
+    args = parser.parse_args()
+
+    status = 0
+    for yaml_path in args.yaml_paths:
+        try:
+            meta = read_dataset_meta(yaml_path)
+        except (OSError, AssertionError) as exc:
+            print(f"crawler_code: cannot read {yaml_path}: {exc}", file=sys.stderr)
+            status = 1
+            continue
+        code_path = get_code_path(yaml_path, meta.get("entry_point"))
+        if code_path is not None:
+            print(code_path)
+    sys.exit(status)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/maintenance/prompt.md
+++ b/contrib/maintenance/prompt.md
@@ -84,9 +84,14 @@ HTTP errors (`Runner failed with HTTPError on <url>`) are the exception among ru
 2. Work through the issue patterns in the report's Issues section. When the report shows only the grouped view, fetch the full issues.json it links to enumerate every occurrence of the patterns you are fixing.
 3. For each fixable group, decide which fix applies: a lookup, an assertion-threshold widening, {% if code_path %}a crawler code change, or a static data update{% else %}or skip it if neither fits{% endif %}. For lookups, follow the consolidation rule under "Result values" in the doc — merge inputs that share a result, keep inputs with different results separate. Respect the existing lookup conventions in the file (lookup names, casing flags, ordering).
 4. Apply the fixes: edit {{ yaml_path }}{% if code_path %}, {{ code_path }}, and any directly referenced static data file required by the warning{% endif %}.
-{% if code_path %}
 5. Verify your changes:
-   - Any code change MUST pass the same checks CI runs, or the PR is dead on arrival: `mypy --strict {{ code_path }}` and `ruff check {{ code_path }}` (and `ruff format`). Note that raw lxml `.xpath()` returns `Any` and fails strict mode — use the typed `h.xpath_*` helpers. Do not open the PR if these fail.
+   - Your changes MUST pass the checks CI runs, or the PR is dead on arrival:
+
+         contrib/lint_dataset.sh {{ yaml_path }}
+
+     Fix what it reports and rerun until it prints `lint_dataset: OK`, then proceed. Note that it applies some formatting fixes in place.
+{% if code_path %}
+   - If mypy flags `Any` coming from a raw lxml `.xpath()` call, switch that call to the typed `h.xpath_*` helpers.
 {% if ci_test %}
    - This crawler runs in CI, so also confirm the fix works end to end: run `zavod crawl --clear-data {{ yaml_path }}`, then read `data/datasets/{{ name }}/issues.log` and confirm the warnings you targeted are gone and that you have not introduced new ones. Do not open the PR if the crawl fails or warnings increase. `jq` (for the JSON logs) and `qsv` (for spot-checking the emitted `data/datasets/{{ name }}/statements.pack`, e.g. `qsv frequency -s prop`) are available.
 {% else %}
@@ -97,5 +102,7 @@ HTTP errors (`Runner failed with HTTPError on <url>`) are the exception among ru
 
 ## Submit
 
-- Commit to a branch. The branch name MUST be exactly `{{ branch }}` — do not invent your own name or add a slug.
-- Open a PR via `mcp__github__create_pull_request` from the `{{ branch }}` branch. The title MUST start with `[{{ name }}]` followed by a short headline, and the body must list the warning patterns being fixed{% if code_path %} and flag any crawler code changes separately from lookup changes{% endif %}.
+- Commit and push as soon as your fixes pass the verification above, before doing anything else. Do not keep investigating or looking for further issues while the work sits uncommitted.
+- The branch name MUST be exactly `{{ branch }}` — do not invent your own name or add a slug.
+- Then open a PR via `mcp__github__create_pull_request` from the `{{ branch }}` branch. The title MUST start with `[{{ name }}]` followed by a short headline, and the body must list the warning patterns being fixed{% if code_path %} and flag any crawler code changes separately from lookup changes{% endif %}.
+- If you find more fixable issues after pushing, add or amend commits on the same branch, push again, and update the PR body.


### PR DESCRIPTION
## Why

The issues agent's prompt told it to verify code fixes with `mypy --strict <file>` and `ruff check <file>`. Neither matches what CI runs — ruff needs `--config zavod/pyproject.toml`, mypy needs `--explicit-package-bases` — and without the config ruff falls back to its own built-in defaults, which are much broader than the rule set `zavod/pyproject.toml` deliberately pins. So a bare `ruff check` reports violations on files CI accepts.

[The `au_nsw_parliament` run on 2026-07-29](https://github.com/opensanctions/opensanctions/actions/runs/30421338793/job/90490337227) hit exactly that. It ran the documented commands, got `I001 Import block is un-sorted`, correctly checked the *unmodified* file to confirm the complaint was pre-existing rather than "fixing" it, then spent six turns reading `.ruff.toml`, `pyproject.toml`, `.pre-commit-config.yml` and `lint_crawlers.yml` to find the real invocation. It exhausted its 60-turn budget (`error_max_turns`) one turn after `RUFF_OK` / `mypy Success` / `YAML_OK` — so it never reached `git push`, no branch or PR exists, and ~12 minutes of verified work was discarded.

## What changed

- **`contrib/lint_dataset.sh`** (new) — one command that mirrors the two lint steps in `lint_crawlers.yml`. It also runs `prek run --files`, which keeps the `mypy-datasets` exclusion list in a single place instead of duplicating it: invoking mypy directly reports errors CI deliberately skips for excluded datasets, i.e. the same trap in a new location.
- **`contrib/maintenance/crawler_code.py`** (new) — CLI over the existing `datasets.get_code_path()`, so the script takes just a dataset YAML and finds the crawler itself. The 28 enrichment datasets (`zavod.runner.local_enricher:enrich`, `zavod.runner.enrich:enrich`) have no dataset-local code, resolve to nothing, and have only their YAML checked.
- **`contrib/maintenance/prompt.md`** — step 5 collapses from four commands and a paragraph of caveats to one command, and is now unconditional, so lookup-only datasets get verification too (previously they had none). The Submit section commits and pushes as soon as verification passes, so a turn-limit cutoff leaves a recoverable branch.
- **`.github/workflows/issues-agent.yml`** — install `prek` and `yamllint` on the lookup-only path, which had neither.

## Verification

| case | result |
|---|---|
| YAML only, crawler derived | ruff + mypy run on `crawler.py`; rc 0 |
| YAML only, **broken** crawler | rc 1 — the derivation is load-bearing |
| enrichment dataset YAML | YAML checks only; rc 0 |
| YAML + its `.py` | deduped; crawler linted once |
| absolute paths (the form the prompt actually renders) | prek, ruff and mypy all accept them |
| missing path / no args | rc 1 / rc 2 |
| all 510 dataset YAMLs through the CLI | 461 resolve, 0 errors, 0 missing files |

Entry-point forms covered: `crawler.py`, `crawler` (no extension), `crawler.py:crawl_warnings`, installed modules. `mypy --strict` and ruff are clean on the new module. The prompt template renders correctly for all three branches (code + `ci_test`, code + blind, lookup-only) using the same `trim_blocks`/`lstrip_blocks` settings `issues_agent.py` uses.

Two portability notes, since this runs on both macOS and CI: `mapfile` and `"${arr[@]}"` under `set -u` both break on bash 3.2 (still macOS's system bash), so the script uses `while read` and the `${arr[@]+"${arr[@]}"}` guard form. `PYTHON` is overridable where the interpreter isn't plain `python3`.

## Deliberately not done

`lint_crawlers.yml` still defines these checks itself, so the script can drift from CI. Wiring that workflow up to the script would also collapse its three lint steps into one — but its `prek` step is currently gated on *Python* having changed while it passes *all* changed `datasets/**` files, so adoption would newly run the hooks on PRs that touch no Python. **41 existing non-Python dataset files fail `trailing-whitespace`** today, so that lands as "unrelated PRs start failing" until they're cleaned up. Left as a follow-up.

Separately, `au_nsw_parliament` itself is still broken and out of scope here: the NSW site was redesigned, `all-members.aspx` now 301s to `/members-and-electorates/members-and-ministers`, and the `prlMembers` table is gone. That needs a crawler rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)