### PR TITLE
[adb_sanctions] Emit every entity as LegalEntity again

### DIFF
--- a/datasets/_global/adb_sanctions/adb_sanctions.yml
+++ b/datasets/_global/adb_sanctions/adb_sanctions.yml
@@ -45,8 +45,7 @@ data:
 assertions:
   min:
     schema_entities:
-      Company: 900
-      Person: 230
+      LegalEntity: 1180
     country_entities:
       cn: 350
       id: 40
@@ -54,8 +53,7 @@ assertions:
     countries: 15
   max:
     schema_entities:
-      Company: 1450
-      Person: 380
+      LegalEntity: 1800
 
 dates:
   formats: ["%d/%b/%Y"]

--- a/datasets/_global/adb_sanctions/crawler.py
+++ b/datasets/_global/adb_sanctions/crawler.py
@@ -42,8 +42,6 @@ Rules:
   put them only in the relevant identifier field.
 """
 
-SCHEMATA = {"Firm": "Company", "Individual": "Person"}
-
 PATTERN_IRREGULAR = r"[;()\\/:]|Reg\b|\bNo\b|Registration|Register|Number|operating|also|\baka\b|CNPJ|known"
 REGEX_IRREGULAR = re.compile(PATTERN_IRREGULAR, re.IGNORECASE)
 REGEX_INTERNAL_URL = re.compile(
@@ -74,11 +72,6 @@ def apply_entity_data(entity: Entity, data: EntityData) -> None:
 
 
 def crawl_row(context: Context, row: dict[str, str | None]) -> None:
-    entity_type = row.pop("entityType")
-    schema = SCHEMATA.get(entity_type or "")
-    if schema is None:
-        raise ValueError(f"Unknown entityType: {entity_type!r}")
-
     full_name = row.pop("name") or ""
     other_name = (row.pop("otherName") or "").replace("\\", "")
     country = row.pop("nationality") or ""
@@ -128,9 +121,7 @@ def crawl_row(context: Context, row: dict[str, str | None]) -> None:
 
     first_org = None
     for entity_data in entities_data:
-        entity = context.make(schema)
-        # TODO: add schema to the key so a Firm and an Individual of the same name
-        # can't collide — needs re-keying the whole dataset.
+        entity = context.make("LegalEntity")
         entity.id = context.make_id(entity_data.name[0], country)
 
         apply_entity_data(entity, entity_data)

--- a/datasets/_global/adb_sanctions/crawler.py
+++ b/datasets/_global/adb_sanctions/crawler.py
@@ -1,6 +1,5 @@
 import json
 import re
-from dataclasses import dataclass
 
 from pydantic import BaseModel, JsonValue
 from rigour.names import contains_split_phrase
@@ -68,83 +67,10 @@ class EntityExtractionResult(BaseModel):
     entities: list[EntityData]
 
 
-@dataclass
-class RowFields:
-    """The row-level values shared by every entity extracted from one row."""
-
-    country: str
-    addresses: list[str]
-    grounds: str | None
-    sanction_type: str | None
-    start_date: str | None
-    end_date: str | None
-    modified_at: str | None
-
-
-def emit_sanctioned_entity(
-    context: Context, schema: str, data: EntityData, fields: RowFields
-) -> Entity:
-    entity = context.make(schema)
-    # TODO: add schema to the key so a Firm and an Individual of the same name
-    # can't collide — needs re-keying the whole dataset.
-    entity.id = context.make_id(data.name[0], fields.country)
+def apply_entity_data(entity: Entity, data: EntityData) -> None:
     for prop in EntityData.model_fields:
         for val in getattr(data, prop):
             entity.add(prop, val)
-    entity.add("country", fields.country)
-    entity.add("address", fields.addresses)
-
-    sanction = h.make_sanction(context, entity)
-    sanction.add("reason", fields.grounds)
-    sanction.add("status", fields.sanction_type)
-    h.apply_date(sanction, "startDate", fields.start_date)
-    h.apply_date(sanction, "endDate", fields.end_date)
-    h.apply_date(sanction, "modifiedAt", fields.modified_at)
-
-    if h.is_active(sanction):
-        entity.add("topics", "debarment")
-
-    context.emit(entity)
-    context.emit(sanction)
-    return entity
-
-
-def extract_entities_data(
-    context: Context, full_name: str, other_name: str
-) -> list[EntityData]:
-    # Names that look regular are taken as-is; the rest go through LLM extraction
-    # and human review, yielding nothing while a review is still pending.
-    if not (
-        REGEX_IRREGULAR.search(full_name)
-        or REGEX_IRREGULAR.search(other_name)
-        or contains_split_phrase(full_name)
-        or contains_split_phrase(other_name)
-    ):
-        alias = [other_name] if other_name.strip() else []
-        return [EntityData(name=[full_name], alias=alias)]
-
-    source_data: JsonValue = {"name": full_name, "other_name": other_name}
-    source_value = JSONSourceValue(
-        key_parts=[full_name, "other_name", other_name],
-        label="entity extraction",
-        data=source_data,
-    )
-    result = run_typed_text_prompt(
-        context=context,
-        prompt=EXTRACT_PROMPT,
-        string=json.dumps(source_data, ensure_ascii=False),
-        response_type=EntityExtractionResult,
-        model=LLM_MODEL_VERSION,
-    )
-    review = review_extraction(
-        context=context,
-        source_value=source_value,
-        original_extraction=result,
-        origin=LLM_MODEL_VERSION,
-    )
-    if not review.accepted:
-        return []
-    return review.extracted_data.entities
 
 
 def crawl_row(context: Context, row: dict[str, str | None]) -> None:
@@ -160,33 +86,82 @@ def crawl_row(context: Context, row: dict[str, str | None]) -> None:
     country = country.replace("Rep. of", "").strip()
     country = country.replace("*2", "").strip()
 
-    fields = RowFields(
-        country=country,
-        addresses=(row.pop("address") or "").split(";"),
-        grounds=row.pop("grounds"),
-        sanction_type=row.pop("sanctionType"),
-        start_date=row.pop("effectiveDateOfSanction"),
-        end_date=row.pop("lapseDateOfSanction"),
-        modified_at=row.pop("changesMadeOn"),
-    )
+    grounds = row.pop("grounds")
+    sanction_type = row.pop("sanctionType")
+    addresses = (row.pop("address") or "").split(";")
+    start_date = row.pop("effectiveDateOfSanction")
+    end_date = row.pop("lapseDateOfSanction")
+    modified_at = row.pop("changesMadeOn")
 
-    entities_data = extract_entities_data(context, full_name, other_name)
+    if (
+        REGEX_IRREGULAR.search(full_name)
+        or REGEX_IRREGULAR.search(other_name)
+        or contains_split_phrase(full_name)
+        or contains_split_phrase(other_name)
+    ):
+        source_data: JsonValue = {"name": full_name, "other_name": other_name}
+        source_value = JSONSourceValue(
+            key_parts=[full_name, "other_name", other_name],
+            label="entity extraction",
+            data=source_data,
+        )
+        result = run_typed_text_prompt(
+            context=context,
+            prompt=EXTRACT_PROMPT,
+            string=json.dumps(source_data, ensure_ascii=False),
+            response_type=EntityExtractionResult,
+            model=LLM_MODEL_VERSION,
+        )
+        review = review_extraction(
+            context=context,
+            source_value=source_value,
+            original_extraction=result,
+            origin=LLM_MODEL_VERSION,
+        )
+        if review.accepted:
+            entities_data = review.extracted_data.entities
+        else:
+            entities_data = []  # we loop over this later regardless
+    else:
+        alias = [other_name] if other_name.strip() else []
+        entities_data = [EntityData(name=[full_name], alias=alias)]
 
-    # entityType describes the subject of the row only. Any further entities the
-    # extraction pulls out of the name fields are parties co-mentioned in them,
-    # whose type the source doesn't state, so don't claim it.
-    if entities_data:
-        subject_data, *comentioned_data = entities_data
-        subject = emit_sanctioned_entity(context, schema, subject_data, fields)
-        for data in comentioned_data:
-            entity = emit_sanctioned_entity(context, "LegalEntity", data, fields)
+    first_org = None
+    for entity_data in entities_data:
+        entity = context.make(schema)
+        # TODO: add schema to the key so a Firm and an Individual of the same name
+        # can't collide — needs re-keying the whole dataset.
+        entity.id = context.make_id(entity_data.name[0], country)
 
-            # Preserve the link the source made by listing them in one row.
+        apply_entity_data(entity, entity_data)
+        entity.add("country", country)
+        entity.add("address", addresses)
+
+        sanction = h.make_sanction(context, entity)
+        sanction.add("reason", grounds)
+        sanction.add("status", sanction_type)
+        h.apply_date(sanction, "startDate", start_date)
+        h.apply_date(sanction, "endDate", end_date)
+        h.apply_date(sanction, "modifiedAt", modified_at)
+
+        if h.is_active(sanction):
+            entity.add("topics", "debarment")
+
+        # create relation to preserve link
+        # when there is more than one org per row
+        if first_org is None:
+            first_org = entity
+        else:
             rel = context.make("UnknownLink")
-            rel.id = context.make_id(subject.first("name"), data.name[0], country)
-            rel.add("subject", subject)
+            rel.id = context.make_id(
+                first_org.first("name"), entity_data.name[0], country
+            )
+            rel.add("subject", first_org)
             rel.add("object", entity)
             context.emit(rel)
+
+        context.emit(entity)
+        context.emit(sanction)
 
     context.audit_data(row)
 

--- a/datasets/_global/adb_sanctions/crawler.py
+++ b/datasets/_global/adb_sanctions/crawler.py
@@ -154,7 +154,14 @@ def crawl_row(context: Context, row: dict[str, str | None]) -> None:
         context.emit(entity)
         context.emit(sanction)
 
-    context.audit_data(row)
+    # The source gives an entityType of "Firm" or "Individual", but we ignore it and
+    # emit LegalEntity. We get many of the same entities from the other development
+    # bank sources. If one of those sources gets the schema wrong, we get an assembly
+    # error. LegalEntity is compatible with both schemata, so it is the safe choice.
+    # We might do it the right way in the future: split the name fields into a name,
+    # aliases and separate related entities, and then use entityType for the subject
+    # of each row. For now, that is not worth the effort.
+    context.audit_data(row, ignore=["entityType"])
 
 
 def crawl(context: Context) -> None:


### PR DESCRIPTION
Rolls back https://github.com/opensanctions/opensanctions/pull/5236 and
https://github.com/opensanctions/opensanctions/pull/5266.

The source does have an entityType field now, but we get many of the same entities
from the other development bank sources. If one of them gets the schema wrong, we
get an assembly error and the whole thing blows up. So for now we just split the
name and emit everything as LegalEntity.

We might do it the right way in the future: split the name fields into a name,
aliases and separate related entities, and only then use entityType for the
subject of each row. For now it's not worth the effort, so there's a comment in
the crawler instead of a TODO.

Also disregarding my `leonhandreke/adb-sanctions-rekey-schema` branch, it was
going the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)