### PR TITLE
Add git and postgresql-client to the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get -qq -y update \
     && apt-get -qq -y upgrade \
     && apt-get -qq -y install --no-install-recommends \
     locales apt-transport-https ca-certificates gnupg \
-    tzdata curl python3-pip python3-venv poppler-utils poppler-data \
-    libicu78 libleveldb1d \
+    tzdata curl git python3-pip python3-venv poppler-utils poppler-data \
+    libicu78 libleveldb1d postgresql-client \
     && apt-get -qq -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The downstream ETL image in opensanctions/operations installs `git` and `postgresql-client` via its own apt layer, which is re-run from scratch on every base image rebuild (the child build is dispatched right after each base publish, so its layers never get cache hits). Installing the two packages here folds them into the runtime stage's existing apt layer, where they add only a few seconds — the layer is already rebuilt daily via the `BUILD_DATE` cache-bust.

Once a `:latest` image including these packages is published, the operations repo can drop the apt stage from `etl/Dockerfile` entirely, cutting its build to roughly a minute.

Both packages are generic tooling that should be reasonable to carry in the public image (~50 MB combined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)