### PR TITLE
[datasets] Consolidate risk theme tags, tag kleptocracy sources

### DIFF
--- a/datasets/_global/c4ads_xinjiang/c4ads_xinjiang.yml
+++ b/datasets/_global/c4ads_xinjiang/c4ads_xinjiang.yml
@@ -22,7 +22,7 @@ description: |
   > to continue profiting from forced labor and other forms of oppression.
 url: https://c4ads.org/reports/long-shadows/
 tags:
-  - issue.slavery
+  - risk.slavery
 publisher:
   name: Center for Advanced Defense Studies
   acronym: C4ADS

--- a/datasets/_global/c4ads_xinjiang_mining/c4ads_xinjiang_mining.yml
+++ b/datasets/_global/c4ads_xinjiang_mining/c4ads_xinjiang_mining.yml
@@ -26,7 +26,7 @@ description: |
   > that perpetrate and support human rights abuses against Turkic peoples in the Uyghur region.
 url: https://c4ads.org/reports/fractured-veins/
 tags:
-  - issue.slavery
+  - risk.slavery
 publisher:
   name: Center for Advanced Defense Studies
   acronym: C4ADS

--- a/datasets/_global/thesentry_atlas/thesentry_atlas.yml
+++ b/datasets/_global/thesentry_atlas/thesentry_atlas.yml
@@ -21,6 +21,8 @@ description: |
 
   This dataset currently includes the following projects:
   - [The Aliyev Empire](https://atlas.thesentry.org/azerbaijan-aliyev-empire/)
+tags:
+  - risk.klepto
 publisher:
   name: The Sentry
   acronym: Sentry

--- a/datasets/br/slavery/br_slavery.yml
+++ b/datasets/br/slavery/br_slavery.yml
@@ -34,7 +34,7 @@ publisher:
   url: https://www.gov.br/trabalho-e-emprego
   official: true
 tags:
-  - issue.slavery
+  - risk.slavery
 url: https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/inspecao-do-trabalho/areas-de-atuacao/combate-ao-trabalho-escravo-e-analogo-ao-de-escravo
 data:
   url: https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/inspecao-do-trabalho/areas-de-atuacao/cadastro_de_empregadores.csv

--- a/datasets/ca/facfoa/ca_facfoa.yml
+++ b/datasets/ca/facfoa/ca_facfoa.yml
@@ -17,6 +17,7 @@ description: |
 url: https://www.publicsafety.gc.ca/cnt/ntnl-scrt/cntr-trrrsm/lstd-ntts/crrnt-lstd-ntts-en.aspx
 tags:
   - list.sanction
+  - risk.klepto
   - issuer.west
 publisher:
   name: "Government of Canada"

--- a/datasets/ch/fiaa_freezes/ch_fiaa_freezes.yml
+++ b/datasets/ch/fiaa_freezes/ch_fiaa_freezes.yml
@@ -76,6 +76,7 @@ dates:
   formats: ["%Y-%m-%d", "%Y-%m"]
 tags:
   - list.sanction
+  - risk.klepto
   - juris.ch
   - issuer.west
 

--- a/datasets/lt/magnitsky_amendments/lt_magnitsky_amendments.yml
+++ b/datasets/lt/magnitsky_amendments/lt_magnitsky_amendments.yml
@@ -33,6 +33,7 @@ http:
   user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15 (zavod; opensanctions.org)"
 tags:
   - list.sanction
+  - risk.klepto
   - juris.eu
   - issuer.west
 


### PR DESCRIPTION
Theme tags were split across two namespaces: `risk.klepto` (in the [published tag vocabulary](https://www.opensanctions.org/docs/metadata/)) and `issue.slavery` (undocumented, three datasets). This moves the latter to `risk.slavery`, so `risk.*` is the single dimension for risk themes and `issue.*` is retired.

It also applies `risk.klepto` to the single-instrument corruption lists that were missing it:

| Dataset | Rationale |
|---|---|
| `ch_fiaa_freezes` | Freezes of looted state assets under the Foreign Illicit Assets Act |
| `ca_facfoa` | Freezing Assets of Corrupt Foreign Officials Act - the direct Canadian analogue |
| `lt_magnitsky_amendments` | Magnitsky designations, matching `lv_magnitsky_list` which already carried the tag |
| `thesentry_atlas` | "violent conflict, repression, and kleptocracy" - had no tags at all |

Broad consolidated lists (`us_ofac_sdn`, `ca_dfatd_sema_sanctions`, `eu_travel_bans`, `be_fod_sanctions`) are deliberately left untagged. Tags are dataset-level, and those bundle dozens of unrelated regimes; the kleptocracy dimension inside them already sits at the right granularity in `meta/programs/` (`US-GLOMAG`, `US-MAGNITSKY`, `GB-HR`, `CA-JVCFOA`).

`risk.klepto` goes from 4 to 8 datasets; `risk.slavery` has 3.

### Follow-ups, not in this PR

- **A human rights tag.** Magnitsky-style instruments cover grand corruption *and* serious human rights abuse. `risk.klepto` only expresses the first half, so `us_klepto_hr_visa` and `lv_magnitsky_list` are currently only partly described.
- **`list.risk` on `thesentry_atlas`**, which now has a theme tag but no list-type tag. `wd_oligarchs` has the same gap.
- **Docs**: a companion change to `content/docs/metadata.md` in the knowledgebase repo adds the `risk.slavery` row and documents the prefix-per-dimension convention. Worth confirming one thing it now states - that `list.sanction.counter` is deliberately applied *without* `list.sanction` (none of its five datasets carry both) to keep counter-sanctions out of a general sanctions search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)