### PR TITLE
Adopt prefixdate 0.6.1

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "orjson == 3.11.9",
     "ijson > 3.2, < 4.0",
     "pdfplumber == 0.11.10",
-    "prefixdate == 0.6.0",
+    "prefixdate == 0.6.1",
     "psycopg2-binary",
     "pyicu == 2.16.2",
     "openai >= 1.33.0, < 3.0.0",


### PR DESCRIPTION
https://github.com/pudo/prefixdate/pull/4 logs a parse failure at debug level instead of warning.

#5319 removed `logging.getLogger("prefixdate").setLevel(logging.ERROR)` so that the new two-digit-year warning in `prefixdate.formats` would reach the issue log. That also unsilenced `prefixdate.parse`, whose long-standing "Date string is invalid" warning names neither the entity nor the property — [46 issues in the 2026-08-08 wd_peps run](https://data.opensanctions.org/artifacts/wd_peps/20260808004930-klz/issues.json), all of them that.

They were not actionable where they surfaced:

- 19 of the 41 distinct values already have a `type.date` lookup in `wd_peps.yml` that rewrites them to month precision. The lookup runs in `value_clean`, and these never got there.
- All of them reach `parse` through `nomenklatura`'s `Claim.is_ended`, which hands the raw Wikidata P582 qualifier to `rigour.dates.ended_before` inside a `try/except ValueError` that already handles the case.

The condition is not lost. It is carried in the return value, and the callers that care act on it: rigour raises `ValueError`, and zavod logs `Rejected property value [birthDate]: 2022-06-31` with `entity_id` and `prop` for any date a crawler actually drops. The two-digit-year warning from `prefixdate.formats` is unaffected.

Separately, `Claim.is_ended` feeding uncleaned source strings to `ended_before` goes against `prefix_interval`'s documented contract. Quiet after this, but worth a look in nomenklatura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)