### PR TITLE
[meta] Program metadata for the OFAC authority-based mapping

### DIFF
--- a/meta/programs/US-BURMA.yml
+++ b/meta/programs/US-BURMA.yml
@@ -10,7 +10,8 @@ summary: Targets persons responsible for the February 2021 military coup in
   persons may not deal with them; designated individuals are also barred from
   entry into the United States. A directive additionally prohibits US persons
   from providing financial services to or for the benefit of the state-owned
-  Myanma Oil and Gas Enterprise.
+  Myanma Oil and Gas Enterprise, which is restricted by that directive rather
+  than blocked.
 issuer: us_ofac
 dataset: us_ofac_sdn
 aliases:

--- a/meta/programs/US-CAATSA.yml
+++ b/meta/programs/US-CAATSA.yml
@@ -2,24 +2,24 @@ id: 210
 title: US Countering America's Adversaries Through Sanctions Act (CAATSA)
 key: US-CAATSA
 url: https://ofac.treasury.gov/sanctions-programs-and-country-information/countering-americas-adversaries-through-sanctions-act-related-sanctions
-summary: 'On August 2, 2017, the President signed into law the "Countering America’s
-  Adversaries Through Sanctions Act" (Public Law 115-44) (CAATSA), which among other
-  things, imposes new sanctions on Iran, Russia, and North Korea.
-
-
-  The CAATSA-Related Sanctions represent the implementation of multiple legal authorities.
-  Some of these authorities are in the form of executive orders issued by the President.
-  Other authorities are public laws (statutes) passed by The Congress. These authorities
-  are further codified by OFAC in its regulations which are published the in Code
-  of Federal Regulations (CFR). Modifications to these regulations are posted in the
-  Federal Register.
-
-
-  [Source: U.S. DEPARTMENT OF THE TREASURY](https://ofac.treasury.gov/sanctions-programs-and-country-information/countering-americas-adversaries-through-sanctions-act-related-sanctions)'
+summary: Targets persons connected to Iran's ballistic missile programme or the
+  Islamic Revolutionary Guard Corps, and specified Russian defence and
+  intelligence actors, sanctions evaders, and persons conducting significant
+  transactions with them. Most designated persons have their US assets frozen
+  and US persons are generally prohibited from dealing with them. Measures
+  vary by designation, because a determination under Section 231 may instead
+  select from the menu of non-blocking sanctions in Section 235, which ranges
+  from
+  denial of export licences and restrictions on loans from US financial
+  institutions to visa restrictions on an entity's corporate officers.
 issuer: us_treasury
-dataset: wd_oligarchs
+dataset: us_ofac_sdn
 aliases:
 - CAATSA
+- CAATSA - IRAN
+- CAATSA - RUSSIA
 target_territories:
 - ir
 - ru
+measures:
+- Asset freeze

--- a/meta/programs/US-CAPTA.yml
+++ b/meta/programs/US-CAPTA.yml
@@ -1,3 +1,14 @@
+# DEPRECATED — do not reference. This key described a list rather than a legal
+# authority: CAPTA entries are designated under separate country authorities
+# (North Korea, Iran, Hizballah, Russia), each of which has its own program.
+# Those entries are attributed by their per-entry program tag instead, with the
+# list name recorded in the sanction summary. Statements naming US-CAPTA will
+# age out of the published data.
+#
+# Those authority programs record the union of their operative measures, so the
+# correspondent-account restriction this key carried lives only in the
+# sanction's `provisions`, until a normalized `Sanction:measures` lands. The
+# receiving programs narrate the variation in their summaries. cf. #4980
 id: 271
 title: Correspondent Account or Payable-Through Account Sanctions List
 key: US-CAPTA

--- a/meta/programs/US-IRAN.yml
+++ b/meta/programs/US-IRAN.yml
@@ -38,6 +38,7 @@ aliases:
   - IRAN-EO13902
   - HRIT-IR
   - IFSR
+  - 561-Related
   - IRGC
   - ISA
 target_territories:

--- a/meta/programs/US-NARCO.yml
+++ b/meta/programs/US-NARCO.yml
@@ -9,7 +9,9 @@ summary: Targets foreign individuals and entities involved in international
   behalf. Property of designated persons under US jurisdiction is blocked, and
   US persons are generally prohibited from transactions with them. Designation
   under some authorities also suspends a natural person's entry into the
-  United States.
+  United States. Some persons receive non-blocking sanctions instead, such as
+  a prohibition on US financial institutions making loans or extending credit
+  to them.
 issuer: us_ofac
 dataset: us_ofac_sdn
 aliases:
@@ -22,4 +24,5 @@ aliases:
   - ILLICIT-DRUGS-EO14059
 measures:
   - Asset freeze
+  - Financial restrictions
   - Travel ban

--- a/meta/programs/US-NS-MBS.yml
+++ b/meta/programs/US-NS-MBS.yml
@@ -1,3 +1,14 @@
+# DEPRECATED — do not reference. This key described a list rather than a legal
+# authority: NS-MBS entries are designated under several unrelated authorities
+# (CAATSA, the Hong Kong Autonomy Act, EO 14024, and others), each of which has
+# its own program. Those entries are attributed by their per-entry program tag
+# instead, with the list name recorded in the sanction summary. Statements
+# naming US-NS-MBS will age out of the published data.
+#
+# Those authority programs record the union of their operative measures, so the
+# menu-based/blocking distinction this key carried lives only in the
+# sanction's `provisions`, until a normalized `Sanction:measures` lands. The
+# receiving programs narrate the variation in their summaries. cf. #4980
 id: 277
 title: Non-SDN Menu-Based Sanctions List (NS-MBS List)
 key: US-NS-MBS

--- a/meta/programs/US-RUSHAR.yml
+++ b/meta/programs/US-RUSHAR.yml
@@ -13,7 +13,9 @@ summary: Targets persons responsible for or supporting specified harmful
   Russia, on exports of luxury goods, and on providing accounting, management
   consulting, and certain other professional services to Russia. Directives
   further restrict dealings in Russian sovereign debt and transactions with
-  major Russian financial institutions, including the Central Bank.
+  major Russian financial institutions, including the Central Bank. Some
+  persons are designated under those directives alone rather than being
+  blocked.
 issuer: us_ofac
 dataset: us_ofac_sdn
 aliases:

--- a/meta/programs/US-UKRRUS-REL.yml
+++ b/meta/programs/US-UKRRUS-REL.yml
@@ -12,7 +12,10 @@ summary: Targets persons responsible for undermining Ukraine's sovereignty and
   imports from them, and exports of goods, services, and technology to them.
   Related restrictions on major Russian financial, energy, and defence
   companies are maintained through the separate Sectoral Sanctions
-  Identifications List.
+  Identifications List. Not every designation is blocking; some persons are
+  subject only to the sectoral directives selected in their individual
+  determination, which restrict dealings in their new debt and equity and in
+  certain energy-sector goods and services.
 issuer: us_ofac
 dataset: us_ofac_sdn
 aliases:
@@ -38,6 +41,7 @@ target_territories:
   - ua-lpr
 measures:
   - Asset freeze
+  - Financial restrictions
   - Investment ban
   - Import restrictions
   - Export control


### PR DESCRIPTION
Split out of #5206 so the program metadata publishes before the attributions change — program data takes a while to propagate to data.opensanctions.org, and #5206 moves 13 entities onto these keys.

Metadata only. No crawler or dataset changes, so no entity data moves here.

### US-CAATSA

`dataset` was `wd_oligarchs`, which emits no `programId` at all — the OFAC datasets ingest the CAATSA designations (81 `CAATSA - RUSSIA` and 20 `CAATSA - IRAN` entries on the SDN List), so it now points at `us_ofac_sdn`. Adds the two tags as aliases and `Asset freeze`, and replaces the quoted Treasury boilerplate summary with one of our own.

The measures are a floor rather than the full union: the Section 235 menu items imposed on the one non-blocking entry (Turkey's SSB, the December 2020 Section 231 determination) could not be verified — State's determination page serves an error and OFAC's program page is unavailable. Worth a follow-up.

### Measures unions

Every consolidated entry that #5206 moves carries a **non-blocking** directive or menu measure, so the programs receiving them record the union of the operative measures, per [`meta/README.md`](https://github.com/opensanctions/opensanctions/blob/main/meta/README.md):

| program | absorbs | change |
|---|---|---|
| US-UKRRUS-REL | EO 13662 Sectoral Directives 1/2/4 | `+Financial restrictions` — Directives 1 and 2 restrict new debt and equity |
| US-NARCO | EO 14059 non-blocking | `+Financial restrictions` — [jy2542](https://home.treasury.gov/news/press-releases/jy2542) prohibits US financial institutions from making loans or extending credit |
| US-RUSHAR, US-BURMA, US-IRAN | EO 14024 Directives 1a/3/4, EO 14014 Directive 1, CAPTA 561 | already covered |

`561-Related` added to US-IRAN's aliases.

Since program `measures` is the union across a regime, the README requires the variation to be clear in the summary, so each receiving program now states that not every designation is blocking. US-SSI and US-IRAN already narrated theirs.

### Deprecations

US-NS-MBS and US-CAPTA named lists rather than authorities. Both get the deprecation header pattern used for GB-SAMLA — the key stays resolvable while published statements age out. Only `us_ofac_cons` ever emitted them (`us_trade_csl` matches those list names with a `topic:` but no `value:`), so nothing else is affected.

Both headers also record that the per-entry blocking/menu-based distinction now lives only in `Sanction:provisions` until a normalized `Sanction:measures` lands.

### Verification

`get_all_programs_by_key()` loads all 258 programs cleanly.

Refs #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)