### PR TITLE
Note that silence_warnings needs a value: to echo the input

### DIFF
--- a/zavod/docs/best_practices/datapatch_lookups.md
+++ b/zavod/docs/best_practices/datapatch_lookups.md
@@ -263,7 +263,7 @@ Each entry in the `options:` list:
 | `prop` | (`type.*` lookups only) Re-route the value to a different property. |
 | `weight` | Integer to disambiguate when multiple options match the same input. |
 | `normalize` / `lowercase` / `asciify` | Override the lookup-level setting. |
-| `silence_warnings` | List of warning types to suppress. Currently the only recognized value is `xss-html-smell`. |
+| `silence_warnings` | List of warning types to suppress. Currently the only recognized value is `xss-html-smell`. Always pair it with a `value:` echoing the input — an option with no `value:` drops the property. |
 | any other key | Available as an attribute on the `Result` object (e.g. `schema`, `start`, `end`, `link`, `is_alias`, `document_schema`). |
 
 


### PR DESCRIPTION
A `type.*` lookup option that sets `silence_warnings` without a `value:` still matches, and `Result.values` is then empty — so `prop_lookup` returns nothing and the property it was meant to preserve is dropped instead. Silently, since the drop happens before any of the warning branches in `value_clean`.

Same failure mode as #5339, and easy to hit while following the XSS recipe a few rows above in the same doc.

One changed line in the option-level key reference, which covers every use of the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)