### PR TITLE
Pass a two-digit year base where sources publish two-digit years

### DIFF
--- a/datasets/_global/c4ads_xinjiang/crawler.py
+++ b/datasets/_global/c4ads_xinjiang/crawler.py
@@ -1,4 +1,5 @@
 import csv
+
 from zavod import Context
 from zavod import helpers as h
 from zavod.shed.internal_data import fetch_internal_data

--- a/datasets/_global/c4ads_xinjiang/crawler.py
+++ b/datasets/_global/c4ads_xinjiang/crawler.py
@@ -1,5 +1,4 @@
 import csv
-
 from zavod import Context
 from zavod import helpers as h
 from zavod.shed.internal_data import fetch_internal_data
@@ -18,7 +17,13 @@ def crawl(context: Context) -> None:
             entity.add("name", name_zho, lang="zho")
             entity.add("name", row.pop("Company_Name_English"), lang="eng")
             entity.add("country", "cn")
-            h.apply_date(entity, "incorporationDate", row.pop("Date_of_Establishment"))
+            h.apply_date(
+                entity,
+                "incorporationDate",
+                row.pop("Date_of_Establishment"),
+                # The XPCC was founded in 1954, so no company is older.
+                two_digit_year_base=1950,
+            )
             entity.add("sector", row.pop("Industry"), lang="zho")
             entity.add("address", addr_zho, lang="zho")
             entity.add("topics", "export.risk")

--- a/datasets/_global/c4ads_xinjiang_mining/crawler.py
+++ b/datasets/_global/c4ads_xinjiang_mining/crawler.py
@@ -27,7 +27,13 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
     own.add("owner", owner.id)
     own.add("asset", entity.id)
     own.add("recordId", row.pop("Permit_Number"))
-    h.apply_date(own, "endDate", row.pop("Permit_Expiration_Date"))
+    h.apply_date(
+        own,
+        "endDate",
+        row.pop("Permit_Expiration_Date"),
+        # No permit on the list predates 1990, and permits expire in the future.
+        two_digit_year_base=1990,
+    )
 
     context.emit(entity)
     context.emit(owner)

--- a/datasets/_global/icij_offshoreleaks/crawler.py
+++ b/datasets/_global/icij_offshoreleaks/crawler.py
@@ -9,6 +9,8 @@ from followthemoney import model
 from zavod import Context, Entity
 from zavod import helpers as h
 
+# The oldest officer relationships in the leaked registers are from the 1950s.
+TWO_DIGIT_RELATIONSHIP_YEAR_BASE = 1950
 SCHEMATA: dict[str, str] = {}
 ADDRESSES_FULL: dict[str, list[str | None]] = {}
 ADDRESSES_COUNTRIES: dict[str, list[str] | None] = {}
@@ -215,8 +217,18 @@ def make_row_relationship(context: Context, row: dict[str, str | None]) -> None:
     if res.schema is not None:
         rel = context.make(res.schema)
         rel.id = context.make_slug(_start, _end, link)
-        h.apply_date(rel, "startDate", row.pop("start_date"))
-        h.apply_date(rel, "endDate", row.pop("end_date"))
+        h.apply_date(
+            rel,
+            "startDate",
+            row.pop("start_date"),
+            two_digit_year_base=TWO_DIGIT_RELATIONSHIP_YEAR_BASE,
+        )
+        h.apply_date(
+            rel,
+            "endDate",
+            row.pop("end_date"),
+            two_digit_year_base=TWO_DIGIT_RELATIONSHIP_YEAR_BASE,
+        )
         rel.add(res.status, row.pop("status"))
         rel.add(res.link, link)
         rel.add("publisher", source_id)

--- a/datasets/_global/un_1718_vessels/crawler.py
+++ b/datasets/_global/un_1718_vessels/crawler.py
@@ -58,7 +58,13 @@ def crawl(context: Context) -> None:
             vessel.add("type", row.pop("type"))
             # Create the sanction
             sanction = h.make_sanction(context, vessel, program_key=PROGRAM_KEY)
-            h.apply_date(sanction, "startDate", row.pop("date_of_designation"))
+            h.apply_date(
+                sanction,
+                "startDate",
+                row.pop("date_of_designation"),
+                # The 1718 Committee was established in 2006.
+                two_digit_year_base=2000,
+            )
             for program in PROGRAMS:
                 value = row.pop(program).strip()
                 if value and value.lower() != "na":

--- a/datasets/_global/un_ga_protocol/crawler.py
+++ b/datasets/_global/un_ga_protocol/crawler.py
@@ -72,15 +72,13 @@ def crawl(context: Context) -> None:
                 topics=["gov.national"],
             )
             start_date = start_date if len(start_date) < 18 else None
-            if start_date is not None:
-                start_date = h.extract_date(
-                    context.dataset,
-                    start_date,
-                    # The UN was founded in 1945, so no appointment is older.
-                    two_digit_year_base=1945,
-                )[0]
             occupancy = h.make_occupancy(
-                context, entity, position, start_date=start_date
+                context,
+                entity,
+                position,
+                start_date=start_date,
+                # The UN was founded in 1945, so no appointment is older.
+                two_digit_year_base=1945,
             )
 
             # entity.add("date_of_appointment", )

--- a/datasets/_global/un_ga_protocol/crawler.py
+++ b/datasets/_global/un_ga_protocol/crawler.py
@@ -1,5 +1,4 @@
 from urllib.parse import urljoin
-
 from rigour.mime.types import PDF
 from rigour.names import remove_person_prefixes
 

--- a/datasets/_global/un_ga_protocol/crawler.py
+++ b/datasets/_global/un_ga_protocol/crawler.py
@@ -1,4 +1,5 @@
 from urllib.parse import urljoin
+
 from rigour.mime.types import PDF
 from rigour.names import remove_person_prefixes
 
@@ -72,6 +73,13 @@ def crawl(context: Context) -> None:
                 topics=["gov.national"],
             )
             start_date = start_date if len(start_date) < 18 else None
+            if start_date is not None:
+                start_date = h.extract_date(
+                    context.dataset,
+                    start_date,
+                    # The UN was founded in 1945, so no appointment is older.
+                    two_digit_year_base=1945,
+                )[0]
             occupancy = h.make_occupancy(
                 context, entity, position, start_date=start_date
             )

--- a/datasets/_global/un_ga_protocol/crawler.py
+++ b/datasets/_global/un_ga_protocol/crawler.py
@@ -77,8 +77,9 @@ def crawl(context: Context) -> None:
                 entity,
                 position,
                 start_date=start_date,
-                # The UN was founded in 1945, so no appointment is older.
-                two_digit_year_base=1945,
+                # As of 2026, longest current head started tenure 1982 (Teodoro Mbasogo).
+                # https://www.guinnessworldrecords.com/world-records/65343-longest-serving-president-current
+                two_digit_year_base=1980,
             )
 
             # entity.add("date_of_appointment", )

--- a/datasets/be/fod_sanctions/crawler.py
+++ b/datasets/be/fod_sanctions/crawler.py
@@ -1,5 +1,4 @@
 from csv import DictReader
-
 from rigour.mime.types import CSV
 
 from zavod import Context
@@ -70,7 +69,15 @@ def crawl_row(
         entity.add("gender", row.pop("Gender"))
         entity.add("birthPlace", row.pop("Birth place"))
         entity.add("country", row.pop("Birth country"))
-        h.apply_dates(entity, "birthDate", row.pop("Birth date"))
+        h.apply_dates(
+            entity,
+            "birthDate",
+            row.pop("Birth date"),
+            # The list holds birth dates from 1925, before the default 100-year
+            # window. A sanctioned person is old enough to have acted, so their
+            # birth date can be another 15 years back.
+            two_digit_year_base=h.TWO_DIGIT_BIRTH_YEAR_BASE - 15,
+        )
         entity.add("position", row.pop("Function"))
     else:
         # There's an organization with the following Firstname
@@ -81,7 +88,13 @@ def crawl_row(
 
     sanction = h.make_sanction(context, entity)
     for listing_date in row.pop("Publication date"):
-        h.apply_date(sanction, "listingDate", listing_date)
+        h.apply_date(
+            sanction,
+            "listingDate",
+            listing_date,
+            # The oldest measures implement UN Security Council Resolution 1267 (1999).
+            two_digit_year_base=1990,
+        )
     for embargo in row.pop("Embargos"):
         program_id = h.lookup_sanction_program_key(context, embargo)
         sanction.add("programId", program_id)

--- a/datasets/be/fod_sanctions/crawler.py
+++ b/datasets/be/fod_sanctions/crawler.py
@@ -1,4 +1,5 @@
 from csv import DictReader
+
 from rigour.mime.types import CSV
 
 from zavod import Context

--- a/datasets/ca/dfatd/crawler.py
+++ b/datasets/ca/dfatd/crawler.py
@@ -92,7 +92,16 @@ def parse_entry(context: Context, node: Element) -> None:
     elif given_name is not None or last_name is not None or dob is not None:
         entity.add_schema("Person")
         h.apply_name(entity, first_name=given_name, last_name=last_name)
-        h.apply_date(entity, "birthDate", dob, original_value=dob_original)
+        h.apply_date(
+            entity,
+            "birthDate",
+            dob,
+            original_value=dob_original,
+            # The list holds birth dates from 1924, before the default 100-year
+            # window. A sanctioned person is old enough to have acted, so their
+            # birth date can be another 15 years back.
+            two_digit_year_base=h.TWO_DIGIT_BIRTH_YEAR_BASE - 15,
+        )
         entity.add("title", title)
     elif entity_name is not None:
         entity.add("name", split_name(entity_name))

--- a/datasets/cn/sanctions/crawler.py
+++ b/datasets/cn/sanctions/crawler.py
@@ -16,6 +16,8 @@ from zavod import helpers as h
 
 
 LOCAL_PATH = Path(__file__).parent
+# China started to publish counter-sanctions in 2019.
+TWO_DIGIT_SANCTION_YEAR_BASE = 2010
 INDEX_CACHE_DAYS = 2
 MFA_INDEX_URL = "https://www.mfa.gov.cn/web/wjb_673085/zfxxgk_674865/gknrlb/fzcqdcs/"
 MOFCOM_INDEX_URL = "https://www.mofcom.gov.cn/zcfb/blgg/gg/{year}/index.html"
@@ -314,8 +316,18 @@ def crawl(context: Context) -> None:
             program_key=h.lookup_sanction_program_key(context, program),
         )
         sanction.set("authority", row.pop("Body", None))
-        h.apply_date(sanction, "startDate", row.pop("Date", None))
-        h.apply_date(sanction, "endDate", row.pop("End date", None))
+        h.apply_date(
+            sanction,
+            "startDate",
+            row.pop("Date", None),
+            two_digit_year_base=TWO_DIGIT_SANCTION_YEAR_BASE,
+        )
+        h.apply_date(
+            sanction,
+            "endDate",
+            row.pop("End date", None),
+            two_digit_year_base=TWO_DIGIT_SANCTION_YEAR_BASE,
+        )
         sanction.add("sourceUrl", row.pop("Source URL", None))
         context.emit(sanction)
         context.emit(entity)

--- a/datasets/il/mod_crypto/crawler.py
+++ b/datasets/il/mod_crypto/crawler.py
@@ -102,7 +102,12 @@ def crawl_csv_row(context: Context, row: dict[str, str]) -> None:
         person = context.make("Person")
         person.id = context.make_id(row.get("id_no") or row.get("passport_no") or name)
         h.apply_name(person, full=name, lang="eng")
-        h.apply_date(person, "birthDate", squash_spaces(row.pop("dob")))
+        h.apply_date(
+            person,
+            "birthDate",
+            squash_spaces(row.pop("dob")),
+            two_digit_year_base=h.TWO_DIGIT_BIRTH_YEAR_BASE,
+        )
         person.add("email", row.pop("email").split(";"))
         person.add("phone", row.pop("phone"))
         for alias in row.pop("alias").split(";"):

--- a/datasets/il/wmd_sanctions/crawler.py
+++ b/datasets/il/wmd_sanctions/crawler.py
@@ -143,7 +143,13 @@ def crawl_row(context: Context, row: dict[str, Any]) -> None:
     entity.add("topics", "sanction")
 
     sanction = h.make_sanction(context, entity)
-    h.apply_dates(sanction, "modifiedAt", clean_date(row.pop("israel_update_date")))
+    h.apply_dates(
+        sanction,
+        "modifiedAt",
+        clean_date(row.pop("israel_update_date")),
+        # No designation on the list predates 2000.
+        two_digit_year_base=2000,
+    )
     h.apply_dates(sanction, "startDate", clean_date(row.pop("isreal_adoption_date")))
 
     context.emit(entity)

--- a/datasets/in/nse_debarred/crawler.py
+++ b/datasets/in/nse_debarred/crawler.py
@@ -117,7 +117,14 @@ def crawl_item(context: Context, input_dict: dict[str, str | None]) -> None:
         sanction.add("duration", period)
         sanction.add("sourceUrl", urls)
         if is_revoked:
-            h.apply_date(sanction, "endDate", period)
+            h.apply_date(
+                sanction,
+                "endDate",
+                period,
+                # No debarment on the list predates 1990, and debarments can end
+                # in the future.
+                two_digit_year_base=1990,
+            )
 
         context.emit(entity)
         context.emit(sanction)

--- a/datasets/us/bis_antiboycott/crawler.py
+++ b/datasets/us/bis_antiboycott/crawler.py
@@ -40,7 +40,13 @@ def crawl(context: Context) -> None:
         entity.add("topics", "export.risk")
 
         sanction = h.make_sanction(context, entity)
-        h.apply_date(sanction, "listingDate", str_row.pop("order_date"))
+        h.apply_date(
+            sanction,
+            "listingDate",
+            str_row.pop("order_date"),
+            # The U.S. antiboycott regulations came into force in 1977.
+            two_digit_year_base=1977,
+        )
 
         context.emit(entity)
         context.emit(sanction)

--- a/datasets/us/de/med_exclusions/crawler.py
+++ b/datasets/us/de/med_exclusions/crawler.py
@@ -1,9 +1,9 @@
 from rigour.mime.types import PDF
 import re
-
 from zavod import Context, helpers as h
 from zavod.extract.zyte_api import fetch_resource
 from normality import squash_spaces
+
 
 REGEX_AKA = re.compile(r"\baka\b|a\.k\.a\.?", re.IGNORECASE)
 # Ruth Diane Jones, DO
@@ -75,7 +75,14 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
     assert (authority := row.pop("oig_medicaid_sanction")) is not None
     sanction.set("authority", squash_spaces(authority))
 
-    h.apply_date(sanction, "startDate", row.pop("effective_date"))
+    h.apply_date(
+        sanction,
+        "startDate",
+        row.pop("effective_date"),
+        # Exclusions cannot predate the 1977 Medicare-Medicaid Anti-Fraud and Abuse
+        # Amendments.
+        two_digit_year_base=1977,
+    )
     reinstated_date = row.pop("reinstated_date")
     h.apply_date(sanction, "endDate", reinstated_date)
 

--- a/datasets/us/de/med_exclusions/crawler.py
+++ b/datasets/us/de/med_exclusions/crawler.py
@@ -1,9 +1,9 @@
 from rigour.mime.types import PDF
 import re
+
 from zavod import Context, helpers as h
 from zavod.extract.zyte_api import fetch_resource
 from normality import squash_spaces
-
 
 REGEX_AKA = re.compile(r"\baka\b|a\.k\.a\.?", re.IGNORECASE)
 # Ruth Diane Jones, DO

--- a/datasets/us/fdic_failed_banks/crawler.py
+++ b/datasets/us/fdic_failed_banks/crawler.py
@@ -37,7 +37,13 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
     entity.add("registrationNumber", row.get("Cert", "").strip())
     # entity.add("notes", f"Cert: {row.get('Cert', '')}")
     # entity.add("notes", f"Fund: {row.get('Fund', '')}")
-    h.apply_date(entity, "dissolutionDate", closing_date)
+    h.apply_date(
+        entity,
+        "dissolutionDate",
+        closing_date,
+        # The FDIC list covers bank failures since October 2000.
+        two_digit_year_base=2000,
+    )
 
     # FIXME: Remove acquiring institution handling for now because it
     # emits a lot of single-property entities that clutter the dataset and

--- a/datasets/us/hi/med_exclusions/crawler.py
+++ b/datasets/us/hi/med_exclusions/crawler.py
@@ -6,7 +6,6 @@ from normality import squash_spaces
 
 from zavod.extract import zyte_api
 
-
 # Exclusions cannot predate the 1977 Medicare-Medicaid Anti-Fraud and Abuse
 # Amendments, and can end in the future.
 TWO_DIGIT_EXCLUSION_YEAR_BASE = 1977

--- a/datasets/us/hi/med_exclusions/crawler.py
+++ b/datasets/us/hi/med_exclusions/crawler.py
@@ -6,6 +6,11 @@ from normality import squash_spaces
 
 from zavod.extract import zyte_api
 
+
+# Exclusions cannot predate the 1977 Medicare-Medicaid Anti-Fraud and Abuse
+# Amendments, and can end in the future.
+TWO_DIGIT_EXCLUSION_YEAR_BASE = 1977
+
 AKA_SPLIT = r"\baka\b|\ba\.k\.a\b|\bAKA\b|\bor\b"
 
 
@@ -48,8 +53,18 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
     entity.add("country", "us")
 
     sanction = h.make_sanction(context, entity)
-    h.apply_date(sanction, "startDate", row.pop("exclusion_date"))
-    h.apply_date(sanction, "endDate", row.pop("reinstatement_date"))
+    h.apply_date(
+        sanction,
+        "startDate",
+        row.pop("exclusion_date"),
+        two_digit_year_base=TWO_DIGIT_EXCLUSION_YEAR_BASE,
+    )
+    h.apply_date(
+        sanction,
+        "endDate",
+        row.pop("reinstatement_date"),
+        two_digit_year_base=TWO_DIGIT_EXCLUSION_YEAR_BASE,
+    )
 
     is_debarred = h.is_active(sanction)
     if is_debarred:

--- a/datasets/us/mo/med_exclusions/crawler.py
+++ b/datasets/us/mo/med_exclusions/crawler.py
@@ -23,7 +23,14 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
     entity.add("country", "us")
 
     sanction = h.make_sanction(context, entity)
-    h.apply_date(sanction, "startDate", row.pop("term_date"))
+    h.apply_date(
+        sanction,
+        "startDate",
+        row.pop("term_date"),
+        # Exclusions cannot predate the 1977 Medicare-Medicaid Anti-Fraud and Abuse
+        # Amendments.
+        two_digit_year_base=1977,
+    )
     h.apply_date(sanction, "date", row.pop("letter_date"))
     sanction.add("reason", row.pop("termination_reason"))
 

--- a/datasets/us/wv/med_exclusions/crawler.py
+++ b/datasets/us/wv/med_exclusions/crawler.py
@@ -52,7 +52,12 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
 
     sanction = h.make_sanction(context, entity)
     h.apply_date(
-        sanction, "startDate", (row.pop("action_date") or "").replace("\n", "")
+        sanction,
+        "startDate",
+        (row.pop("action_date") or "").replace("\n", ""),
+        # Exclusions cannot predate the 1977 Medicare-Medicaid Anti-Fraud and Abuse
+        # Amendments.
+        two_digit_year_base=1977,
     )
     sanction.add("reason", flat(row.pop("reason_for_exclusion_termination")))
     sanction.add("provisions", flat(row.pop("excluded_terminated")))

--- a/zavod/docs/best_practices/dates_meta.md
+++ b/zavod/docs/best_practices/dates_meta.md
@@ -38,8 +38,21 @@ Finally, some datasets are just too messy to fully parse all contained dates. In
 
 ```yaml
 dates:
-    formats: ['%m %y']
+    formats: ['%m %Y']
     year_only: true
 ```
 
 This will parse any string that contains a valid year, such as `Approximately 1960`, or `circa 2007`.
+
+## Two-digit years
+
+A `%y` format needs a `two_digit_year_base`. The two-digit year is read as the first matching year that is not before that year. `h.apply_date`, `h.apply_dates` and `h.extract_date` accept the argument, and warn if a `%y` format matches without it.
+
+```python
+# Birth date: 100 years ago.
+h.apply_date(
+    person, "birthDate", "16-07-68", two_digit_year_base=h.TWO_DIGIT_BIRTH_YEAR_BASE
+)
+# Case date: the earliest possible event year.
+h.apply_date(sanction, "startDate", "16-07-68", two_digit_year_base=2000)
+```

--- a/zavod/docs/best_practices/dates_meta.md
+++ b/zavod/docs/best_practices/dates_meta.md
@@ -56,3 +56,14 @@ h.apply_date(
 # Case date: the earliest possible event year.
 h.apply_date(sanction, "startDate", "16-07-68", two_digit_year_base=2000)
 ```
+
+Helpers that apply dates themselves take the argument too, and you should prefer that
+over parsing the date before calling them. `h.make_occupancy` keys the occupancy ID on
+the date strings as given, so pre-parsing them silently renumbers every occupancy in
+the dataset.
+
+```python
+h.make_occupancy(
+    context, person, position, start_date="16-Jul-68", two_digit_year_base=1945
+)
+```

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "orjson == 3.11.9",
     "ijson > 3.2, < 4.0",
     "pdfplumber == 0.11.10",
-    "prefixdate == 0.5.0",
+    "prefixdate == 0.6.0",
     "psycopg2-binary",
     "pyicu == 2.16.2",
     "openai >= 1.33.0, < 3.0.0",

--- a/zavod/zavod/__init__.py
+++ b/zavod/zavod/__init__.py
@@ -13,6 +13,5 @@ __all__ = [
     "settings",
 ]
 
-logging.getLogger("prefixdate").setLevel(logging.ERROR)
 logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
 logging.getLogger("pdfminer").setLevel(logging.WARNING)

--- a/zavod/zavod/helpers/__init__.py
+++ b/zavod/zavod/helpers/__init__.py
@@ -50,6 +50,7 @@ from zavod.helpers.change import (
 )
 from zavod.helpers.crypto import extract_cryptos
 from zavod.helpers.dates import (
+    TWO_DIGIT_BIRTH_YEAR_BASE,
     apply_date,
     apply_dates,
     backdate,
@@ -132,6 +133,7 @@ __all__ = [
     "replace_months",
     "backdate",
     "within_max_age",
+    "TWO_DIGIT_BIRTH_YEAR_BASE",
     "apply_number",
     "convert_excel_cell",
     "convert_excel_date",

--- a/zavod/zavod/helpers/dates.py
+++ b/zavod/zavod/helpers/dates.py
@@ -22,8 +22,12 @@ NUMBERS = re.compile(r"\b\d+\b")
 ALWAYS_FORMATS = ["%Y-%m-%d", "%Y-%m", "%Y"]
 DateValue = str | date | datetime | None
 MAX_ENFORCEMENT_DAYS = 365 * 5
+# Birth dates are always before now, so a two-digit year denotes the most recent
+# 100 years. Pass this as `two_digit_year_base` when parsing birth dates.
+TWO_DIGIT_BIRTH_YEAR_BASE = RUN_TIME.year - 100
 
 __all__ = [
+    "TWO_DIGIT_BIRTH_YEAR_BASE",
     "extract_date",
     "parse_formats",
     "extract_years",
@@ -79,10 +83,21 @@ def extract_date(
     text: DateValue,
     formats: tuple[str] | None = None,
     fallback_to_original: bool = True,
+    two_digit_year_base: int | None = None,
 ) -> list[str]:
     """
     Extract a date from the provided text using predefined `formats` in the metadata.
     If the text doesn't match any format, returns the original text.
+
+    Args:
+        dataset: The dataset which contains a date format specification.
+        text: The date value to be parsed.
+        formats: A list of date formats to use for parsing, overriding dataset defaults.
+        fallback_to_original: Return the original text if no format matches, instead
+            of raising a `ValueError`.
+        two_digit_year_base: The earliest year a two-digit year may denote. A date
+            parsed from a `%y` format is moved into the century which places it in
+            the 100 years from this year. See `apply_date`.
     """
     if text is None:
         return []
@@ -99,7 +114,9 @@ def extract_date(
     replaced_text = replace_months(dataset, text)
     dataset_formats_ = dataset.dates.formats + ALWAYS_FORMATS
     formats_ = dataset_formats_ if formats is None else list(formats)
-    parsed = parse_formats(replaced_text, formats_)
+    parsed = parse_formats(
+        replaced_text, formats_, two_digit_year_base=two_digit_year_base
+    )
     if parsed.text is not None:
         return [parsed.text]
     if dataset.dates.year_only:
@@ -117,6 +134,7 @@ def apply_date(
     text: DateValue,
     formats: tuple[str] | None = None,
     original_value: str | None = None,
+    two_digit_year_base: int | None = None,
 ) -> None:
     """Apply a date value to an entity, parsing it if necessary and cleaning it up.
 
@@ -130,6 +148,10 @@ def apply_date(
         original_value: If provided, recorded as the entity's original value for
             this property instead of ``text``. Use when ``text`` has already been
             transformed.
+        two_digit_year_base: The earliest year a two-digit year may denote. A date
+            parsed from a `%y` format is moved into the century which places it in
+            the 100 years from this year. Use `TWO_DIGIT_BIRTH_YEAR_BASE` for a
+            birth date, and the earliest possible event year for a case date.
     """
     prop_ = entity.schema.get(prop)
     if prop_ is None or prop_.type != registry.date:
@@ -143,20 +165,40 @@ def apply_date(
 
     if original_value is None:
         original_value = text
-    dates = extract_date(entity.dataset, text, formats=formats)
+    dates = extract_date(
+        entity.dataset,
+        text,
+        formats=formats,
+        two_digit_year_base=two_digit_year_base,
+    )
     return entity.add(prop_, dates, original_value=original_value)
 
 
-def apply_dates(entity: Entity, prop: str, texts: Iterable[DateValue]) -> None:
+def apply_dates(
+    entity: Entity,
+    prop: str,
+    texts: Iterable[DateValue],
+    formats: tuple[str] | None = None,
+    two_digit_year_base: int | None = None,
+) -> None:
     """Apply a list of date values to an entity, parsing them if necessary and cleaning them up.
 
     Args:
         entity: The entity to which the date will be applied.
         prop: The property to which the date will be applied.
         texts: The iterable of date values to be applied.
+        formats: A list of date formats to use for parsing, overriding dataset defaults.
+        two_digit_year_base: The earliest year a two-digit year may denote. See
+            `apply_date`.
     """
     for text in texts:
-        apply_date(entity, prop, text)
+        apply_date(
+            entity,
+            prop,
+            text,
+            formats=formats,
+            two_digit_year_base=two_digit_year_base,
+        )
 
 
 def backdate(date: datetime, delta: timedelta) -> str:

--- a/zavod/zavod/helpers/positions.py
+++ b/zavod/zavod/helpers/positions.py
@@ -143,6 +143,7 @@ def make_occupancy(
     categorisation: PositionCategorisation | None = None,
     status: OccupancyStatus | None = None,
     key_prefix: str | None = None,
+    two_digit_year_base: int | None = None,
 ) -> Entity | None:
     """Creates and returns an Occupancy entity if the arguments meet our criteria
     for PEP position occupancy, otherwise returns None. Also adds the `role.pep` topic
@@ -178,6 +179,10 @@ def make_occupancy(
         start_date: Set if the date the person started occupying the position is known.
         end_date: Set if the date the person left the position is known.
         status: Overrides determining PEP occupancy status
+        two_digit_year_base: The earliest year a two-digit year may denote, applied to
+            all of the dates. Pass this rather than parsing the dates in the crawler,
+            because the occupancy ID is derived from the date strings as given. See
+            `apply_date`.
     """
     assert person.schema.is_a("Person")
     assert position.schema.is_a("Position")
@@ -201,11 +206,15 @@ def make_occupancy(
     occupancy.add("holder", person)
     occupancy.add("post", position)
 
-    h.apply_date(occupancy, "startDate", start_date)
-    h.apply_date(occupancy, "endDate", end_date)
-    h.apply_date(occupancy, "periodStart", period_start)
-    h.apply_date(occupancy, "periodEnd", period_end)
-    h.apply_date(occupancy, "electionDate", election_date)
+    dates = {
+        "startDate": start_date,
+        "endDate": end_date,
+        "periodStart": period_start,
+        "periodEnd": period_end,
+        "electionDate": election_date,
+    }
+    for prop, value in dates.items():
+        h.apply_date(occupancy, prop, value, two_digit_year_base=two_digit_year_base)
 
     if categorisation is not None and not categorisation.is_pep:
         context.log.warning(

--- a/zavod/zavod/tests/fixtures/testdataset1/testdataset1.yml
+++ b/zavod/zavod/tests/fixtures/testdataset1/testdataset1.yml
@@ -28,6 +28,7 @@ http:
 dates:
   formats:
     - "%d. %b %Y"
+    - "%d-%b-%y"
   months:
     mar: März
 names:

--- a/zavod/zavod/tests/helpers/test_dates.py
+++ b/zavod/zavod/tests/helpers/test_dates.py
@@ -1,4 +1,7 @@
+import logging
 from datetime import datetime, timedelta, UTC
+
+import pytest
 from structlog.testing import capture_logs
 
 from zavod.context import Context
@@ -31,6 +34,54 @@ def test_extract_date(testdataset1: Dataset):
     # Check always-accepted formats
     assert "%Y-%m" not in testdataset1.dates.formats
     assert extract_date(testdataset1, "2023-01") == ["2023-01"]
+
+
+def test_extract_date_two_digit_year(
+    testdataset1: Dataset, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The base date selects the century.
+    assert extract_date(
+        testdataset1,
+        "16-07-68",
+        formats=("%d-%m-%y",),
+        two_digit_year_base=1926,
+    ) == ["1968-07-16"]
+    assert extract_date(
+        testdataset1,
+        "16-07-68",
+        formats=("%d-%m-%y",),
+        two_digit_year_base=2000,
+    ) == ["2068-07-16"]
+
+    # Without a base year, the fixed strptime window applies and prefixdate warns.
+    # The warning reaches the dataset issue log through the standard logging chain.
+    with caplog.at_level(logging.WARNING, logger="prefixdate.formats"):
+        assert extract_date(testdataset1, "23-10-64", formats=("%d-%m-%y",)) == [
+            "2064-10-23"
+        ]
+    assert "two-digit year format" in caplog.text, caplog.text
+
+
+def test_apply_date_two_digit_year(testdataset1: Dataset):
+    data = {"id": "doe", "schema": "Person", "properties": {"name": ["John Doe"]}}
+    person = Entity(testdataset1, data)
+    apply_date(
+        person,
+        "birthDate",
+        "16-07-68",
+        formats=("%d-%m-%y",),
+        two_digit_year_base=1926,
+    )
+    assert person.pop("birthDate") == ["1968-07-16"]
+
+    apply_dates(
+        person,
+        "birthDate",
+        ["16-07-68", "23-10-64"],
+        formats=("%d-%m-%y",),
+        two_digit_year_base=1926,
+    )
+    assert sorted(person.pop("birthDate")) == ["1964-10-23", "1968-07-16"]
 
 
 def test_replace_months(testdataset1: Dataset):

--- a/zavod/zavod/tests/helpers/test_positions.py
+++ b/zavod/zavod/tests/helpers/test_positions.py
@@ -225,6 +225,36 @@ def test_make_occupancy(testdataset1: Dataset):
     context.close()
 
 
+def test_make_occupancy_two_digit_year(testdataset1: Dataset):
+    """The base year picks the century, but the ID keys on the date string as it was
+    given, so adopting a base year does not renumber a dataset's occupancies."""
+    context = Context(testdataset1)
+    pos = make_position(context, name="A position", country="ls")
+    person = context.make("Person")
+    person.id = "thabo"
+
+    def make(base):
+        occupancy = make_occupancy(
+            context,
+            person=person,
+            position=pos,
+            current_time=datetime(2000, 1, 3),
+            start_date="16-Jul-68",
+            two_digit_year_base=base,
+        )
+        assert occupancy is not None
+        return occupancy
+
+    based = make(1945)
+    assert based.get("startDate") == ["1968-07-16"]
+
+    # Without a base year, strptime's fixed window puts it in the next century.
+    unbased = make(None)
+    assert unbased.get("startDate") == ["2068-07-16"]
+    assert unbased.id == based.id
+    context.close()
+
+
 def test_occupancy_not_same_start_end_id(testdataset1: Dataset):
     """Test that an occupancy with the same start but no end, and one with the
     same end but no start, don't end up with the same ID. This occurs in the wild


### PR DESCRIPTION
`strptime` reads two-digit years 00-68 as 20xx and 69-99 as 19xx, so a date outside that window parses into the wrong century and is stored as fully valid. `be_fod_sanctions` publishes birth dates like 2068-07-16 today (https://github.com/opensanctions/opensanctions/issues/4940).

- `h.extract_date`, `h.apply_date` and `h.apply_dates` take a `two_digit_year_base`, the earliest year a two-digit year may denote.
- Parsing a `%y` format without a base year raises a dataset issue.
- `h.TWO_DIGIT_BIRTH_YEAR_BASE` is 100 years ago, because birth dates are always before now. Case dates use the earliest possible event year.

The century logic itself lives in prefixdate: https://github.com/pudo/prefixdate/pull/3. **CI fails until that is released** — this branch pins `prefixdate == 0.6.0`, which does not exist yet.

## Which datasets need it

29 datasets configure a `%y` format. For each one I streamed the latest published `statements.pack`, re-ran the dataset's own format list over every date value, and recorded which format actually matched.

**Found** is measured from that pass: counts are published values matching a `%y` format, and "never" means no published value of that property matches one.

**Change** separates the two kinds of claim. *Measured* is the earliest published value of that property parsed by a **four-digit** year format — the only values that can evidence how far back the property reaches, since a two-digit value already carries the wrong century. *Assumed* is my reasoning for the base year, which is domain knowledge and not derived from the data; it is what a reviewer needs to check.

### Base year passed (17)

| Dataset | Found | Change |
|---|---|---|
| `c4ads_xinjiang` | 2707 of 2707 `incorporationDate` are `%m/%d/%y` | `incorporationDate` after 1950. No four-digit value exists to measure against. Assumed: the XPCC was founded in 1954, so no company of its is older. |
| `c4ads_xinjiang_mining` | 7031 of 7031 `endDate` are `%m/%d/%y` | `endDate` after 1990. No four-digit value exists to measure against. Assumed: no mining permit is older, and permits expire in the future. |
| `us_fdic_failed_banks` | 575 of 575 `dissolutionDate` are `%d-%b-%y` | `dissolutionDate` after 2000. No four-digit value exists to measure against. Assumed: the FDIC list covers bank failures since October 2000. |
| `un_ga_protocol` | 521 of 521 appointment dates are `%d-%b-%y` | occupancy `start_date` after 1945. No four-digit value exists to measure against. Assumed: the UN was founded in 1945, so no office-holder was appointed earlier. |
| `us_bis_antiboycott` | 100 of 100 `listingDate` are `%m/%d/%y` | `listingDate` after 1977. No four-digit value exists to measure against. Assumed: the U.S. antiboycott regulations came into force in 1977. |
| `un_1718_vessels` | 57 of 59 `startDate` are `%d-%b-%y` | `startDate` after 2000. No four-digit value exists to measure against. Assumed: the 1718 Committee was established in 2006. |
| `us_hi_med_exclusions` | 206 of 206 `startDate` and 12 of 15 `endDate` are `%m/%d/%y` | both after 1977. Measured: earliest four-digit `endDate` is 2019-06-06, and `startDate` has none. Assumed: exclusions cannot predate the 1977 Medicare-Medicaid Anti-Fraud and Abuse Amendments, and can end in the future. |
| `be_fod_sanctions` | 137 `birthDate` and 137 `listingDate` are `%d-%m-%y`; the rest ISO | `birthDate` after 115 years ago (`h.TWO_DIGIT_BIRTH_YEAR_BASE - 15`), `listingDate` after 1990. Measured: four-digit `birthDate` values run 1925-01-25 to 2004-05-20, so the plain 100-year window starts too late; earliest `listingDate` is 2002-05-29. Assumed: a sanctioned person is old enough to have acted, so 15 years of extra room is safe, and the oldest measures implement UNSCR 1267 (1999). |
| `cn_sanctions` | 156 of 557 `startDate` and 1 of 3 `endDate` are `%d.%m.%y` | both after 2010. Measured: earliest four-digit `startDate` is 2019-12-02, earliest `endDate` 2026-04-24. Assumed: China started to publish counter-sanctions in 2019. |
| `in_nse_debarred` | 330 of 6318 `endDate` match 9 different `REVOKED … %y` formats; `date` never does | `endDate` only, after 1990. Measured: earliest four-digit `endDate` is 2012-04-09. Assumed: no order is older, and a debarment can end in the future. |
| `il_wmd_sanctions` | 121 of 276 `modifiedAt` are `%d %m %y`; `birthDate` and `startDate` never | `modifiedAt` only, after 2000. Measured: earliest four-digit `modifiedAt` is 2018-03-12. Assumed: no designation on the list is older. |
| `us_mo_med_exclusions` | 14 of 263 `startDate` are `%m/%d/%y`; `date` never | `startDate` only, after 1977. Measured: earliest four-digit `startDate` is 2011-02-03. Assumed: the exclusion cannot predate the 1977 Amendments. |
| `us_wv_med_exclusions` | 3 of 165 `startDate` are `%m/%d/%y` | `startDate` only, after 1977. Measured: earliest four-digit `startDate` is 2010-04-20. Assumed: the exclusion cannot predate the 1977 Amendments. |
| `icij_offshoreleaks` | 566 relationship `startDate` and 14 `endDate` are `%d/%m/%y`; incorporation and dissolution dates never, over all 34.2M statements | relationship dates only, after 1950. Not measured — I skipped the second 34.2M-statement pass. Assumed: the oldest officer relationships in the leaked registers are from the 1950s. |
| `ca_dfatd_sema_sanctions` | 1 `birthDate` is `%b-%y` (`Sep-99`); `listingDate` and `buildDate` never | `birthDate` only, after 115 years ago (`h.TWO_DIGIT_BIRTH_YEAR_BASE - 15`). Measured: four-digit `birthDate` values run 1924-02-21 to 2004-08-31, so the plain 100-year window starts too late. Assumed: a sanctioned person is old enough to have acted, so 15 years of extra room is safe. |
| `il_mod_crypto` | 1 `birthDate` is `%m.%d.%y` (`01.02.92`); sanction dates never | `birthDate` only, after 100 years ago (`h.TWO_DIGIT_BIRTH_YEAR_BASE`). Measured: four-digit `birthDate` values run 1952-11-08 to 2003-07-26, inside the window. Assumed: a birth date is always before now. |
| `us_de_med_exclusions` | 1 `startDate` is `%m/%d/%y`; `endDate` never | `startDate` only, after 1977. Measured: earliest four-digit `startDate` is 2007-01-19. Assumed: the exclusion cannot predate the 1977 Amendments. |

### No change (12)

The `%y` format never matches a published value in these, so passing a base year would be speculative. Their `%y` config is dead and worth removing separately.

| Dataset | Found |
|---|---|
| `us_sc_med_exclusions` | all 1345 `startDate` are ISO. Inferred, not measured: the XLSX cells reach the crawler as datetimes, which is why |
| `us_al_med_exclusions` | 2079 dates are ISO or `%m/%d/%Y` |
| `us_ms_med_exclusions` | 312 dates across 3 properties are ISO |
| `us_nd_med_exclusions` | 193 `startDate` are ISO or `%m/%d/%Y` |
| `us_oh_med_exclusions` | 3858 `birthDate` and `startDate` are ISO or `%m/%d/%Y` |
| `afdb_sanctions` | 2543 `startDate` and `endDate` are ISO |
| `au_dfat_sanctions` | 2957 `birthDate` match 8 other formats; 7714 listing dates match none, their raw values being `2026-04-14T00:00:00` (inferred, not measured: they reach the crawler as datetimes) |
| `tr_fcib` | 3732 dates match `%d.%m.%Y`, ISO or `%d %m %Y` |
| `lv_fiu_sanctions` | 186 dates are ISO or `%d.%m.%Y.` |
| `cu_inventario_legislatura` | 470 `birthDate` are ISO |
| `us_bis_oac` | all 211 `listingDate` are `%B %Y`; the configured `%b-%y` never matches |
| `ve_asamblea_nacional` | 6 `birthDate` match `%d-%m-%Y`, `%d/%m/%Y` or `%d %b %Y` |

### The birth-date window

`h.TWO_DIGIT_BIRTH_YEAR_BASE` is `RUN_TIME.year - 100`, a window of 1926-2025 today. Measured against the published data that is too late at the old end for two sanctions lists: four-digit birth dates run 1925-01-25 to 2004-05-20 in `be_fod_sanctions` and 1924-02-21 to 2004-08-31 in `ca_dfatd_sema_sanctions`. A two-digit `24` or `25` there would read as 2024 or 2025.

Both now pass `h.TWO_DIGIT_BIRTH_YEAR_BASE - 15`, a window of 1911-2010. A person on a sanctions list is old enough to have acted, so giving up the last 15 years costs nothing and covers the measured range with room at both ends. `il_mod_crypto` keeps the plain constant, its measured range being 1952-2003.

This changes no published value today: the 137 two-digit birth dates on the Belgian list run 1964 to 2006 and resolve identically under either window. It does move the risk to the other end: a two-digit birth year after 2010 on these two lists would now read as 1911 onwards. That is the trade — you cannot be on a sanctions list at that age — but it is where the window now runs out.

Closes https://github.com/opensanctions/opensanctions/issues/4930
Closes https://github.com/opensanctions/opensanctions/issues/4940
Closes https://github.com/opensanctions/opensanctions/issues/4974

🤖 Generated with [Claude Code](https://claude.com/claude-code)
