### PR TITLE
[us_me_med_exclusions] Run on Wednesdays to dodge weekend portal downtime

### DIFF
--- a/datasets/us/me/med_exclusions/us_me_med_exclusions.yml
+++ b/datasets/us/me/med_exclusions/us_me_med_exclusions.yml
@@ -3,9 +3,12 @@ entry_point: crawler.py
 prefix: us-medme
 coverage:
   start: "2024-12-13"
-  # Run at 10:00 EST because the portal is only available 07:00-19:00 EST
+  # The portal is only available 07:00-19:00 ET Monday-Friday — it is down all
+  # weekend hours and on holidays, expected until Fall 2026. Run mid-morning ET
+  # on Wednesdays so the schedule can never hit a weekend; a holiday failure
+  # self-heals the following week.
   # https://www.maine.gov/dhhs/oms/providers/provider-bulletins/health-pas-online-portal-down-time-update-november-2025-2025-11-20
-  schedule: "17 15 1,15 * *"
+  schedule: "17 15 * * 3"
 load_statements: true
 ci_test: false  # Zyte is not available in CI
 summary: >


### PR DESCRIPTION
The dataset has been failing with "Table data markers not found in page" since 2026-08-01. Investigation:

- The crawler and its page-parsing logic are **fine** — today's portal page parses cleanly with the existing code, and a full local crawl succeeds (2228 entities, no issues, picks up the August 2026 report).
- The root cause is the source's availability window: per the [November 2025 provider bulletin](https://www.maine.gov/dhhs/oms/providers/provider-bulletins/health-pas-online-portal-down-time-update-november-2025-2025-11-20), the Health PAS portal is **down all weekend hours and on holidays** (up 07:00–19:00 ET Mon–Fri only), expected to continue until Fall 2026.
- The `1,15 * *` schedule hits weekends: 2026-08-01 was a Saturday (3 failed retries). The archive shows the same pattern on Feb 1/15 and Mar 1/15 — all Sundays in 2026 — plus Jan 1 (holiday), each followed by an off-schedule manual re-run days later.

Fix: run weekly on Wednesdays (`17 15 * * 3`, mid-morning ET) — the schedule can never hit a weekend, and a rare Wednesday-holiday failure self-heals the following week. Cron can't express "1st and 15th unless weekend" (DOM and DOW are OR'ed), and the source report only updates monthly, so a weekly weekday cadence is the simplest robust option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)