### PR TITLE
[sb_parliament, to_legislative_assembly] Release into peps

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -182,6 +182,7 @@ children:
   - ru_federation_council
   - ru_kremlin_persons
   - rw_parliament
+  - sb_parliament
   - se_riksdag
   - se_soe
   - sg_gov_dir
@@ -197,6 +198,7 @@ children:
   - tj_majlisi_milli
   - tm_mejlis
   - tn_arp
+  - to_legislative_assembly
   - tr_parliament
   - tw_legislature
   - tz_bunge

--- a/datasets/sb/parliament/sb_parliament.yml
+++ b/datasets/sb/parliament/sb_parliament.yml
@@ -4,7 +4,7 @@ prefix: sb-parl
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-17
+  start: 2026-08-07
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/to/legislative_assembly/to_legislative_assembly.yml
+++ b/datasets/to/legislative_assembly/to_legislative_assembly.yml
@@ -4,7 +4,7 @@ prefix: to-fale
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-17
+  start: 2026-08-07
 load_statements: true
 ci_test: true
 summary: >-


### PR DESCRIPTION
Add Solomon Islands National Parliament and Tonga Legislative Assembly PEP crawlers to the peps collection, bump coverage.start to release date.