### PR TITLE
[ui] Match position entity ID in the positions search box

### DIFF
--- a/ui/app/positions/PositionTaggerForm.tsx
+++ b/ui/app/positions/PositionTaggerForm.tsx
@@ -23,7 +23,7 @@ export default function PositionTaggerForm({ searchParams, countries, datasets }
             name="q"
             type="text"
             defaultValue={searchParams.q || ""}
-            placeholder="Search position name"
+            placeholder="Search position name or exact ID"
             className="form-control"
           />
         </Col>

--- a/ui/lib/db.ts
+++ b/ui/lib/db.ts
@@ -435,7 +435,10 @@ export async function getPositions(filters: IPositionFilters = {}): Promise<IPos
     query = query.where('dataset', '=', dataset);
   }
   if (q !== undefined) {
-    query = query.where('caption', 'ilike', `%${q}%`);
+    query = query.where((eb) => eb.or([
+      eb('caption', 'ilike', `%${q}%`),
+      eb('entity_id', '=', q),
+    ]));
   }
   if (is_pep !== undefined) {
     if (is_pep === null) {


### PR DESCRIPTION
The position tagger's search box only matched `caption`, so pasting a position ID — often a Wikidata QID, e.g. `Q97019608` — returned no results.

`q` now also matches `entity_id`, as an exact match rather than a substring (IDs are opaque, and equality stays index-friendly; the caption `ilike '%…%'` is a seq scan either way). The placeholder says so.

No schema or API changes; the form field, URL param and pagination are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)