### PR TITLE
[ro_onpcsb_sanctions] Replace dead PDF hash check with page-reference tripwire

### DIFF
--- a/datasets/ro/onpcsb_sanctions/crawler.py
+++ b/datasets/ro/onpcsb_sanctions/crawler.py
@@ -1,7 +1,5 @@
 import csv
 
-from rigour.mime.types import PDF
-
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
@@ -84,25 +82,26 @@ def crawl_row(context: Context, row: dict[str, str]) -> None:
 
 
 def crawl(context: Context) -> None:
-    url_xpath = ".//a[contains(text(), 'HG nr. 1.272/2005')]/@href"
+    # HG 1.272/2005 has never been amended since its adoption, so the Google
+    # Sheet transcription below cannot go stale. The ONPCSB link to the PDF is
+    # broken (redirect loop), so instead of fetching it, just check that the
+    # decision is still referenced on the ONPCSB legislation page as a tripwire
+    # for it being repealed or replaced.
     assert context.dataset.url is not None
+    # Zyte because the connection times out when connecting from Google Cloud.
     doc = zyte_api.fetch_html(
         context,
         context.dataset.url,
-        url_xpath,
+        "//a[contains(@href, 'pdf')]",
         cache_days=1,
-        absolute_links=True,
         geolocation="RO",
     )
-    pdf_url = h.xpath_string(doc, url_xpath)
-    # Zyte because the connection times out when connecting from Google Cloud.
-    _, _, _, path = zyte_api.fetch_resource(context, "source.pdf", pdf_url, PDF)
-    # Ensure that the PDF our Google Sheet is based on hasn't changed
-    # since we last updated the Google Sheet.
-    h.assert_file_hash(path, "583e5e471beabb3b5bde7b259770998952bdfea0")
-    # AL-ZINDANI, Shaykh Abd-al-Majid
-    # ...
-    # AL AKHTAR TRUST
+    if not h.xpath_elements(doc, ".//a[contains(text(), 'HG nr. 1.272/2005')]"):
+        context.log.warning(
+            "HG nr. 1.272/2005 is no longer referenced on the ONPCSB legislation"
+            " page. Check whether the decision has been repealed or replaced.",
+            url=context.dataset.url,
+        )
 
     path = context.fetch_resource("source.csv", context.data_url)
     with open(path, encoding="utf-8") as fh:


### PR DESCRIPTION
Fixes #4635.

The crawler has been failing since 2026-06-19 because the ONPCSB link to the HG 1.272/2005 PDF is a `www ↔ non-www` redirect loop, which Zyte surfaces as repeated 520 errors.

Research on the legal status (see https://github.com/opensanctions/opensanctions/issues/4635#issuecomment-5236964008): the decision has never been amended since 2005 and Romania has no functioning national designation regime, so the transcribed Google Sheet data cannot go stale.

Changes:
- Drop the PDF download and the `assert_file_hash` check on it.
- Keep fetching the ONPCSB legislation page via Zyte (unblock validator is now a generic "page contains PDF links" check), and **warn** — without failing the crawl — if `HG nr. 1.272/2005` is no longer referenced on it, as a tripwire for the decision being repealed or replaced.
- The Google Sheet CSV remains the data source, unchanged.

Validated: `mypy --strict` passes; local crawl completes with 260 entities, 0 changed statements, empty `issues.log` (reference found, no warning fired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)