### PR TITLE
exporters: don't publish delta_url when the delta exporter is disabled

### DIFF
--- a/zavod/zavod/exporters/__init__.py
+++ b/zavod/zavod/exporters/__init__.py
@@ -43,14 +43,25 @@ EXPORTERS: dict[str, type[Exporter]] = {
     DeltaExporter.FILE_NAME: DeltaExporter,
 }
 
-__all__ = ["export_dataset", "write_dataset_index"]
+__all__ = ["export_dataset", "write_dataset_index", "get_exporter_names"]
+
+
+def get_exporter_names(dataset: Dataset) -> set[str]:
+    """The file names of the exporters enabled for the given dataset.
+
+    A dataset which doesn't configure `exports:` runs the default set. The
+    statistics exporter always runs, because the dataset metadata is derived
+    from its output.
+    """
+    names = set(dataset.model.exports)
+    if not len(names):
+        names.update(DEFAULT_EXPORTERS)
+    names.add(StatisticsExporter.FILE_NAME)
+    return names
 
 
 def export_data(context: Context, view: View) -> None:
-    exporter_names = set(context.dataset.model.exports)
-    if not len(exporter_names):
-        exporter_names.update(DEFAULT_EXPORTERS)
-    exporter_names.add(StatisticsExporter.FILE_NAME)
+    exporter_names = get_exporter_names(context.dataset)
     exporters: list[Exporter] = []
     for name in exporter_names:
         clazz = EXPORTERS.get(name)
@@ -94,7 +105,13 @@ def export_dataset(dataset: Dataset, view: View) -> None:
         context.close()
 
     # Export metadata and issues (after the context is closed & flushed)
-    write_delta_index(dataset)
-    write_dataset_index(dataset, DatasetVersionResult.SUCCESS)
+    # The delta index is built from archived delta exports, so it must only be
+    # written for datasets that still produce them - otherwise it would list
+    # versions from before the exporter was turned off
+    # (https://github.com/opensanctions/opensanctions/issues/5140).
+    delta_enabled = DeltaExporter.FILE_NAME in get_exporter_names(dataset)
+    if delta_enabled:
+        write_delta_index(dataset)
+    write_dataset_index(dataset, DatasetVersionResult.SUCCESS, delta_enabled)
     write_catalog(dataset)
     log.info(f"Exported dataset: {dataset.name}")

--- a/zavod/zavod/exporters/metadata/__init__.py
+++ b/zavod/zavod/exporters/metadata/__init__.py
@@ -84,8 +84,15 @@ def get_base_dataset_metadata(dataset: Dataset) -> dict[str, Any]:
     return meta
 
 
-def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
-    """Export dataset metadata to index.json."""
+def write_dataset_index(
+    dataset: Dataset, result: DatasetVersionResult, delta_enabled: bool
+) -> None:
+    """Export dataset metadata to index.json.
+
+    `delta_enabled` states whether the dataset runs the delta exporter, which
+    the caller knows from the exporters it set up. Only then does the index
+    advertise a `delta_url`.
+    """
     catalog = get_catalog()
     version = get_latest(dataset.name, backfill=True)
     if version is None:
@@ -124,24 +131,30 @@ def write_dataset_index(dataset: Dataset, result: DatasetVersionResult) -> None:
         dataset.name, version.id, STATISTICS_FILE
     )
 
-    delta_index_path = dataset_resource_path(dataset.name, DELTA_INDEX_FILE)
-    if delta_index_path.is_file():
-        # Only generated for successful exports:
-        meta["delta_url"] = make_artifact_url(
-            dataset.name, version.id, DELTA_INDEX_FILE
-        )
-    else:
-        # If the delta index is not available, try to find the newest delta index
-        # generate the URL from that:
-        for version in iter_dataset_versions(dataset.name):
-            object = get_artifact_object(
-                dataset.name, DELTA_EXPORT_FILE, version=version.id
+    # A dataset which doesn't run the delta exporter has no delta feed to offer.
+    # Without this check, a dataset that used to export deltas would keep
+    # advertising a delta_url whose newest entry is the last run before the
+    # exporter was turned off, i.e. a stale feed presented as current
+    # (https://github.com/opensanctions/opensanctions/issues/5140).
+    if delta_enabled:
+        delta_index_path = dataset_resource_path(dataset.name, DELTA_INDEX_FILE)
+        if delta_index_path.is_file():
+            # Only generated for successful exports:
+            meta["delta_url"] = make_artifact_url(
+                dataset.name, version.id, DELTA_INDEX_FILE
             )
-            if object is not None:
-                meta["delta_url"] = make_artifact_url(
-                    dataset.name, version.id, DELTA_INDEX_FILE
+        else:
+            # If the delta index is not available, try to find the newest delta index
+            # generate the URL from that:
+            for version in iter_dataset_versions(dataset.name):
+                object = get_artifact_object(
+                    dataset.name, DELTA_EXPORT_FILE, version=version.id
                 )
-                break
+                if object is not None:
+                    meta["delta_url"] = make_artifact_url(
+                        dataset.name, version.id, DELTA_INDEX_FILE
+                    )
+                    break
 
     # Validate against the published output contract before writing. The model
     # knows a failed run legitimately lacks statistics, so a degraded failure

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -13,7 +13,8 @@ from zavod.archive import VERSIONS_FILE, EXTRA_ARTIFACTS
 from zavod.archive import DELTA_EXPORT_FILE, DELTA_INDEX_FILE
 from zavod.runtime.resources import DatasetResources
 from zavod.runtime.versions import get_latest
-from zavod.exporters import write_dataset_index
+from zavod.exporters import get_exporter_names, write_dataset_index
+from zavod.exporters.delta import DeltaExporter
 
 log = get_logger(__name__)
 
@@ -135,7 +136,8 @@ def archive_failure(dataset: Dataset) -> None:
     dataset_resource_path(dataset.name, DELTA_EXPORT_FILE).unlink(missing_ok=True)
     dataset_resource_path(dataset.name, DELTA_INDEX_FILE).unlink(missing_ok=True)
 
-    write_dataset_index(dataset, DatasetVersionResult.FAILURE)
+    delta_enabled = DeltaExporter.FILE_NAME in get_exporter_names(dataset)
+    write_dataset_index(dataset, DatasetVersionResult.FAILURE, delta_enabled)
     path = dataset_resource_path(dataset.name, INDEX_FILE)
     if not path.is_file():
         log.error(f"Metadata file not found: {path}", dataset=dataset.name)

--- a/zavod/zavod/tests/exporters/test_exporters.py
+++ b/zavod/zavod/tests/exporters/test_exporters.py
@@ -12,12 +12,14 @@ from zavod import Context, settings
 from zavod.entity import Entity
 from zavod.integration.dedupe import get_dataset_linker
 from zavod.store import get_store
-from zavod.exporters import export_dataset
+from zavod.exporters import DEFAULT_EXPORTERS, export_dataset, get_exporter_names
 from zavod.archive import clear_data_path, DATASETS
+from zavod.exporters.delta import DeltaExporter
 from zavod.exporters.ftm import FtMExporter
 from zavod.exporters.names import NamesExporter
 from zavod.exporters.simplecsv import SimpleCSVExporter
 from zavod.exporters.statements import StatementsCSVExporter
+from zavod.exporters.statistics import StatisticsExporter
 from zavod.meta import Dataset, get_catalog, load_dataset_from_path
 from zavod.crawl import crawl_dataset
 from zavod.tests.conftest import DATASET_2_YML, COLLECTION_YML
@@ -408,3 +410,37 @@ def test_consolidate_names_never_remove_ofac_names():
     assert set(entities[0].get("name")) == {"John Doe", "The Tiger"}
     # "Tigger" is demoted (even though it's a name in xx_garbage) because it's a weakAlias in xx_garbage
     assert set(entities[0].get("weakAlias")) == {"Tigger", "The Tiger"}
+
+
+def test_get_exporter_names_config_shapes(testdataset1: Dataset) -> None:
+    """Pin how an `exports:` config resolves to the set of exporters that runs,
+    across every shape the config can take."""
+    stats = StatisticsExporter.FILE_NAME
+
+    # No exports: config at all - the dataset runs the default set, which
+    # includes both statistics and deltas.
+    testdataset1.model.exports = set()
+    assert get_exporter_names(testdataset1) == DEFAULT_EXPORTERS
+    assert stats in DEFAULT_EXPORTERS
+    assert DeltaExporter.FILE_NAME in DEFAULT_EXPORTERS
+
+    # An explicit config replaces the defaults entirely, but statistics is
+    # always added because the dataset metadata is derived from it.
+    testdataset1.model.exports = {FtMExporter.FILE_NAME}
+    assert get_exporter_names(testdataset1) == {FtMExporter.FILE_NAME, stats}
+
+    # Naming statistics explicitly makes no difference.
+    testdataset1.model.exports = {FtMExporter.FILE_NAME, stats}
+    assert get_exporter_names(testdataset1) == {FtMExporter.FILE_NAME, stats}
+
+    # A statistics-only config (as ext_us_ofac_press_releases has) resolves to
+    # statistics alone - notably without the delta exporter.
+    testdataset1.model.exports = {stats}
+    names = get_exporter_names(testdataset1)
+    assert names == {stats}
+    assert DeltaExporter.FILE_NAME not in names
+
+    # Resolving the names doesn't mutate the dataset config.
+    testdataset1.model.exports = {FtMExporter.FILE_NAME}
+    get_exporter_names(testdataset1).add(NamesExporter.FILE_NAME)
+    assert testdataset1.model.exports == {FtMExporter.FILE_NAME}

--- a/zavod/zavod/tests/exporters/test_metadata.py
+++ b/zavod/zavod/tests/exporters/test_metadata.py
@@ -1,11 +1,13 @@
 import json
 import logging
 
+from followthemoney.dataset import Version
 from nomenklatura import Resolver
 from pytest import MonkeyPatch
 from structlog.testing import capture_logs
 
 from zavod import settings
+from zavod.archive import DATASETS, DELTA_EXPORT_FILE, DELTA_INDEX_FILE, INDEX_FILE
 from zavod.archive import STATISTICS_FILE, dataset_resource_path
 from zavod.context import Context
 from zavod.crawl import crawl_dataset
@@ -14,6 +16,8 @@ from zavod.exporters import export_dataset, metadata
 from zavod.exporters.metadata import DatasetVersionResult, write_dataset_index
 from zavod.meta import Dataset
 from zavod.exporters.metadata.model import CatalogDatasetModel
+from zavod.publish import _archive_artifacts
+from zavod.runtime.versions import make_version
 from zavod.store import get_store
 
 
@@ -77,7 +81,7 @@ def test_metadata_collection_issue_count(
     context.log.warning("This is a warning")
     context.close()
 
-    write_dataset_index(collection, DatasetVersionResult.SUCCESS)
+    write_dataset_index(collection, DatasetVersionResult.SUCCESS, delta_enabled=True)
 
     index_path = settings.DATA_PATH / "datasets" / collection.name / "index.json"
     with open(index_path) as fh:
@@ -116,7 +120,9 @@ def test_metadata_validation_warns_on_missing_required_field(
     monkeypatch.setattr(metadata, "get_base_dataset_metadata", drop_required_field)
 
     with capture_logs() as cap_logs:
-        write_dataset_index(collection, DatasetVersionResult.SUCCESS)
+        write_dataset_index(
+            collection, DatasetVersionResult.SUCCESS, delta_enabled=True
+        )
 
     assert any(
         entry.get("log_level") == "warning"
@@ -135,7 +141,9 @@ def test_metadata_failure_no_statistics_no_warning(collection: Dataset) -> None:
 
     assert not dataset_resource_path(collection.name, STATISTICS_FILE).is_file()
     with capture_logs() as cap_logs:
-        write_dataset_index(collection, DatasetVersionResult.FAILURE)
+        write_dataset_index(
+            collection, DatasetVersionResult.FAILURE, delta_enabled=True
+        )
 
     assert not [
         entry
@@ -149,3 +157,65 @@ def test_metadata_failure_no_statistics_no_warning(collection: Dataset) -> None:
         index = json.load(fh)
     assert index["result"] == "failure"
     assert "entity_count" not in index
+
+
+def test_delta_url_not_published_when_delta_exporter_disabled(
+    testdataset1: Dataset, resolver: Resolver[Entity]
+) -> None:
+    """A dataset that turned the delta exporter off must stop advertising a
+    delta_url, even though older versions still have delta exports archived.
+
+    Otherwise consumers keep polling a delta feed that is frozen at the last run
+    which had the exporter enabled
+    (https://github.com/opensanctions/opensanctions/issues/5140).
+    """
+    dataset_path = settings.DATA_PATH / DATASETS / testdataset1.name
+    store = get_store(testdataset1, resolver)
+
+    def export_version(version: str) -> None:
+        make_version(
+            testdataset1, Version.new(version), append_new_version_to_history=True
+        )
+        store.clear()
+        writer = store.writer()
+        writer.add_entity(
+            resolver.apply(
+                Entity.from_data(
+                    testdataset1,
+                    {"id": "EA", "schema": "Person", "properties": {"name": ["Alice"]}},
+                )
+            )
+        )
+        writer.flush()
+        export_dataset(testdataset1, store.view(testdataset1))
+
+    # A run with the delta exporter enabled leaves a delta export in the archive.
+    testdataset1.model.exports = {DELTA_EXPORT_FILE}
+    export_version("aaa")
+    assert (dataset_path / DELTA_INDEX_FILE).is_file()
+    _archive_artifacts(testdataset1)
+
+    # The dataset now only exports statistics. Simulate the clean working
+    # directory of a subsequent run, so the delta index can only come from the
+    # archived version above.
+    testdataset1.model.exports = {STATISTICS_FILE}
+    (dataset_path / DELTA_INDEX_FILE).unlink()
+    (dataset_path / DELTA_EXPORT_FILE).unlink()
+    export_version("bbb")
+
+    with open(dataset_path / INDEX_FILE) as fh:
+        index = json.load(fh)
+
+    # Report which versions the feed would have carried, so a failure here shows
+    # the staleness rather than just the presence of the URL.
+    delta_index_path = dataset_path / DELTA_INDEX_FILE
+    feed_versions: list[str] = []
+    if delta_index_path.is_file():
+        with open(delta_index_path) as fh:
+            feed_versions = sorted(json.load(fh)["versions"])
+
+    assert "delta_url" not in index, (
+        f"index for version {index['version']} advertises "
+        f"{index['delta_url']}, but the delta feed only carries {feed_versions}"
+    )
+    assert not delta_index_path.is_file(), feed_versions


### PR DESCRIPTION
Fixes #5140

`write_delta_index()` rebuilds `delta.json` on every export by scanning *archived* versions for `entities.delta.json`, with no reference to whether the dataset still runs the delta exporter. `write_dataset_index()` then saw that file and published a `delta_url` (and failing that, scanned the archive for old delta exports itself and published one anyway):

```python
# export_dataset(), before
write_delta_index(dataset)                                 # unconditional
write_dataset_index(dataset, DatasetVersionResult.SUCCESS) # publishes delta_url if delta.json exists
```

So `ext_us_ofac_press_releases`, whose `exports:` lists only `statistics.json`, kept advertising a delta feed on every daily run — the newest entry frozen at 2025-10-29, the last run before the exporter came off.

## Changes

- `write_dataset_index()` takes `delta_enabled` and only emits `delta_url` when set. Both the local-`delta.json` branch and the archive-backfill branch are gated; the backfill branch is what was producing the stale URL in production.
- `export_dataset()` skips `write_delta_index()` entirely when the exporter is off, so no stale `delta.json` is written or archived.
- `get_exporter_names(dataset)` lifts the four lines `export_data()` already had, so the "empty `exports:` means defaults, statistics always on" rule has one home. `export_dataset()` and `publish.archive_failure()` derive `delta_enabled` from it.

`delta_enabled` is required rather than defaulted deliberately. A default of `True` would have kept the three existing `write_dataset_index()` test call sites untouched, but it also silently reinstates this bug for any future caller who forgets to pass it — the whole defect is a delta decision made by omission. Making it required means the type checker asks every caller, and there are only two in production code.

An earlier draft put the enabled-exporter lookup in a new `exporters/registry.py`, because `metadata` importing `zavod.exporters` for it would be circular. Passing the flag down instead inverts the dependency — `metadata` stays a leaf and gains no new imports — so that module is gone and `DEFAULT_EXPORTERS`/`EXPORTERS` stay exactly where they were.

## Open question

This stops *advertising* the delta feed; it doesn't touch the `entities.delta.json` artifacts already in `/artifacts/{dataset}/{version}/`. They stay reachable by direct URL for anyone who bookmarked one, and if a dataset ever re-enables the exporter, `write_delta_index()` will pick those pre-gap versions back up and list them alongside new ones — a feed with a silent hole in the middle. Options are to leave them (current behaviour), or have the delta index stop at the first gap. Happy to follow up if you'd prefer the latter, but it seemed out of scope for the fix.

## Manual cleanup

The stale `delta.json` already published for `ext_us_ofac_press_releases` won't be removed by this — the next run just stops linking it, and the copy under `datasets/latest/ext_us_ofac_press_releases/` stays until someone deletes it from the bucket by hand. That matches the existing `_warn_about_stale_latest_files()` policy of warning rather than auto-deleting.

## Verification

- New regression test `test_delta_url_not_published_when_delta_exporter_disabled` reproduces the production scenario: export with the exporter on, archive it, switch `exports` to statistics-only, clear the working dir as a fresh run would, export again. Confirmed red on a pre-fix worktree of main — `index for version …-bbb advertises …/…-bbb/delta.json, but the delta feed only carries ['…-aaa']` — and green here.
- `test_get_exporter_names_config_shapes` pins the exporter resolution across all four config shapes (no `exports:`, explicit without statistics, explicit with statistics, statistics-only), since nothing covered it before. Verified to fail under three separate mutations of the resolution logic.
- `make lint` — clean.
- `pytest zavod/tests/` — 289 passed (287 pre-existing + 2 new).
- `mypy --strict --exclude zavod/tests zavod/` — clean, 124 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
