### PR TITLE
[lt_fiu_freezes] Update index DOM hash for new FNTT orders subpage

### DIFF
--- a/datasets/lt/fiu_freezes/crawler.py
+++ b/datasets/lt/fiu_freezes/crawler.py
@@ -91,7 +91,7 @@ def crawl(context: Context) -> None:
         cache_days=1,
     )
     index_main = h.xpath_element(index_doc, ".//main")
-    h.assert_dom_hash(index_main, "73a409804f5bc0d84cc145859b010bf6a223199e")
+    h.assert_dom_hash(index_main, "805d897c7675f0f1df5d15f2daa5a1ef7c7962ff")
     # LIST OF LEGAL ENTITIES OR OTHER ORGANIZATIONS WITHOUT LEGAL PERSONAL STATUS THAT ARE OWNED
     # OR CONTROLLED BY A SANCTIONED ENTITY
     crawl_page(


### PR DESCRIPTION
The DOM-hash guard on the FIU sanctions index page fired starting with the 2026-08-05 run. Traced the delta: the FIU added one nav item to the section, linking a new subpage "FNTT įsakymai dėl sankcijų taikymo" (https://fntt.lrv.lt/lt/tarptautines-finansines-sankcijos/fntt-isakymai/) — an archive of the director's orders (PDFs) behind freeze-list changes. Nothing else on the page changed.

The newest orders (2026-08-05) add UAB „Litproduktai“, UAB „Next Logistic“ and UAB „Valientė“ to the freeze list. The source updated the crawled table itself on 2026-08-06 (after that day's run), so the existing table crawl picks them up without code changes — verified with a local crawl: clean issues.log, entities 74 → 100, within assertion bounds. The orders page itself is PDF scans, not worth crawling.

This PR only re-pins the index hash to the new page state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)