### PR TITLE
Stop buffering every statement ID when loading a dataset to the database

### DIFF
--- a/zavod/zavod/tools/dump_file.py
+++ b/zavod/zavod/tools/dump_file.py
@@ -5,7 +5,7 @@ from nomenklatura.resolver import Linker
 from zavod.logs import get_logger
 from zavod.meta import Dataset
 from zavod.entity import Entity
-from zavod.tools.util import iter_output_statements
+from zavod.tools.util import iter_output_statements, unique_statements
 
 log = get_logger(__name__)
 
@@ -30,7 +30,8 @@ def dump_dataset_to_file(
         writer = get_statement_writer(fh, format)
         total_count: int = 0
         for dataset in scope.leaves:
-            stmts = iter_output_statements(dataset, linker, external=external)
+            output = iter_output_statements(dataset, linker, external=external)
+            stmts = unique_statements(output)
             for idx, stmt in enumerate(stmts):
                 total_count += 1
                 writer.write(stmt)

--- a/zavod/zavod/tools/load_db.py
+++ b/zavod/zavod/tools/load_db.py
@@ -29,6 +29,9 @@ def load_dataset_to_db(
     """
     engine = get_engine()
     for dataset in scope.leaves:
+        # Duplicate statement IDs are left to the upsert in insert_statements,
+        # which keeps the first row of a conflict just like an in-process
+        # dedupe would - without buffering every ID that has been seen.
         insert_statements(
             engine,
             statement_table,

--- a/zavod/zavod/tools/util.py
+++ b/zavod/zavod/tools/util.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from followthemoney import Statement
 from nomenklatura.resolver import Linker
 
@@ -11,8 +11,11 @@ def iter_output_statements(
     scope: Dataset, linker: Linker[Entity], external: bool = True
 ) -> Generator[Statement, None, None]:
     """Return all the statements in the given dataset that are ready for
-    export. That means they are unique, have a valid ID, and their
-    canonical ID has been resolved.
+    export. That means they have a valid ID and their canonical ID has been
+    resolved.
+
+    Statement IDs are not guaranteed to be unique in this stream; wrap it in
+    `unique_statements` when writing to a sink that cannot reject duplicates.
 
     Args:
         dataset: The dataset to load from the archive.
@@ -22,12 +25,36 @@ def iter_output_statements(
         A generator of statements.
     """
     assert not scope.is_collection
-    seen_ids: set[str] = set()
     for stmt in iter_dataset_statements(scope, external=external):
         if stmt.entity_id is None:
             continue
 
         stmt = linker.apply_statement(stmt)
+        if stmt.id is None:
+            continue
+
+        yield stmt
+
+
+def unique_statements(
+    statements: Iterable[Statement],
+) -> Generator[Statement, None, None]:
+    """Drop statements whose ID has already been seen in the given stream.
+
+    Canonicalisation can collapse two source statements into one when both point
+    at entities that have since been merged, so a sink which cannot reject
+    duplicates itself - a file, mainly - needs this. Buffers every ID it has
+    seen, some 125 bytes per statement, so prefer a database-side conflict
+    clause where one is available.
+
+    Args:
+        statements: The statements to deduplicate.
+
+    Returns:
+        A generator of statements with distinct IDs.
+    """
+    seen_ids: set[str] = set()
+    for stmt in statements:
         if stmt.id is None or stmt.id in seen_ids:
             continue
 


### PR DESCRIPTION
`iter_output_statements` kept a `set[str]` of every statement ID it had yielded. Statement IDs are 40-char SHA-1 hex, so that set costs about **125 bytes per statement** — measured 25 MB per 200k statements, i.e. **~12 GB for a 100M-statement dataset** like `ext_ru_egrul`. It is the entire memory profile of a database load; the insert batch itself is a few MB.

The database does not need it. `insert_statements` upserts with `ON CONFLICT (id) DO NOTHING`, which keeps the first row of a conflict — the same row the set kept — and it does so for duplicates *within* one batch as well:

```sql
insert into t values ('a','1'),('a','2') on conflict (id) do nothing;  -- INSERT 0 1, keeps '1'
```

Verified on PostgreSQL 17 and, through the real `_upsert_statement_batch`, on SQLite. Verified end to end too, by feeding the loader a statement that collides on `id` with an earlier one but carries a later `first_seen`: 200,000 rows land and the survivor keeps the first occurrence's `first_seen`.

Statement IDs in `statements.pack` are already unique by construction, so the only collisions this can see are the ones `Linker.apply_statement` creates when it rewrites an entity-type value to a canonical ID — a small fraction of statements, and precisely the case the upsert handles.

### Why a wrapper rather than a flag

A `unique_statements=True` argument would leave `iter_output_statements` doing two unrelated jobs and hide a 12 GB cost behind a default. The need follows from the **sink** — a file has no uniqueness constraint, a table does — so it belongs at the call site. `dump_dataset_to_file` wraps its stream (per leaf, same scoping as before, so file output is byte-identical); `load_dataset_to_db` does not, with a comment saying why. It also leaves room to narrow the wrapper to entity-type props later without touching any signature.

### Testing

`mypy --strict` clean on 124 files; 287 tests pass, including `test_load_db` (asserts the inserted ID count matches the archive) and `test_dump_file` (asserts the file statement count matches across a real resolver merge).

### Related

Independent of, but measured alongside, opensanctions/nomenklatura#347, which makes the insert itself 1.55x faster on PostgreSQL. This change relies only on the `ON CONFLICT` clause, which predates that PR. Left for later: a `COPY`-based loader (5.3x, needs an entity-prop-scoped dedupe or an unlogged staging table), and whether one transaction per dataset is still the right boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)