### PR TITLE
[us_ofac_sdn] Emit owned parties as Company, not Organization

### DIFF
--- a/datasets/us/ofac/ofac_advanced.py
+++ b/datasets/us/ofac/ofac_advanced.py
@@ -222,7 +222,7 @@ def parse_location(context: Context, refs: Element, location: Element) -> Featur
 
 
 def parse_relation(
-    context: Context, refs: Element, el: Element, parties: dict[str, Schema]
+    context: Context, refs: Element, el: Element, parties: dict[str, Entity]
 ) -> None:
     type_id = el.get("RelationTypeID")
     type_ = get_ref_text(refs, "RelationType", type_id)
@@ -269,8 +269,8 @@ def parse_relation(
         raise ValueError(msg)
 
     try:
-        get_relation_schema(parties[from_id], from_prop.range)
-        get_relation_schema(parties[to_id], to_prop.range)
+        get_relation_schema(parties[from_id].schema, from_prop.range)
+        get_relation_schema(parties[to_id].schema, to_prop.range)
     except InvalidData:
         # HACK: Looks like OFAC just has some link in a direction that makes no
         # semantic sense, so we're flipping them here.
@@ -283,15 +283,14 @@ def parse_relation(
         # )
         from_id, to_id = to_id, from_id
 
-    from_party = context.make(get_relation_schema(parties[from_id], from_prop.range))
-    from_party.id = from_id
-    if not parties[from_id].is_a(from_party.schema) and len(from_party.properties):
-        context.emit(from_party)
+    # The relation implies the party is more specific than its PartySubType said:
+    # something that can be owned is a Company, not just an Organization. The
+    # parties are emitted after all relations are parsed, so this still applies.
+    from_party = parties[from_id]
+    from_party.add_schema(get_relation_schema(from_party.schema, from_prop.range))
 
-    to_party = context.make(get_relation_schema(parties[to_id], to_prop.range))
-    to_party.id = to_id
-    if not parties[to_id].is_a(to_party.schema) and len(to_party.properties):
-        context.emit(to_party)
+    to_party = parties[to_id]
+    to_party.add_schema(get_relation_schema(to_party.schema, to_prop.range))
 
     entity.id = context.make_id("Relation", from_party.id, to_party.id, el.get("ID"))
     entity.add(from_prop, from_party)
@@ -379,7 +378,6 @@ def parse_distinct_party(
         for feat_value in values:
             apply_feature(context, proxy, feat_label, feat_value)
 
-    context.emit(proxy)
     return proxy
 
 
@@ -821,11 +819,16 @@ def crawl(context: Context) -> None:
     # with open(clean_path, "wb") as fh:
     #     fh.write(tostring(doc, pretty_print=True, encoding="utf-8"))
 
-    parties: dict[str, Schema] = {}
+    parties: dict[str, Entity] = {}
     for distinct_party in doc.findall("./DistinctParties/DistinctParty"):
         proxy = parse_distinct_party(context, doc, refs, distinct_party)
         if proxy.id is not None:
-            parties[proxy.id] = proxy.schema
+            parties[proxy.id] = proxy
 
+    # Parsing the relations can make a party's schema more specific, so the
+    # parties are only emitted once every relation has been seen.
     for relation in doc.findall(".//ProfileRelationship"):
         parse_relation(context, refs, relation, parties)
+
+    for proxy in parties.values():
+        context.emit(proxy)

--- a/datasets/us/ofac/us_ofac_cons.yml
+++ b/datasets/us/ofac/us_ofac_cons.yml
@@ -51,10 +51,10 @@ assertions:
   min:
     schema_entities:
       Address: 440
-      Organization: 300
+      Organization: 67
       Security: 200
       Person: 70
-      Company: 4
+      Company: 241
     # Set at roughly a quarter of the production fill rate: low enough that a
     # shift in the shape of the source data doesn't hold up the release, high
     # enough to catch a crawler that stopped parsing a field altogether.
@@ -75,7 +75,7 @@ assertions:
       Organization: 720
       Security: 460
       Person: 160
-      Company: 50
+      Company: 568
 
 # Consolidated List
 # SDN List

--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -48,12 +48,12 @@ assertions:
   min:
     schema_entities:
       Address: 13720
-      Organization: 7330
+      Organization: 5758
       Person: 6245
       Vessel: 995
       CryptoWallet: 570
       Airplane: 320
-      Company: 20
+      Company: 2605
       Security: 5
       LegalEntity: 3
     # Set at roughly a quarter of the production fill rate: low enough that a
@@ -78,7 +78,7 @@ assertions:
       Vessel: 2345
       CryptoWallet: 1340
       Airplane: 750
-      Company: 100
+      Company: 6130
       Security: 100
       LegalEntity: 100
 # Program tags URL: https://ofac.treasury.gov/specially-designated-nationals-list-sdn-list/program-tag-definitions-for-ofac-sanctions-lists


### PR DESCRIPTION
Fixes the `us_ofac_sdn` / `us_ofac_cons` half of #2550. Depends on nothing; #5288 adds the validator that flags this class of problem generally.

> [!WARNING]
> **Read the "What actually changes" section before merging.** ~1% of the upgraded entities are not companies — the IRGC and Iran's nuclear regulator among them. That is a judgement call for a reviewer, not a mechanical one.

## The bug

An OFAC party that another party owns is the `asset` of an `Ownership`, and FTM requires that to be an `Asset`. We emit it as `Organization`, which isn't one: 3,168 references in `us_ofac_sdn`, 279 in `us_ofac_cons`.

`parse_relation` **already** computes the upgrade — `get_relation_schema` contains the exact Organization→Company rule — and tries to emit a stub carrying it:

```python
from_party = context.make(get_relation_schema(parties[from_id], from_prop.range))
from_party.id = from_id
if not parties[from_id].is_a(from_party.schema) and len(from_party.properties):
    context.emit(from_party)
```

A stub has no properties, so `len(from_party.properties)` is always 0 and the branch never fires. `git log -L` dates it: `7368568be` added the working emit, `4cfd59c14` ("do not emit empty entities") appended the guard and killed it, `44143401a` later fixed a copy-paste bug in the still-dead `to_party` branch.

## Why not just revive the stub

1. `Context.emit` refuses entities with no property statements (`has_statements` is False) — it would need a zavod change.
2. The stub's only statement is the synthetic `id` statement, whose value is `sha1(schema_name + sorted(statement ids))`. For a bare `Company` stub that is `sha1("Company")` — a meaningless checksum permanently attached alongside the entity's real `Organization:id` one.

Instead: hold the parties until every relation has been seen, then upgrade the real proxy. A pre-pass can't substitute — `apply_feature` calls `add_schema()` during parsing, so a party's schema isn't final until it is fully built.

## Measured impact — two full crawls, byte-level diff

| | us_ofac_sdn | us_ofac_cons |
|---|---|---|
| entities before / after | 71,949 / **71,949** | 2,047 / **2,047** |
| statements before / after | 699,140 / **699,140** | 20,277 / **20,277** |
| entities changing schema | **3,043** | **279** |
| transitions observed | Organization→Company, nothing else | Organization→Company, nothing else |
| **property** statement IDs changed | **0** | **0** |
| statement IDs added | 3,043 (the `id` checksum, one per changed entity) | 279 |
| rows whose schema column flips | 33,709 (IDs and `first_seen` preserved) | — |
| crawl-time issues | 0 | 0 |
| peak RSS | 1.916 GB vs 1.915 GB (**+0.08%**) | — |
| runtime | −0.2% cycles vs baseline | — |

Both datasets validate clean afterwards (the `LegalEntity: 185 > 100` warning is pre-existing on `main`). The delta feed will show 3,043 modified entities for one run.

## What actually changes — spot-check of the 3,043

Sampled and classified by name, then cross-checked against registration evidence:

- **81.2%** carry a `registrationNumber` / `incorporationDate` / `taxNumber` / `ogrnCode` etc.
- The overwhelming majority read as companies — `Co Ltd`, `LLC`, `S.A.`, `OOO`, Russian JSCs, shipping and trading firms.
- **~30 (≈1%) are not companies.** Named examples now labelled `Company`:

  `ISLAMIC REVOLUTIONARY GUARD CORPS` · `IRAN NUCLEAR REGULATORY AUTHORITY` · `Karen National Army` · `Shor Party` · `RUSSOPHILES FOR THE REVIVAL OF THE FATHERLAND POLITICAL PARTY` · `General Directorate of Mines` (Nicaragua) · `Anti-Globalization Movement of Russia` · `XINJIANG PRODUCTION AND CONSTRUCTION CORPS` · several Iranian state research centres and charitable foundations.

**Root cause of the residue:** OFAC relation type 15003 is labelled *"Owned **or Controlled** By"* and covers both. 3,141 of the 3,207 links use that exact label; the rest are *"Owns, controls, or operates"*. The control cases are real:

```
asset: IRAN NUCLEAR REGULATORY AUTHORITY   owner: ATOMIC ENERGY ORGANIZATION OF IRAN   role: Owned or Controlled By
asset: ISLAMIC REVOLUTIONARY GUARD CORPS   owner: Masoud Jalili                        role: Owned or Controlled By
asset: General Directorate of Mines        owner: Salvador Mansell Castrillo           role: Owned or Controlled By
```

Mapping a control statement onto `Ownership` is the underlying modelling error; this PR makes its consequence visible rather than introducing it.

**There is no gentler target.** `Company` is the *only* schema in FTM that is both `Organization` and `Asset`. And no automatic rule separates the residue: 52 of the 72 name-flagged entities carry registration numbers, because most are legitimately Russian Joint Stock Company research institutes.

## Options for the reviewer

1. **Merge as-is** — fix 3,043 range violations, accept ~30 visibly wrong `Company` labels.
2. **Merge with a lookup-based exclusion list** of OFAC profile IDs that must not be upgraded — keeps the judgement in reviewable YAML, at the cost of ongoing curation as OFAC adds parties.
3. **Don't merge** — treat the violation as a known consequence of OFAC conflating ownership with control, and split relation type 15003 (e.g. `UnknownLink` for the control cases) as separate, larger work.

## Assertions

Updated at the house 85%/200% rule (`contrib/suggest_assertions.py`); without these the datasets fail to publish. Raising the Company *min* is what catches this fix silently regressing.

| | before | after |
|---|---|---|
| sdn `min.Organization` | 7330 | 5758 |
| sdn `min.Company` | 20 | 2605 |
| sdn `max.Company` | 100 | 6130 |
| cons `min.Organization` | 300 | 67 |
| cons `min.Company` | 4 | 241 |
| cons `max.Company` | 50 | 568 |

## Residual risk

`add_schema` now accumulates across relations on a shared proxy, so a party appearing in two relations with mutually incompatible ranges would raise `InvalidData` and fail the crawl. Previously each relation built a throwaway stub and the conflict went unnoticed. Both datasets run clean and every observed upgrade is the same Organization→Company, so no such case exists today — but it is new crash surface on future OFAC data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)