### PR TITLE
[my_investor_alert_list] Split multi-URL website cells properly

### DIFF
--- a/datasets/my/investor_alert_list/crawler.py
+++ b/datasets/my/investor_alert_list/crawler.py
@@ -4,6 +4,20 @@ import re
 from zavod import Context
 from zavod import helpers as h
 
+# The website column lists several URLs per entry, separated by a pipe, whitespace,
+# or both. Whitespace only separates where the next URL begins, because long URLs
+# are wrapped across lines mid-query.
+WEBSITE_SPLIT = re.compile(r"\s*\|\s*|\s+(?=https?://|www\.)", re.IGNORECASE)
+
+
+def split_websites(value: str) -> list[str]:
+    websites: list[str] = []
+    for part in WEBSITE_SPLIT.split(value):
+        part = part.strip()
+        if len(part):
+            websites.append(part)
+    return websites
+
 
 def crawl_item(input_dict: dict[str, str], context: Context) -> None:
     name = input_dict.pop("name")
@@ -24,8 +38,7 @@ def crawl_item(input_dict: dict[str, str], context: Context) -> None:
     if potential_clone:
         entity.add("description", "Potential clone entity")
 
-    for website in input_dict.pop("website").split(" | "):
-        entity.add("website", website)
+    entity.add("website", split_websites(input_dict.pop("website")))
 
     context.emit(entity)
 

--- a/datasets/my/investor_alert_list/my_investor_alert_list.yml
+++ b/datasets/my/investor_alert_list/my_investor_alert_list.yml
@@ -47,7 +47,43 @@ lookups:
           - N/A
           - all pages relating to Futurebarrel on facebook
           - Potential clone entity – ASNB (Amanah Saham Nasional Berhad) Telegram Group / ASNB Investment Malaysia
+          - Kakak safety Trader
         value: null
+      # The Website column separates entries with " | ", but a stray newline,
+      # a missing space or a typo'd pipe leaves several URLs in one value.
+      - match: "https://webull-trade.com I \r\nhttps://www.hrudrt.com/"
+        values:
+          - https://webull-trade.com
+          - https://www.hrudrt.com/
+      - match: "www.inefex.pro |\r\nhttps://www.inefex.org/  |"
+        values:
+          - www.inefex.pro
+          - https://www.inefex.org/
+      - match: "http://wealthvantage.my |\nhttps://sc-com-brokerberdaftar.edgeone.dev/"
+        values:
+          - http://wealthvantage.my
+          - https://sc-com-brokerberdaftar.edgeone.dev/
+      - match: "https://tmgmsea.com |\r\nhttps://tmgmasia.com"
+        values:
+          - https://tmgmsea.com
+          - https://tmgmasia.com
+      - match: "www.cambridgecapitaltrading. comwww.dubalex.com"
+        values:
+          - www.cambridgecapitaltrading.com
+          - www.dubalex.com
+      - match: "|https://chat.whatsapp.com/Jju9FIJR5hE9AC9pgVWox2 |"
+        value: https://chat.whatsapp.com/Jju9FIJR5hE9AC9pgVWox2
+      - match: "https://royalq.company |"
+        value: https://royalq.company
+      - match: "(https://telegram.org/k/#@pelaburanrakiyat25"
+        value: "https://telegram.org/k/#@pelaburanrakiyat25"
+      - match: "https:islamicinc.asia/"
+        value: https://islamicinc.asia/
+      - match: "http://www.xeraya-capital.com (clone website)"
+        value: http://www.xeraya-capital.com
+      # The query string got separated from its URL, so it can't be reassembled.
+      - match: "lang=&ABtestName=ktteam&aff_sub=fdd2ke8t0mk&affiliate=&aff_sub6=2137888407.1739076551 |\r\nhttps://www.inefex.com/international/ |"
+        value: https://www.inefex.com/international/
   type.address:
     options:
       - match: ","

--- a/datasets/my/investor_alert_list/my_investor_alert_list.yml
+++ b/datasets/my/investor_alert_list/my_investor_alert_list.yml
@@ -48,42 +48,22 @@ lookups:
           - all pages relating to Futurebarrel on facebook
           - Potential clone entity – ASNB (Amanah Saham Nasional Berhad) Telegram Group / ASNB Investment Malaysia
           - Kakak safety Trader
+          # A query string that got separated from its URL, so it can't be reassembled.
+          - lang=&ABtestName=ktteam&aff_sub=fdd2ke8t0mk&affiliate=&aff_sub6=2137888407.1739076551
         value: null
-      # The Website column separates entries with " | ", but a stray newline,
-      # a missing space or a typo'd pipe leaves several URLs in one value.
-      - match: "https://webull-trade.com I \r\nhttps://www.hrudrt.com/"
-        values:
-          - https://webull-trade.com
-          - https://www.hrudrt.com/
-      - match: "www.inefex.pro |\r\nhttps://www.inefex.org/  |"
-        values:
-          - www.inefex.pro
-          - https://www.inefex.org/
-      - match: "http://wealthvantage.my |\nhttps://sc-com-brokerberdaftar.edgeone.dev/"
-        values:
-          - http://wealthvantage.my
-          - https://sc-com-brokerberdaftar.edgeone.dev/
-      - match: "https://tmgmsea.com |\r\nhttps://tmgmasia.com"
-        values:
-          - https://tmgmsea.com
-          - https://tmgmasia.com
+      # An "I" typed instead of the "|" that separates this from the next URL.
+      - match: "https://webull-trade.com I"
+        value: https://webull-trade.com
       - match: "www.cambridgecapitaltrading. comwww.dubalex.com"
         values:
           - www.cambridgecapitaltrading.com
           - www.dubalex.com
-      - match: "|https://chat.whatsapp.com/Jju9FIJR5hE9AC9pgVWox2 |"
-        value: https://chat.whatsapp.com/Jju9FIJR5hE9AC9pgVWox2
-      - match: "https://royalq.company |"
-        value: https://royalq.company
       - match: "(https://telegram.org/k/#@pelaburanrakiyat25"
         value: "https://telegram.org/k/#@pelaburanrakiyat25"
       - match: "https:islamicinc.asia/"
         value: https://islamicinc.asia/
       - match: "http://www.xeraya-capital.com (clone website)"
         value: http://www.xeraya-capital.com
-      # The query string got separated from its URL, so it can't be reassembled.
-      - match: "lang=&ABtestName=ktteam&aff_sub=fdd2ke8t0mk&affiliate=&aff_sub6=2137888407.1739076551 |\r\nhttps://www.inefex.com/international/ |"
-        value: https://www.inefex.com/international/
   type.address:
     options:
       - match: ","


### PR DESCRIPTION
The website column lists several URLs per entry, but the separator isn't
consistent: sometimes `" | "`, sometimes a bare newline, sometimes just a space.
We only split on `" | "`, so the rest got glued together and emitted as one
value - and because the host still parsed fine, it never warned. 580 URLs were
affected.

Splitting on newlines naively doesn't work either, because long URLs are wrapped
mid-query in the source (`&utm_content=\r\nII3JijH3Tq&utm_visit=...` is one URL,
not two). So: pipes always separate, and whitespace separates only where the next
URL begins.

That takes us from 3659 to 4239 emitted websites and clears the 12 invalid-URL
warnings from the host validation added in rigour 2.3.1. Six values are left that
splitting can't rescue, so those get lookups:

| value | what's wrong |
|---|---|
| `https://webull-trade.com I` | `I` typed instead of `\|` |
| `https:islamicinc.asia/` | missing slashes |
| `(https://telegram.org/k/#@...` | stray paren |
| `http://www.xeraya-capital.com (clone website)` | prose suffix |
| `www.cambridgecapitaltrading. comwww.dubalex.com` | two hosts, no separator |
| `lang=&ABtestName=...` | query string orphaned from its URL, dropped |

Verified against the live source: 0 invalid values remain and every lookup option
is still referenced.

Three values stay merged because the source has no separator at all between them
(`...&hl=enhttps://apps.apple.com/...`). They validate, so they don't warn - left
alone rather than adding a lookup per cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
