### PR TITLE
Pass merge provenance to Watchful

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,10 +251,21 @@ jobs:
   #   OPERATIONS_DEPLOY_APP_KEY — PEM private key
   trigger-deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    permissions: {}
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     needs: [docker]
     steps:
+      - name: Resolve source revision and pull request
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pull_request=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq 'map(select(.merged_at != null and .base.ref == "main")) | .[0].number // empty')
+          echo "revision=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "pull_request=${pull_request}" >> "$GITHUB_OUTPUT"
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -270,4 +281,4 @@ jobs:
             -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/opensanctions/operations/actions/workflows/build-etl.yml/dispatches \
-            -d '{"ref":"main"}'
+            -d '{"ref":"main","inputs":{"opensanctions_revision":"${{ steps.source.outputs.revision }}","opensanctions_pull_request":"${{ steps.source.outputs.pull_request }}"}}'


### PR DESCRIPTION
## Summary

- resolve the merged pull request associated with each successful main build
- pass the OpenSanctions commit SHA and PR number to the Operations deployment workflow
- allow deployed dataset runs to link back to the change that produced them

The receiving workflow and Watchful support are deployed in opensanctions/operations@8fc0397a.

## Validation

- workflow YAML and repository pre-commit checks pass