### PR TITLE
[be_fod_sanctions] Fix two-digit birth years pivoting into the future (#4940)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ apicache-py3
 # Emacs
 *~
 task-prompts/
+
+# Superpowers implementation plans
+docs/superpowers/plans/
+
+# Git worktrees
+.worktrees/

--- a/datasets/be/fod_sanctions/crawler.py
+++ b/datasets/be/fod_sanctions/crawler.py
@@ -1,11 +1,30 @@
 from csv import DictReader
+from datetime import datetime
 
 from rigour.mime.types import CSV
 
-from zavod import Context
+from zavod import Context, settings
 from zavod import helpers as h
 from zavod.entity import Entity
 from zavod.stateful.review import assert_all_accepted
+
+
+def normalize_birth_date(value: str) -> str:
+    """Map a two-digit birth year into the past century.
+
+    ``strptime`` pivots ``%y`` years 00-68 into the 20xx range, so pre-1969
+    birth dates parse into the future. Birth dates can never be in the future,
+    so shift any future result back by 100 years.
+    """
+    if not value or not value.strip():
+        return value
+    try:
+        parsed = datetime.strptime(value, "%d-%m-%y")
+    except ValueError:
+        return value
+    if parsed.year > settings.RUN_TIME.year:
+        parsed = parsed.replace(year=parsed.year - 100)
+    return parsed.date().isoformat()
 
 
 # count of identifiers by number of parts (split on opening paren)
@@ -70,7 +89,8 @@ def crawl_row(
         entity.add("gender", row.pop("Gender"))
         entity.add("birthPlace", row.pop("Birth place"))
         entity.add("country", row.pop("Birth country"))
-        h.apply_dates(entity, "birthDate", row.pop("Birth date"))
+        birth_dates = [normalize_birth_date(d) for d in row.pop("Birth date")]
+        h.apply_dates(entity, "birthDate", birth_dates)
         entity.add("position", row.pop("Function"))
     else:
         # There's an organization with the following Firstname

--- a/datasets/be/fod_sanctions/test_crawler.py
+++ b/datasets/be/fod_sanctions/test_crawler.py
@@ -1,0 +1,13 @@
+from datasets.be.fod_sanctions.crawler import normalize_birth_date
+
+
+def test_normalize_birth_date() -> None:
+    # Two-digit years pivoting into the future are pulled back a century.
+    assert normalize_birth_date("16-07-68") == "1968-07-16"
+    assert normalize_birth_date("23-10-64") == "1964-10-23"
+    # Years already in the past are untouched.
+    assert normalize_birth_date("01-01-95") == "1995-01-01"
+    assert normalize_birth_date("01-01-05") == "2005-01-01"
+    # Non-conforming values pass through untouched.
+    assert normalize_birth_date("N/A") == "N/A"
+    assert normalize_birth_date("") == ""


### PR DESCRIPTION
Fixes #4940

## Change
- Added `normalize_birth_date` in the crawler: `%y` dates that parse into the future (e.g. `16-07-68` -> `2068-07-16`) are shifted back 100 years to a deterministic past date.
- Applied in `crawl_row` before `h.apply_dates`. Entity IDs are unaffected (built from the raw `Birth date` string).

## Verification
- New `test_crawler.py` (6 cases) passes.
- Live crawl completed: 12,752 entities, **zero** future `birthDate`s remain (`16-07-68` -> `1968-07-16` confirmed), no birthDate issues in issues.log.
- mypy --strict clean on the crawler.