### PR TITLE
wd_categories: link position blocks to their Wikidata items

### DIFF
--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -238,6 +238,7 @@ config:
       country: sa
       position:
         name: Crown Prince of Saudi Arabia
+        wikidata_id: Q12251224
         country: sa
     - category: Government_ministers_of_Bahrain
       topic: role.pep
@@ -377,6 +378,7 @@ config:
       country: kp
       position:
         name: Member of the Supreme People's Assembly
+        wikidata_id: Q21328639
         country: kp
         topics:
           - gov.legislative
@@ -486,6 +488,7 @@ config:
       topic: role.pep
       position:
         name: Secretary-General of the United Nations
+        wikidata_id: Q81066
         country: zz
         topics:
           - gov.igo
@@ -493,6 +496,7 @@ config:
       topic: role.pep
       position:
         name: Under-Secretary-General of the United Nations
+        wikidata_id: Q2932400
         country: zz
         topics:
           - gov.igo
@@ -500,6 +504,7 @@ config:
       topic: role.pep
       position:
         name: Secretary General of the OSCE
+        wikidata_id: Q110934652
         country: zz
         topics:
           - gov.igo
@@ -514,6 +519,7 @@ config:
       topic: role.pep
       position:
         name: Secretary General of the Council of Europe
+        wikidata_id: Q2942251
         country: eu
         topics:
           - gov.igo
@@ -521,6 +527,7 @@ config:
       topic: role.pep
       position:
         name: President of the International Criminal Court
+        wikidata_id: Q7241113
         country: zz
         topics:
           - gov.igo
@@ -528,6 +535,7 @@ config:
       topic: role.pep
       position:
         name: Judge at the International Criminal Court
+        wikidata_id: Q965043
         country: zz
         topics:
           - role.judge
@@ -536,6 +544,7 @@ config:
       topic: role.pep
       position:
         name: Prosecutor of the International Criminal Court
+        wikidata_id: Q7250572
         country: zz
         topics:
           - gov.igo
@@ -549,6 +558,7 @@ config:
       topic: role.pep
       position:
         name: President of the World Bank Group
+        wikidata_id: Q4166474
         country: zz
         topics:
           - gov.igo
@@ -556,6 +566,7 @@ config:
       topic: role.pep
       position:
         name: Managing Director of the International Monetary Fund
+        wikidata_id: Q20054152
         country: zz
         topics:
           - gov.igo
@@ -567,6 +578,7 @@ config:
       topic: role.pep
       position:
         name: Director-General of the World Health Organization
+        wikidata_id: Q62070236
         country: zz
         topics:
           - gov.igo
@@ -574,12 +586,14 @@ config:
       topic: role.pep
       position:
         name: Secretary General of OPEC
+        wikidata_id: Q6596647
         topics:
           - gov.igo
     - category: NATO_Supreme_Allied_Commanders
       topic: role.pep
       position:
         name: NATO Supreme Allied Commander
+        wikidata_id: Q1640949
         topics:
           - gov.igo
           - mil
@@ -587,6 +601,7 @@ config:
       topic: role.pep
       position:
         name: Secretary General of NATO
+        wikidata_id: Q167662
         topics:
           - gov.igo
           - mil
@@ -594,12 +609,14 @@ config:
       topic: role.pep
       position:
         name: Chairperson of the African Union Commission
+        wikidata_id: Q2571270
         topics:
           - gov.igo
     - category: Secretaries_general_of_the_Organization_of_American_States
       topic: role.pep
       position:
         name: Secretary General of the Organization of American States
+        wikidata_id: Q6123153
         topics:
           - gov.igo
     - category: Organization_of_American_States_people
@@ -614,6 +631,7 @@ config:
       topic: role.pep
       position:
         name: Secretary General of the Arab League
+        wikidata_id: Q12180685
         country: zz
         topics:
           - gov.igo
@@ -621,6 +639,7 @@ config:
       topic: role.pep
       position:
         name: Secretary General of the Gulf Cooperation Council
+        wikidata_id: Q104127429
         country: zz
         topics:
           - gov.igo
@@ -628,6 +647,7 @@ config:
       topic: role.pep
       position:
         name: President of Interpol
+        wikidata_id: Q19698214
         country: zz
         topics:
           - gov.igo
@@ -635,6 +655,7 @@ config:
       topic: role.pep
       position:
         name: President of the Inter-American Development Bank
+        wikidata_id: Q58281251
         country: zz
         topics:
           - gov.igo
@@ -650,6 +671,7 @@ config:
       topic: role.pep
       position:
         name: President of the United Nations General Assembly
+        wikidata_id: Q1161813
         country: zz
         topics:
           - gov.igo
@@ -663,6 +685,7 @@ config:
       topic: poi
       position:
         name: President of FIFA
+        wikidata_id: Q22955080
         country: zz
         topics:
           - gov.igo
@@ -670,6 +693,7 @@ config:
       topic: poi
       position:
         name: President of the International Olympic Committee
+        wikidata_id: Q7241513
         country: zz
         topics:
           - gov.igo
@@ -717,6 +741,7 @@ config:
       country: us
       position:
         name: Justice of the Supreme Court of the United States
+        wikidata_id: Q20706330
         country: us
         topics:
           - role.judge
@@ -726,6 +751,7 @@ config:
       country: us
       position:
         name: President of the United States
+        wikidata_id: Q11696
         country: us
         topics:
           - gov.head
@@ -734,6 +760,7 @@ config:
       country: us
       position:
         name: Chief Justice of the United States
+        wikidata_id: Q11147
         country: us
         topics:
           - role.judge
@@ -748,6 +775,7 @@ config:
       country: us
       position:
         name: White House Counsel
+        wikidata_id: Q1296423
         country: us
         topics:
           - role.lawyer
@@ -912,6 +940,7 @@ config:
       topic: role.pep
       position:
         name: President of the European Commission
+        wikidata_id: Q8882
         country: eu
         topics:
           - gov.igo
@@ -924,6 +953,7 @@ config:
       country: eu
       position:
         name: President of the European Council
+        wikidata_id: Q735587
         country: eu
         topics:
           - gov.igo
@@ -940,6 +970,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Chamber of Deputies
+        wikidata_id: Q18534310
         country: mx
         topics:
           - gov.legislative
@@ -949,6 +980,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Chamber of Deputies
+        wikidata_id: Q18534310
         country: mx
         topics:
           - gov.legislative
@@ -958,6 +990,7 @@ config:
       topic: role.pep
       position:
         name: Members of the Senate of the Republic
+        wikidata_id: Q19971999
         country: mx
         topics:
           - gov.legislative
@@ -967,6 +1000,7 @@ config:
       topic: role.pep
       position:
         name: Members of the Senate of the Republic
+        wikidata_id: Q19971999
         country: mx
         topics:
           - gov.legislative
@@ -1011,6 +1045,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Assembly
+        wikidata_id: Q21295982
         country: ec
         topics:
           - gov.legislative
@@ -1020,6 +1055,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Congress
+        wikidata_id: Q22230757
         country: ec
         topics:
           - gov.legislative
@@ -1029,6 +1065,7 @@ config:
       topic: role.pep
       position:
         name: President of the National Assembly
+        wikidata_id: Q6085548
         country: ec
         topics:
           - gov.legislative
@@ -1056,6 +1093,7 @@ config:
       topic: role.pep
       position:
         name: President of Ecuador
+        wikidata_id: Q732562
         country: ec
         topics:
           - gov.head
@@ -1065,6 +1103,7 @@ config:
       topic: role.pep
       position:
         name: Vice President of Ecuador
+        wikidata_id: Q4261569
         country: ec
         topics:
           - gov.executive
@@ -1081,6 +1120,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Assembly
+        wikidata_id: Q21295982
         country: ec
         topics:
           - gov.legislative
@@ -1101,6 +1141,7 @@ config:
       topic: role.pep
       position:
         name: President of Ecuador
+        wikidata_id: Q732562
         country: ec
         topics:
           - gov.head
@@ -1111,6 +1152,7 @@ config:
       topic: role.pep
       position:
         name: Vice President of Ecuador
+        wikidata_id: Q4261569
         country: ec
         topics:
           - gov.executive
@@ -1143,6 +1185,7 @@ config:
       depth: 0
       position:
         name: President of Colombia
+        wikidata_id: Q853475
         country: co
         topics:
           - gov.head
@@ -1155,6 +1198,7 @@ config:
       topic: role.pep
       position:
         name: Mayor of Bogotá
+        wikidata_id: Q21994938
         country: co
         topics:
           - gov.muni
@@ -1168,6 +1212,7 @@ config:
       topic: role.pep
       position:
         name: Senator
+        wikidata_id: Q19254253
         country: co
         topics:
           - gov.legislative
@@ -1183,6 +1228,7 @@ config:
       depth: 0
       position:
         name: President of Colombia
+        wikidata_id: Q853475
         country: co
         topics:
           - gov.head
@@ -1193,6 +1239,7 @@ config:
       topic: role.pep
       position:
         name: Vice President of Colombia
+        wikidata_id: Q17104133
         country: co
         topics:
           - gov.executive
@@ -1209,6 +1256,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Assembly
+        wikidata_id: Q20011182
         country: ve
         topics:
           - gov.legislative
@@ -1220,6 +1268,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Senate of Venezuela
+        wikidata_id: Q20081434
         country: ve
         topics:
           - gov.legislative
@@ -1231,6 +1280,7 @@ config:
       topic: role.pep
       position:
         name: President of Venezuela
+        wikidata_id: Q11942698
         country: ve
         topics:
           - gov.head
@@ -1242,6 +1292,7 @@ config:
       topic: role.pep
       position:
         name: Vice President of Venezuela
+        wikidata_id: Q3556895
         country: ve
         topics:
           - gov.executive
@@ -1263,6 +1314,7 @@ config:
       topic: role.pep
       position:
         name: Deputy of Venezuela
+        wikidata_id: Q20011182
         country: ve
         topics:
           - gov.legislative
@@ -1275,6 +1327,7 @@ config:
       topic: role.pep
       position:
         name: President of Venezuela
+        wikidata_id: Q11942698
         country: ve
         topics:
           - gov.head
@@ -1307,6 +1360,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Assembly
+        wikidata_id: Q18616113
         country: ni
         topics:
           - gov.legislative
@@ -1316,6 +1370,7 @@ config:
       topic: role.pep
       position:
         name: President of Nicaragua
+        wikidata_id: Q852448
         country: ni
         topics:
           - gov.head
@@ -1325,6 +1380,7 @@ config:
       topic: role.pep
       position:
         name: Vice President of Nicaragua
+        wikidata_id: Q3649507
         country: ni
         topics:
           - gov.executive
@@ -1337,6 +1393,7 @@ config:
       topic: role.pep
       position:
         name: Mayor of Managua
+        wikidata_id: Q104881755
         country: ni
         topics:
           - gov.muni
@@ -1349,6 +1406,7 @@ config:
       topic: role.pep
       position:
         name: President of Nicaragua
+        wikidata_id: Q852448
         country: ni
         topics:
           - gov.head
@@ -1382,6 +1440,7 @@ config:
       topic: role.pep
       position:
         name: President of Guatemala
+        wikidata_id: Q6085537
         country: gt
         topics:
           - gov.head
@@ -1391,6 +1450,7 @@ config:
       topic: role.pep
       position:
         name: Vice President of Guatemala
+        wikidata_id: Q5340773
         country: gt
         topics:
           - gov.executive
@@ -1403,6 +1463,7 @@ config:
       topic: role.pep
       position:
         name: Mayor of Guatemala City
+        wikidata_id: Q116790781
         country: gt
         topics:
           - gov.muni
@@ -1412,6 +1473,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Congress of Guatemala
+        wikidata_id: Q18277108
         country: gt
         topics:
           - gov.legislative
@@ -1425,6 +1487,7 @@ config:
       topic: role.pep
       position:
         name: President of Guatemala
+        wikidata_id: Q6085537
         country: gt
         topics:
           - gov.head
@@ -1435,6 +1498,7 @@ config:
       topic: role.pep
       position:
         name: Vice President of Guatemala
+        wikidata_id: Q5340773
         country: gt
         topics:
           - gov.executive
@@ -1449,6 +1513,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Congress of Guatemala
+        wikidata_id: Q18277108
         country: gt
         topics:
           - gov.legislative
@@ -1483,6 +1548,7 @@ config:
       topic: role.pep
       position:
         name: Prime Minister
+        wikidata_id: Q12379704
         country: by
         topics:
           - gov.executive
@@ -1492,6 +1558,7 @@ config:
       topic: role.pep
       position:
         name: Deputy Prime Minister
+        wikidata_id: Q18690228
         country: by
         topics:
           - gov.executive
@@ -1501,6 +1568,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Foreign Affairs
+        wikidata_id: Q2045068
         country: by
         topics:
           - gov.executive
@@ -1510,6 +1578,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Defence
+        wikidata_id: Q44035369
         country: by
         topics:
           - gov.executive
@@ -1519,6 +1588,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Finance
+        wikidata_id: Q106510813
         country: by
         topics:
           - gov.executive
@@ -1528,6 +1598,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Internal Affairs
+        wikidata_id: Q100699741
         country: by
         topics:
           - gov.executive
@@ -1537,6 +1608,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Justice
+        wikidata_id: Q106510814
         country: by
         topics:
           - gov.executive
@@ -1546,6 +1618,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Health Care
+        wikidata_id: Q89775465
         country: by
         topics:
           - gov.executive
@@ -1555,6 +1628,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Transport and Communications
+        wikidata_id: Q60676745
         country: by
         topics:
           - gov.executive
@@ -1564,6 +1638,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Telecommunications and Informatisation
+        wikidata_id: Q28598480
         country: by
         topics:
           - gov.executive
@@ -1573,6 +1648,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Industry
+        wikidata_id: Q106508605
         country: by
         topics:
           - gov.executive
@@ -1582,6 +1658,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Information
+        wikidata_id: Q106399613
         country: by
         topics:
           - gov.executive
@@ -1592,6 +1669,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Sejm
+        wikidata_id: Q19269361
         country: pl
         topics:
           - gov.legislative
@@ -1601,6 +1679,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Sejm
+        wikidata_id: Q19269361
         country: pl
         topics:
           - gov.legislative
@@ -1610,6 +1689,7 @@ config:
       topic: role.pep
       position:
         name: Senator of the Republic of Poland
+        wikidata_id: Q81747225
         country: pl
         topics:
           - gov.legislative
@@ -1619,6 +1699,7 @@ config:
       topic: role.pep
       position:
         name: Senator of the Republic of Poland
+        wikidata_id: Q81747225
         country: pl
         topics:
           - gov.legislative
@@ -1711,6 +1792,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Chamber of Deputies
+        wikidata_id: Q19803234
         country: cz
         topics:
           - gov.legislative
@@ -1719,6 +1801,7 @@ config:
       country: cz
       position:
         name: Member of the Chamber of Deputies
+        wikidata_id: Q19803234
         country: cz
         topics:
           - gov.legislative
@@ -1726,6 +1809,7 @@ config:
       country: cz
       position:
         name: Senator of the Czech Republic
+        wikidata_id: Q18941264
         country: cz
         topics:
           - gov.legislative
@@ -1733,6 +1817,7 @@ config:
       country: cz
       position:
         name: President of the Czech Republic
+        wikidata_id: Q1819381
         country: cz
         topics:
           - gov.head
@@ -1741,6 +1826,7 @@ config:
       topic: role.pep
       position:
         name: Minister of the Czech Republic
+        wikidata_id: Q68081922
         country: cz
         topics:
           - gov.executive
@@ -1762,6 +1848,7 @@ config:
       country: cz
       position:
         name: Judge of the Constitutional Court of the Czech Republic
+        wikidata_id: Q59773473
         country: cz
         topics:
           - gov.judicial
@@ -1776,6 +1863,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Council
+        wikidata_id: Q19967563
         country: sk
         topics:
           - gov.legislative
@@ -1785,6 +1873,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Council
+        wikidata_id: Q19967563
         country: sk
         topics:
           - gov.legislative
@@ -1804,6 +1893,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Assembly of Hungary
+        wikidata_id: Q17590876
         country: hu
         topics:
           - gov.legislative
@@ -1813,6 +1903,7 @@ config:
       topic: role.pep
       position:
         name: Member of the National Assembly of Hungary
+        wikidata_id: Q17590876
         country: hu
         topics:
           - gov.legislative
@@ -1841,6 +1932,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Congress of Deputies
+        wikidata_id: Q18171345
         country: es
         topics:
           - gov.legislative
@@ -1850,6 +1942,7 @@ config:
       topic: role.pep
       position:
         name: Senator of Spain
+        wikidata_id: Q19323171
         country: es
         topics:
           - gov.legislative
@@ -1859,6 +1952,7 @@ config:
       topic: role.pep
       position:
         name: President of the Congress of Deputies
+        wikidata_id: Q17014422
         country: es
         topics:
           - gov.legislative
@@ -1868,6 +1962,7 @@ config:
       topic: role.pep
       position:
         name: President of the Senate of Spain
+        wikidata_id: Q1335465
         country: es
         topics:
           - gov.legislative
@@ -1877,6 +1972,7 @@ config:
       topic: role.pep
       position:
         name: Prime Minister of Spain
+        wikidata_id: Q844587
         country: es
         topics:
           - gov.head
@@ -1886,6 +1982,7 @@ config:
       topic: role.pep
       position:
         name: Deputy Prime Minister of Spain
+        wikidata_id: Q3113035
         country: es
         topics:
           - gov.executive
@@ -1895,6 +1992,7 @@ config:
       topic: role.pep
       position:
         name: Minister of Spain
+        wikidata_id: Q20899145
         country: es
         topics:
           - gov.executive
@@ -1919,6 +2017,7 @@ config:
       topic: role.pep
       position:
         name: Mayor (Spain)
+        wikidata_id: Q5663900
         country: es
         topics:
           - gov.head
@@ -1936,6 +2035,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Senate
+        wikidata_id: Q19305384
         country: nl
         topics:
           - gov.legislative
@@ -1945,6 +2045,7 @@ config:
       topic: role.pep
       position:
         name: Member of the House of Representatives
+        wikidata_id: Q18887908
         country: nl
         topics:
           - gov.legislative
@@ -1959,6 +2060,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Bundestag
+        wikidata_id: Q1939555
         country: de
         topics:
           - gov.legislative
@@ -1968,6 +2070,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Bundesrat
+        wikidata_id: Q15835370
         country: de
         topics:
           - gov.legislative
@@ -2254,6 +2357,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Saeima
+        wikidata_id: Q21191589
         country: lv
         topics:
           - gov.legislative
@@ -2264,6 +2368,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Saeima
+        wikidata_id: Q21191589
         country: lv
         topics:
           - gov.legislative
@@ -2406,6 +2511,7 @@ config:
       country: au
       position:
         name: Member of the Australian Parliament
+        wikidata_id: Q18912794
         country: au
         topics:
           - gov.legislative
@@ -2418,6 +2524,7 @@ config:
       country: au
       position:
         name: Australian Senator
+        wikidata_id: Q6814428
         country: au
         topics:
           - gov.legislative
@@ -2660,6 +2767,7 @@ config:
       topic: role.pep
       position:
         name: Member of the Hellenic Parliament
+        wikidata_id: Q18915989
         country: gr
         topics:
           - gov.legislative
@@ -2707,6 +2815,7 @@ config:
       language: ru
       position:
         name: Head of the Administration of the President of Russia
+        wikidata_id: Q4488944
         country: ru
         topics:
           - gov.executive
@@ -2719,6 +2828,7 @@ config:
       language: ru
       position:
         name: Prime Minister of the Russian Federation
+        wikidata_id: Q842386
         country: ru
         topics:
           - gov.head
@@ -2730,6 +2840,7 @@ config:
       language: ru
       position:
         name: First Deputy Prime Minister of the Russian Federation
+        wikidata_id: Q1965788
         country: ru
         topics:
           - gov.executive
@@ -2740,6 +2851,7 @@ config:
       country: ru
       position:
         name: Deputy Prime Minister of the Russian Federation
+        wikidata_id: Q14805701
         country: ru
         topics:
           - gov.executive
@@ -2750,6 +2862,7 @@ config:
       country: ru
       position:
         name: Head of the Apparatus of the Government of the Russian Federation
+        wikidata_id: Q107883642
         country: ru
         topics:
           - gov.executive
@@ -2815,6 +2928,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Duma of the Russian Federation
+        wikidata_id: Q17276321
         country: ru
         topics:
           - gov.legislative
@@ -2825,6 +2939,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Duma of the Russian Federation
+        wikidata_id: Q17276321
         country: ru
         topics:
           - gov.legislative
@@ -2835,6 +2950,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Duma of the Russian Federation
+        wikidata_id: Q17276321
         country: ru
         topics:
           - gov.legislative
@@ -2857,6 +2973,7 @@ config:
       language: ru
       position:
         name: Deputy of the Federation Council of Russia
+        wikidata_id: Q4516946
         country: ru
         topics:
           - gov.legislative
@@ -2867,6 +2984,7 @@ config:
       language: ru
       position:
         name: Member of the Federation Council of Russia
+        wikidata_id: Q4516946
         country: ru
         topics:
           - gov.legislative
@@ -2877,6 +2995,7 @@ config:
       language: ru
       position:
         name: Member of the Federation Council of Russia
+        wikidata_id: Q4516946
         country: ru
         topics:
           - gov.legislative
@@ -2887,6 +3006,7 @@ config:
       language: ru
       position:
         name: Chairman of the Federation Council of Russia
+        wikidata_id: Q4376672
         country: ru
         topics:
           - gov.legislative
@@ -2907,6 +3027,7 @@ config:
       language: ru
       position:
         name: Member of the Federation Council
+        wikidata_id: Q4516946
         country: ru
         topics:
           - gov.legislative
@@ -2917,6 +3038,7 @@ config:
       language: ru
       position:
         name: Member of the Federation Council
+        wikidata_id: Q4516946
         topics:
           - gov.legislative
           - gov.national
@@ -2925,6 +3047,7 @@ config:
       language: ru
       position:
         name: Member of the Federation Council
+        wikidata_id: Q4516946
         country: ua-cri
         topics:
           - gov.legislative
@@ -2935,6 +3058,7 @@ config:
       language: ru
       position:
         name: Member of the Federation Council
+        wikidata_id: Q4516946
         topics:
           - gov.legislative
           - gov.national
@@ -2944,6 +3068,7 @@ config:
       language: ru
       position:
         name: Member of the Federation Council
+        wikidata_id: Q4516946
         topics:
           - gov.legislative
           - gov.national
@@ -2953,6 +3078,7 @@ config:
       language: ru
       position:
         name: Member of the Federation Council
+        wikidata_id: Q4516946
         topics:
           - gov.legislative
           - gov.national
@@ -2977,6 +3103,7 @@ config:
       language: ru
       position:
         name: Chairman of the Supreme Court of the Russian Federation
+        wikidata_id: Q4431732
         country: ru
         topics:
           - gov.judicial
@@ -3045,6 +3172,7 @@ config:
       country: ua-cri
       position:
         name: Deputy of the State Council of Crimea
+        wikidata_id: Q133268428
         country: ua-cri
         topics:
           - gov.legislative
@@ -3055,6 +3183,7 @@ config:
       country: ua-cri
       position:
         name: Deputy of the Legislative Assembly of Sevastopol
+        wikidata_id: Q133268430
         country: ua-cri
         topics:
           - gov.legislative
@@ -3074,6 +3203,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Council of the Republic of Adygea
+        wikidata_id: Q133268354
         country: ru
         topics:
           - gov.legislative
@@ -3084,6 +3214,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Assembly of the Altai Republic
+        wikidata_id: Q133268350
         country: ru
         topics:
           - gov.legislative
@@ -3094,6 +3225,7 @@ config:
       language: ru
       position:
         name: Deputy of the Altai Krai Legislative Assembly
+        wikidata_id: Q133268339
         country: ru
         topics:
           - gov.legislative
@@ -3104,6 +3236,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of the Amur Oblast
+        wikidata_id: Q133268365
         country: ru
         topics:
           - gov.legislative
@@ -3114,6 +3247,7 @@ config:
       language: ru
       position:
         name: Deputy of the Arkhangelsk Region Assembly of Deputies
+        wikidata_id: Q133268342
         country: ru
         topics:
           - gov.legislative
@@ -3124,6 +3258,7 @@ config:
       language: ru
       position:
         name: Deputy of the Duma of Astrakhan Oblast
+        wikidata_id: Q133268349
         country: ru
         topics:
           - gov.legislative
@@ -3134,6 +3269,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Assembly of the Republic of Bashkortostan
+        wikidata_id: Q133268352
         country: ru
         topics:
           - gov.legislative
@@ -3144,6 +3280,7 @@ config:
       language: ru
       position:
         name: Deputy of the Belgorod Oblast Duma
+        wikidata_id: Q133268343
         country: ru
         topics:
           - gov.legislative
@@ -3154,6 +3291,7 @@ config:
       language: ru
       position:
         name: Deputy of the Bryansk Oblast Duma
+        wikidata_id: Q133268434
         country: ru
         topics:
           - gov.legislative
@@ -3164,6 +3302,7 @@ config:
       language: ru
       position:
         name: Deputy of the People's Hural of the Republic of Buryatia
+        wikidata_id: Q133268401
         country: ru
         topics:
           - gov.legislative
@@ -3174,6 +3313,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Vladimir Oblast
+        wikidata_id: Q133268370
         country: ru
         topics:
           - gov.legislative
@@ -3184,6 +3324,7 @@ config:
       language: ru
       position:
         name: Deputy of the Volgograd Oblast Duma
+        wikidata_id: Q101483020
         country: ru
         topics:
           - gov.legislative
@@ -3194,6 +3335,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Vologda Oblast
+        wikidata_id: Q133268362
         country: ru
         topics:
           - gov.legislative
@@ -3204,6 +3346,7 @@ config:
       language: ru
       position:
         name: Deputy of the Voronezh Oblast Duma
+        wikidata_id: Q133268348
         country: ru
         topics:
           - gov.legislative
@@ -3214,6 +3357,7 @@ config:
       language: ru
       position:
         name: Deputy of the People's Assembly of the Republic of Dagestan
+        wikidata_id: Q115242140
         country: ru
         topics:
           - gov.legislative
@@ -3224,6 +3368,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of the Jewish Autonomous Oblast
+        wikidata_id: Q133268367
         country: ru
         topics:
           - gov.legislative
@@ -3234,6 +3379,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of the Trans-Baikal Territory
+        wikidata_id: Q133268368
         country: ru
         topics:
           - gov.legislative
@@ -3244,6 +3390,7 @@ config:
       language: ru
       position:
         name: Deputy of the Ivanovo Oblast Duma
+        wikidata_id: Q133268390
         country: ru
         topics:
           - gov.legislative
@@ -3254,6 +3401,7 @@ config:
       language: ru
       position:
         name: Deputy of the People's Assembly of the Republic of Ingushetia
+        wikidata_id: Q133268422
         country: ru
         topics:
           - gov.legislative
@@ -3264,6 +3412,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of the Irkutsk Oblast
+        wikidata_id: Q133268426
         country: ru
         topics:
           - gov.legislative
@@ -3274,6 +3423,7 @@ config:
       language: ru
       position:
         name: Deputy of the Parliament of Kabardino-Balkarian Republic
+        wikidata_id: Q133268405
         country: ru
         topics:
           - gov.legislative
@@ -3284,6 +3434,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Kaliningrad Oblast
+        wikidata_id: Q133268391
         country: ru
         topics:
           - gov.legislative
@@ -3294,6 +3445,7 @@ config:
       language: ru
       position:
         name: Deputy of the People's Hural of the Republic of Kalmykia
+        wikidata_id: Q133268400
         country: ru
         topics:
           - gov.legislative
@@ -3304,6 +3456,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Kaluga Oblast
+        wikidata_id: Q133268372
         country: ru
         topics:
           - gov.legislative
@@ -3314,6 +3467,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Kamchatka Krai
+        wikidata_id: Q133268373
         country: ru
         topics:
           - gov.legislative
@@ -3324,6 +3478,7 @@ config:
       language: ru
       position:
         name: Deputy of the  People's Assembly of the Karachay-Cherkess Republic
+        wikidata_id: Q133268399
         country: ru
         topics:
           - gov.legislative
@@ -3334,6 +3489,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of the Republic of Karelia
+        wikidata_id: Q133268366
         country: ru
         topics:
           - gov.legislative
@@ -3344,6 +3500,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Kemerovo Oblast
+        wikidata_id: Q133268417
         country: ru
         topics:
           - gov.legislative
@@ -3354,6 +3511,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Kirov Oblast
+        wikidata_id: Q133268371
         country: ru
         topics:
           - gov.legislative
@@ -3364,6 +3522,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Council of the Komi Republic
+        wikidata_id: Q111236573
         country: ru
         topics:
           - gov.legislative
@@ -3384,6 +3543,7 @@ config:
       language: ru
       position:
         name: Deputy of the Kostroma Oblast Duma
+        wikidata_id: Q133268393
         country: ru
         topics:
           - gov.legislative
@@ -3394,6 +3554,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Krasnodar Krai
+        wikidata_id: Q133268363
         country: ru
         topics:
           - gov.legislative
@@ -3404,6 +3565,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Krasnoyarsk Krai
+        wikidata_id: Q133268376
         country: ru
         topics:
           - gov.legislative
@@ -3414,6 +3576,7 @@ config:
       language: ru
       position:
         name: Deputy of the Kurgan Oblast Duma
+        wikidata_id: Q133268421
         country: ru
         topics:
           - gov.legislative
@@ -3424,6 +3587,7 @@ config:
       language: ru
       position:
         name: Deputy of the Kursk Oblast Duma
+        wikidata_id: Q133268394
         country: ru
         topics:
           - gov.legislative
@@ -3434,6 +3598,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Leningrad Oblast
+        wikidata_id: Q133268377
         country: ru
         topics:
           - gov.legislative
@@ -3444,6 +3609,7 @@ config:
       language: ru
       position:
         name: Deputy of the Lipetsk Oblast Council of Deputies
+        wikidata_id: Q133268395
         country: ru
         topics:
           - gov.legislative
@@ -3454,6 +3620,7 @@ config:
       language: ru
       position:
         name: Deputy of the Magadan Oblast Duma
+        wikidata_id: Q133268396
         country: ru
         topics:
           - gov.legislative
@@ -3464,6 +3631,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Assembly of the Mari El Republic
+        wikidata_id: Q133268424
         country: ru
         topics:
           - gov.legislative
@@ -3474,6 +3642,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Assembly of the Republic of Mordovia
+        wikidata_id: Q133268353
         country: ru
         topics:
           - gov.legislative
@@ -3484,6 +3653,7 @@ config:
       language: ru
       position:
         name: Deputy of the Moscow City Duma
+        wikidata_id: Q96324124
         country: ru
         topics:
           - gov.legislative
@@ -3494,6 +3664,7 @@ config:
       language: ru
       position:
         name: Deputy of the Moscow Oblast Duma
+        wikidata_id: Q110805962
         country: ru
         topics:
           - gov.legislative
@@ -3504,6 +3675,7 @@ config:
       language: ru
       position:
         name: Deputy of the Murmansk Oblast Duma
+        wikidata_id: Q133268397
         country: ru
         topics:
           - gov.legislative
@@ -3514,6 +3686,7 @@ config:
       language: ru
       position:
         name: Deputy of the Assembly of Deputies of the Nenets Autonomous Okrug
+        wikidata_id: Q133268415
         country: ru
         topics:
           - gov.legislative
@@ -3524,6 +3697,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Nizhny Novgorod Oblast
+        wikidata_id: Q133268374
         country: ru
         topics:
           - gov.legislative
@@ -3534,6 +3708,7 @@ config:
       language: ru
       position:
         name: Deputy of the Novgorod Oblast Duma
+        wikidata_id: Q133268402
         country: ru
         topics:
           - gov.legislative
@@ -3544,6 +3719,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Novosibirsk Oblast
+        wikidata_id: Q133268380
         country: ru
         topics:
           - gov.legislative
@@ -3554,6 +3730,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Omsk Oblast
+        wikidata_id: Q133268379
         country: ru
         topics:
           - gov.legislative
@@ -3564,6 +3741,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Orenburg Oblast
+        wikidata_id: Q111242479
         country: ru
         topics:
           - gov.legislative
@@ -3574,6 +3752,7 @@ config:
       language: ru
       position:
         name: Deputy of the Oryol Oblast Council of People's Deputies
+        wikidata_id: Q133268404
         country: ru
         topics:
           - gov.legislative
@@ -3584,6 +3763,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Penza Oblast
+        wikidata_id: Q133268378
         country: ru
         topics:
           - gov.legislative
@@ -3594,6 +3774,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Perm Krai
+        wikidata_id: Q133268384
         country: ru
         topics:
           - gov.legislative
@@ -3604,6 +3785,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Primorsky Krai
+        wikidata_id: Q133268382
         country: ru
         topics:
           - gov.legislative
@@ -3614,6 +3796,7 @@ config:
       language: ru
       position:
         name: Deputy of the Pskov Oblast Assembly of Deputies
+        wikidata_id: Q133268408
         country: ru
         topics:
           - gov.legislative
@@ -3624,6 +3807,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Rostov Oblast
+        wikidata_id: Q133268385
         country: ru
         topics:
           - gov.legislative
@@ -3634,6 +3818,7 @@ config:
       language: ru
       position:
         name: Deputy of the Ryazan Oblast Duma
+        wikidata_id: Q133268409
         country: ru
         topics:
           - gov.legislative
@@ -3644,6 +3829,7 @@ config:
       language: ru
       position:
         name: Deputy of the Samara Regional Duma
+        wikidata_id: Q133268410
         country: ru
         topics:
           - gov.legislative
@@ -3654,6 +3840,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of St. Petersburg
+        wikidata_id: Q111242469
         country: ru
         topics:
           - gov.legislative
@@ -3664,6 +3851,7 @@ config:
       language: ru
       position:
         name: Deputy of the Saratov Oblast Duma
+        wikidata_id: Q133268412
         country: ru
         topics:
           - gov.legislative
@@ -3674,6 +3862,7 @@ config:
       language: ru
       position:
         name: Deputy of the Sakhalin Oblast Duma
+        wikidata_id: Q133268413
         country: ru
         topics:
           - gov.legislative
@@ -3684,6 +3873,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Sverdlovsk Oblast
+        wikidata_id: Q133268383
         country: ru
         topics:
           - gov.legislative
@@ -3704,6 +3894,7 @@ config:
       language: ru
       position:
         name: Deputy of the Parliament of the Republic of North Ossetia — Alania
+        wikidata_id: Q133268406
         country: ru
         topics:
           - gov.legislative
@@ -3714,6 +3905,7 @@ config:
       language: ru
       position:
         name: Deputy of the Smolensk Oblast Duma
+        wikidata_id: Q133268414
         country: ru
         topics:
           - gov.legislative
@@ -3724,6 +3916,7 @@ config:
       language: ru
       position:
         name: Deputy of the Duma of Stavropol Krai
+        wikidata_id: Q133268359
         country: ru
         topics:
           - gov.legislative
@@ -3734,6 +3927,7 @@ config:
       language: ru
       position:
         name: Deputy of the Tambov Oblast Duma
+        wikidata_id: Q133268432
         country: ru
         topics:
           - gov.legislative
@@ -3744,6 +3938,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Council of the Republic of Tatarstan
+        wikidata_id: Q133268355
         country: ru
         topics:
           - gov.legislative
@@ -3754,6 +3949,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Tver Oblast
+        wikidata_id: Q133268388
         country: ru
         topics:
           - gov.legislative
@@ -3764,6 +3960,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Duma of Tomsk Oblast
+        wikidata_id: Q133268360
         country: ru
         topics:
           - gov.legislative
@@ -3774,6 +3971,7 @@ config:
       language: ru
       position:
         name: Deputy of the Tula Oblast Duma
+        wikidata_id: Q133268418
         country: ru
         topics:
           - gov.legislative
@@ -3784,6 +3982,7 @@ config:
       language: ru
       position:
         name: Deputy of the Great Khural of the Tuva Republic
+        wikidata_id: Q133268346
         country: ru
         topics:
           - gov.legislative
@@ -3794,6 +3993,7 @@ config:
       language: ru
       position:
         name: Deputy of the Tyumen Oblast Duma
+        wikidata_id: Q62653950
         country: ru
         topics:
           - gov.legislative
@@ -3804,6 +4004,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Council of the Udmurt Republic
+        wikidata_id: Q108610448
         country: ru
         topics:
           - gov.legislative
@@ -3814,6 +4015,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Ulyanovsk Oblast
+        wikidata_id: Q133268389
         country: ru
         topics:
           - gov.legislative
@@ -3824,6 +4026,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Duma of Khabarovsk Krai
+        wikidata_id: Q133268361
         country: ru
         topics:
           - gov.legislative
@@ -3834,6 +4037,7 @@ config:
       language: ru
       position:
         name: Deputy of the Supreme Council of the Republic of Khakassia
+        wikidata_id: Q133268344
         country: ru
         topics:
           - gov.legislative
@@ -3844,6 +4048,7 @@ config:
       language: ru
       position:
         name: Deputy of the Duma of Khanty-Mansi Autonomous Okrug — Yugra
+        wikidata_id: Q124755389
         country: ru
         topics:
           - gov.legislative
@@ -3854,6 +4059,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of Chelyabinsk Oblast
+        wikidata_id: Q133268386
         country: ru
         topics:
           - gov.legislative
@@ -3864,6 +4070,7 @@ config:
       language: ru
       position:
         name: Deputy of the Parliament of the Chechen Republic
+        wikidata_id: Q133268407
         country: ru
         topics:
           - gov.legislative
@@ -3874,6 +4081,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Council of the Chuvash Republic
+        wikidata_id: Q133268356
         country: ru
         topics:
           - gov.legislative
@@ -3884,6 +4092,7 @@ config:
       language: ru
       position:
         name: Deputy of the Duma of the Chukotka Autonomous Okrug
+        wikidata_id: Q133268427
         country: ru
         topics:
           - gov.legislative
@@ -3904,6 +4113,7 @@ config:
       language: ru
       position:
         name: Deputy of the State Assembly (Il Tumen) of the Republic of Sakha (Yakutia)
+        wikidata_id: Q133268316
         country: ru
         topics:
           - gov.legislative
@@ -3914,6 +4124,7 @@ config:
       language: ru
       position:
         name: Deputy of the Legislative Assembly of the Yamalo-Nenets Autonomous Okrug
+        wikidata_id: Q133268431
         country: ru
         topics:
           - gov.legislative
@@ -3924,6 +4135,7 @@ config:
       language: ru
       position:
         name: Deputy of the Yaroslavl Oblast Duma
+        wikidata_id: Q133268420
         country: ru
         topics:
           - gov.legislative
@@ -3936,6 +4148,7 @@ config:
       language: ru
       position:
         name: Mayor of Moscow
+        wikidata_id: Q1837906
         country: ru
         topics:
           - gov.head
@@ -3949,6 +4162,7 @@ config:
       language: ru
       position:
         name: Head of a municipality
+        wikidata_id: Q4139102
         country: ru
         topics:
           - gov.head
@@ -3960,6 +4174,7 @@ config:
       language: ru
       position:
         name: Head of a district
+        wikidata_id: Q4139102
         country: ru
         topics:
           - gov.head


### PR DESCRIPTION
Adds `wikidata_id` to **215** `position:` blocks in `wd_categories.yml`. 24 already had one, so **239 of 284** are now linked. Additive only — no existing `wikidata_id`, `name`, `country` or `topic` is touched, and the diff is 215 inserted lines, 0 deletions.

## Why

`make_position` uses `wikidata_id` as the entity id. Without one, each block mints a `wd-cat` hash, so the same office arrives twice: once from this crawler and once from `wd_peps`. Linking them collapses that duplication and turns each block from an unverified assertion ("these people held X") into a claim pointing at a real item.

## How the QIDs were established

Name search alone doesn't get there — Wikidata usually labels these offices differently from the yml (`member of the Chamber of Deputies of the Parliament of the Czech Republic` for `Member of the Chamber of Deputies`), and often only in the local language. So resolution used two signals that don't depend on the English phrasing:

- the **Wikipedia category item's P301** ("category's main topic"), which is curated and points straight at the office;
- a **P39 tally over the category's members** — what the people in the category already hold on Wikidata.

Everything the mechanics couldn't settle unambiguously (104 rows) went to per-row review against the item, the category page and the body: 47 corrections, 16 confirmations, 19 "no item exists", 22 "not a position".

One trap worth naming: country agreement and the tally lead are **not** independent signals for a large country. Every Russian office matches Russia, and regional deputies overwhelmingly go on to hold the federal seat — so that pair alone matched `member of the State Duma` to four *regional* dumas. Resolution now requires the name or the P301 to be one of the two signals.

## Deliberately left unlinked

**23 blocks model something P39 cannot express** and should probably lose their `position:` block rather than gain an id:

| kind | blocks |
|---|---|
| party membership (belongs on P102) | Members of United Russia, Members of the LDPR, Yemeni GPC politicians |
| employment, not office | SVR staff |
| corporate board seat | Gazprom board of directors |
| class with no single seat | 6× Australian state local councillors, presidents of the Spanish autonomous communities, mayors of Venezuela / Nicaragua / Guatemala, US presidential advisors, Russian regional governors / regional parliament chairs, cabinet-composition categories |

**23 offices have no Wikidata item at all** — including the Czech Supreme and Supreme Administrative Court judgeships, judges of the Russian Constitutional and Supreme Courts, the ICC Registrar, the WFP Executive Director and four Lithuanian judicial/prosecutorial posts. A QuickStatements creation batch is prepared; those blocks stay unlinked until the items exist.

## Two follow-ups, not in this PR

1. **The Security Council of Russia block declares `Q38715670`**, which is *permanent* member — a strict subset of a category holding 60+ ordinary and ex-officio members. Left untouched pending a decision on whether to create a generic member item or drop the id.
2. **38 specs name a category page that does not exist on the wiki being queried**, so they match nobody and log nothing. `language` defaults to `en` while the title is Czech (8 specs), and category titles are case-sensitive after the first letter (10 Russian oblast specs on `Думы` vs `думы`, plus `White_House_Counsels`, `OSCE_Secretaries_General`, `Under-Secretaries-General_of_the_United_Nations`). Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)