### PR TITLE
[gb_fcdo_sanctions] Add lookups for the RUS3702-3719 designations

### DIFF
--- a/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
+++ b/datasets/gb/fcdo_sanctions/gb_fcdo_sanctions.yml
@@ -60,7 +60,7 @@ assertions:
   max:
     schema_entities:
       Person: 7200
-      Organization: 2090
+      Organization: 3000
       Vessel: 800
 
 lookups:
@@ -1717,6 +1717,69 @@ lookups:
       - match: "USCC: 914403006803743126 "
         props:
           uscCode: "914403006803743126"
+      - match: "'0427410 (IMO Company Number)"
+        props:
+          imoNumber: "0427410"
+      - match: "ACU-3032 (Indian Ministry of Corporate Affairs ID Number)"
+        props:
+          registrationNumber: "ACU-3032"
+      - match: "INN: 7702760164OGRN: 1117746322320"
+        props:
+          innCode: "7702760164"
+          ogrnCode: "1117746322320"
+      - match: "INN: 6229080110OGRN: 1166234055481"
+        props:
+          innCode: "6229080110"
+          ogrnCode: "1166234055481"
+      - match: "INN: 4027052701OGRN: 1024001177606"
+        props:
+          innCode: "4027052701"
+          ogrnCode: "1024001177606"
+      - match: "INN: 7703438961 OGRN: 5177746318976 "
+        props:
+          innCode: "7703438961"
+          ogrnCode: "5177746318976"
+      - match: "TIN: 9703077050OGRN: 1227700133792Central Bank of Russia licence - 3542"
+        props:
+          taxNumber: "9703077050"
+          ogrnCode: "1227700133792"
+          registrationNumber: "3542"
+      - match: "Central Bank of Russia licence: 2790"
+        props:
+          registrationNumber: "2790"
+      - match: "Russian INN - 6163011391"
+        props:
+          innCode: "6163011391"
+      - match: "Russian KPP - 616301001"
+        props:
+          kppCode: "616301001"
+      - match: "Russian OGRN - 1026100001949"
+        props:
+          ogrnCode: "1026100001949"
+      - match: "Russia INN - 3801002781"
+        props:
+          innCode: "3801002781"
+      - match: "Russia OGRN - 1023800000124"
+        props:
+          ogrnCode: "1023800000124"
+      - match: "SWIFT/BIC - BIJORU66"
+        props:
+          swiftBic: "BIJORU66"
+      - match: "Legal Entity Identifier - 2534007T2QFUSCHQPU36"
+        props:
+          leiCode: "2534007T2QFUSCHQPU36"
+      - match: "INN – 2634028786"
+        props:
+          innCode: "2634028786"
+      - match: "OGRN - 1022600000092"
+        props:
+          ogrnCode: "1022600000092"
+      - match: "OKPO 09141558"
+        props:
+          okpoCode: "09141558"
+      - match: "OKVED 64.19"
+        props:
+          okvedCode: "64.19"
   companies:
     normalize: true
     options:
@@ -2387,6 +2450,13 @@ lookups:
           - Seadar Shipping Co Ltd
           - Tika Shipping Ltd
           - Wu Yi Shan Shipmanagement Co
+          - Fan Rong Xuan Ltd
+          - "LLC 'BUREAUCRAT'"
+          - Lam Kee Shipping Ltd
+          - Ming Rong Tai Ltd
+          - SMP Tech Management LLP
+          - Wulio Shipping Ltd
+          - Yuen Fat Shipping Ltd
         value: SAME
       - match: Subsidiary of the Organisation for Technological Industries (OTI) and therefore the Syrian Ministry of Defence
         values:
@@ -2396,6 +2466,10 @@ lookups:
         values:
           - Rida Engineering
           - Sudamin Mining Company
+      - match: "Thenamaris Ships Management, Sundrop Shipping Ltd"
+        values:
+          - Thenamaris Ships Management
+          - Sundrop Shipping Ltd
       - match: "Carrier Tanker Inc, Fornax Ship Management"
         values:
           - Carrier Tanker Inc


### PR DESCRIPTION
Clears all 175 unmatched-lookup warnings on `gb_fcdo_sanctions`.

## Cause

Every warning traced to 19 distinct source values, all in the contiguous block **RUS3702–RUS3719** — the newest UK Russia tranche (six banks, five companies, six shadow-fleet ships, one individual). No lookups had been curated for it yet. The high repeat counts are a CSV artefact: one row per name variant, so RUS3709 alone re-warned 60 times for the same string.

The `reg_number` patterns in `crawler.py` failed on three variations:

| Failure mode | Examples |
|---|---|
| Concatenated, no separator | `TIN: 9703077050OGRN: 1227700133792Central Bank of Russia licence - 3542` |
| Prefix word / en-dash separator | `Russian INN - 6163011391`, `INN – 2634028786` (U+2013) |
| Identifier types with no pattern | `OKPO 09141558`, `OKVED 64.19`, `Legal Entity Identifier - …`, `'0427410 (IMO Company Number)` |

Unmatched values are silently dropped, so these 18 entities were missing their registration identifiers and six ships were missing their owner links.

## Changes

`.yml` only, no code changes:

- 19 `reg_number` options, following the file's existing conventions (`TIN` → `taxNumber`, CBR licence → `registrationNumber`)
- 8 `companies` entries — 7 appended to the pass-through `SAME` list, plus `Thenamaris Ships Management, Sundrop Shipping Ltd` split in two
- `Organization` max assertion 2090 → 3000 (it was flagged "close to bound" at 2007 before this)

## Verification

| Check | Result |
|---|---|
| All 27 issue values resolve through the lookup machinery | 27/27 |
| Normalization collisions in `companies` | none |
| `zavod crawl` | completed, **0 issues** in `issues.log` (was 175) |
| `zavod validate` | exit 0, no assertion failures |
| New owner/parent entities | 9/9 created |

Recovered data, spot-checked:

- `rus3709` (Ozon Bank) → `taxNumber 9703077050`, `ogrnCode 1227700133792`, `registrationNumber 3542`
- `rus3712` (Realist Bank) → `leiCode`, `swiftBic BIJORU66`, `innCode`, `ogrnCode`
- `rus3714` (Teleport Bank) → gained `okpoCode 09141558`, `okvedCode 64.19`
- `rus3703` (Frion Ship Management) → `imoNumber IMO0427410`, `registrationNumber ACU-3032`

## Reviewer notes

`rus3711` and `rus3714` are now cast to `Company` rather than `Organization` — that is `add_reg_property`'s existing behaviour for `kppCode`, not new here, but it is a schema change on those two entities.

Possible follow-up, not in this PR: broadening the `PATTERNS` regexes to accept optional `Russia`/`Russian` prefixes and `-`/`–` separators would absorb ~8 of these variants permanently, instead of needing fresh lookup entries every tranche. That touches how existing values parse, so it seemed worth keeping separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)