### PR TITLE
Adopt blocker-side candidate truncation, drop max_bin walk

### DIFF
--- a/datasets/_externals/ext_eu_esma_firds.yml
+++ b/datasets/_externals/ext_eu_esma_firds.yml
@@ -64,9 +64,7 @@ inputs:
 config:
   topic_gated: true
   index_options:
-    match_batch: 300
     memory: 3000
-  max_bin: 14
   threshold: 0.6
   algorithm: logic-v1
   topics:

--- a/datasets/_externals/ext_gb_coh_psc.yml
+++ b/datasets/_externals/ext_gb_coh_psc.yml
@@ -66,10 +66,8 @@ config:
   topic_gated: true
   index_options:
     max_candidates: 100
-    match_batch: 300
     memory: 4000
   limit: 100
-  max_bin: 14
   threshold: 0.5
   algorithm: regression-v1
   topics:

--- a/datasets/_externals/ext_gb_fca_firds.yml
+++ b/datasets/_externals/ext_gb_fca_firds.yml
@@ -52,10 +52,8 @@ inputs:
 config:
   topic_gated: true
   index_options:
-    match_batch: 300
     memory: 3000
   limit: 100
-  max_bin: 14
   threshold: 0.7
   algorithm: regression-v1
   topics:

--- a/datasets/_externals/ext_gleif.yml
+++ b/datasets/_externals/ext_gleif.yml
@@ -76,7 +76,6 @@ config:
   topic_gated: true
   index_options:
     max_candidates: 25
-    match_batch: 300
     memory: 4000
   threshold: 0.5
   algorithm: regression-v1

--- a/datasets/_externals/ext_icij_offshoreleaks.yml
+++ b/datasets/_externals/ext_icij_offshoreleaks.yml
@@ -71,7 +71,6 @@ inputs:
 config:
   topic_gated: true
   index_options:
-    match_batch: 300
     memory: 4000
   threshold: 0.7
   algorithm: regression-v1

--- a/datasets/_externals/ext_ru_egrul.yml
+++ b/datasets/_externals/ext_ru_egrul.yml
@@ -75,11 +75,9 @@ inputs:
 config:
   index_options:
     max_candidates: 200
-    match_batch: 300
     memory: 3500
   threshold: 0.7
   limit: 100
-  max_bin: 14
   algorithm: regression-v1
   topics:
     - role.pep

--- a/datasets/_externals/ext_us_cms_npi.yml
+++ b/datasets/_externals/ext_us_cms_npi.yml
@@ -68,7 +68,6 @@ inputs:
 config:
   index_options:
     max_candidates: 50
-    match_batch: 200
     memory: 4000
   topics:
     - debarment

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">= 3.12"
 dependencies = [
     "followthemoney == 4.10.1",
-    "nomenklatura == 4.12.5",
+    "nomenklatura == 4.13.0",
     "plyvel == 1.5.1", # Also update macOS install docs
     "rigour == 2.3.1",
     "datapatch >= 1.2.4, < 1.3",

--- a/zavod/zavod/runner/local_enricher.py
+++ b/zavod/zavod/runner/local_enricher.py
@@ -1,5 +1,4 @@
 import logging
-from decimal import Decimal
 from collections.abc import Generator, Iterator
 from followthemoney import registry, model
 from followthemoney.helpers import check_person_cutoff
@@ -35,31 +34,20 @@ class LocalEnricher(BaseEnricher[Dataset]):
     """
     Uses a local index to look up entities in a given dataset.
 
-    Candidates are selected for matching using search index. Candidates are then scored
-    by the matching algorithm to determine if they are a match.
-
-    Entities that have the same rounded score from the blocking index can be
-    considered to be binned together. Many match candidates with very similar names
-    might score the same, or similarly and only one or a small number might eventually be
-    considered a match.
-
-    You don't want to cut off scoring too early using `index_options.max_candidates`,
-    so use `max_bin` to configure the number of bins to step through before halting
-    a given search.
-
-    e.g. if the second 116 in index scores 118, 118, 118, 116, 116, 107 is the
-    positive match, cutting off at rank 4 would miss it out, but cutting off at bin 2
-    means all 116s are considered, the positive match is included. Other cases where
-    index scores are more spread out would score a smaller number of items.
+    The blocking index selects candidates for each subject entity, returning a
+    ranked list already trimmed inside its matching query: at most
+    `index_options.max_candidates` (default 75) candidates per subject, each
+    scoring at least `index_options.min_score_ratio` (default 0.1) of that
+    subject's best candidate. Every candidate in the list is then scored by the
+    matching algorithm, so those two options directly set the matcher CPU cost
+    per subject.
 
     Args:
         `config`: a dictionary of configuration options.
           `dataset`: `str` - the name of the dataset to enrich against.
           `cutoff`: `float` - (default 0.5) the minimum score required to be a match.
-          `limit`: `int` - (default 5) the maximum number of top scoring matches
+          `limit`: `int` - (default 10) the maximum number of top scoring matches
             to return.
-          `max_bin`: `int` - (default 10) the maximum number of rounded index score
-            bins to consider from a given search result.
           `algorithm`: `str` (default logic-v1) - the name of the algorithm
               to use for matching.
           `index_options`: `dict` - options to pass to the index.
@@ -90,7 +78,6 @@ class LocalEnricher(BaseEnricher[Dataset]):
         self._algorithm_config = _algorithm.default_config()
         self._cutoff = float(config.get("cutoff", 0.5))
         self._limit = int(config.get("limit", 10))
-        self._max_bin = int(config.get("max_bin", 10))
 
     def close(self) -> None:
         self.target_store.close()
@@ -115,17 +102,7 @@ class LocalEnricher(BaseEnricher[Dataset]):
             yield same_id_match
 
         scores: list[tuple[float, Entity]] = []
-        last_rounded_score = None
-        bin = 0
-
-        for match_id, index_score in candidates:
-            rounded_score = round(Decimal(index_score), 0)
-            if rounded_score != last_rounded_score:
-                bin += 1
-                last_rounded_score = rounded_score
-            if bin >= self._max_bin:
-                break
-
+        for match_id, _index_score in candidates:
             match = self.target_view.get_entity(match_id.id)
             if match is None:
                 continue

--- a/zavod/zavod/tests/enrich/test_local_enricher.py
+++ b/zavod/zavod/tests/enrich/test_local_enricher.py
@@ -2,7 +2,9 @@ import shutil
 from copy import deepcopy
 
 import pytest
+from nomenklatura.blocker.index import BlockingMatches
 from nomenklatura.judgement import Judgement
+from nomenklatura.resolver import Identifier
 from structlog.testing import capture_logs
 
 from zavod import settings
@@ -185,6 +187,27 @@ def test_expand_issuers(vcontext: Context, testdataset_securities: Dataset):
     assert internals[2].schema.name == "Security"
     assert internals[1].id != internals[2].id
     assert internals[1].id[:-1] == internals[2].id[:-1] == "osv-isin-"
+
+    shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
+
+
+def test_full_candidate_list_scored(vcontext: Context):
+    """The blocker hands over a ranked, pre-trimmed candidate list; every entry
+    in it gets matcher-scored. A true match at the tail of the list, behind a
+    long run of widely-spread higher index scores, must still be found (the
+    former max_bin walk would have halted before reaching it)."""
+    crawl_dataset(vcontext.dataset)
+    enricher = load_enricher(vcontext, DATASET_DATA, "testdataset1")
+    entity = Entity.from_data(vcontext.dataset, UMBRELLA_CORP)
+
+    candidates: BlockingMatches = [
+        (Identifier.get(f"osv-no-such-entity-{i}"), 130.0 - i * 10.0) for i in range(12)
+    ]
+    candidates.append((Identifier.get("osv-umbrella-corp"), 3.0))
+
+    results = list(enricher.match_candidates(entity, candidates))
+    assert len(results) == 1, results
+    assert str(results[0].id) == "osv-umbrella-corp", results[0]
 
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
 


### PR DESCRIPTION
Adopts the blocker changes from nomenklatura [#350](https://github.com/opensanctions/nomenklatura/pull/350) and [#352](https://github.com/opensanctions/nomenklatura/pull/352): match candidates are now trimmed and ranked inside the blocker's matching query — at most `index_options.max_candidates` per subject, each scoring at least `min_score_ratio` (default 0.1) of the subject's best candidate.

- **`LocalEnricher`**: delete the `max_bin` walk from `match_candidates()`. It binned candidates by `round(index_score)` to compensate for the untrimmed list, and its absolute-scale assumption is invalidated by the IDF-based blocker scoring anyway. Every candidate in the (pre-trimmed) list is now matcher-scored; the same-ID short-circuit, `can_match` check, `cutoff` and `limit` are unchanged. The `max_bin` config knob is removed and the class docstring rewritten.
- **External dataset configs**: drop the obsolete `max_bin` keys and the `match_batch` pins (the chunking knob was deleted from nomenklatura; constrained hosts tune `NOMENKLATURA_DUCKDB_THREADS` instead).
- **Tests**: new case asserting the tail of a ranked candidate list still gets scored (the old walk would have halted early on widely-spread scores).

`max_candidates` pins are deliberately unchanged. They were tuned to be generous under the max_bin regime and now directly bound matcher work per subject — re-tuning (especially `ext_ru_egrul: 200`) is a follow-up with before/after output comparison.

**Blocked on the nomenklatura 4.13.0 release** — the pin is already bumped, so CI goes green once it's on PyPI. Verified locally against nomenklatura main: `pytest zavod/tests/enrich/` (10 passed) and `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)