### PR TITLE
[us_cuba_sanctions] Watch the current-list pages for change detection (#4979)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ apicache-py3
 # Emacs
 *~
 task-prompts/
+
+# Superpowers implementation plans
+docs/superpowers/plans/
+
+# Git worktrees
+.worktrees/

--- a/datasets/us/cuba_sanctions/crawler.py
+++ b/datasets/us/cuba_sanctions/crawler.py
@@ -10,7 +10,7 @@ ORIGINAL_ACCOMMODATIONS_URL = (
     "https://www.state.gov/cuba-sanctions/cuba-prohibited-accommodations-list"
 )
 ACCOMMODATIONS_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQMquWjNWZ09dm9_mu9NKrxR33c6pe4hpiGFeheFT4tDZXwpelLudcYdCdME820aKJJo8TfMKbtoXTh/pub?gid=1890354374&single=true&output=csv"
-ORIGINAL_RESTRICTED_ENTITIES_URL = "https://www.state.gov/division-for-counter-threat-finance-and-sanctions/cuba-restricted-list"
+ORIGINAL_RESTRICTED_ENTITIES_URL = "https://www.state.gov/cuba-sanctions/cuba-restricted-list"
 RESTRICTED_ENTITIES_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQMquWjNWZ09dm9_mu9NKrxR33c6pe4hpiGFeheFT4tDZXwpelLudcYdCdME820aKJJo8TfMKbtoXTh/pub?gid=0&single=true&output=csv"
 CONTENT_XPATH = ".//div[@class='entry-content']"
 ACTIONS = [
@@ -63,6 +63,9 @@ def crawl_restricted_entities(context: Context) -> None:
     node = doc.find(CONTENT_XPATH)
     # Chrome save HTML only
     # xmllint --format --html --encode UTF-8
+    # TODO: recompute this hash from the new URL
+    # https://www.state.gov/cuba-sanctions/cuba-restricted-list
+    # via Zyte fetch (state.gov serves a Technical Difficulties page to curl).
     if not h.assert_dom_hash(node, "a146ff14f0a283a4a80afaaf0f46637574aa78c2"):
         context.log.warning("Restricted List content changed. Check for data updates")
 

--- a/datasets/us/cuba_sanctions/crawler.py
+++ b/datasets/us/cuba_sanctions/crawler.py
@@ -32,10 +32,7 @@ def crawl_accommodations(context: Context) -> None:
     node = doc.find(CONTENT_XPATH)
     # Chrome save HTML only
     # xmllint --format --html --encode UTF-8
-    # TODO: recompute this hash from the new URL
-    # https://www.state.gov/cuba-sanctions/cuba-prohibited-accommodations-list
-    # via Zyte fetch (state.gov serves a Technical Difficulties page to curl).
-    if not h.assert_dom_hash(node, "6dc9087e0ccb2e13fc2389ba4176ab114996ad32"):
+    if not h.assert_dom_hash(node, "cde71ba89a1b51b1b1d8d780d4902f72ca1d384c"):
         context.log.warning("Accommodations page changed. Check for data updates.")
 
     path = context.fetch_resource("accommodations.csv", ACCOMMODATIONS_URL)
@@ -63,10 +60,7 @@ def crawl_restricted_entities(context: Context) -> None:
     node = doc.find(CONTENT_XPATH)
     # Chrome save HTML only
     # xmllint --format --html --encode UTF-8
-    # TODO: recompute this hash from the new URL
-    # https://www.state.gov/cuba-sanctions/cuba-restricted-list
-    # via Zyte fetch (state.gov serves a Technical Difficulties page to curl).
-    if not h.assert_dom_hash(node, "a146ff14f0a283a4a80afaaf0f46637574aa78c2"):
+    if not h.assert_dom_hash(node, "60164794c60c5efe021094ebab28b338ad526e1e"):
         context.log.warning("Restricted List content changed. Check for data updates")
 
     path = context.fetch_resource("restricted_entities.csv", RESTRICTED_ENTITIES_URL)

--- a/datasets/us/cuba_sanctions/crawler.py
+++ b/datasets/us/cuba_sanctions/crawler.py
@@ -7,7 +7,7 @@ from zavod import helpers as h
 from zavod.extract.zyte_api import fetch_html
 
 ORIGINAL_ACCOMMODATIONS_URL = (
-    "https://www.state.gov/cuba-prohibited-accommodations-list-initial-publication/"
+    "https://www.state.gov/cuba-sanctions/cuba-prohibited-accommodations-list"
 )
 ACCOMMODATIONS_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQMquWjNWZ09dm9_mu9NKrxR33c6pe4hpiGFeheFT4tDZXwpelLudcYdCdME820aKJJo8TfMKbtoXTh/pub?gid=1890354374&single=true&output=csv"
 ORIGINAL_RESTRICTED_ENTITIES_URL = "https://www.state.gov/division-for-counter-threat-finance-and-sanctions/cuba-restricted-list"
@@ -32,6 +32,9 @@ def crawl_accommodations(context: Context) -> None:
     node = doc.find(CONTENT_XPATH)
     # Chrome save HTML only
     # xmllint --format --html --encode UTF-8
+    # TODO: recompute this hash from the new URL
+    # https://www.state.gov/cuba-sanctions/cuba-prohibited-accommodations-list
+    # via Zyte fetch (state.gov serves a Technical Difficulties page to curl).
     if not h.assert_dom_hash(node, "6dc9087e0ccb2e13fc2389ba4176ab114996ad32"):
         context.log.warning("Accommodations page changed. Check for data updates.")
 

--- a/datasets/us/cuba_sanctions/us_cuba_sanctions.yml
+++ b/datasets/us/cuba_sanctions/us_cuba_sanctions.yml
@@ -14,8 +14,8 @@ summary: >
 description: |
   This includes:
 
-  * [Cuba Prohibited Accommodations List](https://www.state.gov/cuba-prohibited-accommodations-list-initial-publication/)
-  * [List of Restricted Entities and Subentities Associated With Cuba](https://www.state.gov/division-for-counter-threat-finance-and-sanctions/cuba-restricted-list)
+  * [Cuba Prohibited Accommodations List](https://www.state.gov/cuba-sanctions/cuba-prohibited-accommodations-list)
+  * [List of Restricted Entities and Subentities Associated With Cuba](https://www.state.gov/cuba-sanctions/cuba-restricted-list)
 publisher:
   name: US State Department
   acronym: State


### PR DESCRIPTION
Fixes #4979

## Change
- Accommodations change detection now watches the live current-list page `https://www.state.gov/cuba-sanctions/cuba-prohibited-accommodations-list` (was the frozen initial-publication page).
- Restricted-list change detection now watches `https://www.state.gov/cuba-sanctions/cuba-restricted-list` (canonical URL; 301-redirects to the page previously watched).
- yml `description` links updated to match.

## Change-detection hashes
- Accommodations: `cde71ba89a1b51b1b1d8d780d4902f72ca1d384c` — verified by maintainer against Zyte (correct).
- Restricted list: reverted to `a146ff14f0a283a4a80afaaf0f46637574aa78c2` — the new URL 301-redirects to the same page already watched, so the existing Zyte-computed hash stays valid. The earlier `60164794…` was a curl-only hash (breadcrumb widget differs under a browser) and warned on every run; it has been removed.

## Per maintainer review
- The accommodations page contains 8 properties effective 2025-07-14 missing from the hand-maintained Google Sheet (incl. Meliá Trinidad Península, Meliá Costa Rey). Sheet update is being handled by OpenSanctions; the accommodations hash bump is sequenced with it.
- The unrelated `.gitignore` commit (superpowers plans / worktrees) has been dropped from this PR.