### PR TITLE
Document position topics, name recognizability and QID verification

### DIFF
--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -34,7 +34,7 @@ corpus, are authoritative here.
 
 In addition to the general checks (fields, date formats, language, record count):
 
-- Is there a Wikidata ID for the position(s)? (See `zavod/docs/peps.md`; skip QIDs for per-municipality / per-region positions.)
+- Is there a Wikidata ID for the position(s)? (See `zavod/docs/peps.md`; skip QIDs for per-municipality / per-region positions.) Before using one, check on Wikidata that the item is `instance of (P31): position` and that its `applies to jurisdiction (P1001)` matches the country — a plausible label is not enough. The item's English label usually makes a good position name.
 - What are the position types (parliament, cabinet, judiciary, etc.)?
 - Current members only, or historical terms too?
 - Are start/end dates provided?
@@ -109,6 +109,14 @@ Build position names with `h.make_position`. Rules:
       (then `lang="eng"`) is fine instead — see the subnational variant in
       `examples.md`.
 - Include the role, the organisational body where relevant, and the geographic jurisdiction. For members of national parliaments, include `citizenship` (except UK Parliament).
+- A national position's name must be recognizable as belonging to that country when read
+  on its own — either a nationality adjective (`Member of the Swedish Riksdag`) or an
+  of-phrase (`Member of the Senate of the Italian Republic`).
+- **Pass `topics=`** for positions the crawler names itself (`["gov.national", "gov.legislative"]`,
+  `["gov.state", ...]` for sub-national, `gov.executive`/`gov.judicial` by branch). Omit them
+  for positions read out of the source data, where the review and classification system
+  decides. Vocabulary:
+  https://www.opensanctions.org/docs/pep/methodology/
 - Avoid: legislative term, an elected official's constituency, or the country for sub-national representatives.
 - `wikidata_id` becomes the position's entity ID, so never pass the same QID to multiple distinct positions — they'd collapse into one entity. Per-municipality/region positions usually omit `wikidata_id` (per-locality QIDs rarely exist on Wikidata) and rely on `subnational_area=...` to disambiguate; pass a QID only when each subnational position has its own unique Wikidata entry.
 

--- a/.claude/skills/crawler-pep/examples.md
+++ b/.claude/skills/crawler-pep/examples.md
@@ -55,8 +55,9 @@ def crawl_member(
 def crawl(context: Context) -> None:
     position = h.make_position(
         context,
-        name="Member of Parliament",
+        name="Member of the Parliament of Examplia",
         country="xx",
+        topics=["gov.national", "gov.legislative"],
         wikidata_id="Q...",
         lang="eng",  # crawler-supplied names are always English
     )
@@ -80,6 +81,8 @@ PEP status is determined by the UI review workflow, not the crawler.
 ```python
 def crawl_member(context: Context, row: dict[str, Any]) -> None:
     role = row.pop("role")  # source-supplied, in French
+    # No topics: the crawler doesn't know which position this is, so the review and
+    # classification system decides both PEP status and topics.
     position = h.make_position(
         context, name=role, country="fr", lang="fra", translate_name=True
     )
@@ -133,6 +136,7 @@ position = h.make_position(
     context,
     name=f"{res.value} of {commune_label}",   # English name + locality
     country="lu",
+    topics=["gov.muni", "gov.executive"],     # the role and tier are known; only the locality varies
     subnational_area=commune_label,           # NOT wikidata_id — per-locality
     lang="eng",                               # already English after the lookup
 )
@@ -160,12 +164,12 @@ For sources that list officials across known, enumerable position types:
 ```python
 POSITIONS: dict[str, dict[str, Any]] = {
     "dail": {
-        "name": "Member of Dail Eireann",
+        "name": "Member of the Dáil of Ireland",
         "wikidata_id": "Q654291",
     },
     "seanad": {
-        "name": "Senator of Seanad Eireann",
-        "wikidata_id": "Q1396622",
+        "name": "Senator of Ireland",
+        "wikidata_id": "Q18043391",
     },
 }
 
@@ -176,6 +180,7 @@ def crawl(context: Context) -> None:
             context,
             name=config["name"],
             country="ie",
+            topics=["gov.national", "gov.legislative"],
             wikidata_id=config.get("wikidata_id"),
             lang="eng",
         )

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -66,6 +66,8 @@ prohibitions, not low priorities.
 
 The [Position](https://www.opensanctions.org/reference/#schema.Position) `name` property should ideally capture the position and its jurisdiction, but be no more specific than that.
 
+Pass `topics` for positions the crawler names itself, where it knows which position it is building. Omit them for positions read out of the source data, where the review and classification system decides. The vocabulary is described in the [PEP methodology](https://www.opensanctions.org/docs/pep/methodology/).
+
 !!! info "Supplying Wikidata QIDs"
     Most political positions in the world already exist in Wikidata. If your crawler emits only
     a small number of positions, it is best practice to look up the Wikidata QIDs for these
@@ -96,7 +98,11 @@ Do
   to English is an acceptable alternative.
 - include the role
 - include the organizational body where needed
-- include the specific geographic jurisdiction where relevant
+- include the specific geographic jurisdiction where relevant. A national position's
+  name should be recognizable as belonging to that country to someone reading the
+  name on its own — either construction works, a nationality adjective (`Member of
+  the Swedish Riksdag`) or an of-phrase (`Member of the Senate of the Italian
+  Republic`).
 - refer to [Wikidata EveryPolitician](https://www.wikidata.org/wiki/Wikidata:WikiProject_every_politician)
   for examples, specifically [position Q4164871](https://www.wikidata.org/wiki/Q4164871).
   Much careful work has been done there on defining positions in understandable
@@ -112,7 +118,7 @@ Avoid
 
 - Prefer `United States representative` over `Member of the House of Representatives` -
   while it's true that they're a member of the house of representatives, the
-  common generic term is United States representative.
+  common generic term is United States representative, and it names the country.
 - Prefer `Member of the Landtag of Mecklenburg-Vorpommern` over `Member of the Landtag of Mecklenburg-Vorpommern, Germany` -
   the country is already captured
   as a property of the entity.

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -47,6 +47,10 @@ def make_position(
         summary: A short summary of the position.
         description: A longer description of the position.
         country: The country or countries the position is in.
+        topics: The scope and role of the position, e.g. `["gov.national",
+            "gov.legislative"]`. Pass these for positions the crawler names itself;
+            omit them for positions read out of the source data, where the review and
+            classification system decides.
         subnational_area: The state or district the position is in.
         organization: The organization the position is a part of.
         inception_date: The date the position was created.
@@ -56,6 +60,8 @@ def make_position(
         source_url: The URL of the source the position was found in.
         lang: Override the dataset language when the position details are in a
             non-default language.
+        id_hash_prefix: Namespace the generated entity ID, so that positions built
+            from the same name in different contexts do not collide.
         translate_name: If True and the resolved source language is non-English,
             the position name is translated to English via an LLM and stored as
             the `name` (with the original kept as the value's original_value).


### PR DESCRIPTION
Follow-up to the position cleanup in https://github.com/opensanctions/opensanctions/pull/5165 and https://github.com/opensanctions/opensanctions/pull/5186 — the skill and docs didn't say to do any of what those PRs fixed.

- `topics`: pass them for positions the crawler names itself, omit for source-supplied ones where the UI decides. Added to `peps.md`, `SKILL.md`, the `make_position` docstring, and three of the four `examples.md` calls (the source-supplied one gets a comment saying why it has none). Vocabulary links to https://www.opensanctions.org/docs/pep/methodology/ rather than restating it.
- Name should be recognizable as belonging to its country when read on its own — either construction works, `Member of the Swedish Riksdag` or `Member of the Senate of the Italian Republic`.
- QIDs: verify `instance of (P31): position` and `applies to jurisdiction (P1001)` before use. Which caught a live bug — `examples.md` keyed the Seanad on Q1396622, a Mexican football league. Fixed to Q18043391, and the two Irish names now match the merged crawler.
- Docstring also gained the missing `id_hash_prefix` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
