### PR TITLE
[zavod] Validate entity references against their property range

### DIFF
--- a/zavod/docs/best_practices/patterns.md
+++ b/zavod/docs/best_practices/patterns.md
@@ -146,6 +146,10 @@ for name in h.multi_split(names, SPLITS):
     doc.make_links_absolute(context.data_url)
     ```
 
+## Reference entities that fit the property range
+
+Every entity-type property declares the schema its target must have (`ftm ref prop Ownership:asset`), and `zavod validate` warns when a reference doesn't fit. The mistake we make most often is emitting a business that someone owns as an `Organization`, which is not an `Asset` and so can't be the `asset` of an `Ownership` — use `Company`, which inherits from both.
+
 ## Addresses
 
 See the [addresses guide](addresses.md) for the full pattern, country handling, and the choice between `copy_address` and `apply_address`.

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -9,7 +9,7 @@ from zavod.integration import get_dataset_linker
 from zavod.meta.dataset import Dataset
 from zavod.store import get_store
 from zavod.validators import (
-    DanglingReferencesValidator,
+    EntityReferenceValidator,
     SelfReferenceValidator,
     EmptyValidator,
 )
@@ -60,7 +60,7 @@ def emit_entity(ds: Dataset, schema: str, properties: dict[str, list[str]]) -> E
 
 def test_dangling_references(testdataset3) -> None:
     crawl_dataset(testdataset3)
-    validator, logs = run_validator(DanglingReferencesValidator, testdataset3)
+    validator, logs = run_validator(EntityReferenceValidator, testdataset3)
 
     assert logs == {
         (
@@ -71,6 +71,40 @@ def test_dangling_references(testdataset3) -> None:
             "warning",
             "td3-asset-of-nonexistent-co-ownership-nonexistent-co property owner references missing id td3-nonexistent-co",
         ),
+    }
+    assert validator.abort is False
+
+
+def test_property_range() -> None:
+    # All of these have to be emitted through one context: each context run
+    # replaces the dataset's statements rather than appending to them.
+    ds = Dataset({**BASE_DATASET_CONFIG, "name": "test_range"})
+    context = Context(ds)
+    context.begin()
+
+    def make(schema: str, properties: dict[str, list[str]]) -> Entity:
+        entity = Entity.from_data(
+            context.dataset,
+            {"schema": schema, "id": str(uuid.uuid4()), "properties": properties},
+        )
+        context.emit(entity)
+        return entity
+
+    owner = make("Person", {"name": ["Wile E. Coyote"]})
+    # A Company is an Asset, so this ownership is in range and stays quiet.
+    company = make("Company", {"name": ["Acme Inc"]})
+    make("Ownership", {"owner": [owner.id], "asset": [company.id]})
+    # An Organization is not an Asset - the case reported in #2550.
+    org = make("Organization", {"name": ["Acme Foundation"]})
+    make("Ownership", {"owner": [owner.id], "asset": [org.id]})
+    context.close()
+
+    validator, logs = run_validator(EntityReferenceValidator, ds)
+    assert logs == {
+        (
+            "warning",
+            "Ownership:asset should reference Asset, but 1 references point at Organization",
+        )
     }
     assert validator.abort is False
 

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -1,4 +1,5 @@
-from followthemoney import registry
+from collections import Counter, defaultdict
+from followthemoney import registry, Property, Schema
 
 from zavod.archive import dataset_data_path
 from zavod.context import Context
@@ -11,20 +12,61 @@ from zavod.validators.assertions import (
 )
 from zavod.validators.common import BaseValidator
 
+# How many offending references to name per property/schema combination. Some
+# datasets get this wrong thousands of times over; a handful of ids is enough to
+# find the crawler code responsible.
+MAX_RANGE_EXAMPLES = 5
 
-class DanglingReferencesValidator(BaseValidator):
-    """Warns if an entity references an entity that is not in the store."""
+
+class EntityReferenceValidator(BaseValidator):
+    """Warn if an entity reference doesn't resolve, or points at the wrong kind
+    of entity.
+
+    Every entity-type property declares a `range`: the schema its target is
+    supposed to have (an `Ownership:asset` must be an `Asset`, an
+    `Occupancy:holder` must be a `Person`). Nothing can enforce that while the
+    crawler runs, because the referenced entity usually doesn't exist yet when
+    the reference is made. Once the whole dataset is in the store, it becomes
+    checkable - a company emitted as an `Organization` rather than a `Company`
+    shows up here.
+    """
+
+    def __init__(self, context: Context, view: View) -> None:
+        super().__init__(context, view)
+        self.out_of_range: Counter[tuple[Property, Schema]] = Counter()
+        self.examples: dict[tuple[Property, Schema], list[str]] = defaultdict(list)
 
     def feed(self, entity: Entity) -> None:
         for prop in entity.iterprops():
             if prop.type != registry.entity:
                 continue
             for other_id in entity.get(prop):
-                if self.view.has_entity(other_id):
+                other = self.view.get_entity(other_id)
+                if other is None:
+                    self.context.log.warning(
+                        f"{entity.id} property {prop.name} references missing id {other_id}"
+                    )
                     continue
-                self.context.log.warning(
-                    f"{entity.id} property {prop.name} references missing id {other_id}"
-                )
+                if prop.range is None or other.schema.is_a(prop.range):
+                    continue
+                key = (prop, other.schema)
+                self.out_of_range[key] += 1
+                examples = self.examples[key]
+                if len(examples) < MAX_RANGE_EXAMPLES:
+                    examples.append(f"{entity.id} -> {other_id}")
+
+    def finish(self) -> None:
+        for (prop, schema), count in self.out_of_range.most_common():
+            assert prop.range is not None
+            self.context.log.warning(
+                f"{prop.qname} should reference {prop.range.name}, "
+                f"but {count} references point at {schema.name}",
+                prop=prop.qname,
+                range=prop.range.name,
+                referenced_schema=schema.name,
+                count=count,
+                examples=self.examples[(prop, schema)],
+            )
 
 
 # FollowTheMoney prevents direct self-references so we check 1 level deep
@@ -62,7 +104,7 @@ class EmptyValidator(BaseValidator):
 
 
 VALIDATORS: list[type[BaseValidator]] = [
-    DanglingReferencesValidator,
+    EntityReferenceValidator,
     SelfReferenceValidator,
     StatisticsAssertionsValidator,
     EmptyValidator,


### PR DESCRIPTION
Closes #2550. Supersedes #5287, which fixes the same issue by special-casing `Ownership:asset`.

## Why the general form

Every entity-type property in FollowTheMoney declares a `range` — the schema its target is supposed to have (`Ownership:asset → Asset`, `Occupancy:holder → Person`, `Membership:organization → Organization`). All 92 entity-type properties in the model have one, and nothing checks any of them against real data. FtM validates ranges in exactly one place (`followthemoney/mapping/property.py`), and that's mapping-config load time; at data time it only ever sees one entity, so it can't resolve the target.

Validation is the one place that has both the reference and the resolved target, so the check belongs there — for all properties, not just the one in the issue.

## Change

`DanglingReferencesValidator` → `EntityReferenceValidator`. It already walked every entity reference asking *does the target exist*; it now also asks *is the target the right kind of thing*, deriving both from a single `view.get_entity()` instead of `has_entity()`.

Mismatches are aggregated per `(property, target schema)` and reported once in `finish()` with a count and up to 5 example ids:

```
warning  Ownership:asset should reference Asset, but 3168 references point at Organization
         prop=Ownership:asset range=Asset referenced_schema=Organization count=3168
         examples=['ofac-000d5952… -> ofac-55026', …]
```

Per-occurrence warnings would have put 3168 rows in the `us_ofac_sdn` issues log alone. Warning level, no abort — same as the dangling-reference check.

## What this will start flagging

I scanned all 446 local `statements.pack` files (everything except the 15 GB `ext_ru_egrul`): **18 datasets, ~9,400 bad references.**

| property | expected | actual | count |
|---|---|---|---|
| `Ownership:asset` | Asset | Organization | 7,454 |
| `Ownership:asset` | Asset | LegalEntity | 1,789 |
| `Membership:organization` | Organization | LegalEntity | 206 |
| `Family:relative` | Person | LegalEntity | 45 |
| `Associate:person` / `Associate:associate` | Person | Organization / Asset | 44 |
| `Ownership:asset` | Asset | Person | 5 |
| `Membership:organization` | Organization | Person | 5 |
| `Payment:payer` | LegalEntity | Asset | 1 |

By dataset: `us_ofac_sdn` 3168, `c4ads_xinjiang` 2912, `ua_war_sanctions` 937, `us_nv_med_exclusions` 458, `thesentry_atlas` 421, `us_ofac_cons` 279, `ext_ror` 272, `gem_energy_ownership` 218, `md_rise_profiles` 213, `us_nc_med_exclusions` 177, `gb_fcdo_sanctions` 168, `in_nse_debarred` 141, `shu_uyghur_companies` 124, `ch_seco_sanctions` 39, `sa_pcct_terrorism_list` 9, `nz_russia_sanctions` 6, `research` 4, `us_fincen_special_measures` 3.

Spot checks say these are genuine crawler bugs — an owned business emitted as `Organization` instead of `Company` (which inherits `Asset`). Aggregation means those 18 datasets gain 1–3 issue rows each, not thousands. **Fixing the crawlers is deliberately not in this PR** — that's ~9,400 references across datasets as visible as `us_ofac_sdn`, and belongs in separate, individually-reviewable changes.

## Cost

`get_entity()` fetches and assembles where `has_entity()` only scanned keys. On `us_ofac_sdn` (698k statements, 78k entities) `zavod validate` goes from 8.7s to 10.5s. That's well inside the existing budget: `SelfReferenceValidator` already calls `view.get_adjacent()` for every `Thing`, which does a `get_entity()` per neighbour plus the inverted index.

## Tests

- `test_property_range` added: an `Ownership` on a `Company` stays quiet, one on an `Organization` warns.
- `test_dangling_references` unchanged apart from the class name — the dangling message string is byte-identical.
- `pytest zavod/tests/`: 294 passed. `mypy --strict`: clean.
- End-to-end: `zavod validate` on `us_ofac_sdn` produces exactly one aggregated row in `issues.log`; on `eu_meps` (clean) it produces none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)