### PR TITLE
Add list.pep.bulk tag and load_all_datasets() catalog scan

### DIFF
--- a/contrib/check_hierarchy.py
+++ b/contrib/check_hierarchy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Set
 
 from zavod.logs import get_logger, configure_logging
-from zavod.meta import Dataset, get_catalog
+from zavod.meta import Dataset, load_directory_catalog
 
 log = get_logger("check_hierarchy")
 
@@ -12,12 +12,10 @@ InDir = click.Path(dir_okay=True, readable=True, file_okay=False, path_type=Path
 
 
 @click.command()
-@click.argument("datasets_path", type=InDir)
-def main(datasets_path: Path):
+@click.argument("datasets_path", type=InDir, required=False)
+def main(datasets_path: Path | None):
     configure_logging(level=logging.INFO)
-    catalog = get_catalog()
-    for path in datasets_path.glob("**/*.y*ml"):
-        catalog.load_yaml(path)
+    catalog = load_directory_catalog(datasets_path)
 
     collections: Set[Dataset] = set()
     children: Set[Dataset] = set()

--- a/contrib/matcher_training/generate.py
+++ b/contrib/matcher_training/generate.py
@@ -229,7 +229,7 @@ def generate(scope: str, outdir: Path) -> Dict[str, Any]:
     dataset_scope = get_catalog().require(scope)
     datasets = [d for d in dataset_scope.datasets if d.name not in IGNORE_DATASETS]
     datasets = [d for d in datasets if not d.is_collection]
-    dataset = get_multi_dataset([d.name for d in datasets])
+    dataset = get_multi_dataset(get_catalog(), [d.name for d in datasets])
 
     store = get_store(dataset, Linker({}))
     store.sync()

--- a/datasets/_analysis/ann_graph_topics/analyzer.py
+++ b/datasets/_analysis/ann_graph_topics/analyzer.py
@@ -77,7 +77,7 @@ from followthemoney.statement import BASE_ID
 from nomenklatura.store.base import View as BaseView
 
 from zavod import Context, Entity
-from zavod.meta import Dataset, get_multi_dataset
+from zavod.meta import Dataset, get_catalog, get_multi_dataset
 from zavod.constants import ANALYZER_DATASETS, ORIGIN_INFERRED
 from zavod.store import get_store
 from zavod.integration import get_dataset_linker
@@ -378,7 +378,7 @@ def analyze_entity(context: Context, view: View, entity: Entity) -> None:
 
 
 def crawl(context: Context) -> None:
-    scope = get_multi_dataset(context.dataset.inputs)
+    scope = get_multi_dataset(get_catalog(), context.dataset.inputs)
     linker = get_dataset_linker(scope)
     store = get_store(scope, linker)
     store.sync()

--- a/datasets/_analysis/ann_pep_positions/analyzer.py
+++ b/datasets/_analysis/ann_pep_positions/analyzer.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from zavod import Context, Entity
 from zavod.constants import ORIGIN_INFERRED
 from zavod.integration import get_dataset_linker
-from zavod.meta import get_multi_dataset
+from zavod.meta import get_catalog, get_multi_dataset
 from zavod.stateful.positions import OccupancyStatus, categorise_many
 from zavod.store import get_store
 
@@ -109,7 +109,7 @@ def analyze_position(context: Context, entity: Entity) -> set[str]:
 
 
 def crawl(context: Context) -> None:
-    scope = get_multi_dataset(context.dataset.inputs)
+    scope = get_multi_dataset(get_catalog(), context.dataset.inputs)
     linker = get_dataset_linker(scope)
     store = get_store(scope, linker)
     store.sync()

--- a/datasets/_global/un_ga_protocol/un_ga_protocol.yml
+++ b/datasets/_global/un_ga_protocol/un_ga_protocol.yml
@@ -29,6 +29,7 @@ publisher:
 url: "https://www.un.org/dgacm/en/content/protocol/hshgnfa"
 tags:
   - list.pep
+  - list.pep.bulk
 data:
   url: https://www.un.org/dgacm/en/content/protocol/hshgnfa
   format: PDF

--- a/datasets/al/kuvendi/al_kuvendi.yml
+++ b/datasets/al/kuvendi/al_kuvendi.yml
@@ -16,6 +16,8 @@ description: |
 
   This dataset records each sitting member with their name, date of birth (where
   available), email address, and political party.
+tags:
+  - list.pep
 publisher:
   name: Kuvendi i Shqipërisë
   name_en: Assembly of the Republic of Albania

--- a/datasets/bg/jud_declarations/bg_jud_declarations.yml
+++ b/datasets/bg/jud_declarations/bg_jud_declarations.yml
@@ -21,6 +21,7 @@ description: |
   [Source: ЗАКОН ЗА СЪДЕБНАТА ВЛАСТ](https://www.justice.government.bg/home/normdoc/2135560660)
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Инспекторат към Висшия съдебен съвет
   name_en: Inspectorate to the Supreme Judicial Council

--- a/datasets/bg/parliament/bg_parliament.yml
+++ b/datasets/bg/parliament/bg_parliament.yml
@@ -22,6 +22,8 @@ description: |
   which exposes the roster of each assembly and a per-member profile with biographical
   details and a full membership history.
 url: https://www.parliament.bg/en/MP
+tags:
+  - list.pep
 publisher:
   name: National Assembly of the Republic of Bulgaria
   acronym: NA

--- a/datasets/br/pep/br_pep.yml
+++ b/datasets/br/pep/br_pep.yml
@@ -27,6 +27,7 @@ publisher:
   country: "br"
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://portaldatransparencia.gov.br/download-de-dados/pep
 data:
   url: https://portaldatransparencia.gov.br/download-de-dados/pep

--- a/datasets/cl/info_probidad/cl_info_probidad.yml
+++ b/datasets/cl/info_probidad/cl_info_probidad.yml
@@ -29,6 +29,7 @@ description: |
   the Contraloría General de la República (CGR).
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Consejo para la Transparencia
   acronym: CPLT

--- a/datasets/co/funcion_publica/co_funcion_publica.yml
+++ b/datasets/co/funcion_publica/co_funcion_publica.yml
@@ -32,6 +32,7 @@ description: |
   the case so we include the stated end date but indicate occupancy status as unknown.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Deparatamento Administrativo del la Funcion Publica
   name_en: Administrative Department of Public Service

--- a/datasets/co/join_dots/co_join_dots.yml
+++ b/datasets/co/join_dots/co_join_dots.yml
@@ -16,9 +16,9 @@ description: |
 
   From the project site:
 
-  > "Joining the Dots with PEPs" makes available to the public information on 
+  > "Joining the Dots with PEPs" makes available to the public information on
   > public officials’ Financial Declarations, government procurement and
-  > contracting, and contracts and tenders of companies in the extractive 
+  > contracting, and contracts and tenders of companies in the extractive
   > sector, with the aim of identifying possible conflicts of interest,
   > corruption or misuse of public office.
   >
@@ -32,6 +32,7 @@ description: |
   ownership information added as notes to these political office-holders.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Directorio Legislativo/EITI
   description: |

--- a/datasets/cz/pep_declarations/cz_pep_declarations.yml
+++ b/datasets/cz/pep_declarations/cz_pep_declarations.yml
@@ -19,6 +19,7 @@ description: |
   current position and recent roles, which are used to determine PEP status.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Ministerstvo spravedlnosti České republiky
   name_en: Ministry of Justice of the Czech Republic

--- a/datasets/es/mayors_councillors/es_mayors_councillors.yml
+++ b/datasets/es/mayors_councillors/es_mayors_councillors.yml
@@ -8,9 +8,9 @@ coverage:
 summary: >
   Individuals holding mayoral or municipal councillor positions in Spain.
 description: |
-  This dataset contains information on individuals currently serving as mayors or councillors 
-  in Spanish municipalities. It includes their names, roles, political affiliations, and 
-  relevant administrative details. The dataset reflects current officeholders and includes 
+  This dataset contains information on individuals currently serving as mayors or councillors
+  in Spanish municipalities. It includes their names, roles, political affiliations, and
+  relevant administrative details. The dataset reflects current officeholders and includes
   historical data from the 2019–2023 municipal term.
 publisher:
   name: Ministerio de Política Territorial y Memoria Democrática
@@ -18,13 +18,14 @@ publisher:
   acronym: MPT
   official: true
   description: |
-    The Ministry of Territorial Policy and Democratic Memory is the government department 
-    responsible for proposing and executing policy on relations and cooperation with 
+    The Ministry of Territorial Policy and Democratic Memory is the government department
+    responsible for proposing and executing policy on relations and cooperation with
     autonomous communities and local administrations.
   country: es
   url: https://mpt.gob.es/en/ministerio.html
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://mptmd.gob.es/en/portal/politica-territorial/local/sistema_de_informacion_local_-sil-/alcaldes_y_concejales
 data:
   url: https://concejales.redsara.es/consulta/
@@ -41,7 +42,7 @@ assertions:
 lookups:
   positions:
     options:
-      - match: 
+      - match:
           - Alcalde
           - Alcalde en Funciones
         value: Mayor
@@ -55,33 +56,33 @@ lookups:
         value: Managing Councillor
   columns:
     options:
-      - match: 
+      - match:
           - NOMBRE
           - Nombre
         value: name
-      - match: 
+      - match:
           - PROVINCIA
           - Provincia
         value: province
-      - match: 
+      - match:
           - MUNICIPIO
           - Municipio
         value: municipality
-      - match: 
+      - match:
           - FECHA POSESIÓN
           - Fecha de Posesión
         value: start_date
       - match: FECHA BAJA
         value: end_date
-      - match: 
+      - match:
           - COMUNIDAD AUTÓNOMA
           - Comunidad Autónoma
         value: autonomous_community
-      - match: 
+      - match:
           - CÓDIGO INE
           - Código INE
         value: ine_code
-      - match: 
+      - match:
           - LISTA
           - Partido
         value: party

--- a/datasets/eu/public_functions/eu_public_functions.yml
+++ b/datasets/eu/public_functions/eu_public_functions.yml
@@ -47,6 +47,7 @@ description: |
   we could clearly identify as positions which exist in those countries.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Official Journal of the European Union
   acronym: OJEU

--- a/datasets/fr/maires/fr_maires.yml
+++ b/datasets/fr/maires/fr_maires.yml
@@ -18,6 +18,7 @@ description: |
   prefectures, and is updated quarterly.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Ministère de l'Intérieur et des Outre-Mer
   acronym: MIOM

--- a/datasets/ge/declarations/ge_declarations.yml
+++ b/datasets/ge/declarations/ge_declarations.yml
@@ -26,6 +26,7 @@ data:
   format: HTML
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: ანტიკორუფციული ბიურო
   name_en: Anti-Corruption bureau of Georgia

--- a/datasets/hr/public_officials/hr_public_officials.yml
+++ b/datasets/hr/public_officials/hr_public_officials.yml
@@ -24,6 +24,7 @@ http:
   additional_retry_statuses: [403, 415]
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Povjerenstvo za odlučivanje o sukobu interesa
   acronym: Sukobu Interesa

--- a/datasets/id/regional_2018/id_regional_2018.yml
+++ b/datasets/id/regional_2018/id_regional_2018.yml
@@ -20,6 +20,7 @@ description: |
   offline.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Komisi Pemilihan Umum
   name_en: General Elections Commission

--- a/datasets/lt/pep_declarations/lt_pep_declarations.yml
+++ b/datasets/lt/pep_declarations/lt_pep_declarations.yml
@@ -1,6 +1,7 @@
 title: Lithuania PEPs from the register of private interests
 entry_point: crawler.py
 prefix: lt-pinreg
+disabled: true
 coverage:
   frequency: monthly
   start: "2024-08-16"

--- a/datasets/lt/pep_declarations/lt_pep_declarations.yml
+++ b/datasets/lt/pep_declarations/lt_pep_declarations.yml
@@ -19,7 +19,7 @@ description: |
 deprecation: |
   As of April 2025, the Lithuanian Chief Official Ethics Commission (VTEK) has required
   API authentication for access to the declarations search page, which prevents
-  automated crawling of the data. We've [reached out to VTEK to request access](https://github.com/opensanctions/opensanctions/issues/2212), but 
+  automated crawling of the data. We've [reached out to VTEK to request access](https://github.com/opensanctions/opensanctions/issues/2212), but
   not received a response yet. The dataset is therefore marked as deprecated and eventually
   removed in favor of other sources of PEP data for Lithuania.
 publisher:

--- a/datasets/lu/bourgmestres/lu_bourgmestres.yml
+++ b/datasets/lu/bourgmestres/lu_bourgmestres.yml
@@ -35,6 +35,7 @@ dates:
 
 tags:
   - list.pep
+  - list.pep.bulk
 
 assertions:
   min:

--- a/datasets/me/acp_peps/me_acp_peps.yml
+++ b/datasets/me/acp_peps/me_acp_peps.yml
@@ -27,6 +27,7 @@ publisher:
   official: true
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://obsidian.antikorupcija.me/registri/pretraga-izvjestaja-o-prihodima-i-imovini
 data:
   url: https://obsidian.antikorupcija.me/api/ask-interni-pretraga/ank-izvjestaj-imovine/pretraga-izvjestaj-imovine-javni

--- a/datasets/mk/officials/mk_officials.yml
+++ b/datasets/mk/officials/mk_officials.yml
@@ -13,13 +13,14 @@ description: |
   North Macedonia has an asset declaration system established by the Law
   on Prevention of Corruption (LPC, 2002) for elected and appointed officials,
   responsible persons in public entities dealing with State funds, and officials
-  in State bodies and municipal administrations, including judges and prosecutors. 
+  in State bodies and municipal administrations, including judges and prosecutors.
 
   The obligated personnel are required to submit asset declarations to designated offices
   upon taking and leaving office and whenever a change in assets occurs that exceeds
   twenty average salaries.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: State Commission for Prevention of Corruption
   acronym: SCPC

--- a/datasets/ng/chipper_peps/ng_chipper_peps.yml
+++ b/datasets/ng/chipper_peps/ng_chipper_peps.yml
@@ -27,6 +27,7 @@ publisher:
   logo_url: "https://assets.opensanctions.org/images/publishers/chipper-logo.svg"
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://chippercash.com/
 data:
   url: https://docs.google.com/spreadsheets/d/e/2PACX-1vS-0_pci6BoFHpxfPXbDeMD53jvti_TmovR406JK-Z-9lYPCqbUmTk6vZC0hTSRFxHYGTzJJyFRDCxz/pub?output=csv

--- a/datasets/ng/join_dots/ng_join_dots.yml
+++ b/datasets/ng/join_dots/ng_join_dots.yml
@@ -35,6 +35,7 @@ publisher:
   official: false
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://peps.directoriolegislativo.org/nigeria/open-data
 data:
   url: https://peps.directoriolegislativo.org/

--- a/datasets/nz/parliament/nz_parliament.yml
+++ b/datasets/nz/parliament/nz_parliament.yml
@@ -19,6 +19,8 @@ description: |
   their name, year of birth and death, gender, the electorate they represented, and
   their party affiliation across each parliamentary term.
 url: https://catalogue.data.govt.nz/dataset/members-of-parliament
+tags:
+  - list.pep
 publisher:
   name: New Zealand Parliament
   description: |

--- a/datasets/ro/fiu_declarations/ro_fiu_declarations.yml
+++ b/datasets/ro/fiu_declarations/ro_fiu_declarations.yml
@@ -15,6 +15,7 @@ description: |
   aimed at ensuring transparency and preventing illicit financial activities.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: OFICIUL NAȚIONAL DE PREVENIRE ȘI COMBATERE A SPĂLĂRII BANILOR
   name_en: The National Office for Preventing and Combating Money Laundering

--- a/datasets/sg/gov_dir/sg_gov_dir.yml
+++ b/datasets/sg/gov_dir/sg_gov_dir.yml
@@ -31,6 +31,7 @@ publisher:
   official: true
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://www.sgdi.gov.sg
 data:
   url: https://www.sgdi.gov.sg/statutory-boards

--- a/datasets/sk/public_officials/sk_public_officials.yml
+++ b/datasets/sk/public_officials/sk_public_officials.yml
@@ -14,6 +14,7 @@ description: |
   from the official website of the National Council of the Slovak Republic.
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: Národná rada Slovenskej republiky
   name_en: National Council of the Slovak Republic

--- a/datasets/us/navy/us_navy.yml
+++ b/datasets/us/navy/us_navy.yml
@@ -28,6 +28,7 @@ publisher:
   url: https://www.navy.mil
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://www.navy.mil/Leadership/
 data:
   url: https://www.navy.mil/Leadership/

--- a/datasets/us/plum_book/us_plum_book.yml
+++ b/datasets/us/plum_book/us_plum_book.yml
@@ -47,6 +47,7 @@ publisher:
   official: true
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://www.opm.gov/about-us/open-government/plum-reporting/plum-data/
 data:
   url: https://escs.opm.gov/escs-net/api/pbpub/download-data

--- a/datasets/us/state_dept/us_state_dept.yml
+++ b/datasets/us/state_dept/us_state_dept.yml
@@ -22,11 +22,12 @@ description: |
 url: https://www.state.gov/biographies-list/
 tags:
   - list.pep
+  - list.pep.bulk
 publisher:
   name: US State Department
   acronym: State
   description: |
-    The U.S. State Department's stated mission is to protect and promote U.S. 
+    The U.S. State Department's stated mission is to protect and promote U.S.
     security, prosperity, and democratic values and shape an international
     environment in which all Americans can thrive.
   country: us

--- a/datasets/uy/pep/uy_pep.yml
+++ b/datasets/uy/pep/uy_pep.yml
@@ -22,6 +22,7 @@ publisher:
   official: true
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://www.gub.uy/secretaria-nacional-lucha-contra-lavado-activos-financiamiento-terrorismo/comunicacion/publicaciones/lista-pep
 data:
   url: https://www.gub.uy/secretaria-nacional-lucha-contra-lavado-activos-financiamiento-terrorismo/sites/secretaria-nacional-lucha-contra-lavado-activos-financiamiento-terrorismo/files/documentos/publicaciones/Lista_PEP_V31.xlsx

--- a/datasets/za/mm_officials/za_mm_officials.yml
+++ b/datasets/za/mm_officials/za_mm_officials.yml
@@ -25,6 +25,7 @@ publisher:
   url: https://www.treasury.gov.za/
 tags:
   - list.pep
+  - list.pep.bulk
 url: https://municipalmoney.gov.za/
 data:
   url: https://municipaldata.treasury.gov.za/api/cubes/officials/facts

--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -51,6 +51,8 @@ Currently, tags cover the following dimensions:
 - sectors (e.g. `sector.financial`, `sector.maritime`)
 - risk themes (e.g. `risk.klepto`).
 
+Tag matching is by exact string, not by prefix: a dataset tagged only `list.pep.bulk` does not match `list.pep`. Sub-tags qualify a base tag and should be applied alongside it — `list.pep.bulk` marks PEP datasets (also tagged `list.pep`) that are excluded from broad PEP cross-referencing, such as declaration registries and sub-national officeholder lists.
+
 You can find a full overview of available tags [here](https://www.opensanctions.org/docs/metadata/).
 
 ### Publisher

--- a/zavod/zavod/cli/__init__.py
+++ b/zavod/zavod/cli/__init__.py
@@ -8,7 +8,7 @@ from followthemoney.statement import FORMATS
 import requests
 from zavod import settings
 from zavod.logs import configure_logging, get_logger, set_logging_context_dataset_name
-from zavod.meta import load_dataset_from_path, get_multi_dataset, Dataset
+from zavod.meta import load_dataset_from_path, get_catalog, get_multi_dataset, Dataset
 from zavod.stateful.model import create_db
 
 log = get_logger(__name__)
@@ -50,7 +50,7 @@ def _load_datasets(paths: list[Path]) -> Dataset:
     inputs: list[str] = []
     for path in paths:
         inputs.append(_load_dataset(path).name)
-    return get_multi_dataset(inputs)
+    return get_multi_dataset(get_catalog(), inputs)
 
 
 @click.group(help="Zavod data factory")

--- a/zavod/zavod/meta/__init__.py
+++ b/zavod/zavod/meta/__init__.py
@@ -1,8 +1,13 @@
 from pathlib import Path
 from banal import hash_data
 from functools import cache
+from followthemoney.dataset import DataCatalog
 from followthemoney.exc import MetadataException
+from pydantic import ValidationError
+from yaml import YAMLError
 
+from zavod import settings
+from zavod.exc import ConfigurationException
 from zavod.logs import get_logger
 from zavod.meta.dataset import Dataset
 from zavod.meta.catalog import ArchiveBackedCatalog
@@ -22,10 +27,40 @@ def load_dataset_from_path(path: Path) -> Dataset | None:
     return get_catalog().load_yaml(path)
 
 
-def get_multi_dataset(names: list[str]) -> Dataset:
+def load_directory_catalog(datasets_path: Path | None = None) -> ArchiveBackedCatalog:
+    """Build a catalog from every dataset YAML found under the datasets directory.
+
+    Use this to get the full universe of datasets — including unreleased ones and
+    those outside the `default` collection — for evaluating dataset queries: the
+    process-wide catalog is lazy and only knows datasets that were explicitly
+    requested, so `#tag` selectors would silently match against an incomplete
+    catalog. Returns a fresh catalog on every call; get_catalog() is unaffected.
+
+    Args:
+        datasets_path: Directory tree to scan; defaults to settings.DATASETS_PATH
+            (the ZAVOD_DATASETS_PATH environment variable).
+    """
+    path = datasets_path or settings.DATASETS_PATH
+    if not path.is_dir():
+        raise ConfigurationException(
+            f"Datasets path does not exist: {path} (set ZAVOD_DATASETS_PATH)"
+        )
+    catalog = ArchiveBackedCatalog()
+    for yml_path in sorted(path.glob("**/*.y*ml")):
+        try:
+            catalog.load_yaml(yml_path, traverse_children=False)
+        except (YAMLError, ValidationError, MetadataException, TypeError) as exc:
+            log.warning(
+                "Skipping invalid dataset YAML",
+                path=yml_path.as_posix(),
+                error=str(exc),
+            )
+    return catalog
+
+
+def get_multi_dataset(catalog: DataCatalog[Dataset], names: list[str]) -> Dataset:
     """The scopes of a dataset is the set of other datasets on which analysis or
     enrichment should be performed by the runner."""
-    catalog = get_catalog()
     inputs: list[Dataset] = []
     for input_name in names:
         try:
@@ -52,6 +87,5 @@ def get_multi_dataset(names: list[str]) -> Dataset:
             "summary": "Synthetic, ad-hoc virtual collection for multiple input datasets",
             "hidden": True,
         }
-        scope = catalog.make_dataset(data)
-        catalog.add(scope)
+        catalog.make_dataset(data)
     return catalog.require(name)

--- a/zavod/zavod/meta/catalog.py
+++ b/zavod/zavod/meta/catalog.py
@@ -10,7 +10,7 @@ class ArchiveBackedCatalog(DataCatalog[Dataset]):
     def __init__(self) -> None:
         super().__init__(Dataset, {})
 
-    def load_yaml(self, path: Path) -> Dataset | None:
+    def load_yaml(self, path: Path, traverse_children: bool = True) -> Dataset | None:
         with open(path) as fh:
             data = yaml.safe_load(fh)
         if "name" not in data:
@@ -18,8 +18,12 @@ class ArchiveBackedCatalog(DataCatalog[Dataset]):
         dataset = Dataset(data)
         dataset.base_path = path.parent
         self.add(dataset)
-        for name in dataset.model.children:
-            self.get(name)
+        if traverse_children:
+            # Resolving a child via get() may download its index.json from the
+            # archive. Disable when the caller loads the whole dataset tree
+            # anyway (cf. load_directory_catalog); add() links children in any order.
+            for name in dataset.model.children:
+                self.get(name)
         return dataset
 
     def get(self, name: str) -> Dataset | None:

--- a/zavod/zavod/runner/enrich.py
+++ b/zavod/zavod/runner/enrich.py
@@ -3,7 +3,7 @@ from followthemoney.helpers import check_person_cutoff
 from nomenklatura.judgement import Judgement
 from nomenklatura.enrich import Enricher, EnrichmentException, make_enricher
 
-from zavod.meta import Dataset, get_multi_dataset
+from zavod.meta import Dataset, get_catalog, get_multi_dataset
 from zavod.entity import Entity
 from zavod.context import Context
 from zavod.runner.util import check_publishability, is_analyzer_stub, should_promote
@@ -49,7 +49,7 @@ def save_match(
 
 
 def enrich(context: Context) -> None:
-    scope = get_multi_dataset(context.dataset.inputs)
+    scope = get_multi_dataset(get_catalog(), context.dataset.inputs)
     context.log.info(f"Enriching {scope.name} ({[d.name for d in scope.datasets]})")
     store = get_store(scope, context.resolver)
     # Commit the resolver's load-time read so no transaction is held open across

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -223,7 +223,7 @@ def save_match(
 
 
 def enrich(context: Context) -> None:
-    scope = get_multi_dataset(context.dataset.inputs)
+    scope = get_multi_dataset(get_catalog(), context.dataset.inputs)
     # The Context resolver is read-only here (save_match only reads judgements),
     # so its load commits as a no-op along with the cache via context.close().
     context.log.info(f"Enriching {scope.name} ({[d.name for d in scope.datasets]})")

--- a/zavod/zavod/settings.py
+++ b/zavod/zavod/settings.py
@@ -12,14 +12,22 @@ LOG_JSON = as_bool(env_str("ZAVOD_LOG_JSON", "false"))
 # Debug mode
 DEBUG = as_bool(env_str("ZAVOD_DEBUG", "false"))
 
-# Default paths
-_META_RESOURCE_DEFAULT = Path(__file__).parent.parent.parent / "meta"
+# Default paths. Repository-relative defaults assume zavod is installed
+# editable from its checkout inside the opensanctions repository.
+_REPO_ROOT = Path(__file__).parent.parent.parent
 META_RESOURCE_PATH = Path(
-    env.get("ZAVOD_META_RESOURCE_PATH") or _META_RESOURCE_DEFAULT
+    env.get("ZAVOD_META_RESOURCE_PATH") or _REPO_ROOT / "meta"
 ).resolve()
 DATA_PATH_ = env_str("ZAVOD_DATA_PATH", "data")
 DATA_PATH = Path(env_str("OPENSANCTIONS_DATA_PATH", DATA_PATH_)).resolve()
 DATA_PATH.mkdir(parents=True, exist_ok=True)
+
+# Directory tree containing all dataset YAML specifications (the opensanctions
+# repository's datasets/ folder). Used to build the full dataset universe for
+# evaluating dataset queries.
+DATASETS_PATH = Path(
+    env.get("ZAVOD_DATASETS_PATH") or _REPO_ROOT / "datasets"
+).resolve()
 
 # Per-run timestamp
 RUN_VERSION = Version.from_env("ZAVOD_VERSION")

--- a/zavod/zavod/tests/test_dataset.py
+++ b/zavod/zavod/tests/test_dataset.py
@@ -167,11 +167,11 @@ def test_analyzer(analyzer: Dataset, testdataset1: Dataset):
 
 def test_multi_dataset(analyzer: Dataset, testdataset1: Dataset):
     with pytest.raises(MetadataException):
-        get_multi_dataset(["xxxx"])
+        get_multi_dataset(get_catalog(), ["xxxx"])
 
-    ds = get_multi_dataset([analyzer.name])
+    ds = get_multi_dataset(get_catalog(), [analyzer.name])
     assert ds == analyzer
 
-    ds = get_multi_dataset([analyzer.name, testdataset1.name])
+    ds = get_multi_dataset(get_catalog(), [analyzer.name, testdataset1.name])
     assert analyzer in ds.children
     assert testdataset1 in ds.children

--- a/zavod/zavod/tests/test_directory_catalog.py
+++ b/zavod/zavod/tests/test_directory_catalog.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from followthemoney.dataset import evaluate_query, parse_query
+
+from zavod import settings
+from zavod.exc import ConfigurationException
+from zavod.meta import get_catalog, load_directory_catalog
+
+FIXTURES = {
+    # Named so the collection globs before its members, exercising
+    # order-independent child linking without archive fetches:
+    "aaa_collection.yml": {
+        "title": "Test Collection",
+        "children": ["ds_plain", "ds_tagged"],
+    },
+    "ds_plain.yml": {
+        "title": "Plain Dataset",
+    },
+    "ds_tagged.yml": {
+        "title": "Tagged Dataset",
+        "tags": ["foo.bar", "foo.bar.sub"],
+    },
+    "nested/ds_other.yml": {
+        "title": "Other Tagged Dataset",
+        "tags": ["foo.bar"],
+    },
+}
+
+
+@pytest.fixture()
+def datasets_path(tmp_path: Path) -> Path:
+    for rel, data in FIXTURES.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(data))
+    return tmp_path
+
+
+def test_load_directory_catalog(datasets_path: Path) -> None:
+    catalog = load_directory_catalog(datasets_path)
+    for name in ("aaa_collection", "ds_plain", "ds_tagged", "ds_other"):
+        assert catalog.has(name), name
+
+    # Children are linked even though the collection loaded first:
+    collection = catalog.require("aaa_collection")
+    assert collection.is_collection
+    child_names = {c.name for c in collection.children}
+    assert child_names == {"ds_plain", "ds_tagged"}
+
+
+def test_load_directory_catalog_query(datasets_path: Path) -> None:
+    catalog = load_directory_catalog(datasets_path)
+    names = {d.name for d in evaluate_query(catalog, parse_query("#foo.bar"))}
+    assert names == {"ds_tagged", "ds_other"}
+    query = parse_query("#foo.bar - #foo.bar.sub")
+    names = {d.name for d in evaluate_query(catalog, query)}
+    assert names == {"ds_other"}
+    names = {d.name for d in evaluate_query(catalog, "aaa_collection")}
+    assert names == {"ds_plain", "ds_tagged"}
+
+
+def test_load_directory_catalog_is_fresh(datasets_path: Path) -> None:
+    # Every call builds a new catalog; the process-wide singleton stays empty:
+    first = load_directory_catalog(datasets_path)
+    second = load_directory_catalog(datasets_path)
+    assert first is not second
+    assert first.names == second.names
+    assert first is not get_catalog()
+    assert not get_catalog().has("ds_plain")
+
+
+def test_load_directory_catalog_skips_invalid(datasets_path: Path) -> None:
+    (datasets_path / "broken.yml").write_text("title: {invalid")
+    (datasets_path / "not_a_dataset.yml").write_text("- just\n- a\n- list\n")
+    catalog = load_directory_catalog(datasets_path)
+    assert catalog.has("ds_plain")
+    assert not catalog.has("broken")
+    assert not catalog.has("not_a_dataset")
+
+
+def test_load_directory_catalog_missing_path(tmp_path: Path) -> None:
+    with pytest.raises(ConfigurationException, match="does not exist"):
+        load_directory_catalog(tmp_path / "nope")
+
+
+def test_default_datasets_path() -> None:
+    # Defaults to the datasets folder of the repository checkout containing
+    # this zavod installation:
+    repo_root = Path(settings.__file__).resolve().parent.parent.parent
+    assert settings.DATASETS_PATH == repo_root / "datasets"
+    assert settings.DATASETS_PATH.is_dir()


### PR DESCRIPTION
Groundwork for selecting xref scopes via followthemoney dataset queries (e.g. `#list.pep - #list.pep.bulk`) instead of hand-maintained dataset name lists. Two parts:

**New tag `list.pep.bulk`** — applied to the 26 `list.pep` datasets that are not suitable for broad PEP cross-referencing: declaration registries, sub-national officeholder lists, and `un_ga_protocol`, which is matched in a dedicated scope instead. Since tag matching is exact-string (no prefix semantics), these datasets keep their `list.pep` tag alongside the sub-tag; the convention is documented in the metadata docs. Three parliament datasets (`al_kuvendi`, `bg_parliament`, `nz_parliament`) were missing the plain `list.pep` tag and get it here.

**`zavod.meta.load_directory_catalog()`** — builds a catalog from every dataset YAML under a datasets directory, defaulting to `settings.DATASETS_PATH` (`ZAVOD_DATASETS_PATH`, or the `datasets/` folder of the repository checkout containing the zavod installation). Dataset queries with `#tag` selectors need the full dataset universe — including unreleased datasets and ones outside the `default` collection — while the lazy archive-backed catalog only knows explicitly requested datasets, so tag selectors would silently under-match against it.

The function returns a **fresh catalog instance** rather than populating the `get_catalog()` singleton: the two have different metadata sources (repository specs vs published `index.json` artifacts), and mixing them in one instance makes the result depend on load order. To let callers choose which catalog to resolve against, **`get_multi_dataset()` now takes the catalog as an explicit first argument** — a breaking signature change; all existing call sites (enrichers, CLI, the two `_analysis` analyzers, matcher training) pass `get_catalog()` and keep their current behavior.

The scan loads with the new `traverse_children=False` option on `load_yaml()`: child resolution via `get()` can backfill `index.json` artifacts from the archive over the network, which a full directory scan neither needs (`add()` links parents and children in any load order) nor wants.

Verified with `kombinat check-scopes`: the query `#list.pep - #list.pep.bulk` plus the three explicit non-PEP scope members resolves to the previous 157-dataset goodpeps xref scope plus seven datasets promoted out of the bulk tag during review (164 total; an eighth promoted dataset, `lt_pep_declarations`, is newly marked disabled since the source is dead, and disabled datasets are excluded from scope resolution), and `#list.debarment & #sector.devbank` resolves to exactly the five MDB debarment lists. The consumer change (kombinat scope resolution) lands separately in the operations repo and requires this image to be published first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

