### PR TITLE
[gb_fcdo_sanctions] Add type.url lookups for malformed website values

### DIFF
--- a/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
+++ b/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
@@ -310,6 +310,39 @@ lookups:
     options:
       - match: "Unknown"
         value: null
+      - match:
+          - "Social Media: http://vk.com/kazak_nac_guard"
+          - "Social Media: Cossack National Guard http://vk.com/kazak_nac_guard"
+        value: http://vk.com/kazak_nac_guard
+      - match: "Social media: http://vk.com/sobolipress"
+        value: http://vk.com/sobolipress
+      - match: "Official web site: http://soboli.net"
+        value: http://soboli.net
+      - match: "Official web site: http://vvd2003.narod.ru/"
+        value: http://vvd2003.narod.ru/
+      - match: "Red Box Energy Services Pte Ltd | Redbox Energy Services (redboxgroup.com)"
+        value: redboxgroup.com
+      - match: "http:/crimeaport.com/"
+        value: http://crimeaport.com/
+      - match: "www.sasta.ru; www.sasta.ryazan.ru"
+        values:
+          - www.sasta.ru
+          - www.sasta.ryazan.ru
+      - match: "rybar.ru; restmedia.io"
+        values:
+          - rybar.ru
+          - restmedia.io
+      - match: "byex.com and 100ex.com"
+        values:
+          - byex.com
+          - 100ex.com
+      - match: "www.farhang gostar.net/gtb"
+        value: www.farhang-gostar.net/gtb
+      - match: "www.sbu canada.org"
+        value: www.sbu-canada.org
+      - match: "info@surena gc.com"
+        prop: email
+        value: info@surenagc.com
   type.identifier:
     options:
       - match: "Indonesia, number T710219 (issued in Sukoharjo, Central Java, Indonesia)"


### PR DESCRIPTION
Run `20260730144009-hfz` logged **1,284 warnings, all of them `website` URL
rejections** from the stricter URL validation in followthemoney 4.10.1 (#5210).
They come from only 12 entities and 13 distinct values — every one a source
formatting artefact rather than a genuinely unusable URL.

Patched in `type.url` rather than in the crawler, so the fixes stay reviewable
in one place.

| Source value | Result |
|---|---|
| `www.sasta.ru; www.sasta.ryazan.ru` | two values |
| `rybar.ru; restmedia.io` | two values |
| `byex.com and 100ex.com` | two values |
| `Social Media: …/kazak_nac_guard` (2 variants) | `http://vk.com/kazak_nac_guard` |
| `Social media: http://vk.com/sobolipress` | prefix stripped |
| `Official web site: http://soboli.net` | prefix stripped |
| `Official web site: http://vvd2003.narod.ru/` | prefix stripped |
| `Red Box Energy Services Pte Ltd \| … (redboxgroup.com)` | `redboxgroup.com` |
| `http:/crimeaport.com/` | `http://crimeaport.com/` |
| `www.farhang gostar.net/gtb` | `www.farhang-gostar.net/gtb` |
| `www.sbu canada.org` | `www.sbu-canada.org` |
| `info@surena gc.com` | re-routed to `email`, `info@surenagc.com` |

The email re-route mirrors the existing `type.email` entry that sends
`www.surena gc.com` the other way, to `website`.

### Note on the two space-in-hostname repairs

`farhang-gostar.net` and `sbu-canada.org` are inferred. DNS resolves neither,
but that is not evidence — `crimeaport.com`, whose repair is unambiguous, is
also NXDOMAIN, as domains of sanctioned entities routinely are. If we would
rather not assert them, `value: null` drops those two instead.

### Effect

- Takes this dataset's issue count from 1,284 to zero.
- Removes a 1,176× log amplification: `entity.add("website", …)` runs once per
  CSV row and `INU0122` has 3,528 rows (3 websites × 1,176 name/address
  combinations), so one bad value was logged 1,176 times. The value now cleans,
  so it never reaches the warning branch — no change to the row loop needed.
- Drops this dataset's reliance on the temporary URL grace period (#5211).
  Without the lookups, all 13 values are currently published as-is, e.g.
  `website = "Social Media: http://vk.com/kazak_nac_guard"`.

### Verification

Ran `prop_lookup` + `clean_text` over all 13 source strings: each matches an
option and cleans successfully, 0 failures. `yamllint` and `check yaml` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)