### PR TITLE
[zavod] Flag mixed-script names as irregular (name review) (#4598)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ apicache-py3
 # Emacs
 *~
 task-prompts/
+
+# Superpowers implementation plans
+docs/superpowers/plans/
+
+# Git worktrees
+.worktrees/

--- a/zavod/zavod/helpers/names.py
+++ b/zavod/zavod/helpers/names.py
@@ -9,6 +9,7 @@ from pydantic import JsonValue
 from rigour.names import contains_split_phrase, remove_person_prefixes
 from rigour.text import is_nullword
 from rigour.text.scripts import is_dense_script
+from rigour.text.scripts import DENSE_SCRIPTS, text_scripts
 
 from zavod import settings
 from zavod.constants import ORIGIN_INFERRED
@@ -432,6 +433,12 @@ def _check_schema_name_specs(string: str, spec: CleaningSpec) -> Regularity | No
     # spec.reject_leading_digit
     if spec.reject_leading_digit and string[0].isdigit():
         return Regularity(is_irregular=True)
+
+    # spec.reject_mixed_scripts
+    if spec.reject_mixed_scripts:
+        scripts = text_scripts(string)
+        if scripts & DENSE_SCRIPTS and scripts - DENSE_SCRIPTS:
+            return Regularity(is_irregular=True)
 
     return None
 

--- a/zavod/zavod/meta/names.py
+++ b/zavod/zavod/meta/names.py
@@ -49,6 +49,11 @@ class CleaningSpec(BaseModel):
     """If True, names starting with a digit are flagged as irregular. Off by default.
     Useful where leading digits are irregular, e.g. numbering artifacts.
     Some organisation names really have leading digits in the name."""
+    reject_mixed_scripts: bool = False
+    """If True, names that mix a dense script (Han/Hiragana/Katakana/Hangul) with a
+    non-dense script (e.g. Latin) are flagged as irregular. This catches CJK names
+    with a glued-on Latin romanization, while allowing legitimate intra-Japanese
+    kana+kanji names."""
 
     @cached_property
     def reject_chars_consolidated(self) -> set[str]:
@@ -67,6 +72,7 @@ _DEFAULT_SCHEMA_RULES: dict[str, CleaningSpec] = {
     "Person": CleaningSpec(
         reject_chars_baseline=";\\/()[]<>{}:",
         require_space=True,
+        reject_mixed_scripts=True,
     ),
     "LegalEntity": CleaningSpec(
         reject_chars_baseline="/;",

--- a/zavod/zavod/tests/helpers/names/test_regularity.py
+++ b/zavod/zavod/tests/helpers/names/test_regularity.py
@@ -139,3 +139,20 @@ def test_reject_leading_digit(testdataset1: Dataset, testdataset2: Dataset) -> N
         testdataset2, {"id": "b", "schema": "Organization", "properties": {}}
     )
     assert not is_name_irregular(org_no_flag, "1 Some Organization")
+
+
+def test_mixed_scripts_irregular(testdataset1: Dataset):
+    person_data = {"id": "jon", "schema": "Person", "properties": {}}
+    person = Entity(testdataset1, person_data)
+
+    # Han + Latin romanization glued together -> irregular
+    assert is_name_irregular(person, "鄭天財Sra Kacaw")
+    assert is_name_irregular(person, "簡東明Uliw．Qaljupayare")
+
+    # Pure Han -> regular
+    assert not is_name_irregular(person, "习近平")
+    # Japanese kanji + kana (all dense) -> regular
+    assert not is_name_irregular(person, "安倍晋三")
+    assert not is_name_irregular(person, "さとうたろう")
+    # Latin + digits/punctuation (Common excluded) -> regular
+    assert not is_name_irregular(person, "John Smith 2nd")

--- a/zavod/zavod/tests/helpers/names/test_regularity.py
+++ b/zavod/zavod/tests/helpers/names/test_regularity.py
@@ -1,10 +1,18 @@
 from zavod.meta.dataset import Dataset
+from zavod.meta.names import NamesSpec
 from zavod.entity import Entity
 
 from zavod.helpers import (
     is_name_irregular,
     check_name_regularity,
 )
+
+
+def test_default_person_spec_rejects_mixed_scripts() -> None:
+    spec = NamesSpec().schema_rules["Person"]
+    assert spec.reject_mixed_scripts is True
+    spec = NamesSpec().schema_rules["LegalEntity"]
+    assert spec.reject_mixed_scripts is False
 
 
 def test_is_name_irregular(testdataset1: Dataset):


### PR DESCRIPTION
Fixes #4598

## Change
- Added `CleaningSpec.reject_mixed_scripts` (default `False`), set `True` for the default `Person` schema rule.
- `_check_schema_name_specs` flags a name as irregular when it mixes a dense script (Han/Hiragana/Katakana/Hangul) with a non-dense script, using `rigour.text.scripts.text_scripts` + `DENSE_SCRIPTS`.
- Review trigger only (no suggested_prop); catches e.g. `鄭天財Sra Kacaw` while allowing legitimate Japanese kana+kanji.

## Tests
- `test_default_person_spec_rejects_mixed_scripts`, `test_mixed_scripts_irregular` added.
- `pytest zavod/tests/`: 295 passed; mypy --strict clean.