### PR TITLE
[wd_peps] Don't derive positions' countries from multi-country regions

### DIFF
--- a/zavod/zavod/shed/wikidata/country.py
+++ b/zavod/zavod/shed/wikidata/country.py
@@ -2,6 +2,22 @@ from functools import lru_cache
 from nomenklatura.wikidata import WikidataClient, LangText
 from rigour.territories import get_territory_by_qid
 
+# Places we refuse to derive a country from, because their P17 claims name every
+# state they span. Cultural and supranational regions only, plus historical
+# territories `is_historical_country` misses - contested subdivisions keep all of
+# their claimants deliberately.
+SKIP_PLACES: set[str] = {
+    "Q234",  # Flanders (cultural region: BE, FR, NL)
+    "Q210718",  # Asia
+    "Q4412",  # West Africa
+    "Q52062",  # Nordic countries
+    "Q7785",  # Commonwealth of Nations
+    "Q4264",  # Mercosur
+    "Q18348382",  # Colony of New South Wales
+    "Q2334526",  # Province of North Carolina
+    "Q1070529",  # Colony of Virginia
+}
+
 
 @lru_cache(maxsize=5000)
 def is_historical_country(client: WikidataClient, qid: str) -> bool:
@@ -31,6 +47,8 @@ def item_countries(client: WikidataClient, qid: str) -> set[LangText]:
 def _crawl_item_countries(
     client: WikidataClient, qid: str, seen: tuple[str, ...]
 ) -> set[LangText]:
+    if qid in SKIP_PLACES:
+        return set()
     item = client.fetch_item(qid)
     if item is None:
         return set()


### PR DESCRIPTION
The [Flemish Minister of Energy](https://www.opensanctions.org/entities/Q112596519/) position is tagged `country: nl, fr, be`. It comes from Wikidata: the **Flanders (Q234)** item carries three separate `P17` claims — Belgium, France and the Netherlands — because it denotes the *cultural* region, which reaches into French Flanders and Zeelandic Flanders. Two ministerial posts name it via `P1001`, and `item_countries()` reads its whole `P17` set:

```
prop=country value=nl  original_value=Q55   dataset=wd_peps  first_seen 2026-01-15
prop=country value=fr  original_value=Q142  dataset=wd_peps  first_seen 2026-01-15
prop=country value=be  original_value=Q31   dataset=wd_peps  first_seen 2023-09-08
```

Holders inherit it too — `wikidata_occupancy()` copies the position's countries onto the person as `ORIGIN_INFERRED`, so Melissa Depraetere came out as Dutch and French.

`SKIP_PLACES` is checked at the top of `_crawl_item_countries`, so it covers both the direct `item_countries(claim.qid)` calls and the recursive `P361`/`P1001` traversal.

## What's skipped

Surveyed every place used as a position's `P1001` that has more than one `P17`, and split it three ways:

- **Skipped** — Flanders, plus continental and supranational groupings (Asia, West Africa at 18 countries, Nordic countries, Commonwealth of Nations, Mercosur) and three historical colonies whose `P31`/`P279` closure keeps `is_historical_country` from recognising them (New South Wales, North Carolina, Virginia).
- **Left alone** — contested and plain subdivisions: Sevastopol, the Donetsk and Luhansk People's Republics, South Ossetia, Samara Oblast, Bangkok, Minas Gerais, Jerusalem, Constanța County, and others. Naming every claimant is the point there.
- **Already handled** — the remaining historical states (Kingdom of Portugal, Aragon, Bohemia, Castile, Dutch East Indies, Cape Colony, …) resolve as historical, so `wikidata_position` drops those positions before the country traversal runs.

## Effect

Verified with `contrib/wikidata/wd_item_debug.py`:

| | before | after |
|---|---|---|
| Q112596519 Flemish Minister of Energy | `nl, fr, be` | `be` |
| Q112573186 Flemish minister of Agriculture | `nl, fr, be` | `be` |
| Q65177149 Melissa Depraetere | inferred `country: nl, fr` | none (just `citizenship: be`) |

No position loses its country: both affected posts carry their own `P17 = Q31`, and Flemish Government (Q1186029) — the `P361` hop other Flemish positions take — does too, which the traversal reads before it ever reaches `P1001`. `subnationalArea: Flanders` is untouched; that comes from the `P1001` label, not the country lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)