### PR TITLE
[pl_wanted] Remove parental name fields

### DIFF
--- a/datasets/pl/wanted/crawler.py
+++ b/datasets/pl/wanted/crawler.py
@@ -19,15 +19,13 @@ ATTRIBUTES = [
     (False, "birth_place", "//p[contains(text(), 'Miejsce urodzenia:')]/strong/text()"),
     (False, "citizenship", "//p[contains(text(), 'Obywatelstwo:')]/strong/text()"),
     (False, "eye_color", "//p[contains(text(), 'Kolor oczu:')]/strong/text()"),
-    (False, "father_name", "//p[contains(text(), 'Imię ojca:')]/strong/text()"),
     (False, "height", "//p[contains(text(), 'Wzrost:')]/strong/text()"),
-    (
-        False,
-        "mother_maiden_name",
-        "//p[contains(text(), 'Nazwisko panieńskie matki:')]/strong/text()",
-    ),
-    (False, "mother_name", "//p[contains(text(), 'Imię matki:')]/strong/text()"),
     (False, "hair_color", "//li[contains(text(), 'WŁOSY:')]/text()"),
+    # The source also gives the father's given name and the mother's given and maiden
+    # names. Those are deliberately not extracted: they are personal data of people the
+    # register asserts nothing about, and they add nothing to matching that full name,
+    # birth date and birth place don't already carry. See
+    # https://github.com/opensanctions/opensanctions/issues/5336
 ]
 
 
@@ -103,9 +101,6 @@ def crawl_person(context: Context, url: str) -> None:
     person.add("birthPlace", info.pop("birth_place", None))
     person.add("gender", info.pop("gender"))
     person.add("alias", info.pop("alias", None))
-    person.add("fatherName", info.pop("father_name", None))
-    person.add("motherName", info.pop("mother_name", None))
-    person.add("motherName", info.pop("mother_maiden_name", None))
     person.add("height", info.pop("height", None))
     person.add("eyeColor", info.pop("eye_color", None))
     person.add("hairColor", info.pop("hair_color", "").replace("WŁOSY:", ""))


### PR DESCRIPTION
Closes #5336. **Stacked on #5337** — base is `pl-wanted-retry-unrendered-profiles`, so review that one first; this diff shows only the parental-name change. Retarget to `main` once #5337 merges.

## Change

Drops extraction of the father's given name and the mother's given and maiden names, and the `fatherName` / `motherName` emissions they fed:

- `ATTRIBUTES` — removes the `father_name`, `mother_name` and `mother_maiden_name` rows.
- `crawl_person` — removes the three corresponding `person.add(...)` calls.

Per the review in #5336: these are personal data of people the register asserts nothing about, and their only screening function — disambiguating namesakes — is already carried by full name, birth date and birth place. The mother's maiden name additionally sees wide use as a knowledge-based authentication datum, so republishing it in bulk carries misuse potential out of proportion to its matching value.

A comment in `ATTRIBUTES` records why the fields are skipped and links back to #5336, so the omission doesn't read as an oversight for someone to helpfully fill in later. Per the issue's scope note, this is specific to `pl_wanted` and implies nothing about patronymics in sanctions designations.

Nothing else changes: entity IDs are `make_id(full_name, birth_date)` and unaffected, and no lookups referenced these fields.

## Verification

- `mypy --strict`, `ruff check`, `black` clean; pre-commit (incl. `mypy-datasets`) passes.
- Extraction re-run against a live profile page: the 10 remaining fields come out unchanged, and no parental keys remain.
- Checked the `audit_data` contract holds — every extracted key is still popped, and nothing is popped that is no longer extracted — so the removal can't silently trip or mask an audit warning.
- The unrendered-profile gate from #5337 keys on birth date / gender / citizenship, so it is unaffected; re-confirmed it still flags the shell page and passes the live one.

Not run to completion — `ci_test: false`, a full crawl is ~54k pages.

## Follow-up (not in this PR)

The issue's second checkbox — confirming the properties are gone from the website entity pages, the API and the bulk products — needs a full export after merge, so it stays open for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
