### PR TITLE
Label conventions: apply `daily-issues` to issues-agent PRs, document `new-source`

### DIFF
--- a/.claude/docs/crawler-guide.md
+++ b/.claude/docs/crawler-guide.md
@@ -322,3 +322,11 @@ qsv search -s prop "^Person:id$" data/datasets/xx_foo/statements.pack | qsv coun
 ## Before merging
 
 See `zavod/docs/best_practices/merge_checklist.md` for the review criteria the team applies to new crawlers, and `zavod/docs/best_practices/priorities.md` for the Essential / Should / Could / Won't framing that governs what attributes a crawler should extract.
+
+A PR that adds a new crawler MUST carry the `new-source` GitHub label, and its title takes the house `[dataset_name]` prefix:
+
+```bash
+gh pr create --label new-source --title "[xx_foo] Add ... crawler"
+```
+
+Apply the label to an existing PR with `gh pr edit <number> --add-label new-source`.

--- a/.github/ISSUE_TEMPLATE/schedule_maintenance.md
+++ b/.github/ISSUE_TEMPLATE/schedule_maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: Data review reminder for {{ date | date('MMMM YYYY') }}
-labels: daily_issues
+labels: daily-issues
 ---
 
 Please manually check and update the **data** for the following crawlers:

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -151,3 +151,16 @@ jobs:
           claude_args: "--model ${{ matrix.task.model }} --max-turns ${{ matrix.task.max_turns }} --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,Skill,mcp__github__create_pull_request\""
           show_full_output: true
 
+      # The agent opens its PR via mcp__github__create_pull_request, which takes no
+      # labels. The branch name is deterministic, so label it here rather than trusting
+      # the agent to do it. Fails harmlessly when no PR was opened (no fixes needed).
+      - name: Label the PR
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ matrix.task.branch }}" \
+            --repo "${{ github.repository }}" \
+            --add-label daily-issues
+


### PR DESCRIPTION
The issues agent opens one autofix PR per dataset, twice a day, and those PRs are indistinguishable from human work in the PR list. This labels them with the existing `daily-issues` label so they can be filtered and triaged as a batch.

The agent creates its PR via `mcp__github__create_pull_request`, which takes no `labels` parameter — so labelling is a second action either way. Doing it as a workflow step rather than a prompt instruction means it doesn't depend on the model complying, covers PRs opened by older prompt revisions, and stays correct if the PR-opening mechanism changes. The branch name is already deterministic (`contrib/maintenance/issues_agent.py`) and exposed to the job as `matrix.task.branch`, so `gh pr edit` can address the PR directly.

`continue-on-error: true` is load-bearing: the prompt tells the agent not to open a PR when there is nothing to fix, and most matrix entries end that way — without it, every no-op task would report as a failed job.

No permissions change needed; the workflow already grants `issues: write` and `pull-requests: write`, and `run-tasks` inherits them.

Drive-by: `.github/ISSUE_TEMPLATE/schedule_maintenance.md` asked for `labels: daily_issues` with an underscore. No such label exists on the repo, so GitHub silently dropped it. Note that nothing currently consumes this template — `schedule_maintenance.yml` creates a PR via `gh pr create` and never reads it, and the `{{ ... }}` placeholders are `JasonEtco/create-an-issue` syntax with no such action installed. It may be a leftover worth deleting separately.

## Verification

Not verifiable without a live run. After merge, trigger `Issues agent` manually and check `gh pr list --label daily-issues`, plus confirm matrix jobs that opened no PR are still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also: document the `new-source` label

Second commit, same theme. `new-source` is an active convention — 15+ PRs carry it — but `grep -r new-source` over the repo returned zero hits before this, and the label has no description on GitHub either. Adherence reflects that: 20+ merged "Add X PEP crawler" PRs (#5108, #5067, #4969, #5097, #5100, …) have no label.

The rule now lives in `.claude/docs/crawler-guide.md`'s `## Before merging` section, which both the `crawler-pep` and `crawler-sanctions` skills list under "Read upfront".

Not put in `zavod/docs/` (the obvious-looking homes being `best_practices/merge_checklist.md` and `tutorial.md`'s checklist): that directory is published to non-staff zavod framework users, who cannot label PRs on this repo, and per CLAUDE.md it documents how crawlers are written rather than repo process.

Worth noting what this does **not** fix: the unlabelled PRs above are human-authored, and humans don't read `.claude/`. Closing that gap means a `.github/pull_request_template.md`, which doesn't exist today and would show up on every PR in the repo including dependabot's — left as a separate decision.
