### PR TITLE
[us_cuba_sanctions] Restore Zyte for change detection, drop the rekey table

### DIFF
--- a/datasets/us/cuba_sanctions/crawler.py
+++ b/datasets/us/cuba_sanctions/crawler.py
@@ -44,53 +44,6 @@ WATCHED_PAGES = [
 CONTENT_XPATH = ".//div[@class='entry-content']"
 PAL_PROGRAM = "US-DOS-CU-PAL"
 REA_PROGRAM = "US-DOS-CU-REA"
-# One-shot migration for the IDs retired by moving alias names out of `Name`, and by
-# splitting the two Camagüey Plaza rows onto the hotel they both describe. Remove these
-# once the dataset has run in production, per zavod/docs/best_practices/entity_id.md.
-REKEYED = [
-    (
-        "blau-marina-varadero-resort-aka-fiesta-americana-punta-varadero-fiesta-club-adults-only",
-        "blau-marina-varadero-resort",
-    ),
-    ("hotel-kawama-aka-club-kawama", "hotel-kawama"),
-    (
-        "iberostar-bella-vista-aka-iberostar-selection-bella-vista-varadero",
-        "iberostar-bella-vista",
-    ),
-    ("playa-larga-aka-horizontes-playa-larga", "playa-larga"),
-    ("villa-guama-aka-horizontes-villa-guama", "villa-guama"),
-    ("melia-cayo-santa-maria-aka-sol-cayo-santa-maria", "melia-cayo-santa-maria"),
-    ("villa-la-granjita-aka-horizontes-la-granjita", "villa-la-granjita"),
-    ("villa-los-caneyes-aka-horizontes-los-caneyes", "villa-los-caneyes"),
-    (
-        "warwick-cayo-santa-maria-aka-labranda-cayo-santa-maria-hotel",
-        "warwick-cayo-santa-maria",
-    ),
-    ("ma-dolores-aka-horizontes-finca-ma-dolores", "ma-dolores"),
-    ("pestana-cayo-coco-aka-hotel-playa-paraiso", "pestana-cayo-coco"),
-    ("marea-del-portillo-aka-club-amigo-marea-del-portillo", "marea-del-portillo"),
-    (
-        "blau-costa-verde-beach-resort-aka-fiesta-americana-holguin-costa-verde",
-        "blau-costa-verde-beach-resort",
-    ),
-    ("villa-don-lino-also-hotel-don-lino", "villa-don-lino"),
-    (
-        "club-amigo-carisol-los-corales-aka-carisol-los-corales",
-        "club-amigo-carisol-los-corales",
-    ),
-    ("san-basilio-aka-hotel-e-san-basilio", "san-basilio"),
-    ("plaza-also-hotel-islazul-plaza-camaguey", "hotel-plaza-camaguey"),
-    ("also-fiesta-americana-punta-varadero", "blau-marina-varadero-resort"),
-    ("also-fiesta-club-adults-only", "blau-marina-varadero-resort"),
-    ("also-labranda-cayo-santa-maria-hotel", "warwick-cayo-santa-maria"),
-    ("also-fiesta-americana-holguin-costa-verde", "blau-costa-verde-beach-resort"),
-    ("also-hotel-playa-paraiso", "pestana-cayo-coco"),
-    (
-        "alias-empresa-de-certificacion-de-sistemas-de-seguridad-y-proteccion",
-        "agencia-de-certificacion-y-consultoria-de-seguridad-y-proteccion",
-    ),
-    ("alias-ais-remesas", "american-international-services"),
-]
 
 
 def source_rows(context: Context, name: str) -> Iterator[dict[str, str]]:
@@ -198,8 +151,6 @@ def crawl_restricted_entities(context: Context) -> None:
 
 
 def crawl(context: Context) -> None:
-    for old_id, new_id in REKEYED:
-        context.rekey(context.make_slug(old_id), context.make_slug(new_id))
     crawl_accommodations(context)
     crawl_restricted_entities(context)
     check_watched_pages(context)

--- a/datasets/us/cuba_sanctions/crawler.py
+++ b/datasets/us/cuba_sanctions/crawler.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from normality import slugify
 from rigour.mime.types import CSV
+from zavod.extract.zyte_api import fetch_html
 
-from zavod import Context
+from zavod import Context, settings
 from zavod import helpers as h
 
 # Both lists are published as web pages only, so the entity data is transcribed by
@@ -14,11 +15,13 @@ from zavod import helpers as h
 # guards that transcription: each hash covers the text of the page's list, so a
 # revision upstream shows up as a warning. The runbook for reconciling one is in the
 # dataset YAML. Hashes are text-only on purpose: the markup around these lists changes
-# without the lists changing, and it makes a hash reproducible from any fetch of the
+# without the lists changing, and a text hash is reproducible from any fetch of the
 # page rather than only from a rendered one.
 #
-# state.gov answers a bare `curl/*` user agent with a "Technical Difficulties" page, but
-# serves the real page to zavod's own user agent, so these pages need no unblocking.
+# The pages need Zyte even though they are plain HTML: state.gov serves a
+# "Technical Difficulties" page instead of content to datacenter egress addresses,
+# which is what production runs from. A residential connection gets the real page, so
+# this cannot be reproduced by fetching from a laptop.
 LOCAL_PATH = Path(__file__).parent
 ACCOMMODATIONS_URL = (
     "https://www.state.gov/cuba-sanctions/cuba-prohibited-accommodations-list"
@@ -42,6 +45,16 @@ WATCHED_PAGES = [
     ),
 ]
 CONTENT_XPATH = ".//div[@class='entry-content']"
+ACTIONS = [
+    {
+        "action": "waitForSelector",
+        "selector": {
+            "type": "xpath",
+            "value": CONTENT_XPATH,
+        },
+        "timeout": 15,
+    },
+]
 PAL_PROGRAM = "US-DOS-CU-PAL"
 REA_PROGRAM = "US-DOS-CU-REA"
 
@@ -84,15 +97,17 @@ def check_watched_pages(context: Context) -> None:
     The lists are only fetched to be compared, never to be parsed, so a fetch failure
     must not stop the dataset from publishing data that is already in the repository.
     """
+    if settings.ZYTE_API_KEY is None:
+        context.log.info("Skipping page change detection: no Zyte API key configured")
+        return
     for url, expected, message in WATCHED_PAGES:
         try:
-            matched = h.assert_html_url_hash(
-                context, url, expected, path=CONTENT_XPATH, text_only=True
-            )
+            doc = fetch_html(context, url, CONTENT_XPATH, actions=ACTIONS)
         except Exception as exc:
             context.log.warning("Could not fetch watched page", url=url, error=str(exc))
             continue
-        if not matched:
+        node = doc.find(CONTENT_XPATH)
+        if not h.assert_dom_hash(node, expected, text_only=True):
             context.log.warning(message, url=url)
 
 


### PR DESCRIPTION
Two follow-ups to #5290: one fixes a regression that PR introduced, the other completes its ID migration.

## Restore Zyte for the watched-page checks

Dropping Zyte in #5290 was a mistake of mine. The reasoning was that state.gov only rejects a bare `curl/*` user agent and serves the real page to zavod's own — which is true from a residential connection, and false from the addresses production runs on. There it returns the "Technical Difficulties" page, so the content node is absent. The first production run (`20260804101424-emu`) reported exactly that: all three checks warning with `actual: None`.

I verified the production user agent works fine from a laptop, so the gate is on egress address, not UA. That is the blocking Zyte existed to handle, and no amount of local testing would have surfaced it.

The three pages go through `fetch_html` again. **The hashes are unchanged** — a text-only hash is identical whether the page came from Zyte's rendered browser or a plain request, so that part of #5290 stands and is what makes these values verifiable by hand.

Two behaviours kept from #5290, both now doing real work:

- The checks **skip when no Zyte key is configured**, so CI still exercises the CSV parsing and `audit_data` without three failing fetches, and `ci_test` can stay on.
- A fetch error **warns rather than raises**. The entity data lives in this repository, so the dataset must still publish when state.gov is unreachable.

Verified both paths locally: with a key, no hash warnings and `changed=0`; without one, the checks skip with an info log and the crawl is clean.

## Drop the one-shot rekey table

#5290 retired 24 Company IDs when alias names moved out of entity names, and carried a `REKEYED` table mapping each retired ID to its surviving entity. It has now run in production, so the resolver holds the mappings and they persist independently of the calls. `zavod/docs/best_practices/entity_id.md` treats a rekey as a one-shot migration and calls leaving the calls in place a long-term liability, so the 47-line table and its two-line loop are gone.

Emitted statements are unchanged by this: the pack is byte-identical at 9426 statements, and the 43 `zavod/rekey` resolver edges are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)