### PR TITLE
Prune stale mypy excludes

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -51,83 +51,13 @@ repos:
         files: "datasets/"
         exclude: |
           (?x)^(
-          datasets/_analysis|
-          datasets/_collections|
-          datasets/_externals|
-          datasets/_global/c4ads_xinjiang|
-          datasets/_global/c4ads_xinjiang_mining|
-          datasets/_global/ebrd_ineligible|
-          datasets/_global/eiti_soe|
-          datasets/_global/everypolitician|
-          datasets/_global/iso9362_bic|
-          datasets/_global/paris_mou_banned|
-          datasets/_global/ransomwhere|
-          datasets/_global/research|
-          datasets/_global/shu_uyghur_companies|
-          datasets/_global/thesentry_atlas|
-          datasets/_global/un_1718_vessels|
-          datasets/_global/un_ga_protocol|
-          datasets/_global/un_sc_sanctions|
-          datasets/_wikidata|
-          datasets/ae|
-          datasets/cn|
-          datasets/eu|
+          datasets/eu/journal_sanctions|
           datasets/gb/coh|
-          datasets/gb/nca_most_wanted|
-          datasets/gb/nca_press_releases|
-          datasets/id|
-          datasets/in|
           datasets/ky/judicial|
-          datasets/lt|
-          datasets/my|
-          datasets/ng|
-          datasets/no/nbim_exclusions|
-          datasets/np|
-          datasets/ph|
-          datasets/qa|
-          datasets/ro|
-          datasets/rs|
-          datasets/sg/mas_enforcement_actions|
-          datasets/sg/mas_investor_alert|
-          datasets/sg/terrorists|
-          datasets/si|
-          datasets/sk/rpvs|
-          datasets/th/designated_person|
-          datasets/tw|
-          datasets/ua|
-          datasets/us/cia_world_leaders|
-          datasets/us/sec_pause|
-          datasets/us/ice_wanted|
-          datasets/us/irs_ffi|
-          datasets/us/state_terrorist_exclusion|
-          datasets/us/ofac/press_releases|
-          datasets/us/sec/pause|
-          datasets/us/sec/harmed_investors|
-          datasets/us/sec/litigation|
-          datasets/us/occ_enfact|
-          datasets/us/ddtc_enforcements|
-          datasets/us/nk_jointventures|
-          datasets/us/cia_world_factbook|
-          datasets/us/fincen_msb|
-          datasets/us/fbi_lazarus_crypto|
-          datasets/us/sec_litigation_releases|
-          datasets/us/dod_chinese_milcorps|
-          datasets/us/dc/exclusions|
-          datasets/us/fdic_failed_banks|
-          datasets/us/hhs_exclusions|
-          datasets/us/plural_legislators|
-          datasets/us/fed_enforcements|
-          datasets/us/trade_csl|
-          datasets/us/cbp_forced_labor|
-          datasets/us/dhs_uflpa|
-          datasets/us/congress|
+          datasets/lt/pep_declarations|
+          datasets/ng/join_dots|
           datasets/us/bis_denied|
-          datasets/us/state_terrorist_orgs|
-          datasets/us/fincen_special_measures|
-          datasets/us/dea_fugitives|
-          datasets/us/ss_wanted|
-          datasets/uy|
-          datasets/za
+          datasets/za/wanted
           )
         args: ['--strict', '--explicit-package-bases']
   - repo: local

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -37,7 +37,7 @@ repos:
           (?x)^(
           zavod/zavod/tests|
           contrib/|
-          datasets/|
+          datasets/
           )
         args: ['--strict']
 


### PR DESCRIPTION
Most of the paths in the `mypy-datasets` exclude list typecheck cleanly under `--strict` now, so this prunes it from 76 entries down to 7. I verified it by running mypy over all 472 `datasets/**/*.py` and bucketing the errors by file.

Still excluded, because they genuinely still fail: `eu/journal_sanctions` (1 error), `gb/coh` (4), `ky/judicial` (33), `lt/pep_declarations` (14), `ng/join_dots` (2), `us/bis_denied` (18), `za/wanted` (33).

Four of those were directory-level excludes (`eu`, `lt`, `ng`, `za`) where only one crawler in the directory actually fails, so I narrowed them — that puts the siblings under the typechecker. Also dropped three paths that don't exist anymore and two yml-only dirs.

The second commit is separable and a bit more interesting: the `zavod` mypy hook has never run. Its exclude pattern ended with `datasets/|` before the closing paren, and that empty alternative matches every path, so pre-commit has been quietly reporting `(no files to check) Skipped`. With the trailing pipe gone it checks 124 files. Locally it turns up two errors for me, but both are my env being stale (a leftover `urllib3-stubs` shadowing urllib3 2.x's inline types, and a nomenklatura checkout behind 4.12.4) — curious whether CI agrees. Happy to drop that commit if it's a can of worms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)