### PR TITLE
Bump the prek ruff hooks and pass the zavod config to them

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -14,11 +14,14 @@ repos:
         language: fail
         files: 'datasets/.*\.yaml$'
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.16.1
     hooks:
+      # Ruff finds no configuration for files outside zavod/, so without --config it
+      # falls back to its built-in defaults.
       - id: ruff-check
-        args: ['--fix']
+        args: ['--fix', '--config', 'zavod/pyproject.toml']
       - id: ruff-format
+        args: ['--config', 'zavod/pyproject.toml']
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.37.1
     hooks:


### PR DESCRIPTION
Ruff 0.16 added rules to its built-in default set, `I` (isort) and `UP` among them.
`zavod/pyproject.toml` pins `select` to guard against exactly that, but ruff only
finds that file for code that sits under `zavod/`. The prek hooks passed no
`--config`, so they ran `datasets/` on the built-in defaults.

That drift already cost us. Ten crawler PRs went red on `I001` after ruff 0.16
shipped, a rule we do not enforce.

- Pass `--config zavod/pyproject.toml` to `ruff-check` and `ruff-format`, which is
  what `lint_crawlers.yml` already does for its own ruff step.
- Bump `ruff-pre-commit` to `v0.16.1`, matching the ruff CI resolves from
  `zavod[dev]` (`ruff>=0.4.0,<1.0.0`). The hooks and the CI step now agree.

Verified through prek at the new pin: `ruff-check` and `ruff-format` pass over every
Python file in `datasets/` and in `zavod/`. Without the flag the same run reports 398
`I001`.

Note the remaining gap: a bare `ruff check` typed by hand still gets the built-in
defaults, and any new caller has to remember the flag. A root `ruff.toml` holding
`extend = "zavod/pyproject.toml"` would cover those too, at the cost of another config
file.

`contrib/` is not clean for the pinned rule set: 12 `F401`, plus `UP` violations across
26 files. Those are pre-existing on main — no CI job lints `contrib/`
(`lint_crawlers.yml` filters to `^datasets/`, `build.yml` runs prek only on `zavod/`),
and the hooks only see files in a commit. Left alone deliberately. Whoever next
touches one of those files fixes it then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)