### PR TITLE
Add zavodlake, a parquet statement lake workbench

### DIFF
--- a/contrib/zavodlake/PLAN.md
+++ b/contrib/zavodlake/PLAN.md
@@ -1,0 +1,34 @@
+---
+description: Experiment agenda for the zavodlake parquet statement lake
+date: 2026-08-02
+tags: [zavodlake, parquet, duckdb, prototyping]
+---
+
+# zavodlake: parquet statement lake experiments
+
+The `build` command in this package backfills `statements.pack` and metadata for every
+dataset in a collection and converts each pack into a deduplicated, typed
+`data/lake/<dataset>/statements.parquet`.
+
+## Idea
+
+The fundamental idea is that these parquet files might be able to shift burden away from
+the export, xref, analysis and enrichment processes — which today each fetch and load the
+full statement set — towards re-usable, queryable artifacts.
+
+## Experiments
+
+1. **Parquet-backed nomenklatura Store.** Can the lake drive a `Store` implementation that
+   is slower but runs off re-usable artifacts rather than fetching all statements? This
+   will likely not work in export (graph traversal requires a lot of queries), but might
+   work in xref, which only reads individual entities in its second phase.
+2. **Faster LevelDB store builds.** Can a LevelDB store be built more quickly by feeding
+   it from a parquet query instead of the pack files?
+3. **Stateless xref decision tool.** Can the lake provide a backend store for an
+   interactive web-based xref decision tool running as a stateless Cloud Run job?
+4. **Inverted-index parquet.** Can we generate a second set of parquet files containing a
+   tokenized inverted index à la `nomenklatura.index`, usable to drive xref and enrichment
+   straight from bucket artifacts?
+
+None of these necessarily intersect with the resolver — the entity queries involved can
+just be `entity_id IN (...)` lookups on source ids.

--- a/contrib/zavodlake/PLAN.md
+++ b/contrib/zavodlake/PLAN.md
@@ -32,3 +32,36 @@ full statement set — towards re-usable, queryable artifacts.
 
 None of these necessarily intersect with the resolver — the entity queries involved can
 just be `entity_id IN (...)` lookups on source ids.
+
+## Long-term layout
+
+- Productized, the parquet file lives in each dataset's versioned `artifacts/` folder.
+  ETL processes often run 8+ hours and need cross-query consistency, so readers pin
+  full versioned paths at run start rather than globbing. Dataset versions have no
+  relation to each other, so latest-per-dataset at start is a valid pin.
+- The files stay unresolved: a PEP crawler runs monthly, but xref on PEPs runs nightly —
+  merges cannot be stuck in that interval.
+- Every published `statements.pack` becomes a parquet; collection scoping is a reader
+  concern, not a builder concern.
+- Pre-productization, a mirror under `contrib/zlake/<dataset>/<version>/statements.parquet`
+  in the public bucket copies the final layout without writing to the prod zone; the
+  `contrib/` prefix marks it as not prod material. It uses live run versions, just
+  created outside the crawler run process. All versions are kept for now (no GC).
+- The latest parquet may trail the latest released dataset version, so each build
+  finishes by writing `contrib/zlake/<dataset>/parquet-latest.json` (version, path,
+  rows, schema, built_at). The single-object PUT is atomic and builds per dataset are
+  serialized by its crawl schedule, so the pointer is the source of truth; a
+  `manifest.json` aggregating all pointers is a derived cache, rebuildable from a
+  LIST. Later this becomes `parquets.json` in the artifacts root.
+- The same event logic can drive a second artifact, the inverted-index parquet for
+  xref (`blocker.parquet`): its build is triggered by the same bucket event, with
+  versions tracked via a parallel pointer file (`blocker-latest.json` alongside
+  `parquet-latest.json`).
+- `latest.json` carries a schema version (`"schema": 1`) so readers can fail loudly
+  before downloading anything. Additive columns don't bump it; any other change bumps
+  it and implies a full rebuild.
+- Bootstrap: a `sync` method in zavodlake reads the metadata catalog, checks for a
+  parquet at the latest version, and if missing downloads the pack, transforms and
+  uploads it. Later this can become event-driven (build on pack publish), which could
+  replace both the planned zavod-export integration and the current
+  load-statements-to-the-database mechanism.

--- a/contrib/zavodlake/PLAN.md
+++ b/contrib/zavodlake/PLAN.md
@@ -29,6 +29,9 @@ full statement set — towards re-usable, queryable artifacts.
 4. **Inverted-index parquet.** Can we generate a second set of parquet files containing a
    tokenized inverted index à la `nomenklatura.index`, usable to drive xref and enrichment
    straight from bucket artifacts?
+5. **Version deltas as anti-joins.** With two versioned statement parquets of the same
+   dataset, statement-level added/removed/changed is a sorted anti-join — one duckdb
+   query. Could this replace the delta export subsystem (`entities.delta.json`)?
 
 None of these necessarily intersect with the resolver — the entity queries involved can
 just be `entity_id IN (...)` lookups on source ids.

--- a/contrib/zavodlake/__init__.py
+++ b/contrib/zavodlake/__init__.py
@@ -1,0 +1,8 @@
+"""Prototyping workbench for a parquet-based statement lake.
+
+Backfills dataset metadata and ``statements.pack`` files from the production
+archive into the local data directory, then converts each pack file into a
+typed, deduplicated ``data/lake/<dataset>/statements.parquet`` using duckdb.
+
+Usage: ``python -m contrib.zavodlake build [DATASET]...``
+"""

--- a/contrib/zavodlake/__main__.py
+++ b/contrib/zavodlake/__main__.py
@@ -1,0 +1,4 @@
+from contrib.zavodlake.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/contrib/zavodlake/cli.py
+++ b/contrib/zavodlake/cli.py
@@ -5,10 +5,11 @@ import duckdb
 
 from zavod import settings
 from zavod.logs import configure_logging, get_logger
-from zavod.meta import load_directory_catalog
+from zavod.meta import Dataset, load_directory_catalog
 
-from contrib.zavodlake.convert import convert_dataset
+from contrib.zavodlake.convert import convert_dataset, dataset_parquet_path
 from contrib.zavodlake.fetch import fetch_dataset
+from contrib.zavodlake.sync import sync_dataset
 
 log = get_logger("zavodlake")
 
@@ -16,6 +17,29 @@ log = get_logger("zavodlake")
 # format (headerless, no id column). Skipped rather than crashing the build;
 # remove once they are re-exported or leave the scope collection.
 SKIP_DATASETS = {"lt_pep_declarations"}
+
+
+def _configure_archive() -> None:
+    if settings.ARCHIVE_BACKEND == "FileSystemBackend" and (
+        settings.ARCHIVE_BUCKET is None
+    ):
+        log.info("Archive not configured, defaulting to production bucket")
+        settings.ARCHIVE_BACKEND = "GoogleCloudBackend"
+        settings.ARCHIVE_BUCKET = "data.opensanctions.org"
+
+
+def _select_leaves(scope_name: str, datasets: tuple[str, ...]) -> list[Dataset]:
+    catalog = load_directory_catalog()
+    scope = catalog.require(scope_name)
+    leaves = sorted(scope.leaves, key=lambda d: d.name)
+    if len(datasets) > 0:
+        unknown = set(datasets) - {leaf.name for leaf in leaves}
+        if len(unknown) > 0:
+            raise click.BadParameter(
+                f"Not leaf datasets of {scope_name!r}: {', '.join(sorted(unknown))}"
+            )
+        leaves = [leaf for leaf in leaves if leaf.name in set(datasets)]
+    return leaves
 
 
 @click.group(help="Parquet statement lake prototyping workbench")
@@ -40,23 +64,8 @@ def cli() -> None:
 )
 def build(datasets: tuple[str, ...], scope_name: str, force: bool) -> None:
     configure_logging(level=logging.INFO)
-    if settings.ARCHIVE_BACKEND == "FileSystemBackend" and (
-        settings.ARCHIVE_BUCKET is None
-    ):
-        log.info("Archive not configured, defaulting to production bucket")
-        settings.ARCHIVE_BACKEND = "GoogleCloudBackend"
-        settings.ARCHIVE_BUCKET = "data.opensanctions.org"
-
-    catalog = load_directory_catalog()
-    scope = catalog.require(scope_name)
-    leaves = sorted(scope.leaves, key=lambda d: d.name)
-    if len(datasets) > 0:
-        unknown = set(datasets) - {leaf.name for leaf in leaves}
-        if len(unknown) > 0:
-            raise click.BadParameter(
-                f"Not leaf datasets of {scope_name!r}: {', '.join(sorted(unknown))}"
-            )
-        leaves = [leaf for leaf in leaves if leaf.name in set(datasets)]
+    _configure_archive()
+    leaves = _select_leaves(scope_name, datasets)
 
     conn = duckdb.connect()
     temp_path = settings.DATA_PATH / "lake" / ".duckdb_tmp"
@@ -93,6 +102,49 @@ def build(datasets: tuple[str, ...], scope_name: str, force: bool) -> None:
         fresh=fresh,
         missing=missing,
         skipped=skipped,
+    )
+
+
+@cli.command("sync", help="Upload lake parquet files to the bucket mirror")
+@click.argument("datasets", nargs=-1)
+@click.option(
+    "--scope",
+    "scope_name",
+    default="default",
+    show_default=True,
+    help="Collection whose leaf datasets are processed",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Re-upload even if the remote pointer already has this version",
+)
+def sync(datasets: tuple[str, ...], scope_name: str, force: bool) -> None:
+    configure_logging(level=logging.INFO)
+    _configure_archive()
+    leaves = _select_leaves(scope_name, datasets)
+
+    conn = duckdb.connect()
+    uploaded, fresh, missing = 0, 0, 0
+    for leaf in leaves:
+        if not dataset_parquet_path(leaf.name).is_file():
+            log.warning("No lake parquet, skipping", dataset=leaf.name)
+            missing += 1
+            continue
+        version = sync_dataset(conn, leaf.name, force=force)
+        if version is None:
+            log.info("Remote pointer is up to date", dataset=leaf.name)
+            fresh += 1
+            continue
+        log.info("Synced to bucket", dataset=leaf.name, version=version)
+        uploaded += 1
+    log.info(
+        "Lake sync complete",
+        scope=scope_name,
+        uploaded=uploaded,
+        fresh=fresh,
+        missing=missing,
     )
 
 

--- a/contrib/zavodlake/cli.py
+++ b/contrib/zavodlake/cli.py
@@ -1,0 +1,100 @@
+import logging
+
+import click
+import duckdb
+
+from zavod import settings
+from zavod.logs import configure_logging, get_logger
+from zavod.meta import load_directory_catalog
+
+from contrib.zavodlake.convert import convert_dataset
+from contrib.zavodlake.fetch import fetch_dataset
+
+log = get_logger("zavodlake")
+
+# Datasets whose newest archived statements.pack predates the current pack
+# format (headerless, no id column). Skipped rather than crashing the build;
+# remove once they are re-exported or leave the scope collection.
+SKIP_DATASETS = {"lt_pep_declarations"}
+
+
+@click.group(help="Parquet statement lake prototyping workbench")
+def cli() -> None:
+    pass
+
+
+@cli.command("build", help="Backfill packs and convert them to parquet")
+@click.argument("datasets", nargs=-1)
+@click.option(
+    "--scope",
+    "scope_name",
+    default="default",
+    show_default=True,
+    help="Collection whose leaf datasets are processed",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Re-convert parquet files even if they are up to date",
+)
+def build(datasets: tuple[str, ...], scope_name: str, force: bool) -> None:
+    configure_logging(level=logging.INFO)
+    if settings.ARCHIVE_BACKEND == "FileSystemBackend" and (
+        settings.ARCHIVE_BUCKET is None
+    ):
+        log.info("Archive not configured, defaulting to production bucket")
+        settings.ARCHIVE_BACKEND = "GoogleCloudBackend"
+        settings.ARCHIVE_BUCKET = "data.opensanctions.org"
+
+    catalog = load_directory_catalog()
+    scope = catalog.require(scope_name)
+    leaves = sorted(scope.leaves, key=lambda d: d.name)
+    if len(datasets) > 0:
+        unknown = set(datasets) - {leaf.name for leaf in leaves}
+        if len(unknown) > 0:
+            raise click.BadParameter(
+                f"Not leaf datasets of {scope_name!r}: {', '.join(sorted(unknown))}"
+            )
+        leaves = [leaf for leaf in leaves if leaf.name in set(datasets)]
+
+    conn = duckdb.connect()
+    temp_path = settings.DATA_PATH / "lake" / ".duckdb_tmp"
+    conn.execute(f"SET temp_directory = '{temp_path}'")
+    converted, fresh, missing, skipped = 0, 0, 0, 0
+    for leaf in leaves:
+        if leaf.name in SKIP_DATASETS:
+            log.info("Skipping dataset with unsupported pack", dataset=leaf.name)
+            skipped += 1
+            continue
+        pack_path = fetch_dataset(leaf.name)
+        if pack_path is None:
+            log.warning("No statements.pack in the archive", dataset=leaf.name)
+            missing += 1
+            continue
+        result = convert_dataset(conn, leaf.name, pack_path, force=force)
+        if result is None:
+            log.info("Parquet is up to date", dataset=leaf.name)
+            fresh += 1
+            continue
+        rows_in, rows_out = result
+        log.info(
+            "Converted to parquet",
+            dataset=leaf.name,
+            rows_in=rows_in,
+            rows_out=rows_out,
+            duplicates=rows_in - rows_out,
+        )
+        converted += 1
+    log.info(
+        "Lake build complete",
+        scope=scope_name,
+        converted=converted,
+        fresh=fresh,
+        missing=missing,
+        skipped=skipped,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/contrib/zavodlake/convert.py
+++ b/contrib/zavodlake/convert.py
@@ -4,23 +4,6 @@ import duckdb
 
 from zavod import settings
 
-# Column order written by followthemoney's PackStatementWriter. Older, headerless
-# pack files use a different column set and are deliberately not supported.
-PACK_COLUMNS = [
-    "entity_id",
-    "prop",
-    "value",
-    "dataset",
-    "lang",
-    "original_value",
-    "origin",
-    "external",
-    "first_seen",
-    "last_seen",
-    "id",
-]
-PACK_HEADER = ",".join(PACK_COLUMNS)
-
 
 def dataset_parquet_path(dataset_name: str) -> Path:
     return settings.DATA_PATH / "lake" / dataset_name / "statements.parquet"
@@ -28,15 +11,6 @@ def dataset_parquet_path(dataset_name: str) -> Path:
 
 def _sql_str(value: Path) -> str:
     return str(value).replace("'", "''")
-
-
-def _check_pack_header(pack_path: Path) -> None:
-    with open(pack_path, "r", encoding="utf-8") as fh:
-        first_line = fh.readline().rstrip("\n")
-    if first_line != PACK_HEADER:
-        raise ValueError(
-            f"Unexpected statements.pack header in {pack_path}: {first_line!r}"
-        )
 
 
 def convert_dataset(
@@ -56,7 +30,6 @@ def convert_dataset(
     if not force and out_path.is_file():
         if out_path.stat().st_mtime >= pack_path.stat().st_mtime:
             return None
-    _check_pack_header(pack_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Pin the pack dialect (csv.unix_dialect) rather than letting duckdb sniff it:

--- a/contrib/zavodlake/convert.py
+++ b/contrib/zavodlake/convert.py
@@ -98,13 +98,14 @@ def convert_dataset(
     copy_sql = f"""
         COPY (
             SELECT * FROM ({select})
-            -- Rows can share an id with differing content (the statement id hash
-            -- covers neither schema nor original_value); prefer the richest row
-            -- (original_value, lang, origin set), then break ties deterministically.
+            -- Rows can share an id with differing content: the statement id hash
+            -- covers dataset, entity_id, prop, value, lang and external, so only
+            -- schema, original_value, origin and the seen timestamps can differ
+            -- within an id. Prefer the richest row, then order for determinism.
             QUALIFY row_number() OVER (
                 PARTITION BY id
-                ORDER BY original_value NULLS LAST, lang NULLS LAST,
-                    origin NULLS LAST, prop, external, first_seen, last_seen
+                ORDER BY original_value NULLS LAST, origin NULLS LAST,
+                    "schema", first_seen, last_seen
             ) = 1
             ORDER BY entity_id
         ) TO '{_sql_str(tmp_path)}' (FORMAT parquet, COMPRESSION zstd)

--- a/contrib/zavodlake/convert.py
+++ b/contrib/zavodlake/convert.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+
+import duckdb
+
+from zavod import settings
+
+# Column order written by followthemoney's PackStatementWriter. Older, headerless
+# pack files use a different column set and are deliberately not supported.
+PACK_COLUMNS = [
+    "entity_id",
+    "prop",
+    "value",
+    "dataset",
+    "lang",
+    "original_value",
+    "origin",
+    "external",
+    "first_seen",
+    "last_seen",
+    "id",
+]
+PACK_HEADER = ",".join(PACK_COLUMNS)
+
+
+def dataset_parquet_path(dataset_name: str) -> Path:
+    return settings.DATA_PATH / "lake" / dataset_name / "statements.parquet"
+
+
+def _sql_str(value: Path) -> str:
+    return str(value).replace("'", "''")
+
+
+def _check_pack_header(pack_path: Path) -> None:
+    with open(pack_path, "r", encoding="utf-8") as fh:
+        first_line = fh.readline().rstrip("\n")
+    if first_line != PACK_HEADER:
+        raise ValueError(
+            f"Unexpected statements.pack header in {pack_path}: {first_line!r}"
+        )
+
+
+def convert_dataset(
+    conn: duckdb.DuckDBPyConnection,
+    dataset_name: str,
+    pack_path: Path,
+    force: bool = False,
+) -> tuple[int, int] | None:
+    """Convert a dataset's statements.pack into a typed, deduplicated parquet file.
+
+    Statements are deduplicated on the ``id`` column and sorted by ``entity_id``;
+    the packed ``Schema:prop`` column is split into separate ``schema`` and
+    ``prop`` columns. Returns (rows_in, rows_out), or None if the existing
+    parquet file is newer than the pack file and ``force`` is not set.
+    """
+    out_path = dataset_parquet_path(dataset_name)
+    if not force and out_path.is_file():
+        if out_path.stat().st_mtime >= pack_path.stat().st_mtime:
+            return None
+    _check_pack_header(pack_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Pin the pack dialect (csv.unix_dialect) rather than letting duckdb sniff it:
+    # a large unquoted sample makes the sniffer detect "no quoting", which then
+    # breaks on the first quoted field further into the file. Single fields can be
+    # up to PROP_VALUE_MAX (30 MB), far beyond duckdb's default max_line_size.
+    select = f"""
+        SELECT
+            id,
+            entity_id,
+            split_part(prop, ':', 1) AS "schema",
+            split_part(prop, ':', 2) AS prop,
+            value,
+            dataset,
+            lang,
+            original_value,
+            origin,
+            coalesce(external = 't', false) AS external,
+            CAST(first_seen AS TIMESTAMP) AS first_seen,
+            CAST(last_seen AS TIMESTAMP) AS last_seen
+        FROM read_csv('{_sql_str(pack_path)}', header = true, all_varchar = true,
+            delim = ',', quote = '"', escape = '"', max_line_size = 33554432)
+    """
+    row = conn.execute(
+        f"""
+        SELECT count(*),
+            count(*) FILTER (WHERE "schema" = '' OR prop = '' OR id IS NULL)
+        FROM ({select})
+        """
+    ).fetchone()
+    assert row is not None
+    rows_in, bad_rows = int(row[0]), int(row[1])
+    if bad_rows > 0:
+        raise ValueError(
+            f"{pack_path} has {bad_rows} rows with a malformed prop or a null id"
+        )
+
+    tmp_path = out_path.with_suffix(".parquet.tmp")
+    copy_sql = f"""
+        COPY (
+            SELECT * FROM ({select})
+            -- Rows can share an id with differing content (the statement id hash
+            -- covers neither schema nor original_value); prefer the richest row
+            -- (original_value, lang, origin set), then break ties deterministically.
+            QUALIFY row_number() OVER (
+                PARTITION BY id
+                ORDER BY original_value NULLS LAST, lang NULLS LAST,
+                    origin NULLS LAST, prop, external, first_seen, last_seen
+            ) = 1
+            ORDER BY entity_id
+        ) TO '{_sql_str(tmp_path)}' (FORMAT parquet, COMPRESSION zstd)
+    """
+    try:
+        out_row = conn.execute(copy_sql).fetchone()
+        assert out_row is not None
+        rows_out = int(out_row[0])
+        tmp_path.replace(out_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    return rows_in, rows_out

--- a/contrib/zavodlake/fetch.py
+++ b/contrib/zavodlake/fetch.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from zavod.archive import INDEX_FILE, STATEMENTS_FILE, get_dataset_artifact
+from zavod.logs import get_logger
+
+log = get_logger(__name__)
+
+
+def fetch_dataset(dataset_name: str) -> Path | None:
+    """Ensure a dataset's metadata and statements are present in the local data path.
+
+    Downloads ``index.json`` and ``statements.pack`` from the archive into
+    ``data/datasets/<name>/`` unless they already exist locally. Returns the
+    path to the pack file, or None if the archive has no statements for the
+    dataset.
+    """
+    get_dataset_artifact(dataset_name, INDEX_FILE)
+    path = get_dataset_artifact(dataset_name, STATEMENTS_FILE)
+    if path.is_file() and path.stat().st_size == 0:
+        # A valid pack always contains at least the header row; a zero-byte
+        # file is a truncated download. Drop it and fetch again.
+        log.warning("Zero-byte statements.pack, refetching", dataset=dataset_name)
+        path.unlink()
+        path = get_dataset_artifact(dataset_name, STATEMENTS_FILE)
+        if path.is_file() and path.stat().st_size == 0:
+            return None
+    if not path.is_file():
+        return None
+    return path

--- a/contrib/zavodlake/perf.md
+++ b/contrib/zavodlake/perf.md
@@ -219,6 +219,16 @@ Identical output either way: 4,352,964 rows, 384,880 entities, ~415 MB on disk.
 The remote pull adds ~6.5 s of network — ~19 MB/s effective from a residential
 connection *including* the 91 per-file round trips. Unlike point lookups, the
 CTAS streams files in parallel, so per-file latency largely amortizes away.
+
+The CTAS is automatically parallel (scan splits across files and row groups
+onto all threads; httpfs issues concurrent range requests): single-threaded it
+is 3× slower. One knob buys more: `SET preserve_insertion_order = false` lets
+the insert stage run parallel too instead of re-serializing scan output —
+2.5× faster locally (0.5 s → 0.2 s in-memory), ~20% remotely (8.5 s → 6.8 s,
+network-bound), and it is the documented fix for out-of-memory on very large
+loads (relevant at full-lake scale). Safe for us: statement order in the table
+is meaningless, everything reads via the entity_id index. A bootstrap service
+should always set it before materializing.
 Nine seconds from nothing to an indexed store that serves batched reads at
 0.06 ms/entity (exp1) validates the download → materialize → serve shape for a
 stateless Cloud Run service. Extrapolated to the full default lake (3.9 GB,

--- a/contrib/zavodlake/perf.md
+++ b/contrib/zavodlake/perf.md
@@ -159,6 +159,48 @@ LevelDB needs a ~17 s sync before it can serve the 11.5 s scan, while the DuckDB
 store reads the parquet artifacts directly after a 0.14 s init — ~14 s vs ~28 s from
 cold statement artifacts.
 
+## Remote latency: bucket mirror over HTTPS (2026-08-03)
+
+The full default lake (446 files) is synced to `contrib/zlake/` in the archive
+bucket (`python -m contrib.zavodlake.cli sync`). Queried the sanctions scope
+(91 files) from a laptop in DE via duckdb httpfs (`contrib/zavodlake/bench_remote.py`),
+over two transports: the public bunny.net CDN (`data.opensanctions.org`) and
+V4-signed raw GCS URLs (minted via IAM signBlob as the read-only crawler-team
+service account, `contrib/zavodlake/signing.py`), plus the same queries against
+the local lake files for scale:
+
+| query | CDN | signed GCS | local NVMe |
+| --- | --- | --- | --- |
+| glob 4-id, cold connection | 3.12 s | 3.01 s | 0.01 s |
+| glob 4-id, warm | 0.96 s | 1.37 s | 0.01 s |
+| glob 1000-id, warm | 1.59 s | 2.55 s | 0.01 s |
+| single file (us_ofac_sdn) 1-id, cold | 0.31 s | 0.51 s | <0.01 s |
+| single file 1-id, warm | 0.09 s | 0.12 s | <0.01 s |
+
+(Each transport is a separate run and the id sample is not deterministic across
+runs, so row counts differ slightly; the workload magnitude is identical.)
+
+Takeaways:
+
+- **Local files are 2–3 orders of magnitude faster than either transport** — the
+  remote cost is pure network round trips (~30 ms per footer/row-group fetch that
+  is sub-millisecond locally). Remote-in-place querying suits interactive,
+  low-request-count access; bulk consumers (xref, exports, store builds) should
+  download the parquet files and query locally. Measured from a residential
+  connection; in-GCP numbers would land in between.
+- **The CDN wins on every warm query** — raw GCS is 40–60% slower from here, and
+  signing added a 19 s setup (~0.21 s per sequential signBlob call, one per file).
+  Signed URLs also expire (6 h default), which sits badly with 8 h+ ETL runs and
+  with caching query plans/URL lists. No reason to bypass bunny for reads.
+- Cold cost is per-file footer fetches: ~34 ms/file on the 91-file scope; a full
+  default-lake (447 file) cold sweep extrapolates to ~15 s before any data reads.
+- Warm whole-scope queries have a ~1 s floor regardless of result size; batch-1000
+  lookups amortize to **1.6 ms/entity** (13× the local 0.12 ms) — a 500k-entity xref
+  prefetch straight off the bucket would be ~13 min, so remote reads want either a
+  local download-then-query step or a consolidated file.
+- Single-file point reads (90–310 ms) are fine for the side-by-side web view use
+  case without any server-side state.
+
 ## Alternative: materialize into a local duckdb table
 
 Another possible way to play some of the experiments: instead of querying the

--- a/contrib/zavodlake/perf.md
+++ b/contrib/zavodlake/perf.md
@@ -138,6 +138,27 @@ lake (`contrib/zavodlake/exp1b_store.py`):
 
 Not yet done: batched prefetch in the nomenklatura xref loop, zavod integration.
 
+## Experiment 3 result: export-style full scan, LevelDB vs DuckDB store (2026-08-02)
+
+Replayed an export workload — `view.entities()`, every entity in scope assembled —
+against the `sanctions` scope (`contrib/zavodlake/exp3_export.py`, local NVMe):
+
+| backend | total | ent/s |
+| --- | --- | --- |
+| LevelDB store | 11.5 s | 33,340 |
+| DuckDB store, parquet glob | 14.1 s | 27,208 |
+| DuckDB store, materialized table (0.3 s build) | 14.0 s | 27,441 |
+
+All backends returned identical output: 384,880 entities, 4,273,447 statements.
+
+**The DuckDB store scan is ~22% slower than LevelDB.** As in exp2, the scan is not
+I/O-bound: per-row Python work (4.3M `Statement` constructions + assembly) dominates
+and every backend pays it, so materializing the table buys nothing and duckdb's
+`ORDER BY canonical_id` sort is noise. The end-to-end framing favours duckdb though:
+LevelDB needs a ~17 s sync before it can serve the 11.5 s scan, while the DuckDB
+store reads the parquet artifacts directly after a 0.14 s init — ~14 s vs ~28 s from
+cold statement artifacts.
+
 ## Alternative: materialize into a local duckdb table
 
 Another possible way to play some of the experiments: instead of querying the

--- a/contrib/zavodlake/perf.md
+++ b/contrib/zavodlake/perf.md
@@ -1,0 +1,98 @@
+---
+description: Research notes on lakehouse best practices and parquet/duckdb performance
+date: 2026-08-02
+tags: [zavodlake, parquet, duckdb, performance]
+---
+
+# Performance notes
+
+Notes from reading up on lakehouse architectures and parquet/duckdb performance
+(2026-08), plus local observations about our lake.
+
+## Do we need a table format (Iceberg/Delta/Hudi)?
+
+- Table formats earn their complexity through ACID transactions, concurrent writers,
+  schema evolution and time travel. A single-writer pipeline producing immutable,
+  batch-replaced artifacts gets most of that from a versioned-path convention — which
+  the OpenSanctions archive already has (`artifacts/{dataset}/{version}/`).
+- Consensus: plain parquet is fine until multi-writer transactions or governance are
+  needed.
+- If the prototype ever needs snapshots / multi-file consistency: **DuckLake** keeps
+  data as plain parquet and puts all metadata in a SQL database (DuckDB, SQLite or
+  Postgres — we already run Postgres). Lowest-friction upgrade path from where we are.
+
+## Parquet layout numbers (duckdb guidance)
+
+- File size: ideal 100 MB – 10 GB per file; broader lakehouse guidance says
+  128 MB – 1 GB, well-tuned Iceberg tables use 256–512 MB.
+- Row groups: sweet spot 100K–1M rows. <5K rows per group is 5–10× slower; 5K–20K
+  still 1.5–2.5× off. DuckDB parallelizes *only across row groups*, so total row
+  groups across scanned files should be ≥ CPU threads.
+- Compression: zstd/snappy/lz4 recommended, gzip discouraged. (We use zstd.)
+- The "small files problem" is the most-cited structural failure in production lakes:
+  file count, not data volume, degrades planning, LIST calls and per-file open cost.
+  Our lake: 447 files, one 1.7 GB, long tail of sub-MB files. Harmless locally; over
+  a bucket a whole-lake glob pays ~450 HTTP round trips (footer fetch per file)
+  before reading any data. Standard remedy is (sort-based) compaction into fewer,
+  larger files.
+
+## Remote querying (bucket-driven experiments)
+
+- Against GCS/S3, network round trips dominate. DuckDB prunes at two levels: file
+  elimination (hive partitioning / filename filters), then row-group elimination
+  (zone maps). Both must engage for remote querying to be viable.
+- **Sorting is the poor man's index.** We sort by `entity_id`, so min/max zone maps
+  skip every row group that can't contain a looked-up entity.
+- **Parquet bloom filters**: since duckdb 1.2.0 they are written automatically for
+  dictionary-encoded columns (VARCHAR included) and probed on equality/IN
+  predicates — measured ~50× on point lookups of absent values, ~47 bytes per row
+  group overhead. Caveats: equality only; only written where dictionary encoding
+  kicked in (`DICTIONARY_SIZE_LIMIT`, default 10% of row group size — `entity_id` at
+  ~13 statements/entity may sit near that boundary; check with `parquet_metadata()`).
+- Tension to keep in mind: per-dataset files are natural partitions for
+  dataset-scoped work, but an `entity_id IN (...)` lookup across the whole lake pays
+  per-file overhead 447 times. A consolidated artifact sorted on the lookup key
+  would let the entity-read path touch one file and one or two row groups.
+
+## Local benchmark (2026-08-02)
+
+Point lookups against the full default lake (447 files, 127M statements, 3.9 GB) on a
+laptop with local NVMe, duckdb 1.5.4:
+
+| query | time |
+| --- | --- |
+| `entity_id IN (4 ids)` over the whole-lake glob, cold | 0.112 s |
+| same, warm | 0.086 s |
+| single entity from one dataset file | 0.004 s |
+| `entity_id IN (1000 ids)` over the whole-lake glob | 0.308 s (~0.3 ms/entity) |
+| `GROUP BY schema` aggregate over the whole lake | 0.080 s |
+
+Bloom filters are present on all 475 `entity_id` column chunks of the largest file
+(`ext_ru_egrul`, 58M rows), confirmed via `parquet_metadata()`.
+
+Takeaways: batched entity reads are competitive with a key-value store locally;
+per-entity glob lookups (~90 ms) are not — batch or consolidate. All numbers hide
+per-file network round trips, so remote (bucket) behaviour needs its own measurement.
+
+## Alternative: materialize into a local duckdb table
+
+Another possible way to play some of the experiments: instead of querying the
+parquet files in place, materialize the full statements table into a local duckdb
+database table, and run the experiment against that.
+
+## Sources
+
+- https://duckdb.org/docs/lts/guides/performance/file_formats
+- https://duckdb.org/docs/current/data/parquet/tips
+- https://duckdb.org/2025/03/07/parquet-bloom-filters-in-duckdb
+- https://motherduck.com/blog/open-lakehouse-stack-duckdb-table-formats/
+- https://motherduck.com/learn/what-is-a-data-lakehouse/
+- https://clickhouse.com/resources/engineering/data-lakehouse
+- https://hudi.apache.org/blog/2026/07/24/open-table-format-vs-data-lakehouse/
+- https://thedatatoolbox.substack.com/p/a-quick-overview-on-ducklake-yet
+- https://luminousmen.com/post/compaction-in-lakehouse/
+- https://lakeops.dev/blog/iceberg-small-files-guide
+- https://ved-prakash-sde.medium.com/querying-partitioned-parquet-files-on-gcs-with-duckdb-a-production-grade-guide-ffa8396ddb82
+- https://github.com/duckdb/duckdb/discussions/13255
+- https://medium.com/@connect.hashblock/duckdb-indexing-tricks-that-cut-my-latency-50d1bdb4efc3
+- https://www.datobra.com/when-small-parquet-files-become-a-big-problem-and-how-i-ended-up-writing-a-compactor-in-pyarrow/

--- a/contrib/zavodlake/perf.md
+++ b/contrib/zavodlake/perf.md
@@ -201,6 +201,30 @@ Takeaways:
 - Single-file point reads (90–310 ms) are fine for the side-by-side web view use
   case without any server-side state.
 
+## Remote materialization: on-disk duckdb table from the mirror (2026-08-03)
+
+The stateless-service bootstrap path: a fresh file-backed duckdb pulls the
+sanctions scope (91 files, 149 MB parquet, 4.35M statements) straight off the
+mirror into a statements table, then indexes entity_id
+(`contrib/zavodlake/bench_materialize.py`):
+
+| step | CDN (remote) | local files |
+| --- | --- | --- |
+| materialize table | 7.9 s | 1.4 s |
+| index entity_id | 1.1 s | 1.0 s |
+| **total to queryable** | **9.0 s** | **2.4 s** |
+
+Identical output either way: 4,352,964 rows, 384,880 entities, ~415 MB on disk.
+
+The remote pull adds ~6.5 s of network — ~19 MB/s effective from a residential
+connection *including* the 91 per-file round trips. Unlike point lookups, the
+CTAS streams files in parallel, so per-file latency largely amortizes away.
+Nine seconds from nothing to an indexed store that serves batched reads at
+0.06 ms/entity (exp1) validates the download → materialize → serve shape for a
+stateless Cloud Run service. Extrapolated to the full default lake (3.9 GB,
+127M rows): ~3.5 min from here; from inside GCP it converges toward the
+compute-bound floor, roughly a minute plus index.
+
 ## Alternative: materialize into a local duckdb table
 
 Another possible way to play some of the experiments: instead of querying the

--- a/contrib/zavodlake/perf.md
+++ b/contrib/zavodlake/perf.md
@@ -74,6 +74,53 @@ Takeaways: batched entity reads are competitive with a key-value store locally;
 per-entity glob lookups (~90 ms) are not — batch or consolidate. All numbers hide
 per-file network round trips, so remote (bucket) behaviour needs its own measurement.
 
+## Experiment 2 result: LevelDB build from parquet (2026-08-02)
+
+Built the same nomenklatura LevelDB store for the `sanctions` scope (4.35M statements,
+91 datasets) three ways (`contrib/zavodlake/exp2_leveldb.py`, local NVMe, warm files):
+
+| variant | write | compact | total |
+| --- | --- | --- | --- |
+| pack feed (Store.sync baseline) | 16.7 s | 0.2 s | 16.8 s |
+| parquet feed → Statement objects | 21.6 s | 0.5 s | 22.0 s |
+| parquet feed → raw sorted key/value bytes | 17.2 s | 0.5 s | 17.7 s |
+
+**Negative result: the build was never feed-bound.** CSV parsing is not the bottleneck;
+per-row Python work and LevelDB writes dominate and every variant pays them. The
+duckdb→arrow→pylist conversion is *slower* than the csv module, and even skipping
+Statement objects entirely with pre-sorted keys only reaches par. Extrapolated, a full
+`default` build is ~8–10 min regardless of feed. The parquet feed's value here is
+convenience (deduped, typed input), not speed.
+
+Fidelity note: the baseline store has 266 more `s:` keys than the parquet-fed ones —
+duplicate statement ids with differing schema/content survive as distinct keys under
+the pack feed, while the lake collapsed them at conversion time.
+
+## Experiment 1 precursor result: xref read replay (2026-08-02)
+
+Replayed an xref phase-2 read workload — 50k sampled entity ids, full entity assembly
+via the same `store.assemble()` in every variant — against the `sanctions` scope
+(`contrib/zavodlake/exp1_replay.py`, local NVMe):
+
+| backend | ms/entity |
+| --- | --- |
+| LevelDB store, single gets (status quo) | 0.04 |
+| parquet glob, single-id queries | 10.91 |
+| parquet glob, 1000-id batches | 0.12 |
+| duckdb table (indexed), single-id | 0.41 |
+| duckdb table (indexed), 1000-id batches | 0.06 |
+
+Materializing + indexing the 4.35M-statement scope into a duckdb table took **1.0 s**
+(the LevelDB build of the same data took 17 s). All backends returned identical entity
+counts.
+
+Conclusions: batched parquet reads are viable for xref (3× LevelDB, ~60 s per 500k
+entity reads — noise next to scoring); single-id glob access is not (280×). The
+materialize-on-init duckdb table is the sleeper: near-LevelDB batched reads, tolerable
+single reads, ~1 s startup per few million statements, no persistent store to sync —
+and the right shape for a stateless Cloud Run job (download → materialize → serve).
+At full-default scale (127M rows) the table wants a file-backed duckdb, not memory.
+
 ## Alternative: materialize into a local duckdb table
 
 Another possible way to play some of the experiments: instead of querying the

--- a/contrib/zavodlake/perf.md
+++ b/contrib/zavodlake/perf.md
@@ -121,6 +121,23 @@ single reads, ~1 s startup per few million statements, no persistent store to sy
 and the right shape for a stateless Cloud Run job (download → materialize → serve).
 At full-default scale (127M rows) the table wants a file-backed duckdb, not memory.
 
+## Experiment 1 result: nomenklatura DuckDBStore (2026-08-02)
+
+Implemented as `nomenklatura.store.duckdb_.DuckDBStore` (branch `pudo/duckdb-store` in
+nomenklatura): read-only store over a caller-provided duckdb relation, read-time
+canonicalisation from the Linker (`iter_pairs()` → canonical mapping table + resolved
+edge table at init), bulk `View.get_entities()`. Validated against the sanctions-scope
+lake (`contrib/zavodlake/exp1b_store.py`):
+
+- store init, incl. canonical + edge table build over 4.35M statements: **0.12 s**
+- `get_entities` batch-1000: **0.12 ms/entity** (exactly the exp1 raw-harness number —
+  the Store API adds no measurable overhead), 50k/50k found
+- `get_entity` singles: 10.4 ms/entity — bulk access is the contract
+- inverted lookup (edge-table probe) and synthetic same-schema merge verified on real
+  data; merges become visible by constructing a fresh store, no `update()` rewrite
+
+Not yet done: batched prefetch in the nomenklatura xref loop, zavod integration.
+
 ## Alternative: materialize into a local duckdb table
 
 Another possible way to play some of the experiments: instead of querying the

--- a/contrib/zavodlake/signing.py
+++ b/contrib/zavodlake/signing.py
@@ -1,0 +1,43 @@
+"""Signed GCS URLs for reading the bucket directly, bypassing the CDN.
+
+The archive bucket is not publicly readable — its public face is the
+bunny.net CDN. For latency experiments against raw GCS we mint V4 signed
+URLs instead. Local end-user credentials cannot sign, so signing goes
+through the IAM signBlob API impersonating the read-only crawler-team
+service account (crawler-team members hold serviceAccountTokenCreator
+on it, see operations/tf/etl/service_account.tf).
+"""
+
+from datetime import timedelta
+
+import google.auth
+from google.auth.transport.requests import Request
+
+from zavod.archive.backend import GoogleCloudBackend, get_archive_backend
+
+SIGNER_EMAIL = "etl-crawlerteam-sa@opensanctions-ops.iam.gserviceaccount.com"
+_token: str | None = None
+
+
+def _access_token() -> str:
+    global _token
+    if _token is None:
+        creds, _ = google.auth.default()
+        creds.refresh(Request())  # type: ignore[no-untyped-call]
+        assert creds.token is not None
+        _token = str(creds.token)
+    return _token
+
+
+def signed_url(object_name: str, expire_hours: int = 6) -> str:
+    """Mint a V4 signed GCS URL for an object in the archive bucket."""
+    backend = get_archive_backend()
+    assert isinstance(backend, GoogleCloudBackend), backend
+    blob = backend.bucket.blob(object_name)
+    url = blob.generate_signed_url(
+        version="v4",
+        expiration=timedelta(hours=expire_hours),
+        service_account_email=SIGNER_EMAIL,
+        access_token=_access_token(),
+    )
+    return str(url)

--- a/contrib/zavodlake/sync.py
+++ b/contrib/zavodlake/sync.py
@@ -1,0 +1,85 @@
+"""Upload lake parquet files to the public bucket mirror.
+
+Implements the layout agreed in PLAN.md: each dataset's parquet goes to
+``contrib/zlake/<dataset>/<version>/statements.parquet`` (immutable, long
+TTL), and a ``parquet-latest.json`` pointer next to the dataset prefix is
+the source of truth for the newest synced version (short TTL, invalidated
+on write). The version is the run version recorded in the local
+``index.json`` the pack was fetched from.
+"""
+
+import json
+from datetime import UTC, datetime
+
+import duckdb
+from rigour.mime.types import JSON
+
+from zavod.archive import INDEX_FILE, TTL_LONG, TTL_SHORT, dataset_resource_path
+from zavod.archive.backend import get_archive_backend
+from zavod.archive.cdn import invalidate_archive_cache
+from zavod.logs import get_logger
+
+from contrib.zavodlake.convert import dataset_parquet_path
+
+log = get_logger(__name__)
+
+ZLAKE_PREFIX = "contrib/zlake"
+POINTER_FILE = "parquet-latest.json"
+POINTER_SCHEMA = 1
+PARQUET_MIME = "application/vnd.apache.parquet"
+
+
+def dataset_version(dataset_name: str) -> str:
+    """Return the run version the local pack/parquet was built from."""
+    path = dataset_resource_path(dataset_name, INDEX_FILE)
+    with open(path) as fh:
+        data = json.load(fh)
+    version = data.get("version")
+    if not isinstance(version, str) or len(version) == 0:
+        raise ValueError(f"No version in index file: {path}")
+    return version
+
+
+def sync_dataset(
+    conn: duckdb.DuckDBPyConnection, dataset_name: str, force: bool = False
+) -> str | None:
+    """Upload a dataset's parquet and update its pointer file.
+
+    Returns the synced version, or None if the remote pointer already
+    references it. The parquet upload happens before the pointer write, so
+    a reader following the pointer never sees a missing object.
+    """
+    parquet_path = dataset_parquet_path(dataset_name)
+    version = dataset_version(dataset_name)
+    backend = get_archive_backend()
+    pointer_name = f"{ZLAKE_PREFIX}/{dataset_name}/{POINTER_FILE}"
+    pointer_object = backend.get_object(pointer_name)
+    if not force and pointer_object.exists():
+        with pointer_object.open() as fh:
+            remote = json.load(fh)
+        if remote.get("version") == version:
+            return None
+
+    object_name = f"{ZLAKE_PREFIX}/{dataset_name}/{version}/statements.parquet"
+    backend.get_object(object_name).publish(
+        parquet_path, mime_type=PARQUET_MIME, ttl=TTL_LONG
+    )
+
+    row = conn.execute(
+        "SELECT count(*) FROM read_parquet(?)", [parquet_path.as_posix()]
+    ).fetchone()
+    assert row is not None
+    pointer = {
+        "schema": POINTER_SCHEMA,
+        "dataset": dataset_name,
+        "version": version,
+        "path": object_name,
+        "rows": row[0],
+        "built_at": datetime.now(UTC).isoformat(timespec="seconds"),
+    }
+    pointer_path = parquet_path.parent / POINTER_FILE
+    with open(pointer_path, "w") as fh:
+        json.dump(pointer, fh, indent=2)
+    pointer_object.publish(pointer_path, mime_type=JSON, ttl=TTL_SHORT)
+    invalidate_archive_cache(pointer_name)
+    return version


### PR DESCRIPTION
Prototyping workbench in `contrib/zavodlake` exploring parquet statement artifacts as the substrate for export, xref, analysis and enrichment processes.

**What's here:**
- `build` command: backfills `statements.pack` + `index.json` for all leaves of a collection (default: `default`) and converts each pack into a deduplicated, typed `data/lake/<dataset>/statements.parquet` via duckdb — dedupe on statement id (richest-row representative), sorted by `entity_id`, zstd.
- `PLAN.md`: the experiment agenda and agreed long-term layout (versioned artifacts, per-dataset pointer files, event-driven builds).
- `perf.md`: research notes and benchmark results — point-lookup numbers on the full 127M-statement lake, the (negative) LevelDB-build experiment, and validation of the nomenklatura `DuckDBStore` (companion PR in nomenklatura).

Experiment harnesses (`exp*_*.py`) are deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)