### PR TITLE
Tag the remaining four wanted lists with list.wanted

### DIFF
--- a/datasets/gb/nca_most_wanted/gb_nca_most_wanted.yml
+++ b/datasets/gb/nca_most_wanted/gb_nca_most_wanted.yml
@@ -15,6 +15,8 @@ description: |
   > We pursue criminals and bring them to justice.
   > By informing communities and supporting other agencies, we can help identify
   > criminals and speed the law enforcement process.
+tags:
+  - list.wanted
 url: https://www.nationalcrimeagency.gov.uk/most-wanted
 publisher:
   name: National Crime Agency

--- a/datasets/ph/most_wanted/ph_most_wanted.yml
+++ b/datasets/ph/most_wanted/ph_most_wanted.yml
@@ -13,6 +13,8 @@ description: |
   The dataset contains detailed information about individuals wanted by the police authorities in the Cordillera Region. It includes
   various categories of criminals and terrorists. The dataset includes each person's
   name, reward amount, offences, and case-control number (CC No.).
+tags:
+  - list.wanted
 publisher:
   name: Philippine National Police
   acronym: PNP

--- a/datasets/tr/wanted/tr_wanted.yml
+++ b/datasets/tr/wanted/tr_wanted.yml
@@ -11,11 +11,11 @@ summary: >
   List of people considered wanted for terrorism by the Türkiye Ministry of Interior
 description: |
   Türkiye has published a list of its most wanted terrorists, which includes
-  details such as names, birth years, and places of birth. 
+  details such as names, birth years, and places of birth.
 
   These individuals are classified into five color-coded categories,
   ranging from red (kırmızı) — indicating the most wanted — to blue (mavi),
-  green (yeşil), orange (turuncu), and grey (gri). 
+  green (yeşil), orange (turuncu), and grey (gri).
 
   Each category corresponds to a different reward amount for information
   that leads to the capture of these wanted individuals.
@@ -27,6 +27,8 @@ description: |
 
   See [Turkey’s terror list: An attack on lawyers and human
   rights](https://lawyersforlawyers.org/en/turkeys-terror-list-an-attack-on-lawyers-and-human-rights/)
+tags:
+  - list.wanted
 publisher:
   name: Türkiye Ministry of Interior
   country: tr

--- a/datasets/us/ss_wanted/us_ss_wanted.yml
+++ b/datasets/us/ss_wanted/us_ss_wanted.yml
@@ -12,6 +12,8 @@ description: |
 
   The dataset includes details such as the fugitive's name, date of birth, aliases,
   summary of the criminal case, and relevant links to them.
+tags:
+  - list.wanted
 url: https://www.secretservice.gov/investigations/mostwanted
 load_statements: true
 ci_test: false


### PR DESCRIPTION
`gb_nca_most_wanted`, `ph_most_wanted`, `tr_wanted` and `us_ss_wanted` are members of the `wanted` collection but carried no tags at all, so the query `#list.wanted` selected only 10 of the 14 wanted lists. That is the failure mode tag queries are most exposed to: a collection reference would have picked up all 14, while the tag silently under-matches with no error.

With these four tagged, `#list.wanted` and the `wanted` collection resolve to the same 14 datasets — verified against a full-directory catalog scan.

The pre-commit hook also stripped two pre-existing trailing whitespace characters in `tr_wanted.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)