### PR TITLE
adb_sanctions: re-key entities and name the sanctioned party explicitly

### DIFF
--- a/datasets/_global/adb_sanctions/crawler.py
+++ b/datasets/_global/adb_sanctions/crawler.py
@@ -16,15 +16,18 @@ from zavod.stateful.review import (
 )
 
 LLM_MODEL_VERSION = "gpt-5.4"
+# Bumped when the extraction model changes incompatibly, resetting every review.
+CRAWLER_VERSION = 2
 EXTRACT_PROMPT = """Extract structured entity data from an entry from a list
 of debarments from a development bank.
 
-Input: JSON with "name" and "other_name" fields. These fields may contain:
-- One or more distinct legal entity names (e.g. "Company A; Company B")
+Input: JSON with "name" and "other_name" fields describing one sanctioned party.
+These fields may contain:
 - Aliases, abbreviations, former names alongside a primary name
 - Embedded registration numbers, tax IDs, USC codes, national ID numbers
+- Names of other parties, e.g. a proprietor, a director or an affiliated company
 
-For EACH distinct legal entity found, extract:
+For the sanctioned party the entry is about, extract:
   name               - primary legal name(s)
   alias              - alternative or also-known-as names
   weakAlias          - abbreviations, acronyms, short forms
@@ -35,10 +38,13 @@ For EACH distinct legal entity found, extract:
   taxNumber          - tax IDs (TIN, VAT, BIN, e-TIN, IRC, etc.)
   idNumber           - national ID, passport, CNIC, or other personal IDs
 
+For every OTHER party the fields mention, extract:
+  related_entity_name - its name
+
 Rules:
 - Preserve original text exactly (no spelling corrections, no title-casing).
 - Do not invent or expand names not present in the input.
-- If there is only one entity, return a list with one item.
+- Never repeat a name of the sanctioned party as a related entity name.
 - Exclude the numeric/alphanumeric identifier strings from name/alias fields;
   put them only in the relevant identifier field.
 """
@@ -52,7 +58,10 @@ REGEX_INTERNAL_URL = re.compile(
 )
 
 
-class EntityData(BaseModel):
+class EntityExtractionResult(BaseModel):
+    """The properties of the party sanctioned by one row, and the names of the
+    other parties mentioned alongside it."""
+
     name: list[str] = []
     alias: list[str] = []
     weakAlias: list[str] = []
@@ -62,10 +71,7 @@ class EntityData(BaseModel):
     uscCode: list[str] = []
     taxNumber: list[str] = []
     idNumber: list[str] = []
-
-
-class EntityExtractionResult(BaseModel):
-    entities: list[EntityData]
+    related_entity_name: list[str] = []
 
 
 @dataclass
@@ -82,13 +88,23 @@ class RowFields:
 
 
 def emit_sanctioned_entity(
-    context: Context, schema: str, data: EntityData, fields: RowFields
+    context: Context,
+    schema: str,
+    data: EntityExtractionResult,
+    fields: RowFields,
+    *,
+    raw_name: str,
+    key_parts: tuple[str, ...] = (),
 ) -> Entity:
     entity = context.make(schema)
-    # TODO: add schema to the key so a Firm and an Individual of the same name
-    # can't collide — needs re-keying the whole dataset.
-    entity.id = context.make_id(data.name[0], fields.country)
-    for prop in EntityData.model_fields:
+    # Key on the schema so a Firm and an Individual row of the same name get
+    # distinct entities, and on the raw source name rather than the extracted
+    # one so a re-extraction of the same row doesn't re-key the entity.
+    entity.id = context.make_id(schema, raw_name, *key_parts, fields.country)
+    for prop in EntityExtractionResult.model_fields:
+        # The only extracted field that isn't a property of the sanctioned party.
+        if prop == "related_entity_name":
+            continue
         for val in getattr(data, prop):
             entity.add(prop, val)
     entity.add("country", fields.country)
@@ -109,23 +125,23 @@ def emit_sanctioned_entity(
     return entity
 
 
-def extract_entities_data(
-    context: Context, full_name: str, other_name: str
-) -> list[EntityData]:
+def extract_names(
+    context: Context, raw_name: str, other_name: str
+) -> EntityExtractionResult | None:
     # Names that look regular are taken as-is; the rest go through LLM extraction
     # and human review, yielding nothing while a review is still pending.
     if not (
-        REGEX_IRREGULAR.search(full_name)
+        REGEX_IRREGULAR.search(raw_name)
         or REGEX_IRREGULAR.search(other_name)
-        or contains_split_phrase(full_name)
+        or contains_split_phrase(raw_name)
         or contains_split_phrase(other_name)
     ):
         alias = [other_name] if other_name.strip() else []
-        return [EntityData(name=[full_name], alias=alias)]
+        return EntityExtractionResult(name=[raw_name], alias=alias)
 
-    source_data: JsonValue = {"name": full_name, "other_name": other_name}
+    source_data: JsonValue = {"name": raw_name, "other_name": other_name}
     source_value = JSONSourceValue(
-        key_parts=[full_name, "other_name", other_name],
+        key_parts=[raw_name, "other_name", other_name],
         label="entity extraction",
         data=source_data,
     )
@@ -141,10 +157,11 @@ def extract_entities_data(
         source_value=source_value,
         original_extraction=result,
         origin=LLM_MODEL_VERSION,
+        crawler_version=CRAWLER_VERSION,
     )
     if not review.accepted:
-        return []
-    return review.extracted_data.entities
+        return None
+    return review.extracted_data
 
 
 def crawl_row(context: Context, row: dict[str, str | None]) -> None:
@@ -153,7 +170,7 @@ def crawl_row(context: Context, row: dict[str, str | None]) -> None:
     if schema is None:
         raise ValueError(f"Unknown entityType: {entity_type!r}")
 
-    full_name = row.pop("name") or ""
+    raw_name = row.pop("name") or ""
     other_name = (row.pop("otherName") or "").replace("\\", "")
     country = row.pop("nationality") or ""
     country = country.replace("Non ADB Member Country", "")
@@ -170,20 +187,29 @@ def crawl_row(context: Context, row: dict[str, str | None]) -> None:
         modified_at=row.pop("changesMadeOn"),
     )
 
-    entities_data = extract_entities_data(context, full_name, other_name)
+    extracted = extract_names(context, raw_name, other_name)
 
-    # entityType describes the subject of the row only. Any further entities the
-    # extraction pulls out of the name fields are parties co-mentioned in them,
-    # whose type the source doesn't state, so don't claim it.
-    if entities_data:
-        subject_data, *comentioned_data = entities_data
-        subject = emit_sanctioned_entity(context, schema, subject_data, fields)
-        for data in comentioned_data:
-            entity = emit_sanctioned_entity(context, "LegalEntity", data, fields)
+    if extracted is not None:
+        subject = emit_sanctioned_entity(
+            context, schema, extracted, fields, raw_name=raw_name
+        )
+        for related_name in extracted.related_entity_name:
+            # entityType describes the sanctioned party only. The parties merely
+            # co-mentioned in its name fields have no type stated by the source,
+            # so don't claim one. Their name is also all that tells them apart
+            # within the row, so it has to go into the key.
+            entity = emit_sanctioned_entity(
+                context,
+                "LegalEntity",
+                EntityExtractionResult(name=[related_name]),
+                fields,
+                raw_name=raw_name,
+                key_parts=(related_name,),
+            )
 
             # Preserve the link the source made by listing them in one row.
             rel = context.make("UnknownLink")
-            rel.id = context.make_id(subject.first("name"), data.name[0], country)
+            rel.id = context.make_id(subject.id, entity.id)
             rel.add("subject", subject)
             rel.add("object", entity)
             context.emit(rel)


### PR DESCRIPTION
Two ADB entities were being emitted under one ID — a Firm row and an Individual row for the same sole proprietorship — so their statements interleaved and the store gave up on the cluster:

```
Assemble error: NK-hidE4za5TvTg3ziiooWniu: No common schema: Company and Person
```

(from https://data.opensanctions.org/artifacts/adb_sanctions/20260803093313-gor/issues.json)

- The entity key now includes the schema, and uses the row's raw `name` field instead of the extracted primary name — so a re-review of a row doesn't re-key its entity.
- The extraction model gains `related_entity_name` and keeps its existing fields, but the sanctioned party is now the model itself rather than the first item of a list. `entityType` describes only that party, and a review could previously reorder the list and hand the type to somebody else. This is what produced `adb-bc0bcfc5…`, a `Person` named "M/S. A.S. Construction" with the actual human demoted to `alias`.
- Bumps `crawler_version` to 2, which resets all ~583 reviews. Unavoidable: stored `extracted_data` is `{"entities": [...]}` and won't validate against the flattened model.

**The whole dataset re-keys**, so ADB judgements in the resolver go dangling. Verified against all 1,417 live rows: 1,410 distinct subject IDs, no unintended collisions (the 7 shared ones are rows ADB publishes twice with different dates, which should merge).

Not fixed here: the A.S. Construction extraction still needs a manual correction once reviews reset, and `address` splits on `;` while ADB separates with `\r\n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
