### PR TITLE
[egrul] Track source file provenance, and use it to fix end dates

### DIFF
--- a/contrib/egrul/README.md
+++ b/contrib/egrul/README.md
@@ -12,17 +12,18 @@ Install a JVM (on macOS):
 	brew install openjdk@21
 	export JAVA_HOME=$(/usr/libexec/java_home -v 21)
 
-Get some new data. This must be done on rivne.
-
-	pushd ~/operations/workspace/; ./sync-egrul.sh; popd
+New source archives arrive in `gs://egrul.opensanctions.org` on their own: a systemd
+timer on the workspace VM (whose IP is allow-listed at the source) runs
+`operations/workspace/sync-egrul.sh` daily at 03:00, which mirrors any new zips from
+the source into the bucket.
 
 Run:
 
 	# Install pyspark
-	pip install -r contrib/egrul/requirements.txt
-	# Use a persistent local cache of the internal-data bucket
-	mkdir ~/internal-data
-	export LOCAL_BUCKET_CACHE_DIR="$HOME/internal-data"
+	uv pip install -r contrib/egrul/requirements.txt
+	# Use a persistent local cache of the source bucket
+	mkdir ~/egrul.opensanctions.org-cache
+	export LOCAL_BUCKET_CACHE_DIR="$HOME/egrul.opensanctions.org-cache"
 
 	# Run the job!
 	spark-submit --master 'local[*]' -c "spark.driver.memory=10g" --py-files contrib/egrul/egrul_xml.py,contrib/egrul/address.py,contrib/egrul/parse_context.py,contrib/egrul/schema.py contrib/egrul/generate.py
@@ -46,4 +47,4 @@ that last listed it and the archive that stopped listing it.
 
 Until this runs as a cronjobs, here is how:
 
-    gsutil cp -rZ ~/internal-data/ru_egrul/processed/current_2025_01_14 gs://internal-data.opensanctions.org/ru_egrul/processed_2025-01-14
+    gcloud storage cp -r --gzip-local-all ~/egrul.opensanctions.org-cache/ru_egrul/processed/current_2025_01_14 gs://internal-data.opensanctions.org/ru_egrul/processed_2025-01-14

--- a/contrib/egrul/README.md
+++ b/contrib/egrul/README.md
@@ -43,6 +43,13 @@ than one archive: an ownership or directorship that ended carries both the archi
 that last listed it and the archive that stopped listing it.
 
 
+To see the source XML behind a record, feed an `origin` back to the debug tool:
+
+	python contrib/egrul/debug/extract_entity.py \
+		"$LOCAL_BUCKET_CACHE_DIR/egrul/EGRUL_408/15.03.2026/EGRUL408_2026-03-15_1.zip" \
+		2630027580
+
+
 ## Copy finished data to internal-data bucket
 
 Until this runs as a cronjobs, here is how:

--- a/contrib/egrul/README.md
+++ b/contrib/egrul/README.md
@@ -25,12 +25,34 @@ Run:
 	mkdir ~/egrul.opensanctions.org-cache
 	export LOCAL_BUCKET_CACHE_DIR="$HOME/egrul.opensanctions.org-cache"
 
-	# Run the job!
-	spark-submit --master 'local[*]' -c "spark.driver.memory=10g" --py-files contrib/egrul/egrul_xml.py,contrib/egrul/address.py,contrib/egrul/parse_context.py,contrib/egrul/schema.py contrib/egrul/generate.py
+	# Run the job! See the script for what the Spark tuning flags are for.
+	contrib/egrul/run.sh
 
-The checkpoint directory fills up quickly, don't know why yet.
 
-	rm -rf env/spark-checkpoint
+## How current state is assembled
+
+A yearly FULL archive lists every company; a daily archive lists only the companies that
+changed that day. So a company's absence from an archive says nothing, but an ownership or
+directorship absent from a record that *is* in that archive has ended — the registry
+described the company and didn't mention it.
+
+That makes end dates a per-company question, so the job doesn't fold archives into each
+other. Instead it:
+
+1. parses each archive date into its own table (`2026_03_11`),
+2. reduces all of them to skinny appearance tables — which companies, ownerships and
+   directorships each archive listed (`company_appearances`, `relationship_appearances`,
+   `directorship_successor_starts`). These are bucketed by company id, which is what lets
+   every later stage join, window and group without shuffling,
+3. groups those by company to find each relationship's *tenures*: runs of consecutive
+   appearances of its company that list it (`relationship_tenures`). The company's next
+   appearance after a tenure is the archive that ended it, and the day before that is the
+   end date,
+4. joins the tenures back onto the records to pick up each relationship as the last
+   archive that listed it described it, and writes `current_<last archive date>`.
+
+All of these are Hive tables, so a run can be interrupted and resumed, and intermediate
+state can be queried with SQL. Dropping a table recomputes it on the next run.
 
 
 ## Provenance

--- a/contrib/egrul/README.md
+++ b/contrib/egrul/README.md
@@ -25,11 +25,21 @@ Run:
 	export LOCAL_BUCKET_CACHE_DIR="$HOME/internal-data"
 
 	# Run the job!
-	spark-submit --master 'local[*]' -c "spark.driver.memory=10g" --py-files contrib/egrul/egrul_xml.py,contrib/egrul/address.py,contrib/egrul/schema.py contrib/egrul/generate.py
+	spark-submit --master 'local[*]' -c "spark.driver.memory=10g" --py-files contrib/egrul/egrul_xml.py,contrib/egrul/address.py,contrib/egrul/parse_context.py,contrib/egrul/schema.py contrib/egrul/generate.py
 
 The checkpoint directory fills up quickly, don't know why yet.
 
 	rm -rf env/spark-checkpoint
+
+
+## Provenance
+
+Every row in the output CSVs has an `origin` field naming the source files it was
+built from, as `<archive zip name>/<XML file name within the zip>`, comma-separated
+if there is more than one. Combined with `seen_date` that's enough to find the file
+in the source bucket. Rows with several origins are the ones assembled from more
+than one archive: an ownership or directorship that ended carries both the archive
+that last listed it and the archive that stopped listing it.
 
 
 ## Copy finished data to internal-data bucket

--- a/contrib/egrul/README.md
+++ b/contrib/egrul/README.md
@@ -51,8 +51,11 @@ other. Instead it:
 4. joins the tenures back onto the records to pick up each relationship as the last
    archive that listed it described it, and writes `current_<last archive date>`.
 
-All of these are Hive tables, so a run can be interrupted and resumed, and intermediate
-state can be queried with SQL. Dropping a table recomputes it on the next run.
+All of these are Hive tables, so intermediate state can be queried with SQL. Only the
+per-archive tables in step 1 are cached between runs — an archive's contents never change,
+so parsing can be interrupted and resumed. Everything derived from them is rebuilt every
+run, because one new archive can end a relationship belonging to any company anywhere in
+history.
 
 
 ## Provenance

--- a/contrib/egrul/address.py
+++ b/contrib/egrul/address.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Dict, Any
 
 from lxml.etree import _Element
 
-from zavod import Context
+from parse_context import ParseContext
 from zavod import helpers as h
 
 
@@ -40,11 +40,11 @@ def elattr(el: Optional[_Element], attr: str) -> Any:
         return el.get(attr)
 
 
-def parse_address(context: Context, el: _Element) -> Optional[str]:
+def parse_address(pc: ParseContext, el: _Element) -> Optional[str]:
     """
     Parse an address from the XML element and set to entity.
     Args:
-        context: The processing context.
+        pc: The parsing context.
         el: The XML element.
     """
     data: Dict[str, List[str]] = defaultdict(list)
@@ -54,20 +54,26 @@ def parse_address(context: Context, el: _Element) -> Optional[str]:
     # КЛАДР - Классификатор адресов Российской Федерации (old one, since 17.11.2005)
 
     # According to this source: https://www.garant.ru/products/ipo/prime/doc/74812994/
-    if el.tag in [
-        "АдресРФ",  # КЛАДР address structure, Сведения об адресе юридического лица (в структуре КЛАДР)
-        "СвАдрЮЛФИАС",  # ФИАС address structure, Сведения об адресе юридического лица (в структуре ФИАС)
-        "СвРешИзмМН",  # address change, Сведения о принятии юридическим лицом решения об изменении места нахождения
-    ]:
+    if (
+        el.tag
+        in [
+            "АдресРФ",  # КЛАДР address structure, Сведения об адресе юридического лица (в структуре КЛАДР)
+            "СвАдрЮЛФИАС",  # ФИАС address structure, Сведения об адресе юридического лица (в структуре ФИАС)
+            "СвРешИзмМН",  # address change, Сведения о принятии юридическим лицом решения об изменении места нахождения
+        ]
+    ):
         pass
-    elif el.tag in [
-        "СвНедАдресЮЛ",  # Information about address inaccuracy, Сведения о недостоверности адреса
-        "СвМНЮЛ",  # this seems to be  a general location (up to town), not an address,
-        # Сведения о месте нахождения юридического лица
-    ]:
+    elif (
+        el.tag
+        in [
+            "СвНедАдресЮЛ",  # Information about address inaccuracy, Сведения о недостоверности адреса
+            "СвМНЮЛ",  # this seems to be  a general location (up to town), not an address,
+            # Сведения о месте нахождения юридического лица
+        ]
+    ):
         return None  # ignore this one entirely
     else:
-        context.log.warn("Unknown address type", tag=el.tag)
+        pc.log.warn("Unknown address type", tag=el.tag)
         return None
 
     # Still a mess, but at least I gave it some love and order
@@ -117,7 +123,7 @@ def parse_address(context: Context, el: _Element) -> Optional[str]:
         dput(
             data,
             "house_number",
-            f"{bld.get("Тип") or ""} {bld.get("Номер") or ""}".strip(),
+            f"{bld.get('Тип') or ''} {bld.get('Номер') or ''}".strip(),
         )
 
     # To @pudo: this is an apartment/flat number/floor number/office number which is not

--- a/contrib/egrul/debug/extract_entity.py
+++ b/contrib/egrul/debug/extract_entity.py
@@ -1,0 +1,66 @@
+"""Extract the source XML for a single INN out of an EGRUL archive.
+
+Point this at a zip from gs://egrul.opensanctions.org (or at the local cache under
+LOCAL_BUCKET_CACHE_DIR) to see what the crawler actually had to work with, e.g. when
+an `origin` from the output CSVs points at a record that looks wrong. The extracted
+XML is written to a file in the current directory.
+"""
+
+from pathlib import Path
+from typing import Generator
+from zipfile import ZipFile
+
+import click
+from lxml import etree
+from lxml.etree import _Element as Element
+
+# Legal entities carry the INN on СвЮЛ/@ИНН, sole traders on СвИП/@ИННФЛ.
+INN_XPATHS = [
+    "//СвЮЛ[@ИНН=$inn]",
+    "//СвИП[@ИННФЛ=$inn]",
+]
+
+
+def find_entities(data: bytes, inn: str) -> Generator[Element, None, None]:
+    """Yield the entity elements matching the INN in one XML document."""
+    doc = etree.fromstring(data)
+    for xpath in INN_XPATHS:
+        for el in doc.xpath(xpath, inn=inn):
+            yield el
+
+
+@click.command()
+@click.argument("archive", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("inn")
+def main(archive: Path, inn: str) -> None:
+    """Extract the entity with INN from the EGRUL archive at ARCHIVE.
+
+    Writes <INN>-<archive name>.xml in the current directory. All matches in the
+    archive go into that file, each preceded by a comment naming the file it came
+    from, in the same format as the `origin` field of the generated CSVs.
+    """
+    out_path = Path("%s-%s.xml" % (inn, archive.stem))
+    found = 0
+    with ZipFile(archive, "r") as zip, out_path.open("w") as out_fh:
+        for name in zip.namelist():
+            if not name.lower().endswith(".xml"):
+                continue
+            data = zip.read(name)
+            # Parsing every document in a full dump takes minutes, and an INN that
+            # isn't in the raw bytes can't be in the parsed tree either.
+            if inn.encode("utf-8") not in data:
+                continue
+            for el in find_entities(data, inn):
+                found += 1
+                out_fh.write("<!-- %s/%s -->\n" % (archive.name, name))
+                out_fh.write(etree.tostring(el, pretty_print=True, encoding="unicode"))
+
+    if found == 0:
+        out_path.unlink()
+        raise click.ClickException("No entity with INN %s in %s" % (inn, archive))
+
+    click.echo("Wrote %d match(es) to %s" % (found, out_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/egrul/egrul_xml.py
+++ b/contrib/egrul/egrul_xml.py
@@ -5,7 +5,7 @@ from lxml import etree
 from lxml.etree import _Element as Element
 
 from address import parse_address
-from zavod import Context
+from parse_context import ParseContext
 from zavod import helpers as h
 
 NULL_NAMES = {"-", "0"}
@@ -60,7 +60,7 @@ def parse_okved_codes(el: Element) -> set[str]:
 
 
 def entity_id(
-    context: Context,
+    pc: ParseContext,
     name: Optional[str] = None,
     inn: Optional[str] = None,
     ogrn: Optional[str] = None,
@@ -71,7 +71,7 @@ def entity_id(
     The priorities are: INN, OGRN, local_id/name.
 
     Args:
-        context: The processing context.
+        pc: The parsing context.
         name: The name of the entity.
         inn: The INN of the entity.
         ogrn: The OGRN of the entity.
@@ -80,21 +80,21 @@ def entity_id(
         The entity ID or None.
     """
     if inn is not None:
-        return context.make_slug("inn", inn)
+        return pc.make_slug("inn", inn)
     if ogrn is not None:
-        return context.make_slug("ogrn", ogrn)
+        return pc.make_slug("ogrn", ogrn)
     if name is not None:
-        return context.make_id(local_id, name)
+        return pc.make_id(local_id, name)
     return None
 
 
 def make_person(
-    context: Context, el: Element, local_id: Optional[str]
+    pc: ParseContext, el: Element, local_id: Optional[str]
 ) -> Optional[Dict[str, Any]]:
     """
     Parse a person from the XML element.
     Args:
-        context: The processing context.
+        pc: The parsing context.
         el: The XML element.
         local_id: A local ID for the entity.
     Returns:
@@ -124,9 +124,10 @@ def make_person(
         first_name=first_name, patronymic=patronymic, last_name=last_name
     )
     return {
-        "id": entity_id(context, name, inn_code, local_id=local_id),
+        "id": entity_id(pc, name, inn_code, local_id=local_id),
         "schema": "Person",
-        "seen_date": context.data_time.date(),
+        "seen_date": pc.data_time,
+        "origin": [pc.origin],
         "name": name if name not in NULL_NAMES else None,
         "first_name": first_name if first_name not in NULL_NAMES else None,
         "last_name": last_name if last_name not in NULL_NAMES else None,
@@ -137,19 +138,20 @@ def make_person(
 
 
 def make_org(
-    context: Context, el: Element, local_id: Optional[str]
+    pc: ParseContext, el: Element, local_id: Optional[str]
 ) -> Optional[Dict[str, Any]]:
     """
     Parse an organization from the XML element.
     Args:
-        context: The processing context.
+        pc: The parsing context.
         el: The XML element.
         local_id: A local ID for the entity.
     Returns:
         A dictionary representing the organization entity or None.
     """
     org = {
-        "seen_date": context.data_time.date(),
+        "seen_date": pc.data_time,
+        "origin": [pc.origin],
         "schema": "Organization",
     }
 
@@ -158,7 +160,7 @@ def make_org(
         name = name_el.get("НаимЮЛПолн")
         inn = name_el.get("ИНН")
         ogrn = name_el.get("ОГРН")
-        org["id"] = entity_id(context, name, inn, ogrn, local_id)
+        org["id"] = entity_id(pc, name, inn, ogrn, local_id)
         org["name"] = name
         org["inn_code"] = inn
         org["ogrn_code"] = ogrn
@@ -166,7 +168,7 @@ def make_org(
     name_latin_el = el.find("./СвНаимЮЛПолнИн")
     if name_latin_el is not None:
         name_latin = name_latin_el.get("НаимПолн")
-        org["id"] = entity_id(context, name=name_latin, local_id=local_id)
+        org["id"] = entity_id(pc, name=name_latin, local_id=local_id)
         org["name_latin"] = name_latin
 
     foreign_reg_el = el.find("./СвРегИн")
@@ -180,7 +182,7 @@ def make_org(
 
 
 def make_owner(
-    context: Context, company: Dict[str, Any], el: Element
+    pc: ParseContext, company: Dict[str, Any], el: Element
 ) -> Optional[Dict[str, Any]]:
     meta = el.find("./ГРНДатаПерв")
     owner = None
@@ -197,13 +199,13 @@ def make_owner(
     link_record_id: Optional[str] = None
 
     if el.tag == "УчрФЛ":  # Individual founder
-        owner = make_person(context, el, local_id)
+        owner = make_person(pc, el, local_id)
         owner_union["person"] = owner
     elif el.tag == "УчрЮЛИн":  # Foreign company
-        owner = make_org(context, el, local_id)
+        owner = make_org(pc, el, local_id)
         owner_union["legal_entity"] = owner
     elif el.tag == "УчрЮЛРос":  # Russian legal entity
-        owner = make_org(context, el, local_id)
+        owner = make_org(pc, el, local_id)
         owner_union["legal_entity"] = owner
     elif el.tag == "УчрПИФ":  # Mutual investment fund
         # TODO: nested ownership structure, make Security
@@ -220,11 +222,12 @@ def make_owner(
             inn = manager_el.get("ИНН")
             ogrn = manager_el.get("ОГРН")
             owner = {
-                "seen_date": context.data_time.date(),
+                "seen_date": pc.data_time,
+                "origin": [pc.origin],
                 "schema": "LegalEntity",
             }
             owner_union["legal_entity"] = owner
-            owner["id"] = entity_id(context, name, inn, ogrn, local_id)
+            owner["id"] = entity_id(pc, name, inn, ogrn, local_id)
             owner["name"] = name
             owner["inn_code"] = inn
             owner["ogrn_code"] = ogrn
@@ -239,24 +242,25 @@ def make_owner(
                 pb_region = "Российская Федерация"
 
             owner = {
-                "seen_date": context.data_time.date(),
+                "seen_date": pc.data_time,
+                "origin": [pc.origin],
                 "schema": "PublicBody",
             }
             owner_union["legal_entity"] = owner
 
             if pb_name is not None:
-                owner["id"] = entity_id(context, name=pb_name, local_id=local_id)
+                owner["id"] = entity_id(pc, name=pb_name, local_id=local_id)
                 owner["name"] = pb_name
             else:
                 # to @pudo: I'm using local_id==state here to glue together the regions
                 # let me know if you want me to switch it to local_id
-                owner["id"] = entity_id(context, name=pb_region, local_id="state")
+                owner["id"] = entity_id(pc, name=pb_region, local_id="state")
                 owner["name"] = pb_region
 
         # managing body:
         pb_el = el.find("./СвОргОсущПр")
         if pb_el is not None:
-            owner = make_org(context, pb_el, local_id)
+            owner = make_org(pc, pb_el, local_id)
             owner_union["legal_entity"] = owner
     elif el.tag == "УчрДогИнвТов":  # investment partnership agreement.
         # FIXME: should the partnership be its own entity?
@@ -273,11 +277,12 @@ def make_owner(
             inn = manager_el.get("ИНН")
             ogrn = manager_el.get("ОГРН")
             owner = {
-                "seen_date": context.data_time.date(),
+                "seen_date": pc.data_time,
+                "origin": [pc.origin],
                 "schema": "LegalEntity",
             }
             owner_union["legal_entity"] = owner
-            owner["id"] = entity_id(context, name, inn, ogrn, local_id)
+            owner["id"] = entity_id(pc, name, inn, ogrn, local_id)
             owner["name"] = name
             owner["inn_code"] = inn
             owner["ogrn_code"] = ogrn
@@ -285,11 +290,11 @@ def make_owner(
         # Skip municipal ownership
         return None
     else:
-        context.log.warn("Unknown owner type", tag=el.tag)
+        pc.log.warn("Unknown owner type", tag=el.tag)
         return None
 
     if owner is None or owner.get("id") is None:
-        context.log.warning(
+        pc.log.warning(
             "No ID for ownership of company %s, skipping Ownership" % company["id"],
             el=el,
             owner=owner,
@@ -297,7 +302,8 @@ def make_owner(
         return None
 
     ownership: Dict[str, Any] = {
-        "seen_date": context.data_time.date(),
+        "seen_date": pc.data_time,
+        "origin": [pc.origin],
         "date": date.fromisoformat(str(link_date)) if link_date else None,
         "record_id": link_record_id,
         "summary_1": link_summary,
@@ -325,7 +331,7 @@ def make_owner(
     # NOTE(Leon Handreke): Here we re-key (vs. the old crawler) to detect changes in ownership structure
     # The previous key did not contain shares_count and role
     # This ID will also be used to detect changes in ownership when building historic data
-    ownership["id"] = context.make_id(
+    ownership["id"] = pc.make_id(
         str(company["id"]),
         str(owner["id"]),
         str(ownership.get("shares_count")),
@@ -340,31 +346,32 @@ def make_owner(
 
 
 def make_directorship(
-    context: Context, company: Dict[str, Any], el: Element
+    pc: ParseContext, company: Dict[str, Any], el: Element
 ) -> Optional[Dict[str, Any]]:
     """
     Parse a directorship from the XML element.
     Args:
-        context: The processing context.
+        pc: The parsing context.
         company: The company entity.
         el: The XML element.
     Returns:
         A dictionary representing the directorship entity or None.
     """
-    director = make_person(context, el, company["id"])
+    director = make_person(pc, el, company["id"])
     if director is None:
-        context.log.warn("Directorship has no person", company=company["id"])
+        pc.log.warn("Directorship has no person", company=company["id"])
         return None
 
     role = el.find("./СвДолжн")
     if role is None:
-        context.log.warn("Directorship has no role", tag=el)
+        pc.log.warn("Directorship has no role", tag=el)
         return None
 
     directorship = {
         # This ID will also be used to detect changes in directorship when building historic data
-        "id": context.make_id(company["id"], director["id"], role.get("ВидДолжн")),
-        "seen_date": context.data_time.date(),
+        "id": pc.make_id(company["id"], director["id"], role.get("ВидДолжн")),
+        "seen_date": pc.data_time,
+        "origin": [pc.origin],
         "role": role.get("НаимДолжн"),
         "summary": role.get("НаимВидДолжн"),
         "director": director,
@@ -380,13 +387,13 @@ def make_directorship(
 
 
 def build_successor_predecessor(
-    context: Context, other_entity: Dict[str, Any], el: Element
+    pc: ParseContext, other_entity: Dict[str, Any], el: Element
 ) -> Optional[Dict[str, Any]]:
     name = el.get("НаимЮЛПолн")
     inn = el.get("ИНН")
     ogrn = el.get("ОГРН")
     successor_id = entity_id(
-        context,
+        pc,
         name=name,
         inn=inn,
         ogrn=ogrn,
@@ -396,7 +403,8 @@ def build_successor_predecessor(
 
     entity = {
         "schema": "Company",
-        "seen_date": context.data_time.date(),
+        "seen_date": pc.data_time,
+        "origin": [pc.origin],
         "id": successor_id,
         "name_full": name,
         "inn_code": inn,
@@ -410,10 +418,11 @@ def build_successor_predecessor(
     return entity
 
 
-def parse_company(context: Context, el: Element) -> Dict[str, Any]:
+def parse_company(pc: ParseContext, el: Element) -> Dict[str, Any]:
     company: Dict[str, Any] = {
         "schema": "Company",
-        "seen_date": context.data_time.date(),
+        "seen_date": pc.data_time,
+        "origin": [pc.origin],
     }
     inn = el.get("ИНН")
     ogrn = el.get("ОГРН")
@@ -425,7 +434,7 @@ def parse_company(context: Context, el: Element) -> Dict[str, Any]:
         name_short = name_el.get("НаимЮЛСокр")
 
     name = name_full or name_short
-    company["id"] = entity_id(context, name=name, inn=inn, ogrn=ogrn)
+    company["id"] = entity_id(pc, name=name, inn=inn, ogrn=ogrn)
     company["jurisdiction"] = "ru"
     company["name_full"] = name_full
     company["name_short"] = name_short
@@ -458,32 +467,31 @@ def parse_company(context: Context, el: Element) -> Dict[str, Any]:
     for addr_el in el.findall("./СвАдресЮЛ/*"):
         if "addresses" not in company:
             company["addresses"] = []
-        addr = parse_address(context, addr_el)
+        addr = parse_address(pc, addr_el)
         if addr is not None:
             company["addresses"].append(addr)
 
     directorships = []
     # prokura or directors etc.
     for director in el.findall("./СведДолжнФЛ"):
-        directorship = make_directorship(context, company, director)
+        directorship = make_directorship(pc, company, director)
         if directorship:
             directorships.append(directorship)
 
     ownerships = []
     for founder in el.findall("./СвУчредит/*"):
-        ownership_result = make_owner(context, company, founder)
+        ownership_result = make_owner(pc, company, founder)
         if ownership_result:
             ownerships.append(ownership_result)
 
     successions = []
     for successor_el in el.findall("./СвПреем"):
-        succ_entity = build_successor_predecessor(context, company, successor_el)
+        succ_entity = build_successor_predecessor(pc, company, successor_el)
         if succ_entity is not None:
             succ = {
-                "id": context.make_id(
-                    str(company["id"]), "successor", succ_entity["id"]
-                ),
-                "seen_date": context.data_time.date(),
+                "id": pc.make_id(str(company["id"]), "successor", succ_entity["id"]),
+                "seen_date": pc.data_time,
+                "origin": [pc.origin],
                 "successor": succ_entity,
                 "predecessor_id": company["id"],
                 "successor_id": succ_entity["id"],
@@ -491,13 +499,12 @@ def parse_company(context: Context, el: Element) -> Dict[str, Any]:
             successions.append(succ)
 
     for predecessor_el in el.findall("./СвПредш"):
-        pred_entity = build_successor_predecessor(context, company, predecessor_el)
+        pred_entity = build_successor_predecessor(pc, company, predecessor_el)
         if pred_entity is not None:
             pred = {
-                "id": context.make_id(
-                    str(company["id"]), "predecessor", pred_entity["id"]
-                ),
-                "seen_date": context.data_time.date(),
+                "id": pc.make_id(str(company["id"]), "predecessor", pred_entity["id"]),
+                "seen_date": pc.data_time,
+                "origin": [pc.origin],
                 "predecessor": pred_entity,
                 "predecessor_id": pred_entity["id"],
                 "successor_id": company["id"],
@@ -513,20 +520,21 @@ def parse_company(context: Context, el: Element) -> Dict[str, Any]:
     }
 
 
-def parse_sole_trader(context: Context, el: Element) -> Optional[Dict[str, Any]]:
+def parse_sole_trader(pc: ParseContext, el: Element) -> Optional[Dict[str, Any]]:
     inn = el.get("ИННФЛ")
     ogrn = el.get("ОГРНИП")
     t = {
         "schema": "LegalEntity",
-        "id": entity_id(context, inn=inn, ogrn=ogrn),
-        "seen_date": context.data_time.date(),
+        "id": entity_id(pc, inn=inn, ogrn=ogrn),
+        "seen_date": pc.data_time,
+        "origin": [pc.origin],
         "country": "ru",
         "ogrn_code": ogrn,
         "inn_code": inn,
         "legal_form": el.get("НаимВидИП"),
     }
     if t["id"] is None:
-        context.log.warn("No ID for sole trader")
+        pc.log.warn("No ID for sole trader")
         return None
 
     okved_codes = parse_okved_codes(el)
@@ -536,15 +544,15 @@ def parse_sole_trader(context: Context, el: Element) -> Optional[Dict[str, Any]]
 
 
 def parse_xml(
-    context: Context, handle: IO[bytes]
+    pc: ParseContext, handle: IO[bytes]
 ) -> Generator[Dict[str, Any], None, None]:
     doc = etree.parse(handle)
     res: Optional[Dict[str, Any]]
     for el in doc.findall(".//СвЮЛ"):
-        res = parse_company(context, el)
+        res = parse_company(pc, el)
         if res is not None:
             yield res
     for el in doc.findall(".//СвИП"):
-        res = parse_sole_trader(context, el)
+        res = parse_sole_trader(pc, el)
         if res is not None:
             yield res

--- a/contrib/egrul/generate.py
+++ b/contrib/egrul/generate.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 import os
 from pathlib import Path
 import tempfile
-from typing import Generator, Optional, List, Iterable, Dict
+from typing import Generator, List, Iterable, Dict
 from zipfile import ZipFile
 from dataclasses import dataclass
 
@@ -13,6 +13,9 @@ from pyspark import Row, StorageLevel
 from pyspark.sql import SparkSession
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import (
+    array_distinct,
+    array_sort,
+    concat_ws,
     struct,
     udf,
     col,
@@ -23,6 +26,7 @@ from pyspark.sql.functions import (
 from google.cloud.storage import Client  # type: ignore
 
 from egrul_xml import parse_xml
+from parse_context import ParseContext
 from schema import company_record_schema
 from zavod import Context
 from zavod import Dataset
@@ -80,6 +84,9 @@ def update_company_from_new_company(context: Context, old: Row, new: Row) -> Row
 
     result = new
     data_date = new.legal_entity.seen_date
+    # The archive we're folding in is what causes ownerships and directorships it no
+    # longer lists to end, so it's part of the provenance of their end dates.
+    new_origin = list(new.legal_entity.origin)
 
     expired_ownerships = []
     new_ownership_ids = set([o.id for o in result.ownerships])
@@ -94,6 +101,7 @@ def update_company_from_new_company(context: Context, old: Row, new: Row) -> Row
             else:
                 o_dict = o.asDict()
                 o_dict["end_date"] = day_before(data_date)
+                o_dict["origin"] = list(o.origin) + new_origin
                 expired_ownerships.append(Row(**o_dict))
 
     expired_directorships = []
@@ -122,6 +130,7 @@ def update_company_from_new_company(context: Context, old: Row, new: Row) -> Row
                     )
                 else:
                     d_dict["end_date"] = day_before(data_date)
+                d_dict["origin"] = list(d.origin) + new_origin
                 expired_directorships.append(Row(**d_dict))
 
     if expired_directorships or expired_ownerships:
@@ -194,7 +203,7 @@ def get_local_archive_path(blob_url: BlobURL) -> Path:
 
 def crawl_archive(blob_url: BlobURL) -> Generator[dict, None, None]:
     data_date = get_archive_date_from_blob_url(blob_url)
-    context = get_context(data_date)
+    context = get_context()
 
     local_archive_path = get_local_archive_path(blob_url)
     # TODO: Since we cache persistently locally (for running on Leon's machine),
@@ -217,8 +226,13 @@ def crawl_archive(blob_url: BlobURL) -> Generator[dict, None, None]:
             for name in zip.namelist():
                 if not name.lower().endswith(".xml"):
                     continue
+                pc = ParseContext(
+                    origin="%s/%s" % (Path(blob_url.name).name, name),
+                    data_time=data_date,
+                    _context=context,
+                )
                 with zip.open(name, "r") as fh:
-                    for e in parse_xml(context, fh):
+                    for e in parse_xml(pc, fh):
                         yield e
     finally:
         # Don't clean up the temporary file, for now this is being run on Leon's machine and it's
@@ -251,6 +265,17 @@ def crawl_archives_for_date(
     df.unpersist()
 
     return spark.table(table_name)
+
+
+def flatten_origin(df: DataFrame) -> DataFrame:
+    """Join the origin array into one comma-separated field.
+
+    Origins never contain a comma, and the CSV writer can't write arrays anyway.
+    Sorting and deduplicating keeps the output stable across runs.
+    """
+    return df.withColumn(
+        "origin", concat_ws(",", array_sort(array_distinct(col("origin"))))
+    )
 
 
 def write_companies_df_to_csv(df: DataFrame, path_prefix: Path) -> None:
@@ -326,11 +351,19 @@ def write_companies_df_to_csv(df: DataFrame, path_prefix: Path) -> None:
 
     # This is what's required for the Python csv module to read the file with no further options
     csv_options = {"header": True, "escape": '"', "mode": "overwrite"}
-    ownerships_df.write.csv(str(path_prefix / "ownerships"), **csv_options)
-    directorships_df.write.csv(str(path_prefix / "directorships"), **csv_options)
-    successions_df.write.csv(str(path_prefix / "successions"), **csv_options)
-    persons_df.write.csv(str(path_prefix / "persons"), **csv_options)
-    all_legal_entities_df.write.csv(str(path_prefix / "legalentities"), **csv_options)
+    flatten_origin(ownerships_df).write.csv(
+        str(path_prefix / "ownerships"), **csv_options
+    )
+    flatten_origin(directorships_df).write.csv(
+        str(path_prefix / "directorships"), **csv_options
+    )
+    flatten_origin(successions_df).write.csv(
+        str(path_prefix / "successions"), **csv_options
+    )
+    flatten_origin(persons_df).write.csv(str(path_prefix / "persons"), **csv_options)
+    flatten_origin(all_legal_entities_df).write.csv(
+        str(path_prefix / "legalentities"), **csv_options
+    )
 
 
 def get_archive_date_from_blob_url(blob_url: BlobURL) -> date:
@@ -508,14 +541,9 @@ def crawl(context: Context) -> None:
     )
 
 
-def get_context(data_time: Optional[date] = None) -> Context:
+def get_context() -> Context:
     dataset = Dataset.from_path("datasets/ru/egrul/ru_egrul.yml")
-    context = Context(dataset)
-    if data_time is not None:
-        # TODO: This is very hacky, but that's how we pass "what archive are we in"
-        # down the stack right now
-        context.data_time = datetime.combine(data_time, datetime.min.time())
-    return context
+    return Context(dataset)
 
 
 def main() -> None:

--- a/contrib/egrul/generate.py
+++ b/contrib/egrul/generate.py
@@ -195,6 +195,11 @@ def crawl_archives_for_date(
 #
 # The grouping runs over "appearance" tables a few strings wide, so the nested records are
 # only touched again at the end, to pick up the winning version of each relationship.
+#
+# All of these tables are rebuilt on every run, unlike the per-archive tables. They're
+# derived from the whole set of archives, so as soon as one more archive exists they are
+# stale, and a new archive can end a relationship belonging to any company anywhere in
+# history. Reusing them would silently omit whatever arrived since.
 
 # The nested relationship arrays inside a company record, both handled identically.
 RELATIONSHIP_ARRAY_COLUMNS = ("ownerships", "directorships")
@@ -254,40 +259,38 @@ def build_appearance_tables(
     This is the only place the full set of records is scanned for the end-date logic, and
     it reduces them to a few skinny columns that everything downstream groups by.
     """
-    if not spark.catalog.tableExists(COMPANY_APPEARANCES_TABLE):
-        # One row per (company, archive date) already, because the per-date tables are
-        # deduplicated by company id. The company's own origin is kept here so that when
-        # this archive ends a relationship, we can name it as the source of that end date.
-        companies = read_archive_records(
-            spark, archive_dates, ["id", "legal_entity.origin"]
-        )
-        write_company_bucketed_table(
-            companies, COMPANY_APPEARANCES_TABLE, ["id", "archive_date"]
-        )
+    # One row per (company, archive date) already, because the per-date tables are
+    # deduplicated by company id. The company's own origin is kept here so that when this
+    # archive ends a relationship, we can name it as the source of that end date.
+    companies = read_archive_records(
+        spark, archive_dates, ["id", "legal_entity.origin"]
+    )
+    write_company_bucketed_table(
+        companies, COMPANY_APPEARANCES_TABLE, ["id", "archive_date"]
+    )
 
-    if not spark.catalog.tableExists(RELATIONSHIP_APPEARANCES_TABLE):
-        relationships = reduce(
-            DataFrame.unionByName,
-            [
-                read_archive_records(spark, archive_dates, ["id", kind]).select(
-                    "id",
-                    lit(kind).alias("kind"),
-                    # A record can list the same relationship twice, and the window
-                    # functions downstream need one row per appearance. Deduplicating
-                    # within the array does that without a shuffle, and it's enough:
-                    # only ids from the same array can collide, because the per-date
-                    # tables are already deduplicated by company.
-                    explode(
-                        array_distinct(transform(col(kind), lambda r: r["id"]))
-                    ).alias("relationship_id"),
-                    "archive_date",
-                )
-                for kind in RELATIONSHIP_ARRAY_COLUMNS
-            ],
-        )
-        write_company_bucketed_table(
-            relationships, RELATIONSHIP_APPEARANCES_TABLE, ["id", "archive_date"]
-        )
+    relationships = reduce(
+        DataFrame.unionByName,
+        [
+            read_archive_records(spark, archive_dates, ["id", kind]).select(
+                "id",
+                lit(kind).alias("kind"),
+                # A record can list the same relationship twice, and the window functions
+                # downstream need one row per appearance. Deduplicating within the array
+                # does that without a shuffle, and it's enough: only ids from the same
+                # array can collide, because the per-date tables are already deduplicated
+                # by company.
+                explode(array_distinct(transform(col(kind), lambda r: r["id"]))).alias(
+                    "relationship_id"
+                ),
+                "archive_date",
+            )
+            for kind in RELATIONSHIP_ARRAY_COLUMNS
+        ],
+    )
+    write_company_bucketed_table(
+        relationships, RELATIONSHIP_APPEARANCES_TABLE, ["id", "archive_date"]
+    )
 
     return (
         spark.table(COMPANY_APPEARANCES_TABLE),
@@ -304,20 +307,19 @@ def build_successor_start_table(
     successor's start date is a sharper end date than the archive date: the registry's own
     record date can predate the archive that publishes it.
     """
-    if not spark.catalog.tableExists(DIRECTORSHIP_SUCCESSOR_STARTS_TABLE):
-        starts = (
-            read_archive_records(spark, archive_dates, ["id", "directorships"])
-            .select(
-                "id",
-                "archive_date",
-                explode(col("directorships")).alias("directorship"),
-            )
-            .groupBy("id", "archive_date", col("directorship.role").alias("role"))
-            .agg(spark_min("directorship.start_date").alias("successor_start_date"))
+    starts = (
+        read_archive_records(spark, archive_dates, ["id", "directorships"])
+        .select(
+            "id",
+            "archive_date",
+            explode(col("directorships")).alias("directorship"),
         )
-        write_company_bucketed_table(
-            starts, DIRECTORSHIP_SUCCESSOR_STARTS_TABLE, ["id", "archive_date"]
-        )
+        .groupBy("id", "archive_date", col("directorship.role").alias("role"))
+        .agg(spark_min("directorship.start_date").alias("successor_start_date"))
+    )
+    write_company_bucketed_table(
+        starts, DIRECTORSHIP_SUCCESSOR_STARTS_TABLE, ["id", "archive_date"]
+    )
 
     return spark.table(DIRECTORSHIP_SUCCESSOR_STARTS_TABLE)
 
@@ -348,45 +350,44 @@ def build_relationship_tenures(
     The closing archive is null for the tenure that is still listed in the company's
     latest record: that relationship is current, and gets no end date.
     """
-    if not spark.catalog.tableExists(RELATIONSHIP_TENURES_TABLE):
-        appearances = number_company_appearances(company_appearances)
-        dated = relationship_appearances.join(
-            appearances, on=["id", "archive_date"], how="inner"
-        )
+    appearances = number_company_appearances(company_appearances)
+    dated = relationship_appearances.join(
+        appearances, on=["id", "archive_date"], how="inner"
+    )
 
-        # Across a run of consecutive seq values, seq minus a counter over the same rows
-        # stays constant, which is what identifies the run.
-        tenure_id = col("seq") - row_number().over(
-            Window.partitionBy("id", "kind", "relationship_id").orderBy("seq")
-        )
-        tenures = (
-            dated.withColumn("tenure_id", tenure_id)
-            .groupBy("id", "kind", "relationship_id", "tenure_id")
-            .agg(spark_max("seq").alias("last_seq"))
-        )
+    # Across a run of consecutive seq values, seq minus a counter over the same rows
+    # stays constant, which is what identifies the run.
+    tenure_id = col("seq") - row_number().over(
+        Window.partitionBy("id", "kind", "relationship_id").orderBy("seq")
+    )
+    tenures = (
+        dated.withColumn("tenure_id", tenure_id)
+        .groupBy("id", "kind", "relationship_id", "tenure_id")
+        .agg(spark_max("seq").alias("last_seq"))
+    )
 
-        last_seen = appearances.select(
+    last_seen = appearances.select(
+        "id",
+        col("seq").alias("last_seq"),
+        col("archive_date").alias("last_archive_date"),
+    )
+    closing = appearances.select(
+        "id",
+        (col("seq") - 1).alias("last_seq"),
+        col("archive_date").alias("closing_archive_date"),
+    )
+    resolved = (
+        tenures.join(last_seen, on=["id", "last_seq"], how="inner")
+        .join(closing, on=["id", "last_seq"], how="left")
+        .select(
             "id",
-            col("seq").alias("last_seq"),
-            col("archive_date").alias("last_archive_date"),
+            "kind",
+            "relationship_id",
+            "last_archive_date",
+            "closing_archive_date",
         )
-        closing = appearances.select(
-            "id",
-            (col("seq") - 1).alias("last_seq"),
-            col("archive_date").alias("closing_archive_date"),
-        )
-        resolved = (
-            tenures.join(last_seen, on=["id", "last_seq"], how="inner")
-            .join(closing, on=["id", "last_seq"], how="left")
-            .select(
-                "id",
-                "kind",
-                "relationship_id",
-                "last_archive_date",
-                "closing_archive_date",
-            )
-        )
-        write_company_bucketed_table(resolved, RELATIONSHIP_TENURES_TABLE, ["id"])
+    )
+    write_company_bucketed_table(resolved, RELATIONSHIP_TENURES_TABLE, ["id"])
 
     return spark.table(RELATIONSHIP_TENURES_TABLE)
 
@@ -730,8 +731,8 @@ def crawl(context: Context) -> None:
         if date(2022, 1, 1) <= d
     ]
 
-    # Parse every archive into its own table first, so the rest of the job is pure SQL
-    # over the warehouse and can be interrupted and resumed.
+    # Parse every archive into its own table first. These are the only cached step: an
+    # archive's contents never change, so parsing can be interrupted and resumed.
     for archive_date, archives in archives_by_date:
         context.log.info("Processing %s" % archive_date)
         crawl_archives_for_date(spark, archive_date, archives)

--- a/contrib/egrul/generate.py
+++ b/contrib/egrul/generate.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
+from functools import reduce
 import os
 from pathlib import Path
 import tempfile
@@ -9,15 +10,22 @@ from dataclasses import dataclass
 
 import numpy as np
 import pandas
-from pyspark import Row, StorageLevel
-from pyspark.sql import SparkSession
+from pyspark import StorageLevel
+from pyspark.sql import Column, SparkSession, Window
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import (
     array_distinct,
     array_sort,
+    collect_list,
+    concat,
     concat_ws,
-    struct,
-    udf,
+    date_sub,
+    lit,
+    max as spark_max,
+    min as spark_min,
+    row_number,
+    transform,
+    when,
     col,
     coalesce,
     explode_outer,
@@ -71,108 +79,6 @@ class BlobURL:
 
     def __str__(self) -> str:
         return self.url
-
-
-def day_before(d: date) -> date:
-    return d - timedelta(days=1)
-
-
-def update_company_from_new_company(context: Context, old: Row, new: Row) -> Row:
-    """Enriches a company with information from a previous version."""
-    # Doing this in Python is too expensive, we use a Spark join
-    assert old is not None and new is not None, "Both old and new must be present"
-
-    result = new
-    data_date = new.legal_entity.seen_date
-    # The archive we're folding in is what causes ownerships and directorships it no
-    # longer lists to end, so it's part of the provenance of their end dates.
-    new_origin = list(new.legal_entity.origin)
-
-    expired_ownerships = []
-    new_ownership_ids = set([o.id for o in result.ownerships])
-    for o in old.ownerships:
-        # Ownership.id is built from (owner, asset, shares_count, role), so if any of these changes,
-        # we'll add an expired Ownership
-        if o.id not in new_ownership_ids:
-            # If we already have an end date, use that. It might have been set by
-            # a previous run of this function when the new directorship first appeared.
-            if o.end_date:
-                expired_ownerships.append(o)
-            else:
-                o_dict = o.asDict()
-                o_dict["end_date"] = day_before(data_date)
-                o_dict["origin"] = list(o.origin) + new_origin
-                expired_ownerships.append(Row(**o_dict))
-
-    expired_directorships = []
-    new_directorship_ids = set([o.id for o in result.directorships])
-    for d in old.directorships:
-        # Directorship.id is built from (company, director, role), so if any of these changes,
-        # we'll add an expired Directorship
-        if d.id not in new_directorship_ids:
-            # If we already have an end date, use that. It might have been set by
-            # a previous run of this function when the new directorship first appeared.
-            if d.end_date:
-                expired_directorships.append(d)
-            else:
-                # We try to find a new directorship with the same role, and if it has a start_date,
-                # we use that as a better end_date for the previous directorship than just the day we saw it.
-                new_directorship_same_role = [
-                    new_d for new_d in result.directorships if new_d.role == d.role
-                ]
-                d_dict = d.asDict()
-                if (
-                    len(new_directorship_same_role) > 0
-                    and new_directorship_same_role[0].start_date is not None
-                ):
-                    d_dict["end_date"] = day_before(
-                        new_directorship_same_role[0].start_date
-                    )
-                else:
-                    d_dict["end_date"] = day_before(data_date)
-                d_dict["origin"] = list(d.origin) + new_origin
-                expired_directorships.append(Row(**d_dict))
-
-    if expired_directorships or expired_ownerships:
-        result_dict = result.asDict()
-        # context.log.info(
-        #     "Adding %d ended ownerships and %d ended directorships to %s"
-        #     % (len(expired_ownerships), len(expired_directorships), result_dict["id"])
-        # )
-        result_dict["ownerships"].extend(expired_ownerships)
-        result_dict["directorships"].extend(expired_directorships)
-        result = Row(**result_dict)
-    return result
-
-
-def update_companies_from_new_companies(
-    context: Context, old: DataFrame, new: DataFrame
-) -> DataFrame:
-    """Update a dataframe of companies with information from a new version."""
-    context.log.info("Merging %d new" % new.count())
-    old = old.alias("old")
-    new = new.alias("new")
-
-    # We run the python code only on rows where both old and new are present because it's expensive
-    to_merge = old.join(new, on="id", how="inner")
-
-    merge_fn = udf(
-        lambda old, new: update_company_from_new_company(context, old, new),
-        company_record_schema,
-    )
-    merged = (
-        to_merge.withColumn(
-            "merged", merge_fn(struct(col("old.*")), struct(col("new.*")))
-        )
-        # The select at the end "flattens" the company struct back into the root of the dataframe
-        # (instead of being nested in a "new", "old" or "merged" column)
-        .select("merged.*")
-    )
-
-    not_to_merge_old = old.join(new, on="id", how="left_anti")
-    not_to_merge_new = new.join(old, on="id", how="left_anti")
-
-    return merged.union(not_to_merge_old).union(not_to_merge_new)
 
 
 def merge_duplicate_company_records(df: DataFrame) -> DataFrame:
@@ -241,12 +147,16 @@ def crawl_archive(blob_url: BlobURL) -> Generator[dict, None, None]:
         pass
 
 
+def archive_table_name(archive_date: date) -> str:
+    return archive_date.isoformat().replace("-", "_")
+
+
 def crawl_archives_for_date(
     spark: SparkSession,
     archive_date: date,
     archives: List[BlobURL],
 ) -> DataFrame:
-    table_name = archive_date.isoformat().replace("-", "_")
+    table_name = archive_table_name(archive_date)
     if spark.catalog.tableExists(table_name):
         return spark.table(table_name)
 
@@ -265,6 +175,393 @@ def crawl_archives_for_date(
     df.unpersist()
 
     return spark.table(table_name)
+
+
+# === Assembling current state out of the archives ===
+#
+# Every archive is a set of company records, each listing that company's ownerships and
+# directorships at that point in time. A yearly FULL archive lists every company; a daily
+# archive lists only the companies that changed that day. So:
+#
+#   - A company missing from an archive means nothing at all.
+#   - An ownership or directorship missing from a record that *is* in the archive has
+#     ended: the registry described the company and didn't mention it.
+#
+# That makes "when did this end?" a question about the company's own appearances, never
+# about other companies. We therefore don't build current state by folding archives into
+# each other; we group by company instead. Each ownership and directorship gets one
+# "tenure" per run of consecutive appearances of its company that list it, and the
+# company's next appearance after a tenure is the archive that ended it.
+#
+# The grouping runs over "appearance" tables a few strings wide, so the nested records are
+# only touched again at the end, to pick up the winning version of each relationship.
+
+# The nested relationship arrays inside a company record, both handled identically.
+RELATIONSHIP_ARRAY_COLUMNS = ("ownerships", "directorships")
+
+COMPANY_APPEARANCES_TABLE = "company_appearances"
+RELATIONSHIP_APPEARANCES_TABLE = "relationship_appearances"
+DIRECTORSHIP_SUCCESSOR_STARTS_TABLE = "directorship_successor_starts"
+RELATIONSHIP_TENURES_TABLE = "relationship_tenures"
+
+# Every stage after the appearance tables joins, windows or groups by company id, so the
+# tables are bucketed on it and Spark can do all of that without shuffling.
+NUM_BUCKETS = 200
+
+
+def write_company_bucketed_table(
+    df: DataFrame, table_name: str, sort_by: List[str]
+) -> None:
+    """Write a table bucketed and sorted by company id.
+
+    The repartition uses the same hash as Spark's bucketing, so each task writes exactly
+    one bucket; without it every task writes a file into every bucket.
+    """
+    (
+        df.repartition(NUM_BUCKETS, col("id"))
+        .write.mode("overwrite")
+        .bucketBy(NUM_BUCKETS, "id")
+        .sortBy(*sort_by)
+        .saveAsTable(table_name)
+    )
+
+
+def read_archive_records(
+    spark: SparkSession, archive_dates: List[date], columns: List[str]
+) -> DataFrame:
+    """Read the per-archive-date tables as one DataFrame tagged with `archive_date`.
+
+    Deliberately lazy and column-projected: callers ask for the few columns they need so
+    Spark's Parquet reader skips the rest. That matters a lot, because the nested
+    ownership and directorship arrays dwarf everything else in a record.
+    """
+    return reduce(
+        DataFrame.unionByName,
+        [
+            spark.table(archive_table_name(d))
+            .select(*columns)
+            .withColumn("archive_date", lit(d))
+            for d in archive_dates
+        ],
+    )
+
+
+def build_appearance_tables(
+    spark: SparkSession, archive_dates: List[date]
+) -> tuple[DataFrame, DataFrame]:
+    """Materialise which companies, ownerships and directorships each archive listed.
+
+    This is the only place the full set of records is scanned for the end-date logic, and
+    it reduces them to a few skinny columns that everything downstream groups by.
+    """
+    if not spark.catalog.tableExists(COMPANY_APPEARANCES_TABLE):
+        # One row per (company, archive date) already, because the per-date tables are
+        # deduplicated by company id. The company's own origin is kept here so that when
+        # this archive ends a relationship, we can name it as the source of that end date.
+        companies = read_archive_records(
+            spark, archive_dates, ["id", "legal_entity.origin"]
+        )
+        write_company_bucketed_table(
+            companies, COMPANY_APPEARANCES_TABLE, ["id", "archive_date"]
+        )
+
+    if not spark.catalog.tableExists(RELATIONSHIP_APPEARANCES_TABLE):
+        relationships = reduce(
+            DataFrame.unionByName,
+            [
+                read_archive_records(spark, archive_dates, ["id", kind]).select(
+                    "id",
+                    lit(kind).alias("kind"),
+                    # A record can list the same relationship twice, and the window
+                    # functions downstream need one row per appearance. Deduplicating
+                    # within the array does that without a shuffle, and it's enough:
+                    # only ids from the same array can collide, because the per-date
+                    # tables are already deduplicated by company.
+                    explode(
+                        array_distinct(transform(col(kind), lambda r: r["id"]))
+                    ).alias("relationship_id"),
+                    "archive_date",
+                )
+                for kind in RELATIONSHIP_ARRAY_COLUMNS
+            ],
+        )
+        write_company_bucketed_table(
+            relationships, RELATIONSHIP_APPEARANCES_TABLE, ["id", "archive_date"]
+        )
+
+    return (
+        spark.table(COMPANY_APPEARANCES_TABLE),
+        spark.table(RELATIONSHIP_APPEARANCES_TABLE),
+    )
+
+
+def build_successor_start_table(
+    spark: SparkSession, archive_dates: List[date]
+) -> DataFrame:
+    """Collect the earliest directorship start date per company, archive and role.
+
+    Where the archive that dropped a directorship names a successor in the same role, that
+    successor's start date is a sharper end date than the archive date: the registry's own
+    record date can predate the archive that publishes it.
+    """
+    if not spark.catalog.tableExists(DIRECTORSHIP_SUCCESSOR_STARTS_TABLE):
+        starts = (
+            read_archive_records(spark, archive_dates, ["id", "directorships"])
+            .select(
+                "id",
+                "archive_date",
+                explode(col("directorships")).alias("directorship"),
+            )
+            .groupBy("id", "archive_date", col("directorship.role").alias("role"))
+            .agg(spark_min("directorship.start_date").alias("successor_start_date"))
+        )
+        write_company_bucketed_table(
+            starts, DIRECTORSHIP_SUCCESSOR_STARTS_TABLE, ["id", "archive_date"]
+        )
+
+    return spark.table(DIRECTORSHIP_SUCCESSOR_STARTS_TABLE)
+
+
+def number_company_appearances(company_appearances: DataFrame) -> DataFrame:
+    """Number each company's own appearances consecutively, oldest first.
+
+    Absence from an archive is only evidence about a company that is in that archive, so
+    all our reasoning is against the company's own list of appearances rather than the
+    calendar. This sequence number is what makes "consecutive" and "the next one" mean
+    that.
+    """
+    return company_appearances.select("id", "archive_date").withColumn(
+        "seq", row_number().over(Window.partitionBy("id").orderBy("archive_date"))
+    )
+
+
+def build_relationship_tenures(
+    spark: SparkSession,
+    company_appearances: DataFrame,
+    relationship_appearances: DataFrame,
+) -> DataFrame:
+    """Find each relationship's runs of consecutive appearances and what ended each.
+
+    A relationship that disappears and comes back later gets one tenure per run, so a
+    directorship held twice reads as two directorships rather than one long one.
+
+    The closing archive is null for the tenure that is still listed in the company's
+    latest record: that relationship is current, and gets no end date.
+    """
+    if not spark.catalog.tableExists(RELATIONSHIP_TENURES_TABLE):
+        appearances = number_company_appearances(company_appearances)
+        dated = relationship_appearances.join(
+            appearances, on=["id", "archive_date"], how="inner"
+        )
+
+        # Across a run of consecutive seq values, seq minus a counter over the same rows
+        # stays constant, which is what identifies the run.
+        tenure_id = col("seq") - row_number().over(
+            Window.partitionBy("id", "kind", "relationship_id").orderBy("seq")
+        )
+        tenures = (
+            dated.withColumn("tenure_id", tenure_id)
+            .groupBy("id", "kind", "relationship_id", "tenure_id")
+            .agg(spark_max("seq").alias("last_seq"))
+        )
+
+        last_seen = appearances.select(
+            "id",
+            col("seq").alias("last_seq"),
+            col("archive_date").alias("last_archive_date"),
+        )
+        closing = appearances.select(
+            "id",
+            (col("seq") - 1).alias("last_seq"),
+            col("archive_date").alias("closing_archive_date"),
+        )
+        resolved = (
+            tenures.join(last_seen, on=["id", "last_seq"], how="inner")
+            .join(closing, on=["id", "last_seq"], how="left")
+            .select(
+                "id",
+                "kind",
+                "relationship_id",
+                "last_archive_date",
+                "closing_archive_date",
+            )
+        )
+        write_company_bucketed_table(resolved, RELATIONSHIP_TENURES_TABLE, ["id"])
+
+    return spark.table(RELATIONSHIP_TENURES_TABLE)
+
+
+def join_winning_relationship_versions(
+    spark: SparkSession,
+    archive_dates: List[date],
+    tenures: DataFrame,
+    company_appearances: DataFrame,
+    kind: str,
+) -> DataFrame:
+    """Attach each tenure to the relationship as its last archive described it.
+
+    The last archive listing a relationship holds the registry's final word on it, so
+    that's the version we keep. This is the one join that touches the nested records, and
+    it's keyed by company, as is the aggregation that follows.
+    """
+    relationships = (
+        read_archive_records(spark, archive_dates, ["id", kind])
+        .select("id", "archive_date", explode(col(kind)).alias("relationship"))
+        .withColumn("relationship_id", col("relationship.id"))
+    )
+    ends = tenures.where(col("kind") == kind).select(
+        "id",
+        "relationship_id",
+        col("last_archive_date").alias("archive_date"),
+        "closing_archive_date",
+    )
+    closing_origins = company_appearances.select(
+        "id",
+        col("archive_date").alias("closing_archive_date"),
+        col("origin").alias("closing_origin"),
+    )
+    return relationships.join(
+        ends, on=["id", "archive_date", "relationship_id"], how="inner"
+    ).join(
+        # Left join: a tenure with no closing archive is still current.
+        closing_origins,
+        on=["id", "closing_archive_date"],
+        how="left",
+    )
+
+
+def collect_resolved_relationships(
+    tenures: DataFrame, end_date: Column, output_column: str
+) -> DataFrame:
+    """Stamp end date and closing origin onto each relationship, then group by company.
+
+    A relationship the source itself gave an end date keeps that date, and keeps its
+    origin untouched: we only claim the closing archive as provenance for end dates we
+    derived from it.
+    """
+    ends_here = (
+        col("relationship.end_date").isNull() & col("closing_archive_date").isNotNull()
+    )
+    resolved = (
+        col("relationship")
+        .withField(
+            "end_date",
+            when(ends_here, end_date).otherwise(col("relationship.end_date")),
+        )
+        .withField(
+            "origin",
+            when(
+                ends_here, concat(col("relationship.origin"), col("closing_origin"))
+            ).otherwise(col("relationship.origin")),
+        )
+    )
+    return (
+        tenures.select("id", resolved.alias("relationship"))
+        .groupBy("id")
+        .agg(collect_list("relationship").alias(output_column))
+    )
+
+
+def resolve_ownerships(
+    spark: SparkSession,
+    archive_dates: List[date],
+    tenures: DataFrame,
+    company_appearances: DataFrame,
+) -> DataFrame:
+    """Build the final ownerships array per company."""
+    ownerships = join_winning_relationship_versions(
+        spark, archive_dates, tenures, company_appearances, "ownerships"
+    )
+    # The company was described without this ownership on the closing date, so the last
+    # day it can have held is the day before.
+    return collect_resolved_relationships(
+        ownerships, date_sub(col("closing_archive_date"), 1), "ownerships"
+    )
+
+
+def resolve_directorships(
+    spark: SparkSession,
+    archive_dates: List[date],
+    tenures: DataFrame,
+    company_appearances: DataFrame,
+    successor_starts: DataFrame,
+) -> DataFrame:
+    """Build the final directorships array per company, ending each at its successor."""
+    directorships = join_winning_relationship_versions(
+        spark, archive_dates, tenures, company_appearances, "directorships"
+    )
+    successor_starts = successor_starts.select(
+        "id",
+        col("archive_date").alias("closing_archive_date"),
+        "role",
+        "successor_start_date",
+    )
+    directorships = (
+        directorships.alias("tenure")
+        .join(
+            successor_starts.alias("successor"),
+            on=[
+                col("tenure.id") == col("successor.id"),
+                col("tenure.closing_archive_date")
+                == col("successor.closing_archive_date"),
+                # Null-safe so that untitled directorships match each other rather than
+                # dropping out of the comparison.
+                col("tenure.relationship.role").eqNullSafe(col("successor.role")),
+            ],
+            how="left",
+        )
+        .select(
+            col("tenure.id").alias("id"),
+            col("tenure.relationship").alias("relationship"),
+            col("tenure.archive_date").alias("last_archive_date"),
+            col("tenure.closing_archive_date").alias("closing_archive_date"),
+            col("tenure.closing_origin").alias("closing_origin"),
+            col("successor.successor_start_date").alias("successor_start_date"),
+        )
+    )
+    # Only trust the successor's start date if it falls after we last saw this
+    # directorship; otherwise the registry is describing something we can't reconcile and
+    # the archive date is the only date we can defend.
+    successor_end_date = when(
+        col("successor_start_date") > col("last_archive_date"),
+        date_sub(col("successor_start_date"), 1),
+    )
+    return collect_resolved_relationships(
+        directorships,
+        coalesce(successor_end_date, date_sub(col("closing_archive_date"), 1)),
+        "directorships",
+    )
+
+
+def assemble_company_records(
+    spark: SparkSession,
+    archive_dates: List[date],
+    company_appearances: DataFrame,
+    ownerships: DataFrame,
+    directorships: DataFrame,
+) -> DataFrame:
+    """Combine each company's latest record with its resolved ownerships and directorships.
+
+    Everything that isn't an ownership or directorship (the company itself, its
+    successions) is simply taken from the latest record we have for the company; the
+    registry restates all of it on every appearance.
+
+    Companies with no ownerships or directorships at all get a null array rather than an
+    empty one, which the CSV writer's explode treats the same way.
+    """
+    latest = company_appearances.groupBy("id").agg(
+        spark_max("archive_date").alias("archive_date")
+    )
+    return (
+        read_archive_records(
+            spark, archive_dates, ["id", "legal_entity", "successions"]
+        )
+        .join(latest, on=["id", "archive_date"], how="inner")
+        .drop("archive_date")
+        .join(ownerships, on="id", how="left")
+        .join(directorships, on="id", how="left")
+        .select("id", "legal_entity", "successions", "ownerships", "directorships")
+    )
 
 
 def flatten_origin(df: DataFrame) -> DataFrame:
@@ -401,34 +698,9 @@ def list_archives(bucket_name: str, prefix: str) -> List[BlobURL]:
     ]
 
 
-def merge_company_record_dfs(
-    context: Context, records: Iterable[DataFrame]
-) -> DataFrame:
-    """Merge company records using update_companies_from_new_companies."""
-    result = None
-    for record in records:
-        # First iteration, set result to the first crawled DataFrame
-        if result is None:
-            result = record
-            continue
-
-        result = update_companies_from_new_companies(context, result, record)
-        # Reduce number of partitions, otherwise it will explode with every iteration (don't ask me why)
-        # and eventually grind everything to a halt.
-        result = result.coalesce(16)
-        # Checkpoint cuts the lineage of the DataFrame, so we don't
-        # end up with a huge execution plan
-        result = result.checkpoint()
-
-        context.log.info("Updated state has %d company records" % result.count())
-
-    return result
-
-
 def crawl(context: Context) -> None:
     # .enableHiveSupport() is required to use tables in spark.catalog
     spark = SparkSession.builder.appName("ru_egrul").enableHiveSupport().getOrCreate()
-    spark.sparkContext.setCheckpointDir("env/spark-checkpoint")
     spark.sparkContext.setLogLevel("WARN")
 
     archives_406 = [
@@ -458,86 +730,44 @@ def crawl(context: Context) -> None:
         if date(2022, 1, 1) <= d
     ]
 
-    # Process the archives first to have them ready in the warehouse for the
-    # iterative join later.
+    # Parse every archive into its own table first, so the rest of the job is pure SQL
+    # over the warehouse and can be interrupted and resumed.
     for archive_date, archives in archives_by_date:
         context.log.info("Processing %s" % archive_date)
         crawl_archives_for_date(spark, archive_date, archives)
 
-    # The general idea is that we continously fold new data into the existing data, starting at the full dump
-    # at 2022-01-01. Because updating the full dataset with every new incremental update takes too long
-    # (~90s per join on my M4, depending a bit on the size of the new data), we exploit the fact that the operation is
-    # associative (but it's not commutative!). So, we first merge all the months, then fold these into one
-    # yearly partial update, and finally merge that into the full dump, to get the state at the end of the year.
-    # We do this for every year and then merge the years. We could also do chunks of 20 or whatever, it doesn't matter.
-    # What does matter is to reduce the number of joins with very large datasets.
-    # Saving to partial_ tables is not strictly required, but quite useful to interrupt and resume the process when
-    # running locally and running sql queries on it.
-    year_dfs = []
-    for year in [2022, 2023, 2024, 2025, 2026]:
-        year_archives = [
-            (archive_date, archives)
-            for archive_date, archives in archives_by_date
-            if archive_date.year == year
-        ]
-        full_archive = year_archives[0]
-        partial_archives = year_archives[1:]
+    archive_dates = [archive_date for archive_date, _ in archives_by_date]
 
-        year_table_name = "partial_%d" % year
-        if spark.catalog.tableExists(year_table_name):
-            context.log.info("Reading %d from table" % year)
-            year_dfs.append(spark.table(year_table_name))
-            continue
+    context.log.info("Collecting company and relationship appearances")
+    company_appearances, relationship_appearances = build_appearance_tables(
+        spark, archive_dates
+    )
 
-        month_dfs = []
-        for month in range(1, 13):
-            month_table_name = "partial_%d_%02d" % (year, month)
-            if spark.catalog.tableExists(month_table_name):
-                context.log.info("Reading %d-%d from table" % (year, month))
-                month_dfs.append(spark.table(month_table_name))
-                continue
+    successor_starts = build_successor_start_table(spark, archive_dates)
 
-            context.log.info("Processing %d-%d" % (year, month))
-            day_archives = [
-                x for x in partial_archives if x[0].year == year and x[0].month == month
-            ]
-            day_dfs = [crawl_archives_for_date(spark, x[0], x[1]) for x in day_archives]
-            context.log.info("Merging day records for %d-%d" % (year, month))
-            if len(day_dfs) == 0:
-                continue
+    context.log.info("Finding ownership and directorship tenures")
+    tenures = build_relationship_tenures(
+        spark, company_appearances, relationship_appearances
+    )
 
-            month_df = merge_company_record_dfs(context, day_dfs)
-            context.log.info("%d-%d has %d records" % (year, month, month_df.count()))
+    context.log.info("Resolving current ownerships and directorships")
+    ownerships = resolve_ownerships(spark, archive_dates, tenures, company_appearances)
+    directorships = resolve_directorships(
+        spark, archive_dates, tenures, company_appearances, successor_starts
+    )
+    final_df = assemble_company_records(
+        spark, archive_dates, company_appearances, ownerships, directorships
+    )
 
-            month_df.write.saveAsTable(month_table_name)
-            month_df = month_df.persist(StorageLevel.DISK_ONLY)
-            month_dfs.append(month_df)
-
-        context.log.info("Merging partial monthly records for %d" % year)
-        partial_year_df = merge_company_record_dfs(context, month_dfs)
-        full_df = crawl_archives_for_date(spark, full_archive[0], full_archive[1])
-        context.log.info("Merging full and partial daily records for %d" % year)
-        year_df = merge_company_record_dfs(context, [full_df, partial_year_df])
-        # We've computed year_df now, we won't need month_dfs anymore.
-        for month_df in month_dfs:
-            month_df.unpersist()
-        context.log.info("%d has %d records" % (year, year_df.count()))
-
-        # Persist to make sure that Spark doesn't get the idea to throw away and recompute this.
-        year_df = year_df.persist(StorageLevel.DISK_ONLY)
-        year_df.write.saveAsTable(year_table_name, mode="overwrite")
-        year_dfs.append(year_df)
-
-    context.log.info("Merging yearly records")
-    # Each of these (join of ~12M on ~12M records with merge UDF in Python) takes around 8min on M4 10 cores
-    final_df = merge_company_record_dfs(context, year_dfs)
-
-    last_date = archives_by_date[-1][0]
+    last_date = archive_dates[-1]
     final_table_name = "current_" + last_date.isoformat().replace("-", "_")
-    final_df.write.saveAsTable(final_table_name)
+    final_df.write.saveAsTable(final_table_name, mode="overwrite")
 
+    # Read the result back rather than reusing final_df, which would compute the whole
+    # pipeline a second time to write the CSVs.
     write_companies_df_to_csv(
-        final_df, LOCAL_BUCKET_CACHE_DIR / PROCESSESED_PREFIX / final_table_name
+        spark.table(final_table_name),
+        LOCAL_BUCKET_CACHE_DIR / PROCESSESED_PREFIX / final_table_name,
     )
 
 

--- a/contrib/egrul/generate.py
+++ b/contrib/egrul/generate.py
@@ -187,6 +187,10 @@ def crawl_archives_for_date(
 #   - An ownership or directorship missing from a record that *is* in the archive has
 #     ended: the registry described the company and didn't mention it.
 #
+# "Missing" includes a section the registry withholds rather than omits (ОгрДосСв, "access
+# to the information is restricted"): the relationship is no longer published, so we end it
+# rather than carry it forward.
+#
 # That makes "when did this end?" a question about the company's own appearances, never
 # about other companies. We therefore don't build current state by folding archives into
 # each other; we group by company instead. Each ownership and directorship gets one

--- a/contrib/egrul/parse_context.py
+++ b/contrib/egrul/parse_context.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+import structlog
+
+from zavod import Context
+
+
+@dataclass(frozen=True)
+class ParseContext:
+    """Per-XML-file parsing context: which archive member we're in, and when."""
+
+    origin: str
+    data_time: date
+    # TODO: Heavy dependency for what we use it for — entity IDs and logging.
+    _context: Context
+
+    @property
+    def log(self) -> structlog.stdlib.BoundLogger:
+        return self._context.log
+
+    def make_id(self, *parts: Optional[str]) -> Optional[str]:
+        return self._context.make_id(*parts)
+
+    def make_slug(self, *parts: Optional[str]) -> Optional[str]:
+        return self._context.make_slug(*parts)

--- a/contrib/egrul/run.sh
+++ b/contrib/egrul/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run the EGRUL Spark job against the local warehouse.
+set -euo pipefail
+
+# The --py-files paths and the dataset .yml lookup are relative to the repo root.
+cd "$(dirname "$0")/../.."
+# Spark needs a JVM it supports; the default on macOS may be much newer.
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+
+spark-submit --master 'local[*]' \
+	-c spark.driver.memory=15g \
+	`# The per-archive tables are thousands of small Parquet files; pack more per task.` \
+	-c spark.sql.files.openCostInBytes=32m \
+	`# Only ~13% of the relationship rows shuffled into the final join survive it, so let` \
+	`# Spark bloom-filter the wide side first. The defaults are too small to trigger on` \
+	`# tables this size. Unverified - check for BloomFilterMightContain in the plan.` \
+	-c spark.sql.optimizer.runtime.bloomFilter.creationSideThreshold=2g \
+	-c spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold=1g \
+	--py-files contrib/egrul/egrul_xml.py,contrib/egrul/address.py,contrib/egrul/parse_context.py,contrib/egrul/schema.py \
+	contrib/egrul/generate.py

--- a/contrib/egrul/schema.py
+++ b/contrib/egrul/schema.py
@@ -3,6 +3,15 @@ from pyspark.sql.types import StringType, StructType, StructField, DateType, Arr
 entity_fields = [
     StructField("id", StringType(), nullable=False),
     StructField("seen_date", DateType(), nullable=False),
+    # Which source files this record was built from, as
+    # "<archive zip name>/<XML file name within the zip>".
+    #
+    # Provenance is tracked per entity, which is coarser than reality: a single
+    # record can carry values from several files (an expired Ownership's end_date
+    # comes from the archive that stopped listing it, everything else from the
+    # archive that first listed it), and the origin list can't say which value came
+    # from where.
+    StructField("origin", ArrayType(StringType()), nullable=False),
 ]
 
 person_schema = StructType(


### PR DESCRIPTION
Two things: every output row now says which source files it came from, and end dates get derived per company instead of by folding archives into each other.

### `origin`

Every record in the generated CSVs carries the source files it was built from, as `<zip name>/<XML name within the zip>`, comma-separated. Relationships that ended carry two: the archive that last listed them, and the archive that stopped listing them — the latter is what set the end date, so it belongs in the provenance.

It's per-entity, so it can't say which value came from which file. Doing that properly means emitting statements rather than entity rows. Threading the origin down into the parsers wanted a home, hence a small `ParseContext` replacing the `Context` whose `data_time` we were monkeypatching.

### End dates

Reading that new field on a real record turned up an end date two months late, and it turned out to be inherent to the fold: it compared the full dump against merged partial-year state rather than against the nearest archive. So the fold is gone.

A daily archive only contains companies that changed that day, so a company's absence from one says nothing — but an ownership or directorship absent from a record that *is* there has ended. End dates are therefore a per-company question, and no global state fold is needed. Each relationship now gets one "tenure" per run of consecutive appearances of its company that list it, and the company's next appearance after a tenure is the archive that ended it. Two effects:

- A directorship at `ru-inn-9102285376` dropped on 2026-03-11 was dated 2026-05-05. It's now 2026-03-10.
- A relationship that lapses and comes back is two tenures instead of one smeared interval.

The grouping runs over skinny appearance tables bucketed by company id, so the nested records only get joined back at the end. Those tables are rebuilt on every run: they're derived from the whole set of archives, so a single new archive invalidates them.

A record can also withhold a section behind `ОгрДосСв` (access to the information is restricted) rather than omitting it. That counts as missing too: the relationship is no longer published, so we end it rather than carry it forward.

### Also in here

README freshened up (`uv pip`, `gcloud storage` instead of `gsutil`, cache dir named after the bucket, dropped the manual `sync-egrul.sh` instructions since that runs on a timer), a debug tool that dumps one company's source XML out of an archive, and a `run.sh` so the Spark tuning flags live somewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
