### PR TITLE
Configure mypy strict mode in zavod/pyproject.toml

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -100,6 +100,10 @@ branch = true
 [tool.hatch.metadata]
 allow-direct-references = true
 
+[tool.mypy]
+strict = true
+exclude = ["zavod/tests"]
+
 [tool.isort]
 profile = "black"
 use_parentheses = false


### PR DESCRIPTION
Add a `[tool.mypy]` section to `zavod/pyproject.toml` that sets `strict = true` and excludes `zavod/tests`. This matches the flags the Makefile and the pre-commit hook already pass, so any mypy run from `zavod/` uses the same settings — including editor and LSP runs.

No new errors: `mypy zavod/` checks the same 124 source files as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)