### PR TITLE
Release 16 parliament PEP datasets into peps

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -58,15 +58,20 @@ children:
   - bh_shura_council
   - bo_diputados
   - bo_senado
+  - br_chamber_deputies
+  - br_federal_senate
   - br_pep
   - bt_parliament
+  - by_council_republic
   - bz_national_assembly
   - ca_commons
   - ca_foreign_reps
   - ca_senate
   - ch_parlament
+  - ci_national_assembly
   - ci_senate
   - cl_info_probidad
+  - cm_national_assembly
   - cm_senate
   - cn_npc
   - cn_peoples_congress_wikipedia
@@ -80,14 +85,19 @@ children:
   - de_bundesrat
   - de_bundestag
   - dk_pep
+  - dz_apn
+  - dz_council_nation
   - ee_riigikogu
+  - eg_house_representatives
   - es_mayors_councillors
   - es_parliament
+  - et_hopr
   - eu_cor_members
   - eu_meps
   - eu_public_functions
   - everypolitician
   - fi_eduskunta
+  - fj_parliament
   - fr_assemblee
   - fr_hatvp_declarations
   - fr_maires
@@ -95,6 +105,7 @@ children:
   - gb_commons
   - gb_lords
   - ge_declarations
+  - ge_parliament
   - gh_parliament
   - gr_parliament
   - gt_congress
@@ -128,6 +139,7 @@ children:
   - lu_bourgmestres
   - lu_chamber
   - lv_saeima
+  - ma_house_councillors
   - ma_representatives
   - mc_conseil_national
   - me_acp_peps
@@ -147,6 +159,8 @@ children:
   - nl_senate
   - no_brreg
   - no_storting
+  - np_parliament
+  - nu_assembly
   - nz_parliament
   - om_parliament
   - pa_asamblea
@@ -175,12 +189,14 @@ children:
   - si_zvezoskop
   - sk_nrsr_poslanci
   - sk_public_officials
+  - sm_consiglio
   - sn_assembly
   - sr_national_assembly
   - sv_legislature
   - th_cabinet
   - tj_majlisi_milli
   - tm_mejlis
+  - tn_arp
   - tr_parliament
   - tw_legislature
   - tz_bunge

--- a/datasets/br/chamber_deputies/br_chamber_deputies.yml
+++ b/datasets/br/chamber_deputies/br_chamber_deputies.yml
@@ -4,7 +4,7 @@ prefix: br-cd
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-24
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/br/federal_senate/br_federal_senate.yml
+++ b/datasets/br/federal_senate/br_federal_senate.yml
@@ -4,7 +4,7 @@ prefix: br-sf
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-24
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/by/council_republic/by_council_republic.yml
+++ b/datasets/by/council_republic/by_council_republic.yml
@@ -4,7 +4,7 @@ prefix: by-cr
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/ci/national_assembly/ci_national_assembly.yml
+++ b/datasets/ci/national_assembly/ci_national_assembly.yml
@@ -4,7 +4,7 @@ prefix: ci-an
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/cm/national_assembly/cm_national_assembly.yml
+++ b/datasets/cm/national_assembly/cm_national_assembly.yml
@@ -4,7 +4,7 @@ prefix: cm-na
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-24
+  start: 2026-07-29
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/dz/apn/dz_apn.yml
+++ b/datasets/dz/apn/dz_apn.yml
@@ -4,7 +4,7 @@ prefix: dz-apn
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/dz/council_nation/dz_council_nation.yml
+++ b/datasets/dz/council_nation/dz_council_nation.yml
@@ -4,7 +4,7 @@ prefix: dz-con
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/eg/house_representatives/eg_house_representatives.yml
+++ b/datasets/eg/house_representatives/eg_house_representatives.yml
@@ -4,7 +4,7 @@ prefix: eg-hor
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/et/hopr/et_hopr.yml
+++ b/datasets/et/hopr/et_hopr.yml
@@ -4,7 +4,7 @@ prefix: et-hopr
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false  # Paginates every term, well over the 2 minute CI budget.
 summary: >-

--- a/datasets/fj/parliament/fj_parliament.yml
+++ b/datasets/fj/parliament/fj_parliament.yml
@@ -4,7 +4,7 @@ prefix: fj-parl
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/ge/parliament/ge_parliament.yml
+++ b/datasets/ge/parliament/ge_parliament.yml
@@ -4,7 +4,7 @@ prefix: ge-parl
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/ma/house_councillors/ma_house_councillors.yml
+++ b/datasets/ma/house_councillors/ma_house_councillors.yml
@@ -4,7 +4,7 @@ prefix: ma-hoc
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/np/parliament/np_parliament.yml
+++ b/datasets/np/parliament/np_parliament.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: np-pa
 coverage:
   frequency: monthly
-  start: 2026-07-08
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/nu/assembly/nu_assembly.yml
+++ b/datasets/nu/assembly/nu_assembly.yml
@@ -4,7 +4,7 @@ prefix: nu-fono
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-17
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/sm/consiglio/sm_consiglio.yml
+++ b/datasets/sm/consiglio/sm_consiglio.yml
@@ -4,7 +4,7 @@ prefix: sm-cgg
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-

--- a/datasets/tn/arp/tn_arp.yml
+++ b/datasets/tn/arp/tn_arp.yml
@@ -4,7 +4,7 @@ prefix: tn-arp
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-07-29
 load_statements: true
 ci_test: false
 summary: >-


### PR DESCRIPTION
Into peps: br_chamber_deputies, br_federal_senate, by_council_republic, ci_national_assembly, cm_national_assembly, dz_apn, dz_council_nation, eg_house_representatives, et_hopr, fj_parliament, ge_parliament, ma_house_councillors, np_parliament, nu_assembly, sm_consiglio, tn_arp.

pk_senate_members was already released in a prior commit.