### PR TITLE
Avoid false failures when no autofix PR is created

### DIFF
--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -163,13 +163,22 @@ jobs:
 
       # The agent opens its PR via mcp__github__create_pull_request, which takes no
       # labels. The branch name is deterministic, so label it here rather than trusting
-      # the agent to do it. Fails harmlessly when no PR was opened (no fixes needed).
+      # the agent to do it. No PR is a valid outcome when no fixes were needed.
       - name: Label the PR
         if: always()
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr edit "${{ matrix.task.branch }}" \
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "${{ matrix.task.branch }}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::notice::No PR was created; skipping label"
+            exit 0
+          fi
+          gh pr edit "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --add-label daily-issues


### PR DESCRIPTION
## Summary

- check whether the issues agent created an open PR before attempting to label it
- treat the valid no-fix/no-PR outcome as a successful notice
- preserve real failures from GitHub API queries or label updates

## Validation

- repository commit hooks pass
- workflow YAML parses successfully
- yamllint passes