### PR TITLE
Include positions at international organisations in wd_peps

### DIFF
--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -9,6 +9,7 @@ from rigour.territories.territory import Territory
 from zavod.entity import Entity
 from zavod.shed.wikidata.client import WIKIDATA_QUERY_CACHE, create_wikidata_client
 from zavod.shed.wikidata.human import wikidata_basic_human
+from zavod.shed.wikidata.igo import INTL_ORGS
 from zavod.shed.wikidata.position import (
     POSITION_ABOLISHED_CUTOFF,
     position_holders,
@@ -99,6 +100,23 @@ def query_occupation_positions(
     return collect_positions(context, client, query)
 
 
+def query_igo_positions(context: Context, client: WikidataClient) -> set[str]:
+    """Positions in use at registered international bodies, linked via P2389
+    (organization directed by the office) or P361 (part of). These bodies have
+    no territory, so the per-territory sweeps never see their positions."""
+    values = " ".join(f"wd:{qid}" for qid in sorted(INTL_ORGS))
+    query = f"""
+    SELECT DISTINCT ?position ?abolished WHERE {{
+        ?position wdt:P2389|wdt:P361 ?org .
+        VALUES ?org {{ {values} }}
+        {{ ?holder wdt:P39 ?position . ?holder wdt:P31 wd:Q5 . }}
+        UNION {{ ?position wdt:P1308 ?officeholder . }}
+        {ABOLISHED_CLAUSE}
+    }}
+    """
+    return collect_positions(context, client, query)
+
+
 def discover_candidates(context: Context, client: WikidataClient) -> set[str]:
     """Enumerate candidate position QIDs. Positions already categorised as PEP
     in the review database are always included, so a failing discovery query
@@ -116,6 +134,12 @@ def discover_candidates(context: Context, client: WikidataClient) -> set[str]:
         accepted=len(candidates),
         blocked=len(blocked),
     )
+    try:
+        candidates.update(query_igo_positions(context, client))
+    except Exception as exc:  # noqa: BLE001
+        context.log.warning(
+            "International-body position discovery failed", error=str(exc)
+        )
     for territory in all_territories():
         context.log.info(f"Crawling territory: {territory.qid} ({territory.name})")
         try:

--- a/zavod/zavod/shed/wikidata/igo.py
+++ b/zavod/zavod/shed/wikidata/igo.py
@@ -1,0 +1,147 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class IntlOrg:
+    """Registry entry for an international body whose positions are exempt
+    from the country gate in `wikidata_position`."""
+
+    name: str
+    country: str = "zz"
+    topics: frozenset[str] = field(default=frozenset({"gov.igo"}))
+
+
+SPORT = frozenset({"poi"})
+
+# International bodies whose positions OpenSanctions wants despite having no
+# national jurisdiction. A position joins this path when its P2389
+# ("organization directed by the office") or P361 ("part of") points at a
+# registry org: it gets the entry's country code and topics, its own
+# country/jurisdiction claims are ignored (they hold headquarters countries
+# or the org itself more often than anything meaningful), and it enters the
+# position review UI as undecided rather than being silently dropped.
+#
+# Seeded from the 2026-08-05 census of P39-used positions with org links
+# (wikidata workbench, tasks/international_positions.md). Orgs are few and
+# stable; extend this list rather than special-casing positions.
+INTL_ORGS: dict[str, IntlOrg] = {
+    # United Nations system:
+    "Q1065": IntlOrg("United Nations", country="un"),
+    "Q47423": IntlOrg("United Nations General Assembly", country="un"),
+    "Q37470": IntlOrg("United Nations Security Council", country="un"),
+    "Q220563": IntlOrg("United Nations Secretariat", country="un"),
+    "Q170075": IntlOrg("United Nations Economic and Social Council", country="un"),
+    "Q205650": IntlOrg("United Nations Human Rights Council", country="un"),
+    "Q656812": IntlOrg(
+        "Office of the High Commissioner for Human Rights", country="un"
+    ),
+    "Q132551": IntlOrg("United Nations High Commissioner for Refugees", country="un"),
+    "Q846656": IntlOrg("United Nations Relief and Works Agency", country="un"),
+    "Q1065854": IntlOrg(
+        "UN Office for the Coordination of Humanitarian Affairs", country="un"
+    ),
+    "Q161718": IntlOrg("United Nations Development Programme", country="un"),
+    "Q740308": IntlOrg("UNICEF", country="un"),
+    "Q641576": IntlOrg("UN Women", country="un"),
+    "Q2531088": IntlOrg("United Nations Office for Project Services", country="un"),
+    "Q32874": IntlOrg(
+        "UN Economic Commission for Latin America and the Caribbean", country="un"
+    ),
+    "Q3708827": IntlOrg(
+        "United Nations Department of Global Communications", country="un"
+    ),
+    "Q135418656": IntlOrg(
+        "UN Office for Digital and Emerging Technologies", country="un"
+    ),
+    "Q7888477": IntlOrg(
+        "United Nations Office for West Africa and the Sahel", country="un"
+    ),
+    "Q160805": IntlOrg("United Nations Interim Force in Lebanon", country="un"),
+    # UN specialized agencies (the Bretton Woods institutions are deliberately
+    # "zz": they operate as global bodies, not as UN organs):
+    "Q7817": IntlOrg("World Health Organization", country="un"),
+    "Q7809": IntlOrg("UNESCO", country="un"),
+    "Q82151": IntlOrg("Food and Agriculture Organization", country="un"),
+    "Q54129": IntlOrg("International Labour Organization", country="un"),
+    "Q201054": IntlOrg("International Maritime Organization", country="un"),
+    "Q376150": IntlOrg("International Telecommunication Union", country="un"),
+    "Q170424": IntlOrg("World Meteorological Organization", country="un"),
+    "Q177773": IntlOrg("World Intellectual Property Organization", country="un"),
+    "Q7804": IntlOrg("International Monetary Fund"),
+    "Q320863": IntlOrg("World Bank Group"),
+    # International courts:
+    "Q7801": IntlOrg("International Court of Justice"),
+    "Q47488": IntlOrg("International Criminal Court"),
+    "Q122880": IntlOrg("European Court of Human Rights"),
+    "Q3001122": IntlOrg("Eastern Caribbean Supreme Court"),
+    # European Union institutions ("eu" is a rigour pseudo-territory, so many
+    # of their positions already resolve via P1001; the registry makes org-only
+    # links discoverable too):
+    "Q458": IntlOrg("European Union", country="eu"),
+    "Q8889": IntlOrg("European Parliament", country="eu"),
+    "Q10749015": IntlOrg("Bureau of the European Parliament", country="eu"),
+    "Q8880": IntlOrg("European Commission", country="eu"),
+    "Q1501921": IntlOrg("Secretariat-General of the European Commission", country="eu"),
+    "Q8886": IntlOrg("European Council", country="eu"),
+    "Q2067116": IntlOrg("General Secretariat of the Council of the EU", country="eu"),
+    "Q973809": IntlOrg("Foreign Affairs Council", country="eu"),
+    "Q149964": IntlOrg("Eurogroup", country="eu"),
+    "Q1518827": IntlOrg("European Court of Justice", country="eu"),
+    "Q4951": IntlOrg("Court of Justice of the European Union", country="eu"),
+    "Q8900": IntlOrg("European Court of Auditors", country="eu"),
+    "Q8901": IntlOrg("European Central Bank", country="eu"),
+    "Q657898": IntlOrg("European Systemic Risk Board", country="eu"),
+    "Q220893": IntlOrg("European Ombudsman", country="eu"),
+    "Q672941": IntlOrg("European External Action Service", country="eu"),
+    "Q205203": IntlOrg("European Committee of the Regions", country="eu"),
+    "Q1134173": IntlOrg("European Defence Agency", country="eu"),
+    "Q5413070": IntlOrg("European Public Prosecutor's Office", country="eu"),
+    "Q516521": IntlOrg("European Food Safety Authority", country="eu"),
+    "Q192247": IntlOrg("European Investment Bank", country="eu"),
+    # Council of Europe (not the EU):
+    "Q8908": IntlOrg("Council of Europe"),
+    "Q939743": IntlOrg("Parliamentary Assembly of the Council of Europe"),
+    "Q1251615": IntlOrg("Congress of Local and Regional Authorities"),
+    # Other intergovernmental organizations:
+    "Q7184": IntlOrg("NATO"),
+    "Q8475": IntlOrg("Interpol"),
+    "Q41550": IntlOrg("OECD"),
+    "Q7825": IntlOrg("World Trade Organization"),
+    "Q194284": IntlOrg("General Agreement on Tariffs and Trade"),
+    "Q7795": IntlOrg("OPEC"),
+    "Q41984": IntlOrg("International Atomic Energy Agency"),
+    "Q7159": IntlOrg("African Union"),
+    "Q191703": IntlOrg("Organisation of African Unity"),
+    "Q193272": IntlOrg("Economic Community of West African States"),
+    "Q337456": IntlOrg("East African Community"),
+    "Q1115631": IntlOrg("Indian Ocean Commission"),
+    "Q294278": IntlOrg("Organisation of African, Caribbean and Pacific States"),
+    "Q7172": IntlOrg("League of Arab States"),
+    "Q217172": IntlOrg("Gulf Cooperation Council"),
+    "Q47543": IntlOrg("Organisation of Islamic Cooperation"),
+    "Q111169280": IntlOrg("Islamic Organisation for Food Security"),
+    "Q123759": IntlOrg("Organization of American States"),
+    "Q205995": IntlOrg("Caribbean Community"),
+    "Q1153087": IntlOrg("Inter-American Development Bank"),
+    "Q4230": IntlOrg("Union of South American Nations"),
+    "Q9075403": IntlOrg("Ibero-American General Secretariat"),
+    "Q83201": IntlOrg("Non-Aligned Movement"),
+    "Q182379": IntlOrg("Nordic Council of Ministers"),
+    "Q488981": IntlOrg("European Bank for Reconstruction and Development"),
+    "Q2883427": IntlOrg("West African Development Bank"),
+    "Q1010514": IntlOrg("Bureau of International Expositions"),
+    # Treaty-based scientific organizations:
+    "Q42944": IntlOrg("CERN"),
+    "Q42262": IntlOrg("European Space Agency"),
+    "Q151991": IntlOrg("European Southern Observatory"),
+    # International sports bodies — kept out of gov.* topics; their officials
+    # are persons of interest, not government officials:
+    "Q253414": IntlOrg("FIFA", topics=SPORT),
+    "Q40970": IntlOrg("International Olympic Committee", topics=SPORT),
+    "Q35572": IntlOrg("UEFA", topics=SPORT),
+    "Q46199": IntlOrg("International Basketball Federation", topics=SPORT),
+    "Q58733": IntlOrg("CONMEBOL", topics=SPORT),
+    "Q1158": IntlOrg("World Athletics", topics=SPORT),
+    "Q684885": IntlOrg("World Rowing", topics=SPORT),
+    "Q708793": IntlOrg("International Shooting Sport Federation", topics=SPORT),
+}

--- a/zavod/zavod/shed/wikidata/position.py
+++ b/zavod/zavod/shed/wikidata/position.py
@@ -4,7 +4,7 @@ from followthemoney import registry
 from nomenklatura.wikidata import Item, WikidataClient, Claim
 from nomenklatura.wikidata.lang import MULTI_LANG
 from nomenklatura.wikidata.value import clean_wikidata_name
-from rigour.territories import get_territory_by_qid
+from rigour.territories import get_territory, get_territory_by_qid
 from rigour.time import iso_datetime
 
 from zavod import Context, Entity
@@ -15,6 +15,7 @@ from zavod.shed.wikidata.client import WIKIDATA_QUERY_CACHE
 from zavod.util import LangText
 from zavod.stateful.positions import categorise, categorise_many
 from zavod.shed.wikidata.country import is_historical_country, item_countries
+from zavod.shed.wikidata.igo import INTL_ORGS, IntlOrg
 
 
 POSITION_BASICS: set[str] = {
@@ -167,18 +168,34 @@ def wikidata_position(
     position.id = item.id
     position.add("wikidataId", item.id)
 
+    # Positions at registered international bodies (P2389 "organization
+    # directed by the office" / P361 "part of" into INTL_ORGS) carry the
+    # registry's pseudo-country instead of their own country claims.
+    intl_org: IntlOrg | None = None
     for claim in item.claims:
-        if claim.property in ("P1001", "P17", "P27") and claim.qid is not None:
-            if is_historical_country(client, claim.qid):
-                return None
-            for country in item_countries(client, claim.qid):
-                country.apply(position, "country")
+        if claim.property in ("P2389", "P361") and claim.qid is not None:
+            intl_org = INTL_ORGS.get(claim.qid)
+            if intl_org is not None:
+                break
 
-        # jurisdiction:
-        if claim.property == "P1001":
-            territory = get_territory_by_qid(claim.qid)
-            if territory is None or not territory.is_country:
-                claim.text.apply(position, "subnationalArea")
+    for claim in item.claims:
+        if intl_org is None:
+            if claim.property in ("P1001", "P17", "P27") and claim.qid is not None:
+                # Stale associations — ended claims and historical polities —
+                # contribute no country, but they don't kill the position: a
+                # legacy "P1001: RSFSR" must not hide the current Russian
+                # office next to it. Positions belonging *only* to dead states
+                # end up country-less and drop at the gate below.
+                if claim.is_ended() or is_historical_country(client, claim.qid):
+                    continue
+                for country in item_countries(client, claim.qid):
+                    country.apply(position, "country")
+
+            # jurisdiction:
+            if claim.property == "P1001":
+                territory = get_territory_by_qid(claim.qid)
+                if territory is None or not territory.is_country:
+                    claim.text.apply(position, "subnationalArea")
 
         # inception:
         if claim.property == "P571":
@@ -198,14 +215,20 @@ def wikidata_position(
         if claim.property == "P582" and not position.has("dissolutionDate"):
             claim.text.apply(position, "dissolutionDate")
 
+    if intl_org is not None:
+        position.add("country", intl_org.country)
+
     # If no explicit country/jurisdiction is found, try to traverse more obscure
     # properties, like capital of, part of, jurisdiction, etc.
     if not position.has("country"):
         for country in item_countries(client, item.id):
             country.apply(position, "country")
 
-    # Skip all positions that cannot be linked to a country.
-    if not position.has("country"):
+    # Skip all positions that cannot be linked to a country — unless a
+    # reviewer explicitly marked the position PEP-conferring, which must
+    # stay effective as a manual rescue channel for cases the registry and
+    # the traversal both miss.
+    if not position.has("country") and not db_is_pep:
         return None
 
     # Positions dissolved before the cutoff are dropped — unless the position
@@ -249,8 +272,15 @@ def wikidata_position(
     for sub_type, type_topics in SUB_TYPES.items():
         if sub_type in types:
             topics.update(type_topics)
+    if intl_org is not None:
+        topics.update(intl_org.topics)
 
-    is_pep = "role.pep" in topics
+    is_pep: bool | None = "role.pep" in topics
+    if intl_org is not None and is_pep is False:
+        # International-body positions surface in the review UI as undecided
+        # instead of being auto-rejected: registry membership vouches for the
+        # org, a human vouches for the position.
+        is_pep = None
     topics.discard("role.pep")
 
     if "gov.state" in topics:
@@ -353,10 +383,14 @@ def wikidata_occupancy(
 
     # Wikidata persons frequently lack their own citizenship statement, so we
     # associate confirmed PEPs with the position's country. Diplomatic posts
-    # (role.diplo) name the receiving country rather than the person's, so those
+    # (role.diplo) name the receiving country rather than the person's, and
+    # pseudo-countries ("zz", "un", "eu") say nothing about the holder — both
     # are left out.
     if "role.diplo" not in position.get("topics"):
         for country in position.get("country"):
+            territory = get_territory(country)
+            if territory is None or not territory.is_country:
+                continue
             if country not in person.get_type_values(registry.country, matchable=True):
                 person.add("country", country, origin=ORIGIN_INFERRED)
 

--- a/zavod/zavod/tests/shed/test_wikidata_position.py
+++ b/zavod/zavod/tests/shed/test_wikidata_position.py
@@ -1,0 +1,230 @@
+from typing import Any, cast
+
+from nomenklatura.wikidata import Item, WikidataClient
+from nomenklatura.wikidata.lang import LangText
+
+from zavod import settings
+from zavod.context import Context
+from zavod.meta import Dataset
+from zavod.shed.wikidata.position import wikidata_position, wikidata_occupancy
+from zavod.stateful.model import position_table
+from zavod.stateful.positions import categorise
+
+
+class StubClient:
+    """Offline WikidataClient stand-in: ancestor/traversal lookups only find
+    the fixture items passed in, so items are exactly what their JSON says."""
+
+    reference_time = settings.RUN_TIME
+
+    def __init__(self, items: dict[str, dict] | None = None):
+        self._items = items or {}
+
+    def fetch_item(self, qid: str, modified_at: Any = None) -> Item | None:
+        data = self._items.get(qid)
+        if data is None:
+            return None
+        return Item(cast(WikidataClient, self), dict(data))
+
+    def get_label(self, qid: str) -> LangText:
+        return LangText(qid)
+
+
+def make_item(client: StubClient, qid: str, label: str, claims: list[dict]) -> Item:
+    data = {
+        "id": qid,
+        "labels": {"en": {"language": "en", "value": label}},
+        "claims": {},
+    }
+    for idx, claim in enumerate(claims):
+        data["claims"].setdefault(claim["prop"], []).append(
+            {
+                "id": f"{qid}${idx}",
+                "rank": "normal",
+                "mainsnak": {
+                    "snaktype": "value",
+                    "property": claim["prop"],
+                    "datatype": "wikibase-item",
+                    "datavalue": {
+                        "type": "wikibase-entityid",
+                        "value": {"id": claim["qid"]},
+                    },
+                },
+                "qualifiers": claim.get("qualifiers", {}),
+            }
+        )
+    return Item(cast(WikidataClient, client), data)
+
+
+def interpol_sg_item(client: StubClient) -> Item:
+    # Modeled on Q111170012 post-enrichment, with a junk headquarters P17
+    # thrown in (the FIFA-president pattern):
+    return make_item(
+        client,
+        "Q111170012",
+        "Secretary General of Interpol",
+        [
+            {"prop": "P31", "qid": "Q4164871"},  # position
+            {"prop": "P2389", "qid": "Q8475"},  # Interpol
+            {"prop": "P17", "qid": "Q39"},  # Switzerland (junk)
+        ],
+    )
+
+
+def test_igo_position_enrolls_for_review(testdataset1: Dataset):
+    context = Context(testdataset1)
+    categorise.cache_clear()
+    client = StubClient()
+
+    item = interpol_sg_item(client)
+    position = wikidata_position(context, cast(WikidataClient, client), item)
+    # Unreviewed international-body positions don't ship...
+    assert position is None
+    # ...but they enroll in the review DB as undecided, with the registry
+    # country instead of the junk P17:
+    [row] = context.db.execute(position_table.select()).fetchall()
+    assert row.entity_id == "Q111170012"
+    assert row.is_pep is None
+    assert row.countries == ["zz"]
+    assert "gov.igo" in row.topics
+    context.close()
+
+
+def test_igo_position_accepted_after_review(testdataset1: Dataset):
+    context = Context(testdataset1)
+    categorise.cache_clear()
+    client = StubClient()
+
+    item = interpol_sg_item(client)
+    assert wikidata_position(context, cast(WikidataClient, client), item) is None
+    context.db.execute(
+        position_table.update()
+        .where(position_table.c.entity_id == "Q111170012")
+        .values(is_pep=True)
+    )
+    categorise.cache_clear()
+
+    position = wikidata_position(context, cast(WikidataClient, client), item)
+    assert position is not None
+    assert position.get("country") == ["zz"]
+    assert "gov.igo" in position.get("topics")
+    # The junk P17 must not surface anywhere:
+    assert position.get("subnationalArea") == []
+    context.close()
+
+
+def test_db_is_pep_rescues_countryless_position(testdataset1: Dataset):
+    """A reviewed is_pep=True row bypasses the country gate even without a
+    registry hit — the manual rescue channel."""
+    context = Context(testdataset1)
+    categorise.cache_clear()
+    client = StubClient()
+
+    item = make_item(
+        client,
+        "Q999999",
+        "Some orphaned office",
+        [{"prop": "P31", "qid": "Q4164871"}],
+    )
+    # Without a DB verdict, the country gate drops it entirely — it never
+    # even enrolls for review:
+    assert wikidata_position(context, cast(WikidataClient, client), item) is None
+    assert context.db.execute(position_table.select()).fetchall() == []
+
+    context.db.execute(
+        position_table.insert().values(
+            entity_id="Q999999",
+            caption="Some orphaned office",
+            countries=[],
+            topics=[],
+            dataset=testdataset1.name,
+            created_at=settings.RUN_TIME,
+            is_pep=True,
+        )
+    )
+    categorise.cache_clear()
+    position = wikidata_position(context, cast(WikidataClient, client), item)
+    assert position is not None
+    assert position.get("country") == []
+    context.close()
+
+
+def test_historical_claim_does_not_kill_position(testdataset1: Dataset):
+    """A stale jurisdiction next to a current one contributes nothing —
+    it must not drop the whole position."""
+    context = Context(testdataset1)
+    categorise.cache_clear()
+    client = StubClient(items={"Q159": {"id": "Q159", "claims": {}}})
+
+    item = make_item(
+        client,
+        "Q888888",
+        "Governor of Testov Oblast",
+        [
+            {"prop": "P31", "qid": "Q132050"},  # governor (role.pep)
+            {"prop": "P1001", "qid": "Q15180"},  # Soviet Union (historical)
+            {"prop": "P1001", "qid": "Q159"},  # Russia
+        ],
+    )
+    position = wikidata_position(context, cast(WikidataClient, client), item)
+    assert position is not None
+    assert position.get("country") == ["ru"]
+    context.close()
+
+
+def test_igo_occupancy_infers_no_person_country(testdataset1: Dataset):
+    context = Context(testdataset1)
+    client = StubClient()
+
+    person = context.make("Person")
+    person.id = "test-person"
+
+    claim_data = {
+        "id": "x$1",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P39",
+            "datatype": "wikibase-item",
+            "datavalue": {"type": "wikibase-entityid", "value": {"id": "Q111170012"}},
+        },
+        "qualifiers": {
+            "P580": [
+                {
+                    "snaktype": "value",
+                    "property": "P580",
+                    "datatype": "time",
+                    "datavalue": {
+                        "type": "time",
+                        "value": {
+                            "time": "+2020-01-01T00:00:00Z",
+                            "precision": 11,
+                            "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                        },
+                    },
+                }
+            ]
+        },
+    }
+    from nomenklatura.wikidata.model import Claim
+
+    claim = Claim(cast(WikidataClient, client), claim_data, "P39")
+
+    igo_position = context.make("Position")
+    igo_position.id = "wd-igo-pos"
+    igo_position.add("name", "Secretary General of Interpol")
+    igo_position.add("country", "zz")
+    igo_position.add("topics", "gov.igo")
+    occupancy = wikidata_occupancy(context, person, igo_position, claim)
+    assert occupancy is not None
+    assert person.get("country") == []
+
+    national_position = context.make("Position")
+    national_position.id = "wd-national-pos"
+    national_position.add("name", "Minister of Tests")
+    national_position.add("country", "de")
+    national_position.add("topics", "gov.national")
+    occupancy = wikidata_occupancy(context, person, national_position, claim)
+    assert occupancy is not None
+    assert person.get("country") == ["de"]
+    context.close()


### PR DESCRIPTION
## Problem

Positions at international bodies (UN, NATO, Interpol, ICC, FIFA, …) are almost entirely missing from `wd_peps`, for two stacked reasons:

1. **Discovery is territory-scoped** — the sweeps enumerate positions per rigour territory (`P1001|P17`), and international organisations don't have one. Most IGO positions are never even fetched.
2. **The country gate** (`wikidata_position`) drops any position that can't be linked to a country — and it ran before the review-DB verdict, so even a manually accepted position couldn't be rescued.

Where such positions did slip through, they carried a junk country: on Wikidata their P17 mostly holds the headquarters country or the org itself (FIFA president → Switzerland, NATO Secretary General → NATO-as-country). The UN Secretary-General was not in the dataset at all; the manual "Heads of international organisations" block in `wd_categories.yml` was the only reason ICC/Interpol officials existed.

## Approach

A curated registry of international bodies, keyed on the **organisation** QID (`zavod/shed/wikidata/igo.py`, ~90 entries: UN system → `un`, EU institutions → `eu`, everything else → `zz`; sports federations carry `poi` instead of `gov.igo`). Orgs are few and stable, unlike their positions.

A position whose **P2389** ("organization directed by the office") or **P361** ("part of") points at a registry org now:

- carries the registry pseudo-country and topics, ignoring its own country claims entirely (kills the HQ-country junk);
- bypasses the country gate;
- enrolls in the position review DB as **undecided** (`is_pep=NULL`) rather than being silently dropped — a human verdict still gates shipping, and the review-DB seed keeps accepted QIDs sticky across crawls.

Positions lacking org links are being fixed on the Wikidata side (e.g. Secretary General of Interpol, which had nothing but `P31=position`, now has P2389 → Interpol).

## Supporting changes

- `wd_peps` discovery gains `query_igo_positions()`, a sweep with `VALUES` over the registry org QIDs — 144 candidate positions on live WDQS, including the PACE memberships (~8,400 holders), ICJ/ECtHR/ICC judges, UN GA/SC presidents, IMF/World Bank heads.
- A reviewed `is_pep=true` row now bypasses the country gate too — a manual rescue channel for positions the registry misses.
- Occupancy person-country inference skips pseudo-countries (rigour `territory.is_country`), so UN officials aren't stamped `zz` — and MEPs no longer get `eu` inferred as a citizenship-like country.
- A stale P1001/P17/P27 claim (ended, or naming a historical polity) no longer kills the whole position — it just contributes no country. A legacy `P1001: RSFSR` must not hide the current Russian office next to it; wholly-historical positions still drop at the gate.

## Verification

- 5 new unit tests (`zavod/tests/shed/test_wikidata_position.py`): registry enrollment + junk-P17 suppression, post-review acceptance, db-verdict gate bypass, no person-country inference from pseudo-countries, historical-claim softening. `mypy --strict` and ruff clean.
- Live probes via `wd_item_debug.py`: UN SG → `country=un, gov.igo` (previously absent), NATO SG → `zz` (previously Belgium/NATO junk), FIFA/World Bank/Interpol SG enroll as undecided with correct values; a normal national position (member of the Bundestag → `de`) is unaffected.

Newly enrolled positions will surface in the review UI as undecided after the next crawl and ship nothing until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)