### PR TITLE
[et_hopr] Fetch directly instead of via Zyte

### DIFF
--- a/datasets/et/hopr/crawler.py
+++ b/datasets/et/hopr/crawler.py
@@ -7,12 +7,9 @@ from normality import squash_spaces
 from zavod import Context
 from zavod import helpers as h
 from zavod.entity import Entity
-from zavod.extract import zyte_api
 from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.util import Element
 
-
-UNBLOCK_VALIDATOR = './/a[contains(@href, "Members/Index?ElectionId=")]'
 # Terms have up to ~68 pages of eight members; this only guards against the
 # pagination never terminating.
 MAX_PAGES = 100
@@ -45,16 +42,11 @@ class Term:
 
 
 def fetch_page(context: Context, url: str) -> Element:
-    return zyte_api.fetch_html(
-        context,
+    return context.fetch_html(
         url,
-        unblock_validator=UNBLOCK_VALIDATOR,
-        geolocation="et",
         # English names, party and region are only served with this cookie;
         # without it the site responds in Amharic.
-        request_cookies=[
-            {"name": "language", "value": "en", "domain": "www.hopr.gov.et"}
-        ],
+        headers={"Cookie": "language=en"},
         cache_days=14,
     )
 
@@ -67,7 +59,9 @@ def discover_terms(context: Context, doc: Element) -> list[Term]:
     emitted with guessed dates.
     """
     terms: dict[int, Term] = {}
-    for link in h.xpath_elements(doc, UNBLOCK_VALIDATOR):
+    for link in h.xpath_elements(
+        doc, './/a[contains(@href, "Members/Index?ElectionId=")]'
+    ):
         href = h.xpath_string(link, "./@href")
         id_match = re.search(r"ElectionId=(\d+)", href)
         # The switcher labels read like "6th Term MP"; this also excludes the

--- a/datasets/et/hopr/et_hopr.yml
+++ b/datasets/et/hopr/et_hopr.yml
@@ -6,7 +6,7 @@ coverage:
   frequency: monthly
   start: 2026-07-23
 load_statements: true
-ci_test: false  # Zyte
+ci_test: false  # Paginates every term, well over the 2 minute CI budget.
 summary: >-
   Members of the House of Peoples' Representatives, the lower chamber of the
   Ethiopian federal parliament.
@@ -61,10 +61,10 @@ tags:
 assertions:
   min:
     schema_entities:
-      Person: 1500
+      Person: 600
       Position: 1
     country_entities:
-      et: 1500
+      et: 600
   max:
     schema_entities:
       Person: 2500


### PR DESCRIPTION
`et_hopr` has never completed a run. In production it fails on a Zyte `ReadTimeout`, but the timeout is a symptom — **Zyte cannot reach this source at all**:

| Fetch path | Result |
|---|---|
| Zyte `browserHtml` + `geolocation=et` | 520 Website Ban after 115s |
| Zyte `browserHtml`, no geolocation | 520 Website Ban after 92s |
| Zyte `httpResponseBody` + `geolocation=et` | 520 Website Ban after 113s |
| **Direct request + `language=en` cookie** | **HTTP 200 in 1.5s** |

Zyte's message: *"Zyte API could not get a ban-free response in a reasonable time."*

## Why Zyte was there

#5055 introduced it on the premise that the source is geo-blocked — *"unreachable from ordinary egress (DNS resolves, TCP times out / 403 from non-Ethiopian networks)"*. That premise is wrong: the site answers an unauthenticated request from a non-Ethiopian network in 1.5s, with a valid TLS cert, server-rendered HTML and no JS. That PR was self-described as unverified and its other assumptions had already needed correcting (it modelled a `listofmps` Liferay table, since rewritten to `Members/Index` cards).

So this fetches the pages directly. The `language=en` cookie is still required — as a header now; without it the site serves names and regions in Amharic. `ci_test` stays `false` but the comment now gives the real reason (runtime), since Zyte is no longer involved.

## Assertions

Lowered the `Person` floor from 1500 to 600. 1500 was an estimate ("up to ~547 members" × terms) written before any run had succeeded. A full crawl emits **1039** people:

| Term | Period | Emitted |
|---|---|---|
| 6 | 2021– | 503 (`current`) |
| 5 | 2015–2021 | 536 (`ended`) |
| 4, 3, 2 | 2010–2015, 2005–2010, 2000–2005 | 0 |
| 1 | 1995–2000 | 0 — source publishes no member cards |

Nothing is lost in parsing: the source really does publish ~500 per term (term 6: 63 pages / 503 distinct MemberIds). Terms 2–4 are fetched but every occupancy is dropped by `make_occupancy`, which discards terms ended beyond the after-office window (~10 years) — stricter than the deliberately slack-laden `h.earliest_term_start()` the crawler filters on. They are still fetched, so they start counting again if that policy changes.

⚠️ One thing to know: term 6 alone is ~503, so when term 5 ages out of the after-office window (around 2031) the count drops to roughly that and a 600 floor will start failing on its own.

## Verification

- Full crawl: 9 minutes, 2079 entities, 12389 statements, **empty `issues.log`** — no warnings, no errors.
- `zavod validate`: passes.
- `mypy --strict` and `contrib/lint_dataset.sh`: clean.

Related but independent: #5184 splits the Zyte timeout out from `HTTP_TIMEOUT`. This PR does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)