### PR TITLE
Give Zyte API requests their own, longer timeout

### DIFF
--- a/datasets/th/cabinet/th_cabinet.yml
+++ b/datasets/th/cabinet/th_cabinet.yml
@@ -29,12 +29,6 @@ url: https://www.thaigov.go.th/en/cabinet/minister
 data:
   url: https://www.thaigov.go.th/en/cabinet/minister
   format: HTML
-http:
-  # The source sits behind a Cloudflare "Just a moment..." JS challenge, which
-  # Zyte solves via browser rendering. Solving it can take longer than the
-  # default 60s read timeout, so give the Zyte API more time to respond.
-  timeout: 180
-
 assertions:
   min:
     schema_entities:

--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -82,7 +82,8 @@ HTTP requests for GET requests are automatically retried for connection and HTTP
 
 - `http`
     - `user_agent`: string, defaults to the value of the FTM_USER_AGENT setting. Set a custom value for the `User-Agent` header if needed.
-    - `timeout`: integer in seconds, default `60`. Connect and read timeout applied to both the context HTTP session and Zyte API requests. Increase it for sources that are slow to respond.
+    - `timeout`: integer in seconds, default `60`. Connect and read timeout for the context HTTP session. Increase it for sources that are slow to respond.
+    - `zyte_timeout`: integer in seconds, default `300`. Connect and read timeout for Zyte API requests, which is separate because the timeout covers a whole proxied fetch — exit node selection, browser rendering and Zyte's own ban retries — rather than a single request to the source. Lower it only to fail faster on a source known to be unreachable; timing out below Zyte's own budget discards work it has already done.
     - `backoff_factor`: float, default `1`. [Scales the exponential backoff](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.DEFAULT_ALLOWED_METHODS:~:text=with%20None.-,backoff_factor,-(float)%20%E2%80%93).
     - `max_retries`: integer in seconds, default `3`
     - `retry_methods`: List of strings, [default](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.DEFAULT_ALLOWED_METHODS) `['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT', 'TRACE']`

--- a/zavod/zavod/extract/zyte_api.py
+++ b/zavod/zavod/extract/zyte_api.py
@@ -127,7 +127,7 @@ def fetch_resource(
     out_path.parent.mkdir(parents=True, exist_ok=True)
     configure_session(context.http)
 
-    timeout = context.dataset.http.timeout
+    timeout = context.dataset.http.zyte_timeout
     api_response = context.http.post(
         ZYTE_API_URL,
         auth=(settings.ZYTE_API_KEY, ""),
@@ -272,7 +272,7 @@ def fetch(
     context.log.debug(f"Zyte API request: {zyte_request.url}", data=zyte_data)
     configure_session(context.http)
 
-    timeout = context.dataset.http.timeout
+    timeout = context.dataset.http.zyte_timeout
     api_response = context.http.post(
         ZYTE_API_URL,
         auth=(settings.ZYTE_API_KEY, ""),

--- a/zavod/zavod/meta/http.py
+++ b/zavod/zavod/meta/http.py
@@ -25,9 +25,11 @@ class HTTP:
                 "Both 'retry_statuses' and 'additional_retry_statuses' are set."
             )
 
-        # Connect and read timeout in seconds, adhered to by both the context
-        # HTTP session and Zyte API requests.
+        # Connect and read timeout in seconds for the context HTTP session.
         self.timeout: int = data.get("timeout", settings.HTTP_TIMEOUT)
+        # Zyte API requests get their own, longer budget: the timeout covers a
+        # full proxied fetch on Zyte's side, not just one request to the source.
+        self.zyte_timeout: int = data.get("zyte_timeout", settings.ZYTE_TIMEOUT)
         self.backoff_max: int = settings.HTTP_RETRY_BACKOFF_MAX
         self.retry_statuses: list[int] = list(statuses)
         retry_methods: list[str] = ensure_list(

--- a/zavod/zavod/settings.py
+++ b/zavod/zavod/settings.py
@@ -56,10 +56,16 @@ ARCHIVE_BACKFILL_STATEMENTS = as_bool(
 BACKFILL_RELEASE = env_str("ZAVOD_BACKFILL_RELEASE", "latest")
 
 # HTTP settings
-# Connect and read timeout in seconds, applied to both the context HTTP session
-# and Zyte API requests. Can be overridden per-dataset via the `http.timeout`
-# metadata option.
+# Connect and read timeout in seconds for the context HTTP session. Can be
+# overridden per-dataset via the `http.timeout` metadata option.
 HTTP_TIMEOUT = 60
+# A Zyte API request wraps a whole proxied fetch — picking an exit node, browser
+# rendering, and Zyte's own retries against bans — so a healthy one routinely
+# takes minutes, far longer than a direct request to the same page. Timing out
+# below Zyte's own budget just burns the work it already did and, because
+# configure_session retries the POST, multiplies one slow page into a long stall.
+# Overridable per-dataset via the `http.zyte_timeout` metadata option.
+ZYTE_TIMEOUT = int(env.get("ZAVOD_ZYTE_TIMEOUT", 300))
 HTTP_RETRY_TOTAL = int(env.get("ZAVOD_HTTP_RETRY_TOTAL", 3))
 HTTP_RETRY_BACKOFF_FACTOR = float(env.get("ZAVOD_HTTP_RETRY_BACKOFF_FACTOR", 1.0))
 # urllib.util.Retry.DEFAULT_BACKOFF_MAX is 120

--- a/zavod/zavod/tests/test_dataset.py
+++ b/zavod/zavod/tests/test_dataset.py
@@ -3,6 +3,7 @@ from followthemoney.exc import MetadataException
 from followthemoney.model import Model
 from followthemoney.settings import USER_AGENT
 
+from zavod import settings
 from zavod.meta import Dataset, get_catalog, get_multi_dataset
 from zavod.meta.assertion import Assertion
 from zavod.runtime.urls import make_published_url
@@ -88,6 +89,16 @@ def test_basic():
     assert test_ds.http.retry_methods == ["GET"]
     assert test_ds.http.backoff_factor == 0.5
     assert test_ds.http.user_agent == USER_AGENT
+    # Neither timeout is set above, so both fall back to their settings default.
+    # Zyte's is the longer one: it budgets for a whole proxied fetch.
+    assert test_ds.http.timeout == settings.HTTP_TIMEOUT
+    assert test_ds.http.zyte_timeout == settings.ZYTE_TIMEOUT
+    assert test_ds.http.zyte_timeout > test_ds.http.timeout
+    # Each can be overridden independently.
+    timeout_meta = {**TEST_DATASET, "http": {"timeout": 5, "zyte_timeout": 15}}
+    timeout_ds = catalog.make_dataset(timeout_meta)
+    assert timeout_ds.http.timeout == 5
+    assert timeout_ds.http.zyte_timeout == 15
 
     person_schema = Model.instance().get("Person")
     person_spec = test_ds.names.get_spec(person_schema)


### PR DESCRIPTION
`6e4918ebc` lowered `HTTP_TIMEOUT` from 1200s to 60s and started passing it explicitly to the Zyte API POSTs. 60s is a sensible ceiling for a direct request to a source, but a Zyte request is not that — the timeout has to cover picking an exit node, browser rendering, and Zyte's own retries against bans, so a healthy one routinely takes minutes.

Timing out below Zyte's own budget is worse than waiting: it discards work Zyte has already done, and because `configure_session` retries the POST 10 times with backoff, one slow page turns into a stall of many minutes before the crawler finally gives up.

## Change

- `HTTP_TIMEOUT` stays 60s, now documented as applying to the context session only.
- New `ZYTE_TIMEOUT` (300s, env `ZAVOD_ZYTE_TIMEOUT`), read by both Zyte API POSTs.
- New per-dataset `http.zyte_timeout` override, documented in `metadata.md`.
- Removed `th_cabinet`'s `timeout: 180` — the only such override in the tree. It was added for exactly this reason (its comment said so), the crawler fetches solely through Zyte, and the new 300s default supersedes it. Left in place it would only cap the unused direct session, at a value *below* the new default.

## How this surfaced

`et_hopr` failed in production with a Zyte `ReadTimeout` at 60s. The timeout turned out not to be that crawler's real problem — Zyte returns `520 Website Ban` on that source regardless, so it is [being moved off Zyte separately](#5185). But it did expose that one number was being applied to two transports with very different latency profiles.

## Verification

- `mypy --strict` on `zavod/`: clean, 124 files.
- `pytest zavod/tests/`: 287 passed. `test_dataset.py` extended to cover both defaults (asserting Zyte's exceeds the session's) and independent overrides.
- `prek` hooks pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)