### PR TITLE
[eu_journal_sanctions] Map "Between 1959 and 1965" birthDate to a range

### DIFF
--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -100,6 +100,10 @@ lookups:
         values:
           - 1960
           - 1975
+      - match: "Between 1959 and 1965"
+        values:
+          - 1959
+          - 1965
   type.identifier:
     options:
       - match:


### PR DESCRIPTION
The latest run warns twice about a rejected birthDate value "Between 1959 and 1965" (entity `eu-oj-f7b5a7b7235479e01c2ba63c02c149daf024a84b`), so I added a `type.date` lookup for it.

Started out nulling it, but the neighbouring lookups handle the same shape as a range ("Between 1960 and 1975" -> `[1960, 1975]`), so this one does the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)