### PR TITLE
[zyte] Don't let an unusable response survive in the cache

### DIFF
--- a/zavod/zavod/extract/zyte_api.py
+++ b/zavod/zavod/extract/zyte_api.py
@@ -137,14 +137,15 @@ def fetch_resource(
     api_response.raise_for_status()
 
     file_base64 = api_response.json()["httpResponseBody"]
-    with open(out_path, "wb") as fh:
-        fh.write(b64decode(file_base64))
     media_type, charset = get_content_type(api_response.json()["httpResponseHeaders"])
 
     if expected_media_type:
         assert media_type == expected_media_type, (media_type, charset, url)
     if expected_charset:
         assert charset == expected_charset, (media_type, charset, url)
+
+    with open(out_path, "wb") as fh:
+        fh.write(b64decode(file_base64))
 
     return False, media_type, charset, out_path
 
@@ -413,7 +414,12 @@ def fetch_json(
         )
         raise AssertionError(msg)
 
-    doc = json.loads(zyte_result.response_text)
+    try:
+        doc = json.loads(zyte_result.response_text)
+    except json.JSONDecodeError:
+        # A truncated cache entry would otherwise raise on every run until it expires.
+        zyte_result.invalidate_cache(context)
+        raise
 
     if not zyte_result.from_cache and cache_days is not None:
         context.cache.set(zyte_result.cache_fingerprint, zyte_result.response_text)
@@ -464,12 +470,16 @@ def fetch_html(
         cache_days=cache_days,
     )
 
-    doc = html.fromstring(zyte_result.response_text)
-    if absolute_links and isinstance(doc, html.HtmlElement):
-        cast(html.HtmlElement, doc).make_links_absolute(url)
+    doc: etree._Element | None = None
+    try:
+        doc = html.fromstring(zyte_result.response_text)
+    except etree.ParserError as exc:
+        context.log.debug("Response is not parseable HTML", url=url, error=str(exc))
 
-    matches = doc.xpath(unblock_validator)
-    if not isinstance(matches, list) or not len(matches) > 0:
+    # A response that doesn't parse at all — typically an empty body — is as
+    # unusable as one that wasn't unblocked, so both take the same path.
+    matches = doc.xpath(unblock_validator) if doc is not None else None
+    if doc is None or not isinstance(matches, list) or not len(matches) > 0:
         # If we've cached a response that no longer passes validation (likely because the code changed),
         # invalidate it so that we don't just get the same cached response on retry.
         zyte_result.invalidate_cache(context)
@@ -500,6 +510,9 @@ def fetch_html(
             )
         context.log.debug("Unblocking failed", url=url, html=zyte_result.response_text)
         raise UnblockFailedException(url, unblock_validator)
+
+    if absolute_links and isinstance(doc, html.HtmlElement):
+        cast(html.HtmlElement, doc).make_links_absolute(url)
 
     if not zyte_result.from_cache and cache_days is not None:
         context.cache.set(zyte_result.cache_fingerprint, zyte_result.response_text)

--- a/zavod/zavod/tests/extract/test_zyte_api.py
+++ b/zavod/zavod/tests/extract/test_zyte_api.py
@@ -2,6 +2,7 @@ import pytest
 import requests_mock
 from base64 import b64encode
 
+from zavod.archive import dataset_data_path
 from zavod.context import Context
 from zavod.meta.dataset import Dataset
 from zavod.extract.zyte_api import (
@@ -245,9 +246,11 @@ def test_fetch_resource(testdataset1: Dataset):
         with pytest.raises(AssertionError) as exc:
             fetch_resource(context, "source3.csv", url, expected_charset="UTF-8")
         assert "latin-1" in str(exc.value), exc.value
-        # Except when the file exists locally
-        fetch_resource(context, "source2.csv", url, expected_media_type="text/plain")
-        fetch_resource(context, "source3.csv", url, expected_charset="UTF-8")
+        # A rejected response isn't kept, so the next attempt fetches again rather
+        # than being handed back the file that was just turned down.
+        data_path = dataset_data_path(context.dataset.name)
+        assert not data_path.joinpath("source2.csv").exists()
+        assert not data_path.joinpath("source3.csv").exists()
     context.close()
 
 


### PR DESCRIPTION
`fetch_html` parses *before* it validates, so when Zyte hands back an empty
`httpResponseBody` the `ParserError` from `html.fromstring` escapes the
function entirely. Two consequences: the response never reaches the unblock
retry path, so a single empty body kills the whole crawl; and it never reaches
`invalidate_cache()` either, so with `cache_days` set a bad entry sticks around
and fails every run until it expires.

Same shape in `fetch_json`, where a truncated cache entry raises on
`json.loads` forever, and in `fetch_resource`, where a response that fails its
content-type assertion was still written to disk for the next run's
`out_path.exists()` to trust.

So:

- `fetch_html` — a parse failure now takes the existing invalidate-and-retry
  path, instead of escaping before the validator runs.
- `fetch_json` — invalidates the entry when the text doesn't parse.
- `fetch_resource` — asserts before writing, so nothing rejected gets left behind.

I had a shared context manager doing the invalidation across all the callers
and threw it out — in `fetch_text` it provably can't ever fire (the media-type
asserts are gated on `media_type`, which is `None` on a cache hit), which left
one real call site. Not worth it.

One existing test changed: `test_fetch_resource` asserted that a rejected
download stays on disk and gets reused, which is the exact hazard, so I flipped
those two lines. The legit don't-refetch case is still covered above it.

Two things I left alone, happy to do them here if you'd rather: `fetch()` never
checks `statusCode`, so a target-server 404/5xx with a body reads as success;
and `assert text is not None` doesn't catch `""`, which is what Zyte actually
returns for an empty body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
