### PR TITLE
Declare topics on QID-keyed legislature positions

### DIFF
--- a/datasets/au/act_parliament/crawler.py
+++ b/datasets/au/act_parliament/crawler.py
@@ -88,6 +88,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Australian Capital Territory Legislative Assembly",
         country="au",
+        topics=["gov.state", "gov.legislative"],
         subnational_area="Australian Capital Territory",
         wikidata_id="Q6814365",
         lang="eng",

--- a/datasets/au/nt_parliament/crawler.py
+++ b/datasets/au/nt_parliament/crawler.py
@@ -77,6 +77,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Legislative Assembly of the Northern Territory",
         country="au",
+        topics=["gov.state", "gov.legislative"],
         subnational_area="Northern Territory",
         wikidata_id="Q26998278",
         lang="eng",

--- a/datasets/au/qld_parliament/crawler.py
+++ b/datasets/au/qld_parliament/crawler.py
@@ -99,6 +99,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Legislative Assembly of Queensland",
         country="au",
+        topics=["gov.state", "gov.legislative"],
         subnational_area="Queensland",
         wikidata_id="Q18526194",
         lang="eng",

--- a/datasets/au/wa_parliament/crawler.py
+++ b/datasets/au/wa_parliament/crawler.py
@@ -104,6 +104,7 @@ def crawl(context: Context) -> None:
             context,
             name=config["name"],
             country="au",
+            topics=["gov.state", "gov.legislative"],
             subnational_area="Western Australia",
             wikidata_id=config["wikidata_id"],
             lang="eng",

--- a/datasets/az/parliament/crawler.py
+++ b/datasets/az/parliament/crawler.py
@@ -149,6 +149,7 @@ def crawl_member(context: Context, url: str, name: str) -> None:
         context,
         name="Member of the National Assembly of Azerbaijan",
         country="az",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21269547",
         lang="eng",
     )

--- a/datasets/ba/parliament/crawler.py
+++ b/datasets/ba/parliament/crawler.py
@@ -179,6 +179,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the House of Representatives of Bosnia and Herzegovina",
         country="ba",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21290855",
         lang="eng",
     )
@@ -186,6 +187,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the House of Peoples of Bosnia and Herzegovina",
         country="ba",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21328613",
         lang="eng",
     )

--- a/datasets/br/federal_senate/crawler.py
+++ b/datasets/br/federal_senate/crawler.py
@@ -8,6 +8,7 @@ def crawl(context: Context) -> None:
         context,
         name="Senator of Brazil",
         country="br",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q18964326",
         lang="eng",
     )

--- a/datasets/by/council_republic/crawler.py
+++ b/datasets/by/council_republic/crawler.py
@@ -55,6 +55,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Council of the Republic of Belarus",
         country="by",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q15623433",
         lang="eng",
     )

--- a/datasets/by/house_representatives/crawler.py
+++ b/datasets/by/house_representatives/crawler.py
@@ -100,6 +100,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the House of Representatives of Belarus",
         country="by",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q14335901",
         lang="eng",
     )

--- a/datasets/ci/national_assembly/crawler.py
+++ b/datasets/ci/national_assembly/crawler.py
@@ -124,6 +124,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the National Assembly of Côte d'Ivoire",
         country="ci",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21295981",
         lang="eng",
     )

--- a/datasets/cm/national_assembly/crawler.py
+++ b/datasets/cm/national_assembly/crawler.py
@@ -44,6 +44,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the National Assembly of Cameroon",
         country="cm",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21295975",
         lang="eng",
     )

--- a/datasets/cm/senate/crawler.py
+++ b/datasets/cm/senate/crawler.py
@@ -8,6 +8,7 @@ def crawl(context: Context) -> None:
         context,
         name="Senator of Cameroon",
         country="cm",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21295128",
         lang="eng",
     )

--- a/datasets/cn/npc/crawler.py
+++ b/datasets/cn/npc/crawler.py
@@ -108,6 +108,7 @@ def crawl(context: Context) -> None:
         context,
         "Member of the National People's Congress of China",
         country="cn",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q10891456",
         lang="eng",
     )

--- a/datasets/cn/peoples_congress_wikipedia/crawler.py
+++ b/datasets/cn/peoples_congress_wikipedia/crawler.py
@@ -111,6 +111,7 @@ def crawl_item(
         context,
         "Member of the National People's Congress of China",
         country="cn",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q10891456",
         lang="eng",
     )

--- a/datasets/cu/inventario_legislatura/crawler.py
+++ b/datasets/cu/inventario_legislatura/crawler.py
@@ -34,6 +34,7 @@ def crawl(context: Context) -> None:
         context,
         "Member of the National Assembly of People's Power of Cuba",
         country="cu",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21272829",
         lang="eng",
     )

--- a/datasets/dz/apn/crawler.py
+++ b/datasets/dz/apn/crawler.py
@@ -68,6 +68,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the People's National Assembly of Algeria",
         country="dz",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21290886",
         lang="eng",
     )

--- a/datasets/dz/council_nation/crawler.py
+++ b/datasets/dz/council_nation/crawler.py
@@ -108,6 +108,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Council of the Nation of Algeria",
         country="dz",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21290885",
         lang="eng",
     )

--- a/datasets/eg/house_representatives/crawler.py
+++ b/datasets/eg/house_representatives/crawler.py
@@ -85,6 +85,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the House of Representatives of Egypt",
         country="eg",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21290857",
         lang="eng",
     )

--- a/datasets/et/hopr/crawler.py
+++ b/datasets/et/hopr/crawler.py
@@ -184,6 +184,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the House of Peoples' Representatives of Ethiopia",
         country="et",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21328614",
         lang="eng",
     )

--- a/datasets/fj/parliament/crawler.py
+++ b/datasets/fj/parliament/crawler.py
@@ -58,6 +58,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Parliament of Fiji",
         country="fj",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q18145348",
         lang="eng",
     )

--- a/datasets/gb/lords/crawler.py
+++ b/datasets/gb/lords/crawler.py
@@ -42,6 +42,7 @@ def crawl_member(
         context,
         name="Member of the House of Lords",
         country="gb",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q18952564",
         lang="eng",
     )

--- a/datasets/ge/parliament/crawler.py
+++ b/datasets/ge/parliament/crawler.py
@@ -78,6 +78,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Parliament of Georgia",
         country="ge",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21290878",
         lang="eng",
     )

--- a/datasets/lv/saeima/crawler.py
+++ b/datasets/lv/saeima/crawler.py
@@ -47,6 +47,7 @@ def crawl_item(context: Context, unid: str) -> None:
         context,
         "Member of the Saeima of Latvia",
         country="lv",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21191589",
         lang="eng",
     )

--- a/datasets/ma/house_councillors/crawler.py
+++ b/datasets/ma/house_councillors/crawler.py
@@ -136,6 +136,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the House of Councillors of Morocco",
         country="ma",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21328580",
         lang="eng",
     )

--- a/datasets/mc/conseil_national/crawler.py
+++ b/datasets/mc/conseil_national/crawler.py
@@ -40,6 +40,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the National Council of Monaco",
         country="mc",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21328626",
         lang="eng",
     )

--- a/datasets/mx/deputies/crawler.py
+++ b/datasets/mx/deputies/crawler.py
@@ -40,6 +40,7 @@ def crawl_item(context: Context, input_dict: dict[str, Any]) -> None:
         context,
         "Member of the Chamber of Deputies of Mexico",
         country="mx",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q18534310",
         lang="eng",
     )

--- a/datasets/mx/senators/crawler.py
+++ b/datasets/mx/senators/crawler.py
@@ -135,6 +135,7 @@ def crawl(context: Context) -> None:
         context,
         "Member of the Senate of Mexico",
         country="mx",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q19971999",
         lang="eng",
     )

--- a/datasets/nl/house_of_representatives/crawler.py
+++ b/datasets/nl/house_of_representatives/crawler.py
@@ -74,6 +74,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the House of Representatives of the Netherlands",
         country="nl",
+        topics=["gov.national", "gov.legislative"],
         summary="Member of the lower house of the bicameral parliament of the Netherlands, the States General",
         wikidata_id="Q18887908",
         lang="eng",

--- a/datasets/nu/assembly/crawler.py
+++ b/datasets/nu/assembly/crawler.py
@@ -48,6 +48,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Niue Assembly",
         country="nu",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q40011889",
         lang="eng",
     )

--- a/datasets/pg/parliament/crawler.py
+++ b/datasets/pg/parliament/crawler.py
@@ -153,6 +153,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the National Parliament of Papua New Guinea",
         country="pg",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21294916",
         lang="eng",
     )

--- a/datasets/pk/na_members/crawler.py
+++ b/datasets/pk/na_members/crawler.py
@@ -93,6 +93,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the National Assembly of Pakistan",
         country="pk",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q20760546",
         lang="eng",
     )

--- a/datasets/pk/senate_members/crawler.py
+++ b/datasets/pk/senate_members/crawler.py
@@ -96,6 +96,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Senate of Pakistan",
         country="pk",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q20081441",
         lang="eng",
     )

--- a/datasets/sk/nrsr_poslanci/crawler.py
+++ b/datasets/sk/nrsr_poslanci/crawler.py
@@ -86,6 +86,7 @@ def crawl(context: Context) -> None:
         context,
         POSITION_NAME,
         country="sk",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id=POSITION_QID,
         lang="eng",
     )

--- a/datasets/sm/consiglio/crawler.py
+++ b/datasets/sm/consiglio/crawler.py
@@ -56,6 +56,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Grand and General Council of San Marino",
         country="sm",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q20968670",
         lang="eng",
     )

--- a/datasets/tn/arp/crawler.py
+++ b/datasets/tn/arp/crawler.py
@@ -21,6 +21,7 @@ def crawl(context: Context) -> None:
         context,
         name="Member of the Assembly of the Representatives of the People of Tunisia",
         country="tn",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q29169698",
         lang="eng",
     )

--- a/datasets/tr/parliament/crawler.py
+++ b/datasets/tr/parliament/crawler.py
@@ -101,6 +101,7 @@ def crawl_item(context: Context, item: Element) -> None:
         context,
         "Member of the Grand National Assembly of Turkey",
         country="tr",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q21030356",
         lang="eng",
     )


### PR DESCRIPTION
Follow-up to https://github.com/opensanctions/opensanctions/pull/5165. 37 of the 131 `make_position` calls that pass a static QID declared no `topics`.

- 33 national legislature memberships → `["gov.national", "gov.legislative"]`
- 4 Australian state parliaments (ACT, NT, QLD, WA) → `["gov.state", "gov.legislative"]`, matching what `au/nsw`, `au/vic`, `au/sa` and `au/tas` already pass

Every one is a plain member-of-the-legislature position, so the topics follow from the chamber. Inserted after `country=` to match the dominant argument order.

Skipped: `pg/parliament:107`, the provincial governor position. PNG governors also sit in the National Parliament, so I'm not sure whether that's `gov.executive` or `gov.legislative`, and it's the one case where the answer isn't mechanical.

This may be a no-op for the data: every one of these datasets calls `categorise()`, so positions that have been running a while likely already carry topics in the categorisation table. This fixes what the crawler *declares*, which is what feeds the `make_occupancy` after-office window on a fresh position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
