### PR TITLE
[wd_categories] Keep our own spec keys out of the PetScan query

### DIFF
--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -31,6 +31,13 @@ QUERY = {
     "search_max_results": 1000,
     "sortorder": "ascending",
 }
+# PetScan parameters a category spec may override. Everything else in a spec
+# configures our own behaviour and must be removed before the remainder is
+# merged into the query: the request URL is the cache key, so a stray key makes
+# an edit to unrelated metadata (a position name, say) silently re-fetch the
+# category. PetScan ignores parameters it doesn't know, so the leak is invisible
+# in the results.
+PETSCAN_KEYS = {"depth", "language", "negcats", "search_max_results"}
 # That one time a PEP customer asked to be included....
 ALWAYS_PERSONS = ["Q21258544"]
 
@@ -162,14 +169,18 @@ def crawl_category(state: CrawlState, category_crawl_spec: dict[str, Any]) -> No
     if "topic" in category_crawl_spec:
         topics.append(category_crawl_spec.pop("topic"))
     country: str | None = category_crawl_spec.pop("country", None)
+    cat: str = category_crawl_spec.pop("category", "")
+    position_data: dict[str, Any] = category_crawl_spec.pop("position", {})
+
+    unknown = sorted(set(category_crawl_spec) - PETSCAN_KEYS)
+    if len(unknown):
+        raise ValueError(f"Unknown keys in category spec {cat!r}: {unknown}")
 
     query = dict(QUERY)
-    cat: str = category_crawl_spec.pop("category", "")
     query["categories"] = cat.strip()
     query.update(category_crawl_spec)
     state.log.info(f"Crawl category: {cat}")
 
-    position_data: dict[str, Any] = category_crawl_spec.pop("position", {})
     position: Entity | None = None
     if "name" in position_data:
         position = h.make_position(


### PR DESCRIPTION
Investigated https://www.opensanctions.org/issues/wd_categories/ — 29 warnings, all `Date string is invalid: <date>` from `prefixdate.parse`, for 22 impossible calendar dates (31 April/June/September/November, 30–31 February, `2018-02-29`). The run itself succeeded.

This PR fixes the in-repo bug that surfaced them. The warnings themselves come from nomenklatura and need a separate upstream change — see "Follow-ups" below.

## Where the warnings come from

They are *not* the crawler adding a bad date to an entity. That path logs **two** warnings: prefixdate's, plus zavod's own `Rejected property value [<prop>]: <value>` from `zavod/zavod/runtime/cleaning.py:186`, which carries the entity ID and property. The production log has zero `Rejected property value` lines, so no entity property is involved.

The single call site that logs prefixdate's warning and then swallows the error is `Claim.is_ended()` (`nomenklatura/wikidata/model.py:82`). It reads the raw `P582` (end time) qualifier text and calls `rigour.dates.ended_before`, which parses via prefixdate — logging the warning — then raises `ValueError`, which `is_ended` catches and reads as "ended".

The hot caller is `_type_props` (`model.py:228`), backing `Item.types`:

```python
for claim in item.claims:
    ended = claim.is_ended() and claim.qid != "Q3024240"   # called for EVERY claim
    if ended or claim.qid is None:
        continue
    if claim.property in ("P31", "P279"):                  # ...then filtered to two props
        types.append(claim.qid)
```

`is_ended()` runs on every claim before the P31/P279 filter, so an invalid end date on a `P39`, `P69` or `P108` statement is parsed and warned about even though the result is discarded. `Item.types` is the first thing both `wikidata_basic_human` and `wikidata_position` touch, so the warning fires before any entity is built — reproduced in isolation with a synthetic item whose one `P39` statement has `P582 = +2006-09-31T00:00:00Z`.

The dates are genuine Wikidata data-entry errors, mostly bot-imported. Across Wikidata these 22 values sit on 804 `P39` qualifiers, 237 `P69` and 215 `P108`; `2006-09-31` alone appears on 627 `P39` statements — the end of the 2002–2006 Swedish Riksdag term, which actually ended 2006-10-02.

## Why they appeared on 2026-08-07 and not before

The five preceding runs have a **0-byte** `issues.log`. No date-handling code changed: prefixdate 0.5.0 already logged this warning (checked the 0.5.0 wheel), nomenklatura 4.13.0 touched only the blocker, and rigour 2.3.1 landed 07-30 with clean runs after it.

What changed is the crawled item set, and this crawler caused it. `crawl_category` merges the leftovers of a category spec into the PetScan query, but pops `position` only *afterwards*:

```python
query.update(category_crawl_spec)                                  # position still in here
...
position_data: dict[str, Any] = category_crawl_spec.pop("position", {})   # too late
```

So all 284 of 594 specs with a `position:` block sent it to PetScan as a Python-repr'd parameter:

```
doit=&depth=4&format=csv&categories=Crown_princes_of_Saudi_Arabia&position=%7B%27name%27%3A+%27Crown+Prince+of+Saudi+Arabia%27%2C+%27wikidata_id%27%3A+%27Q12251224%27%2C+%27country%27%3A+%27sa%27%7D
```

PetScan ignores unknown parameters — I confirmed the two responses are byte-identical — but the request URL is the `context.fetch_text` cache key. 8e80912c1 (2026-08-06, between the last clean run and the first noisy one) added `wikidata_id` to 215 position blocks, invalidating those 215 cached category listings. The refreshed listings pulled in items that hadn't been crawled before, some of them carrying the invalid dates. Entity count moved 340,706 → 342,435.

## The fix

Pop `category` and `position` before the merge, and reject spec keys that are neither ours nor a PetScan parameter we support, so a typo in a key like `negcats` fails the crawl instead of silently doing nothing. All 594 existing specs pass the check.

## Impact

The next run re-fetches the 284 affected categories once, then the URLs stay stable across unrelated metadata edits — position names, countries and topics stop bouncing the category cache.

The warnings themselves are mostly harmless: where the invalid date sits on `P39`/`P69`/`P108`, `is_ended()`'s answer is discarded. Where it sits on `P31`/`P279` (9 statements Wikidata-wide) or a country claim like `P27`/`P1001` (1–2), the `ValueError` fallback quietly treats the claim as ended, so a type or a country can be dropped.

## Follow-ups, not in this PR

- **nomenklatura**: move the `claim.property in ("P31", "P279")` check above the `is_ended()` call in `_type_props`. Behaviour-preserving, removes nearly all of this noise, and stops parsing every date qualifier on every item in the type closure — worth something on a 7-hour crawl.
- **nomenklatura**: have `is_ended()` report the unparseable date itself rather than leaving prefixdate's contextless warning as the only trace. The current issue entry has no QID, property or entity, so it can't be acted on from the issues page.
- **Wikidata**: the `2006-09-31` Riksdag cluster (627 statements) is a worthwhile upstream cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
