### PR TITLE
[wd_categories] Cover Lithuanian PEP offices from lt.wikipedia

### DIFF
--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -2065,13 +2065,6 @@ config:
       language: fi
 
     # country: Lithuania
-    #
-    # Replaces the coverage of lt_pep_declarations, whose source (the VTEK
-    # register of private interests) started requiring API authentication in
-    # April 2025. lt.wikipedia categorises Lithuanian office-holders by office
-    # much more completely than en.wikipedia. A position is only asserted where
-    # the category is specific to one office; ambassadors and mayors vary by
-    # posting or municipality, so those only get the topic.
     - category: Lietuvos_politikai
       language: lt
       country: lt

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -2064,17 +2064,206 @@ config:
     - category: Suomen_hallinto
       language: fi
 
+    # country: Lithuania
+    #
+    # Replaces the coverage of lt_pep_declarations, whose source (the VTEK
+    # register of private interests) started requiring API authentication in
+    # April 2025. lt.wikipedia categorises Lithuanian office-holders by office
+    # much more completely than en.wikipedia. A position is only asserted where
+    # the category is specific to one office; ambassadors and mayors vary by
+    # posting or municipality, so those only get the topic.
     - category: Lietuvos_politikai
       language: lt
       country: lt
-    - category: Lietuvos_parlamentų_nariai
+
+    - category: Lietuvos_prezidentai
       language: lt
       country: lt
       topic: role.pep
+      position:
+        name: President of Lithuania
+        wikidata_id: Q878222
+        country: lt
+        topics:
+          - gov.head
+          - gov.national
+    - category: Lietuvos_ministrai_pirmininkai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Prime Minister of Lithuania
+        wikidata_id: Q845439
+        country: lt
+        topics:
+          - gov.head
+          - gov.national
+    - category: Lietuvos_vicepremjerai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Deputy Prime Minister of Lithuania
+        country: lt
+        topics:
+          - gov.executive
+          - gov.national
+    # Excluded: ministers of other polities (Soviet LSSR, the 1941 Provisional
+    # Government) and vice-ministers that wikipedia files under the ministers.
     - category: Lietuvos_ministrai
       language: lt
       country: lt
       topic: role.pep
+      negcats: |
+        Lietuvos_TSR_ministrai
+        Lietuvos_laikinosios_vyriausybės_ministrai
+        Lietuvos_susisiekimo_viceministrai
+      position:
+        name: Minister of Lithuania
+        country: lt
+        topics:
+          - gov.executive
+          - gov.national
+    - category: Lietuvos_viceministrai
+      language: lt
+      country: lt
+      topic: role.pep
+      negcats: |
+        Lietuvos_TSR_viceministrai
+      position:
+        name: Vice-Minister of Lithuania
+        country: lt
+        topics:
+          - gov.executive
+          - gov.national
+
+    # Lietuvos_parlamentų_nariai spans every parliament back to the Grand Duchy,
+    # so no one position fits it. Seimo_nariai is the Seimas of the restored
+    # republic; the QID is the one lt_seimas uses, so it's the same entity.
+    - category: Lietuvos_parlamentų_nariai
+      language: lt
+      country: lt
+      topic: role.pep
+    - category: Seimo_nariai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Member of the Seimas of Lithuania
+        wikidata_id: Q18507240
+        country: lt
+        topics:
+          - gov.legislative
+          - gov.national
+    - category: LR_Seimo_pirmininkai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Speaker of the Seimas of Lithuania
+        wikidata_id: Q12663218
+        country: lt
+        topics:
+          - gov.legislative
+          - gov.national
+    - category: Europos_Parlamento_nariai_(Lietuva)
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Member of the European Parliament
+        wikidata_id: Q27169
+        country: eu
+        topics:
+          - gov.igo
+          - gov.legislative
+
+    # Courts of final instance only - Court of Appeal decisions can still be
+    # appealed to the Supreme Court, so its judges aren't PEPs by definition.
+    - category: LR_Konstitucinio_Teismo_teisėjai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Justice of the Constitutional Court of Lithuania
+        country: lt
+        topics:
+          - gov.judicial
+          - gov.national
+    - category: Lietuvos_Aukščiausiojo_Teismo_teisėjai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Judge of the Supreme Court of Lithuania
+        country: lt
+        topics:
+          - gov.judicial
+          - gov.national
+    - category: Lietuvos_vyriausiojo_administracinio_teismo_teisėjai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Judge of the Supreme Administrative Court of Lithuania
+        country: lt
+        topics:
+          - gov.judicial
+          - gov.national
+    - category: Lietuvos_generaliniai_prokurorai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Prosecutor General of Lithuania
+        wikidata_id: Q132068652
+        country: lt
+        topics:
+          - gov.judicial
+          - gov.national
+    - category: LR_generalinio_prokuroro_pavaduotojai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Deputy Prosecutor General of Lithuania
+        country: lt
+        topics:
+          - gov.judicial
+          - gov.national
+
+    - category: Lietuvos_banko_vadovai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Governor of the Bank of Lithuania
+        wikidata_id: Q109496871
+        country: lt
+        topics:
+          - gov.financial
+          - gov.national
+    - category: Lietuvos_kariuomenės_vadai
+      language: lt
+      country: lt
+      topic: role.pep
+      position:
+        name: Chief of Defence of Lithuania
+        wikidata_id: Q55607326
+        country: lt
+        topics:
+          - gov.security
+          - gov.national
+
+    # Lietuvos_diplomatai as a whole also holds consuls and junior diplomats,
+    # so only the ambassadors are marked.
+    - category: Lietuvos_ambasadoriai
+      language: lt
+      country: lt
+      topic: role.pep
+
+    # Deputy mayors are left out: lt isn't in MUNI_COUNTRIES in
+    # zavod.shed.wikidata.position, so LT municipal positions get dropped.
     - category: Lietuvos_apskričių_viršininkai
       language: lt
       country: lt

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -2095,14 +2095,8 @@ config:
       language: lt
       country: lt
       topic: role.pep
-      position:
-        name: Deputy Prime Minister of Lithuania
-        country: lt
-        topics:
-          - gov.executive
-          - gov.national
-    # Excluded: ministers of other polities (Soviet LSSR, the 1941 Provisional
-    # Government) and vice-ministers that wikipedia files under the ministers.
+    # Excluded: ministers of polities other than the present-day republic, being
+    # the Soviet LSSR and the 1941 Provisional Government.
     - category: Lietuvos_ministrai
       language: lt
       country: lt
@@ -2110,25 +2104,12 @@ config:
       negcats: |
         Lietuvos_TSR_ministrai
         Lietuvos_laikinosios_vyriausybės_ministrai
-        Lietuvos_susisiekimo_viceministrai
-      position:
-        name: Minister of Lithuania
-        country: lt
-        topics:
-          - gov.executive
-          - gov.national
     - category: Lietuvos_viceministrai
       language: lt
       country: lt
       topic: role.pep
       negcats: |
         Lietuvos_TSR_viceministrai
-      position:
-        name: Vice-Minister of Lithuania
-        country: lt
-        topics:
-          - gov.executive
-          - gov.national
 
     # Lietuvos_parlamentų_nariai spans every parliament back to the Grand Duchy,
     # so no one position fits it. Seimo_nariai is the Seimas of the restored
@@ -2163,13 +2144,6 @@ config:
       language: lt
       country: lt
       topic: role.pep
-      position:
-        name: Member of the European Parliament
-        wikidata_id: Q27169
-        country: eu
-        topics:
-          - gov.igo
-          - gov.legislative
 
     # Courts of final instance only - Court of Appeal decisions can still be
     # appealed to the Supreme Court, so its judges aren't PEPs by definition.


### PR DESCRIPTION
lt_pep_declarations died when VTEK put its register of private interests behind API authentication. Add lt.wikipedia categories for the Lithuanian offices that are PEP positions by definition - president, prime minister and deputies, ministers and vice-ministers, Seimas members and its speaker, LT members of the European Parliament, the courts of final instance, the prosecutor general and deputies, the central bank governor, the chief of defence and ambassadors - and assert positions wherever the category is specific to a single office.