### PR TITLE
[us_finra_actions] Sort listing by case ID for stable pagination

### DIFF
--- a/datasets/us/finra_actions/crawler.py
+++ b/datasets/us/finra_actions/crawler.py
@@ -9,6 +9,12 @@ older slice of the (shifting) list, so records skip or duplicate across pages.
 
 Mitigations:
 
+- We sort by case ID (an unexposed but accepted sort key) instead of the
+  default newest-first action date. Case IDs are near-unique, so the origin's
+  unstable ordering among sort-key ties (which reshuffles rows across page
+  boundaries between fetches under the date sort) has almost nothing to act
+  on, and new cases get the highest IDs so they append at the end of the
+  listing instead of shifting every page.
 - Every request carries a per-run `cache_bust` query parameter so Varnish
   treats each page URL as unique and fetches fresh from origin.
 - The Zyte fetch validator requires a populated table and rejects the
@@ -20,7 +26,7 @@ Mitigations:
 
 from lxml.etree import _Element
 from secrets import token_urlsafe
-from urllib.parse import parse_qs, urljoin, urlparse
+from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
@@ -50,7 +56,7 @@ def crawl_item(context: Context, row: dict[str, _Element]) -> None:
     source_url = case_id_el.get("href")
     if source_url is not None:
         source_url = urljoin(context.data_url, source_url)
-    date = h.element_text(row.pop("action_date_sort_ascending"))
+    date = h.element_text(row.pop("action_date"))
 
     for name in names:
         entity = context.make("LegalEntity")
@@ -104,7 +110,13 @@ def crawl(context: Context) -> None:
     cache_bust = token_urlsafe(8)
     while max_page is None or page_num <= max_page:
         context.log.info(f"Crawling page {page_num} of {max_page}")
-        url = f"{context.data_url}?page={page_num}&cache_bust={cache_bust}"
+        params = {
+            "order": "field_fda_case_id_txt",
+            "sort": "asc",
+            "page": page_num,
+            "cache_bust": cache_bust,
+        }
+        url = f"{context.data_url}?{urlencode(params)}"
         # Zyte because occasional cloudflare javascript challenge.
         response = zyte_api.fetch_html(
             context, url, RESULT_ROW_VALIDATOR, absolute_links=True

--- a/datasets/us/finra_actions/crawler.py
+++ b/datasets/us/finra_actions/crawler.py
@@ -108,6 +108,8 @@ def crawl(context: Context) -> None:
     # A single token for the whole crawl bypasses Varnish's stale per-page
     # entries without varying between our own pages within one run.
     cache_bust = token_urlsafe(8)
+    prev_case_id = ""
+    ordering_warned = False
     while max_page is None or page_num <= max_page:
         context.log.info(f"Crawling page {page_num} of {max_page}")
         params = {
@@ -138,6 +140,20 @@ def crawl(context: Context) -> None:
         assert table is not None, "Validated FINRA page did not contain a table"
 
         for row in h.parse_html_table(table):
+            # Duplicate IDs are legitimate (one row per document of a case),
+            # so equality is fine; only a decrease means the sort parameters
+            # are no longer being respected.
+            case_id = h.element_text(row["case_id"])
+            if case_id < prev_case_id and not ordering_warned:
+                context.log.warning(
+                    "Case IDs are no longer in ascending order — is the "
+                    "sort parameter still respected?",
+                    case_id=case_id,
+                    previous_case_id=prev_case_id,
+                    page=page_num,
+                )
+                ordering_warned = True
+            prev_case_id = case_id
             crawl_item(context, row)
 
         page_num += 1


### PR DESCRIPTION
## Problem

`us_finra_actions` flips ~500 entities in and out per weekly crawl (#4632). Tracing IDs across the four most recent runs shows ~98% of each run's DELs reappear as ADDs in the very next run — only ~7–9 ADDs and ~4 DELs per run are genuine. The cache-bust mitigation (97c01797f) didn't change this.

Root cause (confirmed by fetching the same listing page three times within seconds, each with a fresh cache-bust token — three different row sets in three different orders): the default newest-first action-date sort has **no stable tiebreaker at the origin**, so every page fetch returns a differently-ordered slice of the tied rows, and rows slide across page boundaries — skipped on one side, duplicated on the other. ~1–2 unstable rows per boundary × ~1,290 pages ≈ the observed ~500 flips.

## Fix

Sort by case ID (`order=field_fda_case_id_txt&sort=asc` — not exposed in the UI but accepted by the Drupal view):

- Case IDs are near-unique, so the tie groups the instability acts on barely exist. Repeated fetches of the same deep page return identical rows in identical order, correctly sorted and continuous across page boundaries (page 800 ends `2015044269501`, page 801 starts `2015044269901`).
- New cases get the highest IDs, so they append at the end of the listing instead of shifting all ~1,290 pages down like the newest-first sort does.
- The date column is no longer the active sort column, so its parsed header key changes from `action_date_sort_ascending` to `action_date`.
- A warn-once check logs if case IDs ever arrive out of ascending order, so we learn quickly if FINRA stops respecting the sort parameter. Equal neighbours are fine (one row per document of a case).

Known residual ties: two junk rows with empty case IDs (they sort first, and also have empty names), and same-case multi-document rows (same sanction key, so ordering between them doesn't matter).

## Testing

- Verified sort acceptance, per-page stability (3 identical fetches of page 800), and boundary continuity via Zyte.
- Short live crawls: pagination detected (1,293 pages), rows parse cleanly, ordering warning stays quiet.
- `mypy --strict` and pre-commit hooks pass.

The first production run will produce one last churny delta as boundary-duplicate artifacts settle; deltas should be near-flat after that.

Closes #4632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
