### PR TITLE
[wd_peps] Query one territory QID at a time in position discovery

### DIFF
--- a/datasets/_wikidata/peps/crawler.py
+++ b/datasets/_wikidata/peps/crawler.py
@@ -68,18 +68,24 @@ def query_usage_positions(
 
     All the territory's QIDs are swept, not just the primary one: aliases cover
     entities like the Russia/Belarus Union State (an alias of `ru`), whose organ
-    positions would otherwise be invisible to jurisdiction-based discovery."""
-    values = " ".join(f"wd:{qid}" for qid in sorted(territory.qids))
-    query = f"""
-    SELECT DISTINCT ?position ?abolished WHERE {{
-        ?position wdt:P1001|wdt:P17 ?territory .
-        VALUES ?territory {{ {values} }}
-        {{ ?holder wdt:P39 ?position . ?holder wdt:P31 wd:Q5 . }}
-        UNION {{ ?position wdt:P1308 ?officeholder . }}
-        {ABOLISHED_CLAUSE}
-    }}
-    """
-    return collect_positions(context, client, query)
+    positions would otherwise be invisible to jurisdiction-based discovery.
+
+    One query per QID: batching them into a single `VALUES` block makes the
+    query planner give up on large territories — the six QIDs of `gb` together
+    exceed the query service's own execution limit, while each on its own is
+    comfortably inside it."""
+    positions: set[str] = set()
+    for qid in sorted(territory.qids):
+        query = f"""
+        SELECT DISTINCT ?position ?abolished WHERE {{
+            ?position wdt:P1001|wdt:P17 wd:{qid} .
+            {{ ?holder wdt:P39 ?position . ?holder wdt:P31 wd:Q5 . }}
+            UNION {{ ?position wdt:P1308 ?officeholder . }}
+            {ABOLISHED_CLAUSE}
+        }}
+        """
+        positions.update(collect_positions(context, client, query))
+    return positions
 
 
 def query_occupation_positions(


### PR DESCRIPTION
Batching all of a territory's QIDs into a single `VALUES` block made the query planner give up on the largest jurisdictions. Measured against the live query service, every multi-QID large territory exceeded the service's own execution limit, while each QID on its own stayed well inside it:

| territory | `?territory` values | result |
|---|---|---|
| `gb` | `Q145 Q161885 Q174193 Q46395 Q4970586 Q5613380` | **timeout** |
| | `Q145` alone | 30s, 2102 rows |
| | the other five, each alone | <1s, 154 rows total |
| `us` | `Q30 Q1783171` | **timeout** |
| | `Q30` alone | 53s, 3319 rows |
| | `Q1783171` alone | <1s, 4 rows |
| `cn` | `Q148 Q29520` | **timeout** |
| | `Q148` alone | 37s, 364 rows |
| | `Q29520` alone | 1s, 9 rows |

Since the failure was caught by the per-territory `except` in `discover_candidates`, this was silent: the US, UK and China were losing their entire jurisdiction-based sweep on every crawl, and only kept the positions already accepted in the review database plus whatever the occupation query found.

The split is equivalent, not an approximation — `VALUES ?territory` is a disjunction and `collect_positions` unions rows one at a time, so partitioning by QID yields the same position set. A position attached to two of a territory's QIDs simply appears in both partitions with identical `?abolished` rows.

Cost is 756 queries instead of 590 across the whole sweep (+28%); only 94 of 590 swept territories have more than one QID. Results are cached via `WIKIDATA_QUERY_CACHE`.

### Still outstanding

`Q30` at 53s sits close to the 60s cap — inside it on this run, but it would fall out on a slower one, and US holder counts only grow. Two levers not taken here, in the order worth trying:

1. Split the `UNION` into separate `P39`-holder and `P1308` queries. That shape under a shared `?position` binding plus an `OPTIONAL` is what typically derails the plan, and the `P1308` branch is tiny.
2. Lift `ABOLISHED_CLAUSE` out of discovery. The `p:P576|p:P582` path with a nested `BestRank` blank node runs per candidate position and only feeds a cutoff comparison, so it could be a second cheap query — or move to classification, where the item is fetched anyway.

### Testing

`mypy --strict` clean; the six/two/two per-QID queries verified against the live endpoint as above. The full crawler was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)