### PR TITLE
Drop removed setup-buildx install input

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -68,8 +68,6 @@ jobs:
         run: echo "BUILD_DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          install: true
       - name: Login to Github Container Registry
         uses: docker/login-action@v4.5.2
         with:


### PR DESCRIPTION
setup-buildx-action v4.0.0 removed the deprecated `install` input, so passing it only produces an "Unexpected input(s) 'install'" warning on every build-ui run. No replacement is needed: the image build goes through `docker/build-push-action`, which invokes buildx directly, and Docker Engine ≥ 23 aliases `docker build` to buildx anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)