### PR TITLE
Remove intrinsic dataset uniqueness rule

### DIFF
--- a/zavod/zavod/integration/logic.py
+++ b/zavod/zavod/integration/logic.py
@@ -6,28 +6,6 @@ from zavod.entity import Entity
 
 log = get_logger(__name__)
 USER = "zavod/logic"
-UNIQUE_DATASETS = {"us_ofac_sdn", "eu_fsf", "un_sc_sanctions", "in_mha_banned"}
-
-
-def logic_unique(
-    resolver: Resolver[Entity],
-    common: Schema,
-    left: Entity,
-    right: Entity,
-    score: float,
-) -> float | None:
-    """We consider the legal entities on the given unique lists to be, de jure, different."""
-    if common.is_a("Address"):
-        return score
-    both = left.datasets.intersection(right.datasets)
-    uniques = both.intersection(UNIQUE_DATASETS)
-    if len(uniques) > 0:
-        if left.id is not None and right.id is not None:
-            scope = "|".join(sorted(uniques))
-            log.info(f"{scope} negative match: {left.id} <> {right.id}")
-            resolver.decide(left.id, right.id, Judgement.NEGATIVE, user=USER)
-            return None
-    return score
 
 
 def logic_vessel_match(
@@ -159,9 +137,6 @@ def logic_decide(
     if res_score is None:
         return None
     res_score = logic_identifiers(resolver, common, left, right, res_score)
-    if res_score is None:
-        return None
-    res_score = logic_unique(resolver, common, left, right, res_score)
     if res_score is None:
         return None
     res_score = logic_pkpro_ids(resolver, common, left, right, res_score)


### PR DESCRIPTION
## Summary

Remove the rule that automatically creates negative deduplication judgements whenever two entities originate from the same supposedly intrinsically deduplicated sanctions dataset.

## Problem

`logic_unique()` assumed that distinct source records in OFAC SDN, EU FSF, UN Security Council, and India MHA necessarily represented different real-world entities. That assumption does not hold when a publisher creates separate listing records for different sanctions programs, regulations, or regimes.

The rule wrote a persistent negative resolver judgement before ordinary automatic matching could act. It applied regardless of matching score and covered every schema except `Address`. Most strong evidence, including identical names, birth dates, tax numbers, passports, and general registration identifiers, could not override it.

## Confirmed impact

In the current EU FSF source data, 27 high-confidence duplicate pairs share an exact normalized name together with a birth date or strong identifier. Fifteen span different sanctions programs.

A confirmed production error is Hassan Dahir Aweys:

- EU records `eu-fsf-eu-315-75` and `eu-fsf-eu-3711-12` represent the same person under different programs.
- UN records `unsc-111944` and `unsc-6908034` likewise represent him under different UN regimes.
- The live resolver currently divides these records into two canonical clusters, each containing one EU and one UN fragment.

Other cross-program EU duplicates, including Viktor Medvedchuk and Voice of Europe, have eventually converged through other resolver paths. Those indirect merges do not make the negative judgement correct and can create contradictory resolver edges.

## Root cause

The affected source identifiers identify listing or designation records, not globally unique real-world subjects:

- EU reference numbers can be program- or regulation-specific.
- UN records are issued under separate sanctions committees and regimes.
- India MHA publishes overlapping list categories and name variants.
- OFAC is more identity-oriented, but sharing one blanket rule across these structurally different sources is unsafe.

## Change

Remove `logic_unique()` rather than making it program-aware. Program equality is not sufficient because same-program duplicates also exist.

Existing identifier-, vessel-, Pakistan-, and security-specific logic remains unchanged.

## Resolver cleanup

Existing negative `zavod/logic` judgements persist after this code change and must be soft-deleted separately before rerunning xref.

```sql
BEGIN;

SELECT count(*) AS negative_logic_decisions
FROM resolver
WHERE "user" = $$zavod/logic$$
  AND judgement = $$negative$$
  AND deleted_at IS NULL;

UPDATE resolver
SET deleted_at =
    to_char(
        clock_timestamp() AT TIME ZONE $$UTC$$,
        $$YYYY-MM-DD"T"HH24:MI:SS.US$$
    ) || $$+0$$
WHERE "user" = $$zavod/logic$$
  AND judgement = $$negative$$
  AND deleted_at IS NULL
RETURNING id, source, target, created_at, deleted_at;

COMMIT;
```

This intentionally soft-deletes every active negative decision attributed to `zavod/logic`, including Pakistan identifier decisions. The resolver table does not record which function produced a judgement.

## Training-data impact

Rule-produced `zavod/logic` judgements are retained in matcher training data and comprise a large share of negative examples. Regenerating the training data after resolver cleanup will prevent these false negative labels from continuing to affect training and evaluation.

## Validation

- pre-commit hooks passed, including Ruff and mypy
- `git diff --check`
- no new tests, by request