### PR TITLE
[eu_sanctions_map] Resolve journal link for Regulation 2026/1848

### DIFF
--- a/datasets/eu/sanctions_map/crawler.py
+++ b/datasets/eu/sanctions_map/crawler.py
@@ -108,6 +108,8 @@ def crawl_regime(context: Context) -> None:
 
 def crawl_vessels(context: Context) -> None:
     path = context.fetch_resource("vessels.xlsx", VESSELS_URL)
+    # read_only is not just an optimisation here: the full parser silently discards
+    # any row containing a cached formula error, and dozens of rows have #REF! dates.
     workbook: openpyxl.Workbook = openpyxl.load_workbook(
         path, read_only=True, data_only=True
     )

--- a/datasets/eu/sanctions_map/eu_sanctions_map.yml
+++ b/datasets/eu/sanctions_map/eu_sanctions_map.yml
@@ -80,12 +80,16 @@ lookups:
       - match:
           - 09346732 # Invalid IMO
         prop: registrationNumber
+  # The journal column sometimes contains the hyperlink's display text instead of its
+  # address. The values below are the link targets of the corresponding cells.
   type.url:
     options:
       - match: Regulation - EU - 2025/2618 - EN - EUR-Lex
         value: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=oj:L_202502618
       - match: Regulation - EU - 2026/506 - EN - EUR-Lex
         value: https://eur-lex.europa.eu/eli/reg/2026/506/oj/eng
+      - match: Regulation - 2026/1848 - EN - EUR-Lex
+        value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L_202601848
   type.date:
     options:
       - match: "#REF!"


### PR DESCRIPTION
The journal column of the designated vessels XLSX holds hyperlinks whose display text is sometimes the regulation title rather than its address. 41 vessel sanctions were dropping `sourceUrl` because of it. Added the lookup for the newest regulation, with the value taken from the cell's real link target.

`parse_xlsx_sheet` has `extract_links=True`, which would make this self-healing and kill the recurring lookup toil. I tried it and backed out: it needs `read_only=False`, and under that openpyxl 3.1.5 silently discards every row containing a cached formula error (`<c t="e"><f>#REF!</f>`). 56 vessel rows have `#REF!` dates, so it costs 56 vessels — worse than the bug it fixes. Left a comment at the `load_workbook` call so `read_only` doesn't look like a mere optimisation. Worth knowing for other crawlers too.

Verified against the 08:48 production run: issues 41 → 0, entity counts identical (LegalEntity 765, Vessel 862, Person 17, Sanction 739), `sourceUrl` statements 1370 → 1411. Couldn't run `zavod export` locally (no resolver DB), so I compared statement packs instead.

Follow-up worth considering: joining hyperlink targets from the sheet XML by display text would drop the lookup entirely, since every non-empty cell has a hyperlink and each title maps to exactly one target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
