### PR TITLE
Bundle of small data fixes

### DIFF
--- a/datasets/_externals/ext_black_sea_mou_psc.yml
+++ b/datasets/_externals/ext_black_sea_mou_psc.yml
@@ -44,8 +44,8 @@ assertions:
       Company: 1
   max:
     schema_entities:
-      Vessel: 430
-      Company: 350
+      Vessel: 1720
+      Company: 1400
 inputs:
   - ann_graph_topics
   # - debarment

--- a/datasets/_externals/ext_ru_egrul.yml
+++ b/datasets/_externals/ext_ru_egrul.yml
@@ -75,7 +75,7 @@ inputs:
 config:
   index_options:
     max_candidates: 200
-    memory: 3500
+    memory: 7000
   threshold: 0.7
   limit: 100
   algorithm: regression-v1

--- a/datasets/_externals/ext_tokyo_mou_psc.yml
+++ b/datasets/_externals/ext_tokyo_mou_psc.yml
@@ -76,5 +76,5 @@ assertions:
       Company: 50
   max:
     schema_entities:
-      Vessel: 4000
+      Vessel: 8000
       Company: 300

--- a/datasets/gb/coh/gb_coh_disqualified.yml
+++ b/datasets/gb/coh/gb_coh_disqualified.yml
@@ -93,6 +93,7 @@ lookups:
           - Not Known
           - Unknown
           - Not Disclosed
+          - African
         value: null
       - match: Botswanan
         value: BW


### PR DESCRIPTION
Quick round of data fixes:

- **[gb_coh_disqualified]** Map the nationality value "African" to null in the `type.country` lookup — there is no FTM country code for a continent, so it joins the other non-country values (Other, Not Known, …). Fixes the rejected-property warning.
- **[ext_black_sea_mou_psc]** Raise the max entity assertions: Vessel 430 → 1720, Company 350 → 1400. Observed counts (1173 vessels, 705 companies) had outgrown the thresholds; a single doubling (860/700) would still fail, so these are doubled twice.
- **[ext_tokyo_mou_psc]** Double the Vessel max assertion 4000 → 8000 (observed 4130).
- **[ext_ru_egrul]** Raise the blocker index DuckDB memory budget from 3500 to 7000 MB. Sanity-checked: `index_options.memory` maps to DuckDB `memory_limit` in MB, and the dataset runs in a 12Gi/15Gi pod — the same size as ext_gb_coh_psc which already runs with 8000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)