### PR TITLE
dates: declare base_century for two-digit-year parsing across 29 datasets (#4974)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ apicache-py3
 # Emacs
 *~
 task-prompts/
+
+# Superpowers implementation plans
+docs/superpowers/plans/
+
+# Git worktrees
+.worktrees/

--- a/datasets/_global/afdb_sanctions/afdb_sanctions.yml
+++ b/datasets/_global/afdb_sanctions/afdb_sanctions.yml
@@ -43,6 +43,7 @@ data:
 
 dates:
   formats: ["%Y/%m/%d", "%d-%b-%Y", "%d-%m-%Y", "%d-%b-%y"]
+  base_century: 2000
   months:
     "Sep": "Sept"
 names:

--- a/datasets/_global/c4ads_xinjiang/c4ads_xinjiang.yml
+++ b/datasets/_global/c4ads_xinjiang/c4ads_xinjiang.yml
@@ -42,6 +42,7 @@ assertions:
 
 dates:
   formats: ["%m/%d/%y"]
+  base_century: 1930
 
 lookups:
   type.name:

--- a/datasets/_global/c4ads_xinjiang_mining/c4ads_xinjiang_mining.yml
+++ b/datasets/_global/c4ads_xinjiang_mining/c4ads_xinjiang_mining.yml
@@ -49,3 +49,4 @@ assertions:
 
 dates:
   formats: ["%m/%d/%y"]
+  base_century: 2000

--- a/datasets/_global/icij_offshoreleaks/icij_offshoreleaks.yml
+++ b/datasets/_global/icij_offshoreleaks/icij_offshoreleaks.yml
@@ -45,6 +45,7 @@ dates:
       "%d.%m.%Y",
       "%d/%m/%y",
     ]
+  base_century: 1930
 assertions:
   min:
     schema_entities:

--- a/datasets/_global/un_1718_vessels/un_1718_vessels.yml
+++ b/datasets/_global/un_1718_vessels/un_1718_vessels.yml
@@ -48,6 +48,7 @@ data:
   lang: eng
 dates:
   formats: ["%d-%b-%y"]
+  base_century: 2000
 tags:
   - list.sanction
   - sector.maritime

--- a/datasets/_global/un_ga_protocol/un_ga_protocol.yml
+++ b/datasets/_global/un_ga_protocol/un_ga_protocol.yml
@@ -35,6 +35,7 @@ data:
   format: PDF
 dates:
   formats: ["%d-%b-%y"]
+  base_century: 2000
 
 assertions:
   min:

--- a/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
+++ b/datasets/au/dfat_sanctions/au_dfat_sanctions.yml
@@ -76,6 +76,7 @@ dates:
     - "/%m/%d%Y"
     - "%d %B %Y"
     - "%B %Y"
+  base_century: 1930
 
 lookups:
   sanction.program:

--- a/datasets/be/fod_sanctions/be_fod_sanctions.yml
+++ b/datasets/be/fod_sanctions/be_fod_sanctions.yml
@@ -45,6 +45,7 @@ data:
 
 dates:
   formats: ["%d-%m-%y"]
+  base_century: 1930
 
 assertions:
   min:

--- a/datasets/ca/dfatd/ca_dfatd_sema_sanctions.yml
+++ b/datasets/ca/dfatd/ca_dfatd_sema_sanctions.yml
@@ -43,6 +43,7 @@ data:
   format: XML
 dates:
   formats: ["%Y", "%d-%m-%Y", "%b-%y"]
+  base_century: 2000
 
 assertions:
   min:

--- a/datasets/cn/sanctions/cn_sanctions.yml
+++ b/datasets/cn/sanctions/cn_sanctions.yml
@@ -58,6 +58,7 @@ data:
   format: CSV
 dates:
   formats: ["%d.%m.%y", "%d.%m.%Y"]
+  base_century: 2000
 tags:
   - list.sanction.counter
   - list.export

--- a/datasets/cu/inventario_legislatura/cu_inventario_legislatura.yml
+++ b/datasets/cu/inventario_legislatura/cu_inventario_legislatura.yml
@@ -42,6 +42,7 @@ data:
   format: HTML
 dates:
   formats: ["%d/%m/%Y", "%d/%m/%y"]
+  base_century: 1930
 
 assertions:
   min:

--- a/datasets/il/mod_crypto/il_mod_crypto.yml
+++ b/datasets/il/mod_crypto/il_mod_crypto.yml
@@ -38,6 +38,7 @@ data:
 ci_test: false # No Zyte key in CI
 dates:
   formats: ["%d/%m/%Y", "%m/%d/%Y", "%d.%m.%Y", "%m.%d.%Y", "%m.%d.%y"]
+  base_century: 1930
 tags:
   - list.sanction
   - sector.crypto

--- a/datasets/il/wmd_sanctions/il_wmd_sanctions.yml
+++ b/datasets/il/wmd_sanctions/il_wmd_sanctions.yml
@@ -44,6 +44,7 @@ dates:
     - "%d %b %Y"
     - "%d %m %Y"
     - "%d %m %y"
+  base_century: 1930
   months:
     Mar: במרץ
     Apr: באפריל

--- a/datasets/in/nse_debarred/in_nse_debarred.yml
+++ b/datasets/in/nse_debarred/in_nse_debarred.yml
@@ -98,6 +98,7 @@ dates:
     - "REVOKED ON %d.%m.%Y  (AS INFORMED BY SEBI VIDE EMAIL)"
     - "DEBARMENT REVOKED VIDE SEBI ORDER DATED %d-%b-%y"
     - "REVOKED ON %d.%m.%Y IN CASE OF HIND AGRO OILS LTD"
+  base_century: 2000
 
 assertions:
   min:

--- a/datasets/lv/fiu_sanctions/lv_fiu_sanctions.yml
+++ b/datasets/lv/fiu_sanctions/lv_fiu_sanctions.yml
@@ -48,6 +48,7 @@ data:
   format: XLSX
 dates:
   formats: ["%d/%m/%y", "%d.%m.%Y."]
+  base_century: 1930
 
 assertions:
   min:

--- a/datasets/tr/fcib/tr_fcib.yml
+++ b/datasets/tr/fcib/tr_fcib.yml
@@ -43,6 +43,7 @@ data:
   format: html
 dates:
   formats: ["%d.%m.%Y", "%m/%d/%Y", "%m/%d/%y", "%d %m %Y"]
+  base_century: 1930
   months:
     1: Ocak
     2: Şubat

--- a/datasets/us/al/med_exclusions/us_al_med_exclusions.yml
+++ b/datasets/us/al/med_exclusions/us_al_med_exclusions.yml
@@ -51,6 +51,7 @@ ci_test: false
 
 dates:
   formats: ["%m/%d/%y", "%m/%d/%Y"]
+  base_century: 2000
 
 assertions:
   min:

--- a/datasets/us/bis_antiboycott/us_bis_antiboycott.yml
+++ b/datasets/us/bis_antiboycott/us_bis_antiboycott.yml
@@ -42,6 +42,7 @@ data:
   format: html
 dates:
   formats: ["%m/%d/%y"]
+  base_century: 1930
 
 assertions:
   min:

--- a/datasets/us/bis_oac/us_bis_oac.yml
+++ b/datasets/us/bis_oac/us_bis_oac.yml
@@ -41,6 +41,7 @@ data:
 
 dates:
   formats: ["%b-%y", "%B %Y"]
+  base_century: 1930
 
 assertions:
   min:

--- a/datasets/us/de/med_exclusions/us_de_med_exclusions.yml
+++ b/datasets/us/de/med_exclusions/us_de_med_exclusions.yml
@@ -40,6 +40,7 @@ data:
 
 dates:
   formats: ["%m/%d/%Y", "%m/%d/%y", "Reinstated effective %m/%d/%Y"]
+  base_century: 2000
 
 assertions:
   min:

--- a/datasets/us/fdic_failed_banks/us_fdic_failed_banks.yml
+++ b/datasets/us/fdic_failed_banks/us_fdic_failed_banks.yml
@@ -28,6 +28,7 @@ data:
 
 dates:
   formats: ["%B %d, %Y", "%d-%b-%y"]
+  base_century: 2000
 assertions:
   min:
     schema_entities:

--- a/datasets/us/hi/med_exclusions/us_hi_med_exclusions.yml
+++ b/datasets/us/hi/med_exclusions/us_hi_med_exclusions.yml
@@ -52,6 +52,7 @@ ci_test: false
 
 dates:
   formats: ["%m/%d/%Y", "%m/%d/%y"]
+  base_century: 2000
 
 assertions:
   min:

--- a/datasets/us/mo/med_exclusions/us_mo_med_exclusions.yml
+++ b/datasets/us/mo/med_exclusions/us_mo_med_exclusions.yml
@@ -38,6 +38,7 @@ ci_test: false
 
 dates:
   formats: ["%m/%d/%y"]
+  base_century: 2000
 assertions:
   min:
     schema_entities:

--- a/datasets/us/ms/med_exclusions/us_ms_med_exclusions.yml
+++ b/datasets/us/ms/med_exclusions/us_ms_med_exclusions.yml
@@ -40,6 +40,7 @@ data:
   lang: eng
 dates:
   formats: ["%m.%d.%y", "%B %d, %Y", "%B %d,%Y", "%m/%d/%Y", "%m/%d/%y"]
+  base_century: 1930
 
 assertions:
   min:

--- a/datasets/us/nd/med_exclusions/us_nd_med_exclusions.yml
+++ b/datasets/us/nd/med_exclusions/us_nd_med_exclusions.yml
@@ -30,6 +30,7 @@ data:
   lang: eng
 dates:
   formats: ["%m/%d/%Y", "%m/%d/%y"]
+  base_century: 2000
 assertions:
   min:
     schema_entities:

--- a/datasets/us/oh/med_exclusions/us_oh_med_exclusions.yml
+++ b/datasets/us/oh/med_exclusions/us_oh_med_exclusions.yml
@@ -40,6 +40,7 @@ ci_test: false
 
 dates:
   formats: ["%m/%d/%Y", "%m/%d/%y"]
+  base_century: 1930
 assertions:
   min:
     schema_entities:

--- a/datasets/us/sc/med_exclusions/us_sc_med_exclusions.yml
+++ b/datasets/us/sc/med_exclusions/us_sc_med_exclusions.yml
@@ -49,6 +49,7 @@ ci_test: false
 
 dates:
   formats: ["%m/%d/%y"]
+  base_century: 2000
 
 assertions:
   min:

--- a/datasets/us/wv/med_exclusions/us_wv_med_exclusions.yml
+++ b/datasets/us/wv/med_exclusions/us_wv_med_exclusions.yml
@@ -31,6 +31,7 @@ data:
   lang: eng
 dates:
   formats: ["%m/%d/%Y", "%m/%d/%y"]
+  base_century: 2000
 
 assertions:
   min:

--- a/datasets/ve/asamblea_nacional/ve_asamblea_nacional.yml
+++ b/datasets/ve/asamblea_nacional/ve_asamblea_nacional.yml
@@ -38,6 +38,7 @@ data:
 dates:
   formats:
     ["%d/%m/%Y", "%d/%m/%y", "%d-%m-%Y", "%d-%m-%y", "%d %b %Y", "%d – %m – %y"]
+  base_century: 1930
   months:
     Mar: de marzo de
     Apr: de Abril de

--- a/zavod/docs/best_practices/dates_meta.md
+++ b/zavod/docs/best_practices/dates_meta.md
@@ -43,3 +43,23 @@ dates:
 ```
 
 This will parse any string that contains a valid year, such as `Approximately 1960`, or `circa 2007`.
+
+## Two-digit years: the `base_century` option
+
+`%y` matches two-digit years, and Python pivots those on an arbitrary boundary
+(00-68 → 20xx, 69-99 → 19xx), which can mis-parse pre-1969 dates into the future.
+To make the pivot deterministic, declare the century window the source data
+belongs to:
+
+```yaml
+dates:
+    formats: ['%d-%m-%y']
+    base_century: 1900
+```
+
+Two-digit years are mapped into the 100-year window starting at `base_century`
+(`1900` → 1900–1999, `2000` → 2000–2099). A dataset mixing 19xx birth dates with
+20xx listing dates can use an intermediate floor such as `1930` (window 1930–2029).
+Whenever a configured format contains `%y`, `base_century` is required; if a source
+has values spanning multiple centuries, prefer handling them per-property in the
+crawler instead of a single dataset-wide window.

--- a/zavod/zavod/helpers/dates.py
+++ b/zavod/zavod/helpers/dates.py
@@ -1,7 +1,7 @@
 import re
 from functools import lru_cache
 from normality import stringify
-from prefixdate import parse_formats
+from prefixdate import parse_format, parse_formats, DatePrefix, Precision
 from rigour.dates import ended_before
 from datetime import datetime, date, timedelta, UTC
 from typing import TYPE_CHECKING
@@ -73,6 +73,17 @@ def replace_months(dataset: Dataset, text: str) -> str:
     return spec.months_re.sub(lambda m: spec.mappings[m.group().lower()], text)
 
 
+def _apply_base_century(parsed: DatePrefix, base_century: int) -> DatePrefix:
+    """Map the two-digit year of a parsed date into the century window
+    starting at ``base_century`` (e.g. 1900 -> 1900-1999, 1930 -> 1930-2029)."""
+    if parsed.dt is None:
+        return parsed
+    two_digit = parsed.dt.year % 100
+    year = base_century + ((two_digit - base_century) % 100)
+    dt = parsed.dt.replace(year=year)
+    return DatePrefix(dt, precision=parsed.precision)
+
+
 @lru_cache(maxsize=5000)
 def extract_date(
     dataset: Dataset,
@@ -99,9 +110,25 @@ def extract_date(
     replaced_text = replace_months(dataset, text)
     dataset_formats_ = dataset.dates.formats + ALWAYS_FORMATS
     formats_ = dataset_formats_ if formats is None else list(formats)
-    parsed = parse_formats(replaced_text, formats_)
-    if parsed.text is not None:
-        return [parsed.text]
+    parsed = None
+    matched_format = None
+    for fmt in formats_:
+        candidate = parse_format(replaced_text, fmt)
+        if candidate.precision != Precision.EMPTY:
+            parsed = candidate
+            matched_format = fmt
+            break
+    if parsed is not None and parsed.text is not None:
+        base_century = dataset.dates.base_century
+        if (
+            matched_format is not None
+            and "%y" in matched_format
+            and base_century is not None
+        ):
+            parsed = _apply_base_century(parsed, base_century)
+        text = parsed.text
+        assert text is not None
+        return [text]
     if dataset.dates.year_only:
         years = extract_years(text)
         if len(years):

--- a/zavod/zavod/meta/dates.py
+++ b/zavod/zavod/meta/dates.py
@@ -1,6 +1,6 @@
 import re
 from typing import Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from banal import ensure_list
 
 from zavod.logs import get_logger
@@ -17,6 +17,14 @@ class DatesSpec(BaseModel):
     months: dict[str | int, str | list[str]] = {}
     mappings: dict[str, str] = Field(default_factory=dict, exclude=True, init=False)
     months_re: re.Pattern[str] | None = Field(default=None, exclude=True, init=False)
+
+    @model_validator(mode="after")
+    def require_base_century_for_two_digit_years(self) -> "DatesSpec":
+        for fmt in self.formats:
+            if "%y" in fmt and self.base_century is None:
+                msg = f"Date format {fmt!r} uses %y, which requires a base_century"
+                raise ValueError(msg)
+        return self
 
     def model_post_init(self, _: Any) -> None:
         """Process months mapping after model initialization."""

--- a/zavod/zavod/meta/dates.py
+++ b/zavod/zavod/meta/dates.py
@@ -13,6 +13,7 @@ class DatesSpec(BaseModel):
 
     year_only: bool = False
     formats: list[str] = []
+    base_century: int | None = None
     months: dict[str | int, str | list[str]] = {}
     mappings: dict[str, str] = Field(default_factory=dict, exclude=True, init=False)
     months_re: re.Pattern[str] | None = Field(default=None, exclude=True, init=False)

--- a/zavod/zavod/tests/conftest.py
+++ b/zavod/zavod/tests/conftest.py
@@ -34,6 +34,7 @@ DATASET_SECURITIES_YML = (
 DATASET_MARITIME_YML = (
     FIXTURES_PATH / "testdataset_maritime" / "testdataset_maritime.yml"
 )
+DATASET_DATES_YML = FIXTURES_PATH / "testdataset_dates" / "testdataset_dates.yml"
 COLLECTION_YML = FIXTURES_PATH / "collection.yml"
 XML_DOC = FIXTURES_PATH / "doc.xml"
 
@@ -96,6 +97,13 @@ def testdataset_securities() -> Dataset:
 @pytest.fixture(scope="function")
 def testdataset_maritime() -> Dataset:
     dataset = load_dataset_from_path(DATASET_MARITIME_YML)
+    assert dataset is not None
+    return dataset
+
+
+@pytest.fixture(scope="function")
+def testdataset_dates() -> Dataset:
+    dataset = load_dataset_from_path(DATASET_DATES_YML)
     assert dataset is not None
     return dataset
 

--- a/zavod/zavod/tests/fixtures/testdataset_dates/testdataset_dates.yml
+++ b/zavod/zavod/tests/fixtures/testdataset_dates/testdataset_dates.yml
@@ -1,0 +1,22 @@
+entry_point: testentrypoint1
+title: OpenSanctions Date Pivot Validation Dataset
+prefix: osd
+hidden: true
+resolve: false
+summary: >
+  Dataset used to validate base_century handling of two-digit date years.
+description: |
+  Fictional data. Used to test that %y dates pivot into the configured century.
+publisher:
+  name: OpenSanctions
+  description: |
+    Manually created by the project team.
+  url: https://www.opensanctions.org
+  official: false
+url: https://github.com/opensanctions/opensanctions
+data:
+  url: https://docs.google.com/spreadsheets/d/e/2PACX-1vTYliJOm1mk2PrsL0m_BVn2sEbpHIdQ2fuzavp0gqOLndgzCw7gtr9Npqwa_FerVrQBfYFiDeKuwfV-/pub?gid=0&single=true&output=csv
+  format: CSV
+dates:
+  formats: ["%d-%m-%y"]
+  base_century: 1900

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -139,6 +139,13 @@ def test_apply_base_century() -> None:
     assert _apply_base_century(month, 1900).text == "1968-07"
 
 
+def test_extract_date_base_century(testdataset_dates: Dataset) -> None:
+    assert "%d-%m-%y" in testdataset_dates.dates.formats
+    assert testdataset_dates.dates.base_century == 1900
+    assert extract_date(testdataset_dates, "16-07-68") == ["1968-07-16"]
+    assert extract_date(testdataset_dates, "01-01-05") == ["1905-01-01"]
+
+
 def test_within_max_age(vcontext: Context):
     assert within_max_age(vcontext, RUN_TIME.date().isoformat())
     # A year-precision date whose year straddles the cutoff may be as late as

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -1,13 +1,15 @@
 from datetime import datetime, timedelta, UTC
 from structlog.testing import capture_logs
 
+from prefixdate import parse_format
+
 from zavod.context import Context
 from zavod.entity import Entity
 from zavod.meta.dataset import Dataset
 from zavod.meta.dates import DatesSpec
 from zavod.helpers.dates import extract_years, extract_date, backdate
 from zavod.helpers.dates import replace_months, apply_date, apply_dates
-from zavod.helpers.dates import within_max_age
+from zavod.helpers.dates import within_max_age, _apply_base_century
 from zavod.settings import RUN_TIME
 
 FORMATS = ["%b %Y", "%d.%m.%Y", "%Y-%m"]
@@ -125,6 +127,16 @@ def test_dates_spec_base_century() -> None:
     assert spec.base_century == 1930
     spec = DatesSpec(formats=["%d-%m-%Y"])
     assert spec.base_century is None
+
+
+def test_apply_base_century() -> None:
+    parsed = parse_format("16-07-68", "%d-%m-%y")
+    assert parsed.text == "2068-07-16"
+    assert _apply_base_century(parsed, 1900).text == "1968-07-16"
+    assert _apply_base_century(parsed, 1930).text == "1968-07-16"
+    assert _apply_base_century(parsed, 2000).text == "2068-07-16"
+    month = parse_format("07-68", "%m-%y")
+    assert _apply_base_century(month, 1900).text == "1968-07"
 
 
 def test_within_max_age(vcontext: Context):

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -4,6 +4,7 @@ from structlog.testing import capture_logs
 from zavod.context import Context
 from zavod.entity import Entity
 from zavod.meta.dataset import Dataset
+from zavod.meta.dates import DatesSpec
 from zavod.helpers.dates import extract_years, extract_date, backdate
 from zavod.helpers.dates import replace_months, apply_date, apply_dates
 from zavod.helpers.dates import within_max_age
@@ -117,6 +118,13 @@ def test_apply_date(testdataset1: Dataset):
 def test_backdate():
     assert backdate(datetime(2023, 8, 3), timedelta(days=0)) == "2023-08-03"
     assert backdate(datetime(2023, 8, 3), timedelta(days=182)) == "2023-02-02"
+
+
+def test_dates_spec_base_century() -> None:
+    spec = DatesSpec(formats=["%d-%m-%y"], base_century=1930)
+    assert spec.base_century == 1930
+    spec = DatesSpec(formats=["%d-%m-%Y"])
+    assert spec.base_century is None
 
 
 def test_within_max_age(vcontext: Context):

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta, UTC
 from structlog.testing import capture_logs
 
+import pytest
+from pydantic import ValidationError
 from prefixdate import parse_format
 
 from zavod.context import Context
@@ -144,6 +146,15 @@ def test_extract_date_base_century(testdataset_dates: Dataset) -> None:
     assert testdataset_dates.dates.base_century == 1900
     assert extract_date(testdataset_dates, "16-07-68") == ["1968-07-16"]
     assert extract_date(testdataset_dates, "01-01-05") == ["1905-01-01"]
+
+
+def test_dates_spec_requires_base_century_for_two_digit_years() -> None:
+    with pytest.raises(ValidationError):
+        DatesSpec(formats=["%d-%m-%y"])
+    spec = DatesSpec(formats=["%d-%m-%y"], base_century=1900)
+    assert spec.base_century == 1900
+    # %Y formats and ISO formats do not require base_century
+    DatesSpec(formats=["%d-%m-%Y", "%Y-%m-%d"])
 
 
 def test_within_max_age(vcontext: Context):


### PR DESCRIPTION
Fixes #4974 (Option A)

## Change
- Added `DatesSpec.base_century: int | None` (default `None` preserves current behavior).
- `extract_date` now tracks the matched format and, when it contains `%y` and `base_century` is set, remaps the two-digit year into the window `[base_century, base_century+100)`.
- Rolled out `base_century` to all 29 datasets configuring `%y` (see plan for per-dataset values; mixed birth/listing-date sources use `1930`, pure 2000s sources `2000`).
- `DatesSpec` now rejects any configured `%y` format without `base_century`.
- Documented in `zavod/docs/best_practices/dates_meta.md`.

## Tests
- `test_apply_base_century`, `test_dates_spec_base_century`, `test_extract_date_base_century`, `test_dates_spec_requires_base_century_for_two_digit_years` added; fixture dataset `testdataset_dates` added.
- `pytest zavod/tests/`: 297 passed; mypy --strict clean.

## Note
`icij_offshoreleaks` spans centuries; `base_century: 1930` is the documented least-bad single window. be_fod_sanctions also carries a standalone crawler fix in #4940 that is redundant-but-harmless once this config lands.