### PR TITLE
Consolidate issues agent guidance

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,5 +59,5 @@ jobs:
           # --system-prompt) keeps Claude Code's default behavior and adds to it.
           claude_args: >-
             --model claude-opus-5 --max-turns 30
-            --append-system-prompt "On autofix/* PRs you are tuning datapatch lookups and small crawler fixes. Key references: zavod/docs/best_practices/datapatch_lookups.md (lookups) and .claude/docs/crawler-guide.md. The repo CLAUDE.md maps the rest of the documentation."
+            --append-system-prompt "On autofix/* PRs, preserve the issues-agent PR's narrow scope. Follow zavod/docs/best_practices/datapatch_lookups.md for lookups and zavod/docs/best_practices/change_detection.md for hash changes. The repo CLAUDE.md maps the rest of the documentation."
             --allowed-tools "Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,Skill"

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -118,22 +118,17 @@ jobs:
           # prek + yamllint back contrib/lint_dataset.sh, which the agent runs to
           # verify its edits; zavod[dev] supplies them on the crawler path.
           pip install requests pyyaml prek yamllint
-          # poppler-utils (pdftotext/pdftoppm) so the agent can read PDF source
-          # documents even for datasets whose task doesn't install zavod.
-          sudo apt-get install -y -qq poppler-utils
 
       - name: Install system dependencies
-        if: ${{ matrix.task.needs_zavod }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          # libicu-dev/poppler-utils for zavod; jq + xmllint for the agent to
-          # inspect JSON issue logs and XML source documents while debugging.
+          # Give every agent the same source-inspection tools. libicu-dev backs
+          # zavod's ICU dependency when the full package is installed.
           sudo apt-get install -y -qq libicu-dev poppler-utils jq libxml2-utils
 
       - name: Install qsv
-        if: ${{ matrix.task.needs_zavod }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/issues-agent.yml
+++ b/.github/workflows/issues-agent.yml
@@ -64,9 +64,9 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     name: ${{ matrix.task.name }}
-    # Match build.yml so `zavod crawl` behaves the same as in normal CI: the
-    # agent runs the crawler to verify its fixes (for datasets where ci_test
-    # allows it), so it needs a working zavod install, not just lookup edits.
+    # Match build.yml so an agent can run `zavod crawl` when the change warrants
+    # it and ci_test allows it. Local crawler edits also need the same environment
+    # for linting and type-checking even when the crawler cannot run in CI.
     env:
       OPENSSL_CONF: "contrib/openssl.cnf"
       FTM_USER_AGENT: "Mozilla/5.0 (compatible; github-actions-zavod/0.8; tech@opensanctions.org)"
@@ -108,8 +108,8 @@ jobs:
           # instead of rebuilt every time.
           cache-dependency-path: zavod/pyproject.toml
 
-      # The full zavod install is only needed for crawler datasets (mypy +
-      # crawling). Enrichment and lookup-only datasets edit YAML only, but the
+      # The full zavod install is only needed when local crawler code is editable
+      # (mypy and, when warranted, crawling). Enrichment datasets edit YAML only, but the
       # agent still needs the contrib.maintenance tools (diagnose,
       # aggregate_issues) that the prompt's diagnostic report points at.
       - name: Install maintenance tool dependencies
@@ -137,8 +137,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # qsv is the standard tool for spot-checking emitted data
-          # (e.g. `qsv frequency -s prop statements.pack`), see crawler-guide.md.
+          # qsv is the standard tool for spot-checking emitted data, e.g.
+          # `qsv frequency -s prop statements.pack`.
           # Resolve the latest release asset rather than pinning a version.
           URL=$(gh release view --repo dathere/qsv --json assets \
             -q '.assets[] | select(.name | test("^qsv-.*x86_64-unknown-linux-gnu.zip$")) | .url' \
@@ -152,7 +152,7 @@ jobs:
         working-directory: zavod
         run: |
           python -m pip install --upgrade pip wheel
-          pip install --no-cache-dir -e ".[dev]"
+          pip install -e ".[dev]"
 
       - uses: anthropics/claude-code-action@v1
         with:
@@ -161,7 +161,7 @@ jobs:
           # allowlist exact so other bots cannot start an agent implicitly.
           allowed_bots: opensanctions-watchful
           prompt: ${{ env.TASK_PROMPT }}
-          claude_args: "--model ${{ matrix.task.model }} --max-turns ${{ matrix.task.max_turns }} --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,Skill,mcp__github__create_pull_request\""
+          claude_args: "--model claude-opus-5 --max-turns ${{ matrix.task.max_turns }} --allowed-tools \"Bash,View,Edit,Write,GlobTool,GrepTool,WebFetch,Skill,mcp__github__create_pull_request\""
           show_full_output: true
 
       # The agent opens its PR via mcp__github__create_pull_request, which takes no

--- a/contrib/maintenance/issues_agent.py
+++ b/contrib/maintenance/issues_agent.py
@@ -15,8 +15,8 @@ GitHub silently drops a job output when it spots anything resembling a secret
 in it ("Skip output 'matrix' since it may contain secret"), which breaks the
 fromJson() strategy expression downstream.
 
-This module holds only agent policy — model/turn selection, branch naming and
-PR dedup. The shared mechanics live in the sibling modules of this package.
+This module holds only agent policy — turn budgets, branch naming and PR dedup.
+The shared mechanics live in the sibling modules of this package.
 """
 
 import argparse
@@ -41,17 +41,10 @@ from .github import (
 )
 from .issues import is_issue_ignored, issues_checksum
 
-# Match compute to task difficulty. Lookup/assertion edits on YAML are mechanical,
-# so a mid-tier model with few turns suffices. Datasets with a crawler may need an
-# actual code fix — stronger reasoning, plus turns to run mypy, crawl, and iterate.
-MODEL_LOOKUP = "claude-sonnet-5"
-MODEL_CODE = "claude-opus-5"
-MAX_TURNS_LOOKUP = 30
-MAX_TURNS_CODE_VERIFIABLE = 100  # ci_test true: edit, then crawl-verify and iterate
-MAX_TURNS_CODE_BLIND = 60  # ci_test false: edit + mypy/ruff, no crawl loop
-# Rendered per dataset with the diagnostic context (paths, branch, ci_test) so
-# the prompt can branch between lookup-only and code-fix instructions. autoescape
-# stays off (default) so markdown and YAML examples pass through untouched.
+DEFAULT_MAX_TURNS = 80
+# Rendered per dataset with the diagnostic context (paths, branch, ci_test) so the
+# prompt can state its edit scope and whether end-to-end verification is available.
+# Autoescape stays off (default) so Markdown and YAML examples pass through untouched.
 PROMPT = Template(
     (Path(__file__).parent / "prompt.md").read_text(),
     trim_blocks=True,
@@ -170,21 +163,11 @@ def index_jobs(prompts_dir: Path, dataset_name: str | None = None) -> None:
         ci_test = dataset_meta.get("ci_test", True)
         code_path = get_code_path(path, entry_point)
 
-        # Only crawler datasets can require code, so only they need zavod
-        # installed (for mypy and crawling) and the heavier model/turn budget.
-        if code_path is not None:
-            model = MODEL_CODE
-            max_turns = MAX_TURNS_CODE_VERIFIABLE if ci_test else MAX_TURNS_CODE_BLIND
-            needs_zavod = True
-        else:
-            model = MODEL_LOOKUP
-            max_turns = MAX_TURNS_LOOKUP
-            needs_zavod = False
-
+        # Local crawler code needs zavod's development dependencies for linting and
+        # type-checking even when ci_test is false and the crawler cannot run in CI.
+        needs_zavod = code_path is not None
         deploy_config = dataset_meta.get("deploy", {})
-        max_turns = deploy_config.get("issues_turns", max_turns)
-        if max_turns > MAX_TURNS_CODE_VERIFIABLE:
-            model = MODEL_CODE
+        max_turns = deploy_config.get("issues_turns", DEFAULT_MAX_TURNS)
 
         # The report is the prompt's single source of runtime facts (run
         # verdict, artifact links, the issues themselves); the template only
@@ -213,7 +196,6 @@ def index_jobs(prompts_dir: Path, dataset_name: str | None = None) -> None:
                 "dataset": name,
                 "name": title,
                 "branch": branch,
-                "model": model,
                 "max_turns": max_turns,
                 "needs_zavod": needs_zavod,
             }

--- a/contrib/maintenance/prompt.md
+++ b/contrib/maintenance/prompt.md
@@ -9,7 +9,7 @@ The diagnostic report below is the source of runtime facts. It resolves the data
 ## Choose the correct kind of fix
 
 - **Datapatch lookup — preferred for source-specific exceptions.** Use a lookup when known source values or classes of values can be corrected with exact, `contains` or regex matching. Prefer this to accumulating literal branches and regular expressions in crawler code. Before editing a lookup, read `zavod/docs/best_practices/datapatch_lookups.md` and follow its warning recipes, result-consolidation rules and existing conventions in {{ yaml_path }}.
-- **Assertion bound.** Change an assertion only when the report and source history support legitimate drift. For count metrics, lower a failing minimum to a sensible round value near 80% of the observed count, or raise a failing maximum to roughly twice the observed count. Do not accommodate collapsed, explosive or unexplained output. For fill rates, use a small margin within 0–1. The shared rules are in `zavod/docs/metadata.md#maintaining-assertion-bounds`.
+- **Assertion bound.** Unless the report shows collapsed or explosive output or evidence of a crawler or source-access failure, propose a bounded assertion update for human review even when you cannot determine whether the drift is legitimate. State that uncertainty and the available evidence in the PR. For count metrics, lower a failing minimum to a sensible round value near 80% of the observed count, or raise a failing maximum to roughly twice the observed count. For fill rates, use a small margin within 0–1. The shared rules are in `zavod/docs/metadata.md#maintaining-assertion-bounds`.
 - **Metadata correction.** Correct a source URL or other dataset configuration when the report and current source show that the metadata is wrong.
 {% if code_path %}
 - **Crawler code.** Change {{ code_path }} when the problem is systematic parsing or transformation logic that should work for unseen values, rather than an enumerable set of source exceptions. Search `zavod/docs` for the specific helper or best-practice guide relevant to the change.
@@ -40,7 +40,7 @@ You may modify {{ yaml_path }}, {{ code_path }} and directly related static data
 No dataset-local crawler code is available. Modify only {{ yaml_path }} and skip issues that require crawler or shared-framework changes.
 {% endif %}
 
-Investigate every reported pattern, but change only what you can resolve confidently from the report, source data and documentation. A partial fix is valid. Do not guess, and do not open a PR when nothing warrants a repository change.
+Investigate every reported pattern, but change only what you can resolve confidently from the report, source data and documentation, except for the explicitly reviewable assertion-bound proposals above. A partial fix is valid. Do not guess, and do not open a PR when nothing warrants a repository change.
 
 ## Verify
 

--- a/contrib/maintenance/prompt.md
+++ b/contrib/maintenance/prompt.md
@@ -1,112 +1,79 @@
-You are a data engineer tasked with fixing the warnings and errors produced by a dataset's latest run in an ETL workflow. The dataset is `{{ name }}`.
+Fix the warnings and errors from the latest run of the `{{ name }}` dataset and submit one combined PR containing the fixes you can support with evidence.
 
-A diagnostic report of the dataset's current runtime state follows below: it resolves the relevant file paths, links each run's artifacts on data.opensanctions.org, and contains the issues to fix — inlined in full when there are few, or as grouped message patterns with one example each when there are many. Work from the report; only fetch the issues.json linked in it when the report shows the grouped view and you need every occurrence of a pattern (e.g. all distinct unmapped values).
-
-Your task is to fix as many of the reported issues as you confidently can and submit a single combined PR.
+The diagnostic report below is the source of runtime facts. It resolves the dataset files, links the run artifacts and shows the issues in full or grouped by message pattern. When it shows grouped issues, fetch the linked issues.json only if you need to enumerate every value in a pattern.
 
 ## Diagnostic report
 
 {{ report }}
 
-{% if code_path %}
-## Three kinds of fix
+## Choose the correct kind of fix
 
-1. **Lookups (preferred — always try this first).** Most value-level dirt (an unmapped country, an unparseable date, an unknown gender) is fixed by adding a lookup option to {{ yaml_path }}. Lookups are low-risk and reviewable, so reach for them whenever they can express the fix.
-2. **Crawler code changes.** When a warning cannot be expressed as a lookup — e.g. a parsing bug, a field read from the wrong column, a value that needs transforming before it is added — edit the crawler at {{ code_path }} instead. Keep the change as small and targeted as possible.
-3. **Static data fixes.** Some crawlers read a repository-owned data file, such as CSV or YAML, containing data extracted from sources that are difficult to automate. Update these files when a warning identifies new source data. Preserve the existing schema and follow any dataset-specific instructions in the metadata or crawler comments.
+- **Datapatch lookup — preferred for source-specific exceptions.** Use a lookup when known source values or classes of values can be corrected with exact, `contains` or regex matching. Prefer this to accumulating literal branches and regular expressions in crawler code. Before editing a lookup, read `zavod/docs/best_practices/datapatch_lookups.md` and follow its warning recipes, result-consolidation rules and existing conventions in {{ yaml_path }}.
+- **Assertion bound.** Change an assertion only when the report and source history support legitimate drift. For count metrics, lower a failing minimum to a sensible round value near 80% of the observed count, or raise a failing maximum to roughly twice the observed count. Do not accommodate collapsed, explosive or unexplained output. For fill rates, use a small margin within 0–1. The shared rules are in `zavod/docs/metadata.md#maintaining-assertion-bounds`.
+- **Metadata correction.** Correct a source URL or other dataset configuration when the report and current source show that the metadata is wrong.
+{% if code_path %}
+- **Crawler code.** Change {{ code_path }} when the problem is systematic parsing or transformation logic that should work for unseen values, rather than an enumerable set of source exceptions. Search `zavod/docs` for the specific helper or best-practice guide relevant to the change.
+- **Static data.** Update repository-owned CSV, YAML or other static data in {{ crawler_dir }} when it contains a maintained extraction of source information.
+{% endif %}
+{% if code_path %}
+## Change-detection warnings
+
+For `DOM hash changed`, `URL hash changed` and `File hash changed`, follow `zavod/docs/best_practices/change_detection.md`. Inspect and understand the changed source; inference-based extraction from an unstructured page or document is allowed.
+
+- If source data changed, incorporate it into the dataset before accepting the new hash.
+- If the change is demonstrably cosmetic, the new hash may be accepted, but the PR must explain what changed and why dataset output is unaffected. Improve the monitor scope when the same noise is likely to recur.
+- If the impact is unresolved, retain the old hash and skip the issue.
+{% endif %}
+
+`There are N unaccepted items for dataset ...` is review-system backlog, cleared outside this repository. Do not make a repository change for that warning alone.
+
+## Execution boundary
+
+{% if code_path %}
+This task has Zavod installed. You may modify {{ yaml_path }}, {{ code_path }} and directly related static data inside {{ crawler_dir }}. Do not modify files outside {{ crawler_dir }}.
+
+- Keep crawler changes minimal and limit output differences to those justified by the reported issues.
+- Preserve entity IDs: do not change inputs to `make_id` or `make_slug`, and never put PII into `make_slug`.
 {% else %}
-## How to fix
-
-This dataset has no dataset-local crawler code (see the report), so the only thing you can change is the metadata YAML. Warnings are fixed by adding lookup options to {{ yaml_path }}. A lookup maps a dirty source value (an unmapped country, an unparseable date, an unknown gender) to a clean one. They are low-risk and reviewable.
+This task deliberately runs without Zavod or the wider OpenSanctions application dependencies installed. Modify only {{ yaml_path }}. Do not run `zavod`, `ftm`, or Python commands that import Zavod application modules, and do not edit crawler or shared framework code. Available fixes are lookups, assertion bounds and evidence-backed metadata corrections; skip issues that require anything else.
 {% endif %}
 
-## Reference
+Investigate every reported pattern, but change only what you can resolve confidently from the report, source data and documentation. A partial fix is valid. Do not guess, and do not open a PR when nothing warrants a repository change.
 
-Datapatch lookups — the YAML structure, matching modes, result fields, the property-name → type-lookup mapping, and the recipe for each fixable warning — are documented at:
+## Verify
 
-`zavod/docs/best_practices/datapatch_lookups.md`
+Run the exact static checks used by dataset CI:
 
-The "Common runtime warnings and the lookup that fixes them" and "Property name to type lookup" sections on that page are the primary reference. Use them to translate each warning into a lookup option.
+    contrib/lint_dataset.sh {{ yaml_path }}
 
-The full FollowTheMoney property listing, when a warning mentions a property not covered by the mapping table, is at: https://www.opensanctions.org/reference/
+It may apply formatting fixes. Resolve every finding and rerun it until it prints `lint_dataset: OK`.
 {% if code_path %}
 
-When a fix needs a crawler code change, `.claude/docs/crawler-guide.md` is the hub: it covers the common patterns and links the relevant `zavod/docs` best-practice guides (dates, addresses, HTML/XPath, entity IDs, helpers). Read it, then the specific guide matching the warning.
-{% endif %}
-
-## Assertion failures
-
-Some issues are not dirty values but assertion failures (`min`-bound failures are errors that fail the whole run; `max`-bound failures are warnings), e.g.:
-
-    Assertion schema_entities failed for Security: 669973 is not <= threshold 418000
-
-These mean the dataset's expected size envelope, declared under `assertions:` in {{ yaml_path }}, no longer matches reality because the source legitimately grew or shrank. The report's assertion table compares every declared threshold against the last successful run's statistics — use it to locate the entry to edit and to see which direction reality drifted. See the "Data assertions" section of `zavod/docs/metadata.md` for how thresholds work. **Widen the envelope in the direction it drifted.** Never tighten a threshold toward the current value — that just re-breaks on the next run.
-
-Read the message as `<value> is not <op> threshold <threshold>` and edit the matching entry under `assertions.min.<metric>.<key>` or `assertions.max.<metric>.<key>` (the `<metric>`, e.g. `schema_entities`, and `<key>`, e.g. `Security`, come straight from the message):
-
-- `is not <= threshold` — a `max:` bound was exceeded (the count grew). Raise that `max:` entry to a round number comfortably **above** `<value>` (roughly +15–20%). Example: value 5200 over a max of 4000 → set the max to `6000`.
-- `is not >= threshold` — a `min:` bound was undercut (the count shrank). Lower that `min:` entry to a round number comfortably **below** `<value>` (roughly −15–20%, never below 0). Example: value 117 under a min of 130 → set the min to `100`.
-
-The same logic applies to the other count metrics (`entity_count`, `countries`, `country_entities`). For `property_fill_rate` the threshold is a 0–1 rate, so widen by a small decimal margin instead of rounding.
-
-Exception: when the failing value has collapsed far below the last-good value in the report's assertion table (say, hundreds down to near zero), the crawl or the source is broken — do not widen the envelope to fit a broken run. {% if code_path %}Investigate the crawler instead, or skip it.{% else %}Skip it.{% endif %} For ordinary drift, if you cannot tell whether it is legitimate or a sign the crawler broke, still open the PR with the widened threshold — a reviewer can close it if the envelope should not move.
-
-## Hash-change warnings
-
-Investigate `DOM hash changed`, `URL hash changed`, and `File hash changed` warnings. Hash monitors are often used when data is published in an unstructured page or document that cannot be extracted deterministically. Inspect the changed source and determine what substantive data changed. You may extract that information using inference, then update the dataset's checked-in static data or crawler logic as appropriate.
-
-Update the expected hash only in the same change that incorporates the changed source content into the dataset. Never submit a hash-only change merely to silence the warning. If you cannot confidently incorporate the source change — including when it requires editing an external system unavailable to you — leave the old hash in place and skip the issue.
-
-## Leave these for humans
-
-Some issues are deliberate signals for a maintainer to investigate, not something to auto-fix. Skip them — do not edit anything in response to:
-
-- Review-system backlog: `There are N unaccepted items for dataset ...`. These are cleared by a human in the review UI, not by editing the repository.
-
-HTTP errors (`Runner failed with HTTPError on <url>`) are the exception among runtime failures: when the report shows the failure persisting across several runs, the source has likely moved the file or started blocking the crawler. Locate the new URL on the source's website and update `data.url` in the metadata (or the fetch in the crawler). If you cannot determine a fix, leave it for humans.
-
-## Scope
-
-{% if code_path %}
-- Code changes must be minimal, targeted, and behavior-preserving: fix only the warning at hand, do not refactor, and do not change what the crawler emits beyond that fix.
-- Never change entity IDs — do not alter the values passed to `make_id` / `make_slug`, and never put PII into `make_slug`. Re-keying entities breaks downstream data.
-{% endif %}
-- When adding lookups, NEVER define new YAML options or structures beyond what the datapatch reference describes. Editing existing `assertions:` thresholds is allowed, as described above.
-{% if code_path %}
-- NEVER modify files outside {{ crawler_dir }}.
-{% else %}
-- NEVER modify any file other than {{ yaml_path }}.
-{% endif %}
-- To inspect PDF source documents (many findings and Federal Register rules are PDFs), `pdftotext -layout <file> -` is available; `pdftoppm -png` renders pages as images when the text layout is ambiguous.
-- It is fine to open a PR that fixes only some of the issues.
-- If the correct fix for a value is genuinely uncertain — i.e. you cannot determine from context what it should be — skip that issue. Do not guess. A skipped issue gets human review later; a wrong fix ships incorrect data.
-- Do NOT open a PR if no fixes are needed.
-
-## Workflow
-
-1. Read `zavod/docs/best_practices/datapatch_lookups.md` in full before producing any fixes. The lookup YAML format and the warning-to-recipe mapping in that file are authoritative; do not rely on memory or invent syntax.
-2. Work through the issue patterns in the report's Issues section. When the report shows only the grouped view, fetch the full issues.json it links to enumerate every occurrence of the patterns you are fixing.
-3. For each fixable group, decide which fix applies: a lookup, an assertion-threshold widening, {% if code_path %}a crawler code change, or a static data update{% else %}or skip it if neither fits{% endif %}. For lookups, follow the consolidation rule under "Result values" in the doc — merge inputs that share a result, keep inputs with different results separate. Respect the existing lookup conventions in the file (lookup names, casing flags, ordering).
-4. Apply the fixes: edit {{ yaml_path }}{% if code_path %}, {{ code_path }}, and any directly referenced static data file required by the warning{% endif %}.
-5. Verify your changes:
-   - Your changes MUST pass the checks CI runs, or the PR is dead on arrival:
-
-         contrib/lint_dataset.sh {{ yaml_path }}
-
-     Fix what it reports and rerun until it prints `lint_dataset: OK`, then proceed. Note that it applies some formatting fixes in place.
-{% if code_path %}
-   - If mypy flags `Any` coming from a raw lxml `.xpath()` call, switch that call to the typed `h.xpath_*` helpers.
+If assertions are the only change, assess them from the report and skip the crawl: `zavod crawl` does not evaluate assertion bounds.
 {% if ci_test %}
-   - This crawler runs in CI, so also confirm the fix works end to end: run `zavod crawl --clear-data {{ yaml_path }}`, then read `data/datasets/{{ name }}/issues.log` and confirm the warnings you targeted are gone and that you have not introduced new ones. Do not open the PR if the crawl fails or warnings increase. `jq` (for the JSON logs) and `qsv` (for spot-checking the emitted `data/datasets/{{ name }}/statements.pack`, e.g. `qsv frequency -s prop`) are available.
+For any other change, run a clean end-to-end crawl:
+
+    zavod crawl --clear-data {{ yaml_path }}
+
+Read `data/datasets/{{ name }}/issues.log`. The issues you targeted must be gone and no new warnings or errors may have appeared. Do not open the PR if the crawl fails or makes the issue set worse.
 {% else %}
-   - This crawler CANNOT run in CI (it needs credentials we don't have here, or is too slow), so you cannot verify the fix by crawling. State clearly in the PR body that the code change is unverified and needs human review before merge.
+This crawler cannot run in CI because it needs unavailable credentials or exceeds the CI runtime budget. Do not attempt to crawl it. For crawler-code or static-data changes, state clearly in the PR that the change is unverified and needs human review before merge.
 {% endif %}
-   - Assertion-threshold changes need no verification — a widened bound is taken on trust and reviewed by a human. Do not try to crawl to confirm it.
+{% else %}
+
+Do not attempt an end-to-end crawl. The lint command above is the complete verification available in this non-Zavod task.
 {% endif %}
 
 ## Submit
 
-- Commit and push as soon as your fixes pass the verification above, before doing anything else. Do not keep investigating or looking for further issues while the work sits uncommitted.
-- The branch name MUST be exactly `{{ branch }}` — do not invent your own name or add a slug.
-- Then open a PR via `mcp__github__create_pull_request` from the `{{ branch }}` branch. The title MUST start with `[{{ name }}]` followed by a short headline, and the body must list the warning patterns being fixed{% if code_path %} and flag any crawler code changes separately from lookup changes{% endif %}.
-- If you find more fixable issues after pushing, add or amend commits on the same branch, push again, and update the PR body.
+After investigating all patterns and verifying all intended changes:
+
+1. Commit and push the changes on the branch named exactly `{{ branch }}`.
+2. Open one PR using `mcp__github__create_pull_request` from that branch. The title must start with `[{{ name }}]` followed by a short headline.
+{% if code_path %}
+3. In the body, list the warning patterns addressed and the evidence for each fix. Separate lookup, assertion, metadata, crawler and static-data changes as applicable. For an accepted cosmetic hash change, explain why it has no data impact; for an unverified non-CI code change, flag the missing crawl verification.
+{% else %}
+3. In the body, list the warning patterns addressed and the evidence for each lookup, assertion or metadata fix.
+{% endif %}
+
+If no repository change is justified, do not commit or open a PR.

--- a/contrib/maintenance/prompt.md
+++ b/contrib/maintenance/prompt.md
@@ -49,14 +49,14 @@ Run the exact static checks used by dataset CI:
     contrib/lint_dataset.sh {{ yaml_path }}
 
 It may apply formatting fixes. Resolve every finding and rerun it until it prints `lint_dataset: OK`.
-{% if ci_test %}
+{% if code_path and ci_test %}
 Run a clean crawl when the change is significant enough that end-to-end behavior needs verification; routine lookup and assertion fixes generally need only lint.
 
     zavod crawl --clear-data {{ yaml_path }}
 
 When you crawl, read `data/datasets/{{ name }}/issues.log`. The issues you targeted must be gone and no new warnings or errors may have appeared. Do not open the PR if the crawl fails or makes the issue set worse.
 {% else %}
-This dataset cannot be crawled in CI; lint is the available verification. Do not attempt a crawl.
+This agent run has lint-only verification. Do not attempt a crawl.
 {% endif %}
 
 ## Submit

--- a/contrib/maintenance/prompt.md
+++ b/contrib/maintenance/prompt.md
@@ -27,6 +27,8 @@ For PDFs, start with `pdftotext -layout <file> -`; use `pdftoppm -png <file> <pr
 
 `There are N unaccepted items for dataset ...` is review-system backlog, cleared outside this repository. Do not make a repository change for that warning alone.
 
+`jq` is available for inspecting JSON issue logs, and `qsv` for checking `statements.pack`, for example `qsv frequency -s prop <file>`.
+
 ## Execution boundary
 
 {% if code_path %}
@@ -34,7 +36,6 @@ You may modify {{ yaml_path }}, {{ code_path }} and directly related static data
 
 - Keep crawler changes minimal and limit output differences to those justified by the reported issues.
 - Preserve entity IDs: do not change inputs to `make_id` or `make_slug`, and never put PII into `make_slug`.
-- `jq` is available for inspecting JSON issue logs, and `qsv` for checking `statements.pack`, for example `qsv frequency -s prop <file>`.
 {% else %}
 No dataset-local crawler code is available. Modify only {{ yaml_path }} and skip issues that require crawler or shared-framework changes.
 {% endif %}

--- a/contrib/maintenance/prompt.md
+++ b/contrib/maintenance/prompt.md
@@ -19,6 +19,8 @@ The diagnostic report below is the source of runtime facts. It resolves the data
 
 For `DOM hash changed`, `URL hash changed` and `File hash changed`, follow `zavod/docs/best_practices/change_detection.md`. Inspect and understand the changed source; inference-based extraction from an unstructured page or document is allowed.
 
+For PDFs, start with `pdftotext -layout <file> -`; use `pdftoppm -png <file> <prefix>` when visual structure or scanned content makes text extraction ambiguous.
+
 - If source data changed, incorporate it into the dataset before accepting the new hash.
 - If the change is demonstrably cosmetic, the new hash may be accepted, but the PR must explain what changed and why dataset output is unaffected. Improve the monitor scope when the same noise is likely to recur.
 - If the impact is unresolved, retain the old hash and skip the issue.
@@ -32,6 +34,7 @@ You may modify {{ yaml_path }}, {{ code_path }} and directly related static data
 
 - Keep crawler changes minimal and limit output differences to those justified by the reported issues.
 - Preserve entity IDs: do not change inputs to `make_id` or `make_slug`, and never put PII into `make_slug`.
+- `jq` is available for inspecting JSON issue logs, and `qsv` for checking `statements.pack`, for example `qsv frequency -s prop <file>`.
 {% else %}
 No dataset-local crawler code is available. Modify only {{ yaml_path }} and skip issues that require crawler or shared-framework changes.
 {% endif %}

--- a/contrib/maintenance/prompt.md
+++ b/contrib/maintenance/prompt.md
@@ -15,7 +15,6 @@ The diagnostic report below is the source of runtime facts. It resolves the data
 - **Crawler code.** Change {{ code_path }} when the problem is systematic parsing or transformation logic that should work for unseen values, rather than an enumerable set of source exceptions. Search `zavod/docs` for the specific helper or best-practice guide relevant to the change.
 - **Static data.** Update repository-owned CSV, YAML or other static data in {{ crawler_dir }} when it contains a maintained extraction of source information.
 {% endif %}
-{% if code_path %}
 ## Change-detection warnings
 
 For `DOM hash changed`, `URL hash changed` and `File hash changed`, follow `zavod/docs/best_practices/change_detection.md`. Inspect and understand the changed source; inference-based extraction from an unstructured page or document is allowed.
@@ -23,19 +22,18 @@ For `DOM hash changed`, `URL hash changed` and `File hash changed`, follow `zavo
 - If source data changed, incorporate it into the dataset before accepting the new hash.
 - If the change is demonstrably cosmetic, the new hash may be accepted, but the PR must explain what changed and why dataset output is unaffected. Improve the monitor scope when the same noise is likely to recur.
 - If the impact is unresolved, retain the old hash and skip the issue.
-{% endif %}
 
 `There are N unaccepted items for dataset ...` is review-system backlog, cleared outside this repository. Do not make a repository change for that warning alone.
 
 ## Execution boundary
 
 {% if code_path %}
-This task has Zavod installed. You may modify {{ yaml_path }}, {{ code_path }} and directly related static data inside {{ crawler_dir }}. Do not modify files outside {{ crawler_dir }}.
+You may modify {{ yaml_path }}, {{ code_path }} and directly related static data inside {{ crawler_dir }}. Do not modify files outside {{ crawler_dir }}.
 
 - Keep crawler changes minimal and limit output differences to those justified by the reported issues.
 - Preserve entity IDs: do not change inputs to `make_id` or `make_slug`, and never put PII into `make_slug`.
 {% else %}
-This task deliberately runs without Zavod or the wider OpenSanctions application dependencies installed. Modify only {{ yaml_path }}. Do not run `zavod`, `ftm`, or Python commands that import Zavod application modules, and do not edit crawler or shared framework code. Available fixes are lookups, assertion bounds and evidence-backed metadata corrections; skip issues that require anything else.
+No dataset-local crawler code is available. Modify only {{ yaml_path }} and skip issues that require crawler or shared-framework changes.
 {% endif %}
 
 Investigate every reported pattern, but change only what you can resolve confidently from the report, source data and documentation. A partial fix is valid. Do not guess, and do not open a PR when nothing warrants a repository change.
@@ -47,21 +45,14 @@ Run the exact static checks used by dataset CI:
     contrib/lint_dataset.sh {{ yaml_path }}
 
 It may apply formatting fixes. Resolve every finding and rerun it until it prints `lint_dataset: OK`.
-{% if code_path %}
-
-If assertions are the only change, assess them from the report and skip the crawl: `zavod crawl` does not evaluate assertion bounds.
 {% if ci_test %}
-For any other change, run a clean end-to-end crawl:
+Run a clean crawl when the change is significant enough that end-to-end behavior needs verification; routine lookup and assertion fixes generally need only lint.
 
     zavod crawl --clear-data {{ yaml_path }}
 
-Read `data/datasets/{{ name }}/issues.log`. The issues you targeted must be gone and no new warnings or errors may have appeared. Do not open the PR if the crawl fails or makes the issue set worse.
+When you crawl, read `data/datasets/{{ name }}/issues.log`. The issues you targeted must be gone and no new warnings or errors may have appeared. Do not open the PR if the crawl fails or makes the issue set worse.
 {% else %}
-This crawler cannot run in CI because it needs unavailable credentials or exceeds the CI runtime budget. Do not attempt to crawl it. For crawler-code or static-data changes, state clearly in the PR that the change is unverified and needs human review before merge.
-{% endif %}
-{% else %}
-
-Do not attempt an end-to-end crawl. The lint command above is the complete verification available in this non-Zavod task.
+This dataset cannot be crawled in CI; lint is the available verification. Do not attempt a crawl.
 {% endif %}
 
 ## Submit
@@ -70,10 +61,6 @@ After investigating all patterns and verifying all intended changes:
 
 1. Commit and push the changes on the branch named exactly `{{ branch }}`.
 2. Open one PR using `mcp__github__create_pull_request` from that branch. The title must start with `[{{ name }}]` followed by a short headline.
-{% if code_path %}
-3. In the body, list the warning patterns addressed and the evidence for each fix. Separate lookup, assertion, metadata, crawler and static-data changes as applicable. For an accepted cosmetic hash change, explain why it has no data impact; for an unverified non-CI code change, flag the missing crawl verification.
-{% else %}
-3. In the body, list the warning patterns addressed and the evidence for each lookup, assertion or metadata fix.
-{% endif %}
+3. In the body, list the warning patterns addressed, the evidence for each fix, the applicable lookup, assertion, metadata, crawler or static-data changes, and the verification performed. Explain why an accepted cosmetic hash change has no data impact, and flag crawler or static-data changes that could not be crawl-verified.
 
 If no repository change is justified, do not commit or open a PR.

--- a/contrib/maintenance/prompt.md
+++ b/contrib/maintenance/prompt.md
@@ -27,7 +27,7 @@ For PDFs, start with `pdftotext -layout <file> -`; use `pdftoppm -png <file> <pr
 
 `There are N unaccepted items for dataset ...` is review-system backlog, cleared outside this repository. Do not make a repository change for that warning alone.
 
-`jq` is available for inspecting JSON issue logs, and `qsv` for checking `statements.pack`, for example `qsv frequency -s prop <file>`.
+`jq` is available for inspecting JSON issue logs, and `qsv` for inspecting CSV files such as `statements.pack`, for example `qsv frequency -s prop <file>`.
 
 ## Execution boundary
 

--- a/zavod/docs/best_practices/change_detection.md
+++ b/zavod/docs/best_practices/change_detection.md
@@ -1,0 +1,71 @@
+# Change detection
+
+Change detectors turn a source revision into an explicit maintenance signal. Use them
+when a crawler depends on content that cannot be exhaustively checked by deterministic
+parsing: a hand-maintained extraction from a PDF, a page whose prose determines crawler
+configuration, or a document whose replacement needs review even when its URL is stable.
+
+A hash is an acknowledgement marker, not a correctness check. It proves that the bytes
+or text are the version a maintainer reviewed; it does not prove that the crawler
+interpreted them correctly.
+
+## Choose the smallest stable input
+
+Monitor only the content whose change requires action. Headers, footers, timestamps,
+advertising and generated markup make whole-page hashes noisy and train maintainers to
+ignore warnings.
+
+- [`h.assert_dom_hash`][zavod.helpers.assert_dom_hash] monitors a parsed HTML/XML node.
+  Prefer `text_only=True` when markup changes are irrelevant.
+- [`h.assert_html_url_hash`][zavod.helpers.assert_html_url_hash] fetches an HTML page and
+  monitors the whole document or a selected node.
+- [`h.assert_url_hash`][zavod.helpers.assert_url_hash] hashes the raw response body at a
+  URL. Use it for a stable document URL whose bytes are expected to change only when a
+  new source version is published.
+- [`h.assert_file_hash`][zavod.helpers.assert_file_hash] hashes an already-downloaded
+  file. Use it when the crawler must fetch or unpack the file before choosing what to
+  monitor.
+
+The helpers return `False` and log a warning when the hash differs. Set
+`raise_exc=True` only when continuing would emit wrong or ambiguous data.
+
+```python
+expected = "30aca6ba4b245649db4bee16e0798d661080bd9a"
+if not h.assert_dom_hash(article, expected, text_only=True):
+    context.log.warning(
+        "Page hash changed: update the hand-maintained programme mapping "
+        "before accepting the new hash."
+    )
+```
+
+Put a short runbook next to the assertion when resolving it requires more than inspecting
+the diff. Name the repository-owned static file, crawler configuration or external system
+that must be updated. Record known facts and actions, not guesses about how the publisher
+might behave.
+
+## Respond to a changed hash
+
+Inspect the changed source before editing the expected hash. For unstructured pages and
+documents, including PDFs, it is fine to extract the changed information through careful
+human or model inference when deterministic parsing is impractical.
+
+Classify the change before acting:
+
+1. **The source data changed.** Incorporate the revision into the crawler, its
+   repository-owned static data, or the documented external data store. Update the
+   expected hash in the same maintenance change, then verify the resulting dataset.
+2. **Only irrelevant presentation or metadata changed.** Confirm that the crawler output
+   and any hand-maintained extraction remain correct. The new hash may then be accepted,
+   but explain in the PR what changed and why it has no data impact. If the same kind of
+   noise is likely to recur, narrow the monitored node or use `text_only=True` instead.
+3. **The impact is unresolved.** Leave the old hash in place. Do not suppress the warning
+   or accept a source revision that has not been understood.
+
+Never update a hash merely because the new value appears in the warning. A substantive
+source revision and its dataset update belong together; a cosmetic revision needs an
+explicit, evidence-based explanation.
+
+Change detection complements [strict interpretation](strict_interpretation.md). Prefer a
+deterministic structural guard when one can express the invariant: required dictionary
+keys, typed XPath selectors with count expectations, categorical lookups and dataset
+assertions produce more useful failures than a broad content hash.

--- a/zavod/docs/best_practices/change_detection.md
+++ b/zavod/docs/best_practices/change_detection.md
@@ -1,71 +1,99 @@
-# Change detection
+Change detectors identify source revisions that require review when a crawler cannot
+interpret every relevant change deterministically.
 
-Change detectors turn a source revision into an explicit maintenance signal. Use them
-when a crawler depends on content that cannot be exhaustively checked by deterministic
-parsing: a hand-maintained extraction from a PDF, a page whose prose determines crawler
-configuration, or a document whose replacement needs review even when its URL is stable.
+A detector does not need to extract the changed data itself. It can watch a stable sentinel
+such as a document URL, publication identifier, version date, or content hash and ask for
+review when it encounters one that has not been acknowledged.
 
-A hash is an acknowledgement marker, not a correctness check. It proves that the bytes
-or text are the version a maintainer reviewed; it does not prove that the crawler
+Use change detection when a crawler depends on content that cannot be exhaustively checked
+by deterministic parsing: a hand-maintained extraction from a PDF, a page whose prose
+determines crawler configuration, or a document whose replacement needs review even when
+its URL is stable.
+
+## Separate discovery from extraction
+
+If a crawler can discover revisions reliably but cannot interpret them reliably in code,
+split discovery from extraction:
+
+- Keep the reviewed extraction in a repository-owned CSV or similar static file. The
+  crawler reads this file to produce the dataset.
+- Poll an authoritative index, document table, or version feed for stable sentinels that
+  identify source revisions.
+- Treat a sentinel as reviewed when rows in the static file cite it, or when it is
+  explicitly recorded as having no data impact. Warn about every other sentinel and
+  include enough source context to begin a review.
+
+Put a short extraction runbook in the dataset metadata next to the reviewed-sentinel
+configuration. Resolving a warning means inspecting the source, updating the static data
+when needed, and acknowledging the sentinel in the same pull request. A human or agent can
+draft the extraction. The repository diff is the unit that a maintainer reviews.
+
+This pattern is a good fit when discovery is deterministic, a stable sentinel exists, and
+the curated extraction is small enough to review in Git. If the source publishes structured
+data that can be interpreted directly, parse it instead and use structural guards to detect
+unexpected values or shapes.
+
+A hash is one kind of acknowledgment marker, not a correctness check. It proves that the
+bytes or text are the version a maintainer reviewed; it does not prove that the crawler
 interpreted them correctly.
 
 ## Choose the smallest stable input
 
 Monitor only the content whose change requires action. Headers, footers, timestamps,
-advertising and generated markup make whole-page hashes noisy and train maintainers to
+advertising, and generated markup make whole-page hashes noisy and train maintainers to
 ignore warnings.
 
 - [`h.assert_dom_hash`][zavod.helpers.assert_dom_hash] monitors a parsed HTML/XML node.
-  Prefer `text_only=True` when markup changes are irrelevant.
+  If markup changes are irrelevant, prefer `text_only=True`.
 - [`h.assert_html_url_hash`][zavod.helpers.assert_html_url_hash] fetches an HTML page and
   monitors the whole document or a selected node.
 - [`h.assert_url_hash`][zavod.helpers.assert_url_hash] hashes the raw response body at a
   URL. Use it for a stable document URL whose bytes are expected to change only when a
   new source version is published.
 - [`h.assert_file_hash`][zavod.helpers.assert_file_hash] hashes an already-downloaded
-  file. Use it when the crawler must fetch or unpack the file before choosing what to
-  monitor.
+  file. If the crawler must fetch or unpack the file before choosing what to monitor, use
+  this helper.
 
-The helpers return `False` and log a warning when the hash differs. Set
-`raise_exc=True` only when continuing would emit wrong or ambiguous data.
+The helpers return `False` and log a warning when the hash differs. If continuing would
+emit wrong or ambiguous data, set `raise_exc=True`.
 
 ```python
 expected = "30aca6ba4b245649db4bee16e0798d661080bd9a"
 if not h.assert_dom_hash(article, expected, text_only=True):
     context.log.warning(
-        "Page hash changed: update the hand-maintained programme mapping "
+        "Page hash changed: update the hand-maintained program mapping "
         "before accepting the new hash."
     )
 ```
 
-Put a short runbook next to the assertion when resolving it requires more than inspecting
-the diff. Name the repository-owned static file, crawler configuration or external system
-that must be updated. Record known facts and actions, not guesses about how the publisher
-might behave.
+If resolving the warning requires more than inspecting the diff, put a short runbook next
+to the assertion. Name the repository-owned static file, crawler configuration, or external
+system that must be updated. Record known facts and actions, not guesses about how the
+publisher might behave.
 
 ## Respond to a changed hash
 
-Inspect the changed source before editing the expected hash. For unstructured pages and
-documents, including PDFs, it is fine to extract the changed information through careful
-human or model inference when deterministic parsing is impractical.
+Inspect the changed source before editing the expected hash. If deterministic parsing is
+impractical, you can extract changed information from unstructured pages and documents,
+including PDFs, through human or model inference.
 
 Classify the change before acting:
 
-1. **The source data changed.** Incorporate the revision into the crawler, its
-   repository-owned static data, or the documented external data store. Update the
-   expected hash in the same maintenance change, then verify the resulting dataset.
-2. **Only irrelevant presentation or metadata changed.** Confirm that the crawler output
-   and any hand-maintained extraction remain correct. The new hash may then be accepted,
-   but explain in the PR what changed and why it has no data impact. If the same kind of
-   noise is likely to recur, narrow the monitored node or use `text_only=True` instead.
-3. **The impact is unresolved.** Leave the old hash in place. Do not suppress the warning
-   or accept a source revision that has not been understood.
+- **The source data changed.** Incorporate the revision into the crawler, its
+  repository-owned static data, or the documented external data store. Update the expected
+  hash in the same maintenance change, then verify the resulting dataset.
+- **Only irrelevant presentation or metadata changed.** Confirm that the crawler output
+  and any hand-maintained extraction remain correct. The new hash may then be accepted,
+  but explain in the PR what changed and why it has no data impact. If the same kind of
+  noise is likely to recur, narrow the monitored node or use `text_only=True` instead.
+- **The impact is unresolved.** Leave the old hash in place. Do not suppress the warning
+  or accept a source revision that has not been understood.
 
 Never update a hash merely because the new value appears in the warning. A substantive
 source revision and its dataset update belong together; a cosmetic revision needs an
 explicit, evidence-based explanation.
 
-Change detection complements [strict interpretation](strict_interpretation.md). Prefer a
-deterministic structural guard when one can express the invariant: required dictionary
-keys, typed XPath selectors with count expectations, categorical lookups and dataset
+Change detection complements [strict interpretation](strict_interpretation.md). If a
+deterministic structural guard can express the invariant, prefer it: required dictionary
+keys, typed XPath selectors with count expectations, categorical lookups, and dataset
 assertions produce more useful failures than a broad content hash.

--- a/zavod/docs/best_practices/datapatch_lookups.md
+++ b/zavod/docs/best_practices/datapatch_lookups.md
@@ -8,6 +8,24 @@ The mechanism comes from the [datapatch](https://pypi.org/project/datapatch/) li
     Avoid using lookups to express something not evident in the data. For example, do not make a date more precise than it is in the data, even if you know your version to be true.
 
 
+## Prefer data mappings over special-case code
+
+Use a lookup when a correction can be expressed as an enumerable set or class of source
+values. Exact matches, substring matches and regular expressions all belong in the
+dataset metadata when they encode exceptions such as known misspellings, source labels,
+placeholder values or malformed identifiers.
+
+Prefer this even when an `if` statement or regex in the crawler could produce the same
+result. Source-specific branches accumulate into deep, hard-to-review decision trees;
+lookups keep those decisions declarative, grouped and visible to reviewers.
+
+Use crawler code when the rule is a general part of parsing or transformation rather than
+a collection of known cases: selecting the correct column, splitting a structured field,
+following pagination, or applying an algorithm that should work for unseen values. A
+growing chain of literal comparisons or regexes added one warning at a time is a signal
+that the rule belongs in a lookup.
+
+
 ## Two ways lookups get invoked
 
 Lookups appear under the `lookups:` key in the dataset YAML. Each named lookup is invoked in one of two ways:
@@ -201,7 +219,7 @@ Pass `warn_unmatched=True` to log a warning when a value matches no option — t
 For lookups where any unmatched value should halt the crawl, set `required: true` on the lookup itself. A miss then raises `LookupException`.
 
 
-## Common runtime warnings and the lookup that fixes them
+## Common runtime warnings involving lookups
 
 Several warnings emitted by `zavod` are best fixed by adding a lookup option. Each row below names the warning, what triggered it, and the lookup recipe.
 
@@ -213,6 +231,8 @@ Several warnings emitted by `zavod` are best fixed by adding a lookup option. Ea
 | `HTML/XSS suspicion in property value: <value>` | The value contains HTML tags or entity references — usually leftover markup from extraction. | Map the dirty value to its cleaned text via a `type.<type>` lookup. If the markup is genuinely intended (rare), add `silence_warnings: [xss-html-smell]` to the option. |
 | `Property value for <prop> exceeds type length: <value>` | The value is longer than the type's `max_length`. `zavod` warns but does not truncate. | `type.<type>` lookup with a shorter `value:`. |
 | `Failed to validate <format> identifier: <value>` | The value did not validate against a known identifier format (`bic`, `isin`, `lei`, `iban`, `inn`, `ogrn`, `npi`, `uei`, `qid`, `uscc`, `imo`). | `type.identifier` lookup with `match: <value>` and a corrected `value:`, or `value: null`. |
+| `No matching lookup found.` | A named lookup called with `warn_unmatched=True` has no option for the source value. | Add an option to that named lookup after determining the value's meaning. If it represents a new structural category, update the crawler's modelling as well. |
+| `Invalid type lookup property re-write` | An existing `prop:` result names a property unavailable on the entity's schema. | Correct the destination property or split the option by schema. Do not silence the warning: the value otherwise falls back to its original property. |
 
 ### Property name to type lookup
 

--- a/zavod/docs/best_practices/strict_interpretation.md
+++ b/zavod/docs/best_practices/strict_interpretation.md
@@ -47,9 +47,10 @@ context.audit_data(row, ignore=["hair_colour", "committee_memberships"])
 Extract the in-scope fields with selections that fail when the page no longer matches expectations, and leave the rest of the page alone:
 
 - [`h.xpath_element`][zavod.helpers.xpath_element] raises on zero or multiple matches; `expect_exactly=` pins a known count; open-ended selections get an `assert len(items) > 0, items`.
-- [`h.assert_dom_hash`][zavod.helpers.assert_dom_hash] warns when a hand-parsed page region drifts.
+- A [change detector](change_detection.md) warns when hand-parsed or manually
+  maintained source content drifts.
 
-See [XPath and HTML](xpath_and_html.md) for the full toolkit and selector-quality guidance.
+See [XPath and HTML](xpath_and_html.md) for selector-quality guidance.
 
 ## Assert the invariants of a valid parse
 

--- a/zavod/docs/best_practices/xpath_and_html.md
+++ b/zavod/docs/best_practices/xpath_and_html.md
@@ -78,19 +78,10 @@ items = h.xpath_elements(doc, ".//h2[text()='The Section']/following-sibling::ul
 assert len(items) > 0, items
 ```
 
-## Use content hashes to flag silent changes
+## Detect changes in hand-parsed content
 
-To get a warning when page content changes from a previously hardcoded hash, use [`h.assert_dom_hash`][zavod.helpers.assert_dom_hash]. This catches drift that would otherwise need to be noticed manually: data extracted by hand, or a new section that should trigger a review of the parser. Scope the hash to a specific block of content, not the whole document, so frequently changing parts of the site (headers, footers, ads) do not trigger spurious warnings.
-
-By default, `h.assert_dom_hash` logs a warning and returns `False` when the hash does not match, allowing the crawler to continue. Use the return value to log a maintainer-facing message that explains what to recheck before updating the hash:
-
-```python
-expected = "30aca6ba4b245649db4bee16e0798d661080bd9a"
-if not h.assert_dom_hash(article, expected, text_only=True):
-    context.log.warning(
-        "Page hash changed: confirm the referenced lists are still the "
-        "UNSC Taliban and Al-Qaida lists before updating the hash."
-    )
-```
-
-Pass `text_only=True` to ignore markup churn (class renames, added wrappers) and hash only the visible text. Pass `raise_exc=True` to turn the check into a hard failure when continuing past a change is unacceptable. For checking a whole page by URL rather than a sub-tree, use [`h.assert_html_url_hash`][zavod.helpers.assert_html_url_hash].
+Use [`h.assert_dom_hash`][zavod.helpers.assert_dom_hash] when a change to a particular
+HTML region needs human review, such as content extracted by hand or prose that controls
+crawler configuration. Pass `text_only=True` to ignore markup churn and monitor visible
+text. The [change-detection guide](change_detection.md) covers monitor selection, scoping
+and the rules for accepting a new hash.

--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -151,13 +151,31 @@ HTTP requests for GET requests are automatically retried for connection and HTTP
 
 ### Data assertions
 
-Data assertions are intended to "smoke test" the data. Assertions are checked on export. If assertions aren't met, warnings are emitted.
+Data assertions smoke-test the exported dataset against its expected shape. They run
+during `zavod run`; `zavod validate` applies them to a development run. A failed `min`
+assertion is an error and prevents export, while a failed `max` assertion emits a warning.
 
-Data assertions are checked when running `zavod run` (and `zavod validate` is useful when developing a crawler).
+When creating count assertions, base them on a known healthy crawl. Set minima roughly
+10–20% below the expected value to allow normal variation, unless the source has a known
+hard minimum. Set maxima around twice the expected value to leave room for ordinary
+growth while still catching duplication and runaway parsing.
 
-Data assertions are useful to communicate our expectations about what's in a dataset. `min` validations set a baseline for what should be in the dataset and are fatal to the export if they fail. `max` validations emit a warning when the dataset has grown beyond the validity of our earlier baseline (or if something's gone horribly wrong and emitted way more than expected)
+### Maintaining assertion bounds
 
-It's a good idea to add assertions at the start of writing a crawler, and then see whether those expectations are met when the crawler is complete. A good rule of thumb for datasets that change over time is minima 10% below the expected number to allow normal variation, unless there's a known hard minimum, and a maximum around twice the expected number of entities to leave room to grow.
+A violated bound is a signal to explain the latest run, not an instruction to fit the
+envelope around any output. Compare the run with the last successful statistics and, when
+needed, its delta or source history.
+
+When a count change is legitimate, move the bound outward from the observed value and
+round it in the safe direction:
+
+- Lower a failing minimum to about 80% of the observed count.
+- Raise a failing maximum to about twice the observed count.
+
+Do not update a bound when the output collapsed, exploded or otherwise cannot be
+explained. Repair the crawler or source access instead. For `property_fill_rate`, stay
+within the 0–1 domain and choose a small margin that preserves the assertion's intended
+quality signal; count rounding and doubling do not apply.
 
 A basic assertion block can look like this:
 
@@ -178,6 +196,8 @@ assertions:
 
 
 #### Assertion types
+
+**`entity_count`** asserts on the total number of entities in the dataset.
 
 **`schema_entities`** asserts on the number of entities of a given schema.
 

--- a/zavod/mkdocs.yml
+++ b/zavod/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - helpers.md
   - Best practices:
       - best_practices/strict_interpretation.md
+      - best_practices/change_detection.md
       - best_practices/caching.md
       - best_practices/patterns.md
       - best_practices/addresses.md


### PR DESCRIPTION
## Summary

- add authoritative Zavod guidance for change detection, datapatch choice, and assertion maintenance
- simplify the issues-agent prompt around one fix taxonomy and evidence-based scope
- use Opus with an 80-turn default for every task, retaining per-dataset `issues_turns` overrides
- let `code_path` control only editable scope and Zavod dependency installation
- let `ci_test` control only whether crawl verification is available
- make crawling proportional to the actual change instead of mandatory for every non-assertion edit
- enable the existing pip cache by removing `--no-cache-dir`

## Execution semantics

- every task receives `claude-opus-5` and 80 turns by default
- local crawler code causes Zavod to be installed for linting/type-checking, even when `ci_test: false`
- datasets without local crawler code remain YAML-only
- `ci_test: false` tasks lint only and must not attempt a crawl
- `ci_test: true` tasks crawl when the change is significant enough to need end-to-end verification; routine lookup and assertion fixes generally lint only
- hash-change handling is independent of these capability decisions

## Verification

- rendered all `code_path` / `ci_test` prompt combinations with strict Jinja undefined handling
- generated representative matrix tasks for CI and non-CI local crawlers, a no-code dataset, and an `issues_turns` override
- confirmed the matrix no longer contains a model and uses 80 turns unless overridden
- parsed workflow YAML and built Zavod documentation
- ran repository hooks and `git diff --check`

The MkDocs build retains two existing non-fatal `griffe` warnings from `zavod/extract/zyte_api.py:333`.