### PR TITLE
[ua_war_sanctions] Don't cache listing pages

### DIFF
--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -432,9 +432,7 @@ def crawl_vessel_page(context: Context, url: str) -> None:
 
 def fetch_listing(context: Context, path: str, page: int) -> Element:
     url = f"{context.data_url}/{path}?page={page}&per-page={LISTING_PER_PAGE}"
-    return fetch_html(
-        context, url, UNBLOCK, html_source="httpResponseBody", cache_days=CACHE_DAYS
-    )
+    return fetch_html(context, url, UNBLOCK, html_source="httpResponseBody")
 
 
 def listing_max_page(doc: Element) -> int:


### PR DESCRIPTION
Listings are sorted newest-id-first, so a page number isn't a stable key — records added at the front push everything below them onto later pages. With `cache_days=7` a single enumeration mixed page snapshots taken up to a week apart (~86 new companies/day ≈ 50 pages of drift), so pages overlapped (records read twice) and left gaps (records read never). The gaps are silent: `crawl_listing` only warns on a page with *zero* detail links, and a page that just repeats already-seen records parses fine.

That's where the ~20% shortfall in the runs failing since 2026-07-28 comes from — Person 5367 → ~4400, LegalEntity 7173 → ~5700. I checked the alternatives against the live source with a cold cache: every section's listing enumerates its exact full count, every detail endpoint emits cleanly at both ends of its id range, and the current resolver only collapses 1.4% of the persons. So it's not the source, not the parsing, not dedup.

Detail pages keep `CACHE_DAYS` — a detail URL always denotes the same record, and they're ~93% of the ~19k fetches per sweep. Cost is +1101 requests/run (the 1284 listing pages previously cost ~183), so roughly 2.9h → 4h.

Not in here, but worth doing next:

- Re-read the page bound from every page rather than freezing it from page 1. Every page carries a correct last-page link, so this is free and it closes the remaining mid-crawl drift (~1 page over a 4h run).
- Assert enumerated ids against the `Total: N` that every listing prints. That would have caught this on day one instead of it surfacing two days later as a threshold failure.

Related: https://github.com/opensanctions/opensanctions/pull/5178 widens the Person/LegalEntity minimums for this same shortfall. I don't think those bounds should move — the entities are really missing. Its `emit_holding_parent` change is worth keeping though; the 8 dangling Rostec edges are structural (they're the 8 top-level holdings, all naming id 16 as parent, and id 16 is only reachable via sanctions/companies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)