### PR TITLE
[pl_wanted] Retry profiles the source failed to render

### DIFF
--- a/datasets/pl/wanted/crawler.py
+++ b/datasets/pl/wanted/crawler.py
@@ -1,3 +1,7 @@
+import time
+
+from zavod.util import Element
+
 from zavod import Context
 from zavod import helpers as h
 
@@ -27,20 +31,58 @@ ATTRIBUTES = [
 ]
 
 
-def crawl_person(context: Context, url: str) -> None:
-    doc = context.fetch_html(url, cache_days=7)
+def extract_attributes(doc: Element, url: str) -> dict[str, str]:
+    """Read the labelled fields off a profile page, without judging completeness.
 
-    info = dict()
-    for required, key, xpath in ATTRIBUTES:
+    Fields the source gives as '-' come back as empty strings. Required fields are
+    deliberately not enforced here: on a shell page every field is missing at once,
+    and that has to be told apart from a real profile with a gap in it, so the
+    `required` flag is checked by the caller once the page is known to have rendered.
+    """
+    info: dict[str, str] = {}
+    for _, key, xpath in ATTRIBUTES:
         matches = h.xpath_strings(doc, xpath)
         text = ""
-        if required or matches:
+        if matches:
             assert len(matches) == 1, (key, url, matches)
             text = matches[0].strip()
-        text = "" if text == "-" else text
+        info[key] = "" if text == "-" else text
+    return info
+
+
+def fetch_person(context: Context, url: str) -> tuple[Element, dict[str, str]] | None:
+    """Fetch a profile page, returning None if the source never rendered the record.
+
+    The site intermittently serves a shell page: every field reads '-', the photo and
+    physical-description blocks are absent, and only the name survives because it is
+    drawn from the page title. Since responses are cached for a week, a single such
+    response would keep breaking the crawl for days, so the cache entry is evicted and
+    the request retried before the profile is given up on.
+    """
+    for attempt in range(4):
+        if attempt:
+            time.sleep(2**attempt)
+        doc = context.fetch_html(url, cache_days=7)
+        info = extract_attributes(doc, url)
+        # A real profile always states at least one of these, so all three being
+        # blank means the record body didn't render rather than being unknown.
+        if any(info[key] for key in ("birth_date", "gender", "citizenship")):
+            return doc, info
+        context.clear_url(url)
+        context.log.info("Profile did not render, evicted it from the cache", url=url)
+    context.log.warning("Skipping profile the source failed to render", url=url)
+    return None
+
+
+def crawl_person(context: Context, url: str) -> None:
+    fetched = fetch_person(context, url)
+    if fetched is None:
+        return
+    doc, info = fetched
+
+    for required, key, _ in ATTRIBUTES:
         if required:
-            assert text, (key, url)
-        info[key] = text
+            assert info[key], (key, url)
 
     if not info["birth_date"]:
         # The birth date is what distinguishes namesakes in the entity ID, so without
@@ -87,7 +129,7 @@ def crawl_person(context: Context, url: str) -> None:
         "//p[contains(text(), 'Podstawy poszukiwań:')]/following-sibling::ul[1]//li",
     )
     if not crimes:
-        context.log.warn("No crimes found for person", entity_id=person.id, url=url)
+        context.log.warning("No crimes found for person", entity_id=person.id, url=url)
     for crime in crimes:
         person.add("notes", h.element_text(crime))
 


### PR DESCRIPTION
Supersedes #5334, which I'm closing. Fixes the failure in run `20260806083323-gmt` (6 consecutive failures since 2026-08-05).

## What actually happened

The crawl aborted on `assert text, ("gender", …)` for [one profile](https://poszukiwani.policja.gov.pl/pos/form/r715686855,CIESIELCZYK-ALEKSANDER.html). That profile was not missing a gender — the whole record failed to render. The cached response body has every field as `-`:

```
Drugie imię: -   Imię ojca: -   Imię matki: -   Nazwisko panieńskie matki: -
Płeć: -          Miejsce urodzenia: -           Data urodzenia: -
Pseudonim: -     Ostatnie miejsce zameldowania: -               Obywatelstwo: -
Podstawy poszukiwań:  <li><a href="">-</a></li>
```

The `Wzrost` / `Kolor oczu` / `WŁOSY` blocks and the photo are absent entirely, and the crime links have empty `href=""`. Only the `<h2>` name survives, because it comes from the page title rather than the record.

It's transient. The trailer comment is a render timestamp: the cached copy says `WebAdministrator (05.08.2026 15:42)` — matching when the failures began — while a fetch today returns a fully populated record (`Płeć: mężczyzna`, `Wzrost: 176-180 CM`, real crime links), byte-identical across repeated requests.

Two things then combined to make one bad response fatal for a week:

- `gender` was the only required attribute a shell page fails, so the assertion fired there and pointed at gender rather than at the empty record.
- `cache_days=7` is jittered by `randomize_cache` into a random 4–10 days, so the poisoned entry kept re-breaking every subsequent run.

## Change

Detect the shell page explicitly — a profile stating none of birth date, gender or citizenship did not render — then `context.clear_url(url)` and retry (4 attempts, 2/4/8s backoff), and finally warn and skip. This follows the existing pattern in `datasets/ro/cdep_deputies/crawler.py`.

The cache eviction is the load-bearing part: even if the in-run retries lose, the next run starts from a fresh request instead of being pinned to the stale copy.

`gender` stays **required**, so a real profile genuinely missing one still fails loudly. Required attributes are now checked after the shell-page gate, because on a shell page they are all absent at once.

Also fixes a pre-existing `log.warn` → `log.warning` that ruff (G010) flagged once the file was touched.

## Why not #5334

That PR made `gender` optional. It would have gone green while making things worse:

- **Silent data loss.** With gender optional, extraction falls through to the `birth_date` check — also `-` on a shell page — so the person is dropped with a "Skipping person without a birth date" warning and vanishes for 4–10 days. One record out of ~54k doesn't trip the 40k–100k assertion.
- **It removes the only detector.** `full_name` still passes on a shell page, so gender was the sole signal that anything was wrong.

Its premise doesn't hold either: `Płeć: -` is not a normal state for this source (see below), and the `type.gender: nieznana → null` lookup it cited is a real published value, unrelated to `-`.

## Verification

- `mypy --strict`, `ruff check`, `black` clean; pre-commit (incl. `mypy-datasets`) passes.
- Ran the new extraction against the real shell-page body and against a live fetch of the same URL: shell page detected, live page not, and the live field values are identical to what the previous code extracted.
- **False positives:** 32 profiles sampled off the index all pass the gate cleanly — none flagged as unrendered, none missing a required field. Gender was populated on all 32 (`mężczyzna` ×31, `kobieta` ×1), which is the evidence that `Płeć: -` marks the glitch rather than an unknown gender.
- Live crawl through the real code path: 6 index pages (~190 profiles), zero warnings or errors. Not run to completion — `ci_test: false` because a full run is ~54k pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
