### PR TITLE
[zavod] Drop the pre-fingerprint HTTP cache key from fetch_text

### DIFF
--- a/zavod/zavod/context.py
+++ b/zavod/zavod/context.py
@@ -341,16 +341,7 @@ class Context:
             url, auth=auth, method=method, data=data, encoding=encoding
         )
         if cache_days is not None:
-            text = None
-
-            if method == "GET" and encoding is None:
-                # keeping the old caching keys that was GET requests only
-                text = self.cache.get(url, max_age=cache_days)
-
-            if text is None:
-                # if the old cache is empty, try to get the cache by fingerprint
-                text = self.cache.get(fingerprint, max_age=cache_days)
-
+            text = self.cache.get(fingerprint, max_age=cache_days)
             if text is not None:
                 self.log.debug("HTTP cache hit", url=url, fingerprint=fingerprint)
                 return text


### PR DESCRIPTION
`fetch_text` has been checking two cache keys: the request fingerprint, and — for plain GETs — the bare URL, with a `# keeping the old caching keys that was GET requests only` comment. That shim went in with https://github.com/opensanctions/opensanctions/commit/dcc86d786 in April 2024, when caching moved to fingerprints, so the existing cache wouldn't all go cold at once. Fair enough at the time.

But `context.py:368` is the only thing that writes into that cache and it only ever writes fingerprints, `Cache.get` is an exact-match lookup (no prefix matching), and nothing in the repo caches for longer than six months. So the bare-URL lookup has returned `None` for every request since roughly October 2024. No test covered it either.

It's not free dead code, though:

- It's encoding-blind by construction, so https://github.com/opensanctions/opensanctions/commit/8e316b62c had to add `and encoding is None` to it when introducing the encoding override.
- `clear_url` only evicts the fingerprint, which is right in practice but reads as a bug against the two-key lookup — I went and "fixed" that this morning before working out the branch was unreachable.

So: one lookup, one key. `clear_url` becomes correct on paper too, no behaviour change for anything live.

I dug this out from the eu_journal_sanctions side (https://github.com/opensanctions/opensanctions/pull/5234), which is written assuming this is in.

Ran the full zavod suite: 290 pass, the 3 `test_local_enricher` failures are pre-existing on main (`'LocalEnricher' object has no attribute 'filter_topics'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)