### PR TITLE
[eu_journal_sanctions] Resolve the EU's "Myanmar/Burma" country string

### DIFF
--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -140,6 +140,10 @@ lookups:
         values:
           - ua
           - ru
+      # The EU's standard designation for Myanmar. Drop this once a rigour
+      # release resolves the slash form on its own.
+      - match: Myanmar/Burma
+        value: mm
   type.email:
     options:
       - match: "general@angstrem.r"


### PR DESCRIPTION
Five recent Myanmar designations in the source sheet (List IDs 149–153) spell the
country `Myanmar/Burma`, which is the form used throughout the EU's legal acts.
The value was rejected outright, so those five entities were emitted with no
`country` at all:

```
Rejected property value [country]: Myanmar/Burma
```

## Why it fails

`rigour`'s `normalize_territory_name` has `/` in `SKIP_CHARACTERS`, where
characters are **deleted** rather than replaced with a space. So `Myanmar/Burma`
normalises to `myanmarburma`, while the `mm` territory's `full_name`
`Myanmar (Burma)` normalises to `myanmar burma` — the space before the `(` does
the work. The two never meet.

Ten other territory names in rigour already contain glued slashes, including
`mm`'s own `BIRMANIE/MYANMAR`.

## This change

A `type.country` lookup mapping `Myanmar/Burma` → `mm`.

The sheet could carry the fix instead — the older Myanmar rows already use
`Myanmar; Burma`, which resolves fine. It's here rather than in the sheet
because the EU uses the slash form in every Myanmar act, so a sheet fix has to
be repeated for each new designation. A follow-up adds `Myanmar/Burma` to `mm`'s
`names_strong` in rigour; this lookup can be dropped once that ships, hence the
comment.

Verified through zavod's lookup machinery: `Myanmar/Burma → ['mm']`, and the
existing `Crimea, Ukraine → ['ua-cri']` still resolves.

## Not in this PR

Also in the same `issues.json`, handled outside the code:

- The nine malformed `website` cells (four warned, five that passed validation
  with commas or `(offline)` annotations embedded) have been fixed directly in
  the source spreadsheet. Validator now reports 0 rejected / 0 junk across all
  6,311 rows on both tabs.
- `"Beget" LLC` is now fully present in `eu_fsf` as `eu-fsf-eu-14754-84`, so its
  row on the unconsolidated tab can be deleted — it is already on the context
  tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)