### PR TITLE
helpers: validate ISINs in make_security before minting entities (#4941)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ apicache-py3
 # Emacs
 *~
 task-prompts/
+
+# Superpowers implementation plans
+docs/superpowers/plans/
+
+# Git worktrees
+.worktrees/

--- a/datasets/_global/gleif/crawler.py
+++ b/datasets/_global/gleif/crawler.py
@@ -240,6 +240,9 @@ def parse_lei_record(
         proxy.add_schema("Company")
         proxy.add("topics", "corp.public")
         security = h.make_security(context, isin)
+        if security is None:
+            context.log.warn("Invalid ISIN", isin=isin, lei=lei)
+            continue
         security.add("issuer", proxy.id)
         security.add("country", entity.findtext("LegalJurisdiction"))
         context.emit(security)

--- a/datasets/eu/esma_saris/crawler.py
+++ b/datasets/eu/esma_saris/crawler.py
@@ -66,6 +66,9 @@ def crawl(context: Context) -> None:
                 context.log.warn("No ISIN", row=row)
                 return
             entity = h.make_security(context, isin)
+            if entity is None:
+                context.log.warn("Invalid ISIN, skipping row", isin=isin)
+                continue
             entity.add("name", row.pop("instrumentFullName", isin))
 
             sanction = h.make_sanction(

--- a/datasets/ru/nsd_isin/crawler.py
+++ b/datasets/ru/nsd_isin/crawler.py
@@ -57,6 +57,9 @@ def crawl_item(context: Context, url: str) -> None:
         context.log.warn("No ISIN code on page", url=url)
         return
     security = h.make_security(context, isin_code)
+    if security is None:
+        context.log.warn("Invalid ISIN on page", isin=isin_code, url=url)
+        return
     security.add("sourceUrl", url)
     security.add("topics", "invest.ban")
     for prop, prop_val in values["security"].items():

--- a/zavod/zavod/helpers/securities.py
+++ b/zavod/zavod/helpers/securities.py
@@ -1,17 +1,33 @@
+from rigour.ids import ISIN
+
 from zavod.constants import ORIGIN_INFERRED
 from zavod.context import Context
 from zavod.entity import Entity
+from zavod.logs import get_logger
+
+log = get_logger(__name__)
 
 ISIN_NON_COUNTRY = ("XS", "XD", "XC", "XF", "CS", "QS")
 
 
-def make_security(context: Context, isin: str) -> Entity:
-    """Make a security entity."""
-    isin = isin.upper()
+def make_security(context: Context, isin: str) -> Entity | None:
+    """Make a security entity from an ISIN, or None if the value is not a valid ISIN.
+
+    Args:
+        context: The crawler context.
+        isin: The ISIN to validate and normalize.
+
+    Returns:
+        A ``Security`` entity, or ``None`` if ``isin`` fails validation.
+    """
+    normalized = ISIN.normalize(isin)
+    if normalized is None:
+        log.warning("Invalid ISIN, skipping security", isin=isin)
+        return None
     entity = context.make("Security")
-    entity.id = f"isin-{isin}"
-    entity.add("isin", isin)
-    cc = isin[:2]
+    entity.id = f"isin-{normalized}"
+    entity.add("isin", normalized)
+    cc = normalized[:2]
     if cc not in ISIN_NON_COUNTRY:
         entity.add("country", cc, origin=ORIGIN_INFERRED)
     return entity

--- a/zavod/zavod/shed/firds.py
+++ b/zavod/zavod/shed/firds.py
@@ -27,6 +27,8 @@ def parse_element(context: Context, file_name: str, elem: etree._Element) -> Non
         # Skip OTC derivatives and other special case securities
         return
     security = h.make_security(context, isin)
+    if security is None:
+        return
     security.add("name", attr.findtext(f"./{NS}FullNm"))
     security.add("alias", attr.findtext(f"./{NS}ShrtNm"))
     security.add("classification", attr.findtext(f"./{NS}ClssfctnTp"))

--- a/zavod/zavod/tests/helpers/test_securities.py
+++ b/zavod/zavod/tests/helpers/test_securities.py
@@ -5,14 +5,32 @@ from zavod.helpers.securities import make_security
 
 def test_make_security(testdataset1: Dataset):
     context = Context(testdataset1)
-    entity = make_security(context, "XS1234567890")
-    assert entity.id == "isin-XS1234567890"
+
+    entity = make_security(context, "US0378331005")
+    assert entity is not None
+    assert entity.id == "isin-US0378331005"
     assert entity.schema.name == "Security"
-    assert entity.get("isin") == ["XS1234567890"]
+    assert entity.get("isin") == ["US0378331005"]
+    assert entity.first("country") == "us"
+
+    entity = make_security(context, "XS1234567896")
+    assert entity is not None
+    assert entity.id == "isin-XS1234567896"
+    assert entity.schema.name == "Security"
+    assert entity.get("isin") == ["XS1234567896"]
     assert not len(entity.get("country"))
 
-    entity = make_security(context, "DE1234567890")
-    assert entity.id == "isin-DE1234567890"
-    assert entity.schema.name == "Security"
+    entity = make_security(context, "DE1234567896")
+    assert entity is not None
+    assert entity.id == "isin-DE1234567896"
     assert entity.first("country") == "de"
+
+    # Input normalization: lowercase + surrounding whitespace
+    entity = make_security(context, "  us0378331005  ")
+    assert entity is not None
+    assert entity.id == "isin-US0378331005"
+
+    # Invalid / unparseable input must not mint an entity
+    assert make_security(context, "N/A") is None
+    assert make_security(context, "US0378331003") is None
     context.close()


### PR DESCRIPTION
Fixes #4941

## Change
- `make_security` now returns `Entity | None`, gated on `rigour.ids.ISIN.normalize` (strip + checksum + uppercase). Invalid input (e.g. `N/A`, bad checksum) yields `None` instead of a global `isin-*` ID collision.
- Country is inferred only from a validated ISIN.
- Callers updated to handle `None`: `ru/nsd_isin`, `eu/esma_saris`, `_global/gleif`, and `zavod/shed/firds.py` (a 4th caller the plan's audit missed).

## Tests
- `test_securities.py` rewritten with valid ISINs (US0378331005, XS1234567896, DE1234567896) + normalization and invalid-input cases. The old test used ISINs that fail the checksum.
- `pytest zavod/tests/`: 293 passed; mypy --strict clean (zavod + 3 crawlers).

## Note
Rejecting/normalizing changes some already-published entity IDs (e.g. trailing-space IDs). Flagged for coordination per the issue.