### PR TITLE
Allow targeted issues-agent runs

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -2,7 +2,12 @@
 name: Issues agent
 
 "on":
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: "Run only this dataset; empty means all eligible datasets"
+        required: false
+        type: string
   schedule:
     - cron: "0 3 * * 1-5"
     # 12:00 UTC = 14:00 CEST (summer) / 13:00 CET (winter). GHA cron is always
@@ -35,8 +40,13 @@ jobs:
         id: gen
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_DATASET: ${{ inputs.dataset }}
         run: |
-          MATRIX=$(python -m contrib.maintenance.issues_agent --prompts-dir task-prompts)
+          args=(--prompts-dir task-prompts)
+          if [ -n "$TARGET_DATASET" ]; then
+            args+=(--dataset "$TARGET_DATASET")
+          fi
+          MATRIX=$(python -m contrib.maintenance.issues_agent "${args[@]}")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
       # The prompts travel as an artifact, not inside the matrix output: they
@@ -163,4 +173,3 @@ jobs:
           gh pr edit "${{ matrix.task.branch }}" \
             --repo "${{ github.repository }}" \
             --add-label daily-issues
-

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -5,7 +5,7 @@ name: Issues agent
   workflow_dispatch:
     inputs:
       dataset:
-        description: "Run only this dataset; empty means all eligible datasets"
+        description: "Always run this dataset; empty scans all eligible datasets"
         required: false
         type: string
   schedule:

--- a/contrib/maintenance/issues_agent.py
+++ b/contrib/maintenance/issues_agent.py
@@ -4,8 +4,8 @@ Invoked by .github/workflows/issues-agent.yml as:
 
     python -m contrib.maintenance.issues_agent
 
-Pass ``--dataset <name>`` to consider only one dataset. This is used for
-human-triggered runs; scheduled runs omit it and retain the full scan.
+Pass ``--dataset <name>`` to run one dataset regardless of the eligibility
+filters used by the scheduled scan.
 
 Emits the matrix JSON on stdout and writes each task's prompt to
 <prompts-dir>/<dataset>.md; everything human-readable goes to stderr. The
@@ -22,10 +22,12 @@ PR dedup. The shared mechanics live in the sibling modules of this package.
 import argparse
 import json
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
 from jinja2 import Template
+from requests import RequestException
 
 from .archive import MAX_ISSUES, get_issues, get_versions, iter_catalog_datasets
 from .datasets import get_code_path, get_path_from_name, read_dataset_meta
@@ -66,60 +68,100 @@ def log(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def index_jobs(prompts_dir: Path, dataset_name: str | None = None) -> None:
-    outage_datasets = get_outage_datasets()
-    open_autofix_branches = get_open_autofix_branches()
-    tasks: list[Any] = []
-    target_found = False
+def should_spawn_agent(
+    dataset: dict[str, Any],
+    outage_datasets: set[str],
+    open_autofix_branches: set[str],
+) -> bool:
+    """Apply the eligibility policy used by unfiltered scans."""
+    name = dataset.get("name")
+    if not name:
+        return False
+    if dataset.get("type") == "collection":
+        return False
 
-    for dataset in iter_catalog_datasets():
+    levels = dataset.get("issue_levels", {})
+    if levels.get("warning", 0) + levels.get("error", 0) == 0:
+        return False
+    if name in outage_datasets:
+        log(f"Documented outage: {name}")
+        return False
+    if dataset_has_open_pr(name, open_autofix_branches):
+        log(f"Open PR exists: {name}")
+        return False
+
+    versions = get_versions(name)
+    if versions is None or versions.latest is None:
+        log(f"No archived runs: {name}")
+        return False
+    issues = get_issues(name, versions.latest) or []
+    if len(issues) > MAX_ISSUES:
+        log(f"Fubar: {name} ({MAX_ISSUES}+ issues in latest run)")
+        return False
+    if not any(i.get("level") in ("warning", "error") for i in issues):
+        log(f"Latest run is clean: {name}")
+        return False
+    # Don't spawn an agent when a run produced nothing anyone can act on.
+    # Mixed runs (an ignored infrastructure error alongside real issues)
+    # still get a task.
+    if all(is_issue_ignored(i) for i in issues):
+        log(f"Only transient infrastructure issues: {name}")
+        return False
+
+    checksum = issues_checksum(issues)
+    branch = f"{branch_prefix(name)}{checksum[:10]}"
+    if has_closed_pr_for_branch(branch):
+        log(f"Already handled (closed PR): {name} ({branch})")
+        return False
+    return True
+
+
+def index_jobs(prompts_dir: Path, dataset_name: str | None = None) -> None:
+    tasks: list[Any] = []
+    datasets: Iterable[dict[str, Any]]
+
+    if dataset_name is not None:
+        # A targeted run should not depend on any of the remote policy inputs.
+        datasets = [{"name": dataset_name}]
+        outage_datasets: set[str] = set()
+        open_autofix_branches: set[str] = set()
+    else:
+        datasets = iter_catalog_datasets()
+        outage_datasets = get_outage_datasets()
+        open_autofix_branches = get_open_autofix_branches()
+
+    for dataset in datasets:
         name = dataset.get("name")
         if not name:
             continue
-        if dataset_name is not None and name != dataset_name:
-            continue
-        target_found = True
         # The catalogs are only a discovery index: a cheap pre-filter for
         # which datasets are worth a look. The authoritative issue contents
         # and counts come from the latest run in versions.json below — the
         # same run the embedded diagnostic report describes, which can be
         # fresher than the catalog snapshot.
-        levels = dataset.get("issue_levels", {})
-        if levels.get("warning", 0) + levels.get("error", 0) == 0:
-            continue
-        if name in outage_datasets:
-            log(f"Documented outage: {name}")
+        if dataset_name is None and not should_spawn_agent(
+            dataset, outage_datasets, open_autofix_branches
+        ):
             continue
 
-        if dataset_has_open_pr(name, open_autofix_branches):
-            log(f"Open PR exists: {name}")
-            continue
-
-        versions = get_versions(name)
-        if versions is None or versions.latest is None:
-            log(f"No archived runs: {name}")
-            continue
-        issues = get_issues(name, versions.latest) or []
-        if len(issues) > MAX_ISSUES:
-            log(f"Fubar: {name} ({MAX_ISSUES}+ issues in latest run)")
-            continue
+        # Targeted manual runs deliberately bypass eligibility. Missing or
+        # unavailable archive state becomes diagnostic context for the agent
+        # instead of preventing the task from being created.
+        try:
+            versions = get_versions(name)
+            issues = (
+                get_issues(name, versions.latest) or []
+                if versions is not None and versions.latest is not None
+                else []
+            )
+        except (RequestException, json.JSONDecodeError) as exc:
+            log(f"Could not load latest issues for {name}: {exc}")
+            issues = []
         errors = sum(1 for i in issues if i.get("level") == "error")
         warnings = sum(1 for i in issues if i.get("level") == "warning")
-        if warnings + errors == 0:
-            log(f"Latest run is clean: {name}")
-            continue
-        # Don't spawn an agent when a run produced nothing anyone can act on.
-        # Mixed runs (an ignored infrastructure error alongside real issues)
-        # still get a task.
-        if all(is_issue_ignored(i) for i in issues):
-            log(f"Only transient infrastructure issues: {name}")
-            continue
 
         checksum = issues_checksum(issues)
         branch = f"{branch_prefix(name)}{checksum[:10]}"
-        if has_closed_pr_for_branch(branch):
-            log(f"Already handled (closed PR): {name} ({branch})")
-            continue
 
         path = get_path_from_name(name)
         crawler_dir = Path(path).parent.as_posix()
@@ -163,7 +205,8 @@ def index_jobs(prompts_dir: Path, dataset_name: str | None = None) -> None:
             for n, label in ((errors, "error"), (warnings, "warning"))
             if n > 0
         ]
-        title = f"[{name}]: {', '.join(counts)}"
+        summary = ", ".join(counts) if counts else "targeted run"
+        title = f"[{name}]: {summary}"
         (prompts_dir / f"{name}.md").write_text(prompt)
         tasks.append(
             {
@@ -176,8 +219,6 @@ def index_jobs(prompts_dir: Path, dataset_name: str | None = None) -> None:
             }
         )
 
-    if dataset_name is not None and not target_found:
-        log(f"Dataset not found in catalog: {dataset_name}")
     print(json.dumps(tasks))
 
 
@@ -193,7 +234,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--dataset",
-        help="consider only this dataset; omit to scan every eligible dataset",
+        help="always run this dataset; omit to scan every eligible dataset",
     )
     args = parser.parse_args()
     args.prompts_dir.mkdir(parents=True, exist_ok=True)

--- a/contrib/maintenance/issues_agent.py
+++ b/contrib/maintenance/issues_agent.py
@@ -4,6 +4,9 @@ Invoked by .github/workflows/issues-agent.yml as:
 
     python -m contrib.maintenance.issues_agent
 
+Pass ``--dataset <name>`` to consider only one dataset. This is used for
+human-triggered runs; scheduled runs omit it and retain the full scan.
+
 Emits the matrix JSON on stdout and writes each task's prompt to
 <prompts-dir>/<dataset>.md; everything human-readable goes to stderr. The
 prompts travel to the run-tasks job as a workflow artifact rather than inside
@@ -63,15 +66,19 @@ def log(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def index_jobs(prompts_dir: Path) -> None:
+def index_jobs(prompts_dir: Path, dataset_name: str | None = None) -> None:
     outage_datasets = get_outage_datasets()
     open_autofix_branches = get_open_autofix_branches()
     tasks: list[Any] = []
+    target_found = False
 
     for dataset in iter_catalog_datasets():
         name = dataset.get("name")
         if not name:
             continue
+        if dataset_name is not None and name != dataset_name:
+            continue
+        target_found = True
         # The catalogs are only a discovery index: a cheap pre-filter for
         # which datasets are worth a look. The authoritative issue contents
         # and counts come from the latest run in versions.json below — the
@@ -169,6 +176,8 @@ def index_jobs(prompts_dir: Path) -> None:
             }
         )
 
+    if dataset_name is not None and not target_found:
+        log(f"Dataset not found in catalog: {dataset_name}")
     print(json.dumps(tasks))
 
 
@@ -182,6 +191,10 @@ if __name__ == "__main__":
         default=Path("task-prompts"),
         help="directory to write one <dataset>.md prompt file per task into",
     )
+    parser.add_argument(
+        "--dataset",
+        help="consider only this dataset; omit to scan every eligible dataset",
+    )
     args = parser.parse_args()
     args.prompts_dir.mkdir(parents=True, exist_ok=True)
-    index_jobs(args.prompts_dir)
+    index_jobs(args.prompts_dir, dataset_name=args.dataset)


### PR DESCRIPTION
## Summary

- add an optional dataset input to manual issues-agent workflow dispatches
- filter the generated task matrix to that dataset when supplied
- preserve the existing full scan for scheduled and unfiltered manual runs

The existing eligibility policy remains unchanged: documented outages, open autofix PRs, previously handled issue sets, and runs containing only ignored infrastructure issues still produce no task.

## Validation

- repository pre-commit checks pass
- workflow YAML parses successfully
- issues-agent CLI help loads successfully