### PR TITLE
[my_moha_sanctions] Switch to XML

### DIFF
--- a/datasets/my/moha_sanctions/crawler.py
+++ b/datasets/my/moha_sanctions/crawler.py
@@ -1,74 +1,83 @@
-import string
-
-from datapatch import Lookup
-from normality import squash_spaces
-from pdfplumber.page import Page
-from rigour.mime.types import PDF
-from typing import Any
+from rigour.mime.types import XML
 
 from zavod import Context, helpers as h
-from zavod.extract.zyte_api import fetch_html
+from zavod.extract.zyte_api import fetch_html, fetch_resource
+from zavod.util import Element
 
-ID_SPLITS = [f"({c}) " for c in string.ascii_lowercase[:17]]  # a-q
-ALIAS_SPLITS = [f"{c}) " for c in string.ascii_lowercase[:17]]  # a-q
-INVALID_ROWS = "Name"
-
-
-def rename_headers(
-    context: Context, row: dict[str, str | None], custom_lookup: Lookup
-) -> dict[str, str | None]:
-    result = {}
-    for old_key, value in row.items():
-        new_key = custom_lookup.get_value(old_key)
-        if new_key is None:
-            context.log.warning("Unknown column title", column=old_key)
-            new_key = old_key
-        result[new_key] = value
-    return result
+SOURCE_MEDIA_TYPE = "text/xml"
+# Fields holding several values separate them with a pipe.
+VALUE_SPLITS = ["|"]
+# Names carry aliases after an at sign, e.g. "Mansor @ Termizi bin Mat Hussin".
+NAME_SPLITS = ["@"]
+# Identifier fields use a slash in addition to the pipe.
+NUMBER_SPLITS = ["|", "/"]
+# All entries sit in a single section, so individuals and groups are told apart
+# by the set of columns each entry carries.
+PERSON_COLUMNS = 13
+ORGANIZATION_COLUMNS = 7
 
 
-def clean_value(v: str | None) -> str | None:
-    if not v:
-        return v
-    v = squash_spaces(v)
-    return "" if v == "-" else v
+def clean_value(value: str) -> str | None:
+    """Return None for the placeholder the source uses for missing values."""
+    value = value.strip()
+    return None if value in ("", "-") else value
 
 
-def crawl_row(
-    context: Context,
-    row: dict[str, str | None],
-    schema: str,
-    key: str,
-) -> None:
-    names = row.pop("name")
+def parse_entry(context: Context, entry: Element) -> dict[str, str | None]:
+    """Map an entry's numbered fields onto the stable keys used below.
+
+    Column labels are numbered and their wording varies between the individual
+    and group tables (and contains typos), so they are resolved through a
+    lookup rather than slugified.
+    """
+    row: dict[str, str | None] = {}
+    for field in h.xpath_elements(entry, "./field"):
+        label = field.get("name")
+        if label is None:
+            raise ValueError(f"Field without a name in entry {entry.get('id')}")
+        key = context.lookup_value("columns", label)
+        if key is None:
+            raise ValueError(f"Unknown column: {label!r}")
+        if key in row:
+            raise ValueError(f"Duplicate column: {label!r}")
+        row[key] = clean_value(h.element_text(field))
+    return row
+
+
+def crawl_entry(context: Context, entry: Element) -> None:
+    row = parse_entry(context, entry)
+    if len(row) == PERSON_COLUMNS:
+        assert "birth_date" in row, row
+        schema, key = "Person", "person"
+    elif len(row) == ORGANIZATION_COLUMNS:
+        schema, key = "Organization", "group"
+    else:
+        raise ValueError(f"Unexpected number of columns: {len(row)}")
+
     reference = row.pop("reference_no")
-    # Early exits for headers or invalid rows
-    if not names or INVALID_ROWS in names:
-        return
+    if reference is None:
+        raise ValueError(f"Entry {entry.get('id')} has no reference number")
+
     entity = context.make(schema)
     entity.id = context.make_slug(key, reference)
-    entity.add("name", names.split("@"))
+    entity.add("name", h.multi_split(row.pop("name"), NAME_SPLITS))
     entity.add("topics", "sanction")
     entity.add("address", row.pop("address"))
-
-    alias_splits = ID_SPLITS if entity.schema.is_a("Person") else ALIAS_SPLITS
-    for field in ["alias", "other_name"]:
-        value = row.pop(field, None)
-        if value:
-            entity.add("alias", h.multi_split(value, alias_splits))
+    for field in ("alias", "other_name"):
+        entity.add("alias", h.multi_split(row.pop(field, None), VALUE_SPLITS))
 
     if entity.schema.is_a("Person"):
-        entity.add("title", row.pop("title", None))
-        h.apply_date(entity, "birthDate", row.pop("birth_date", None))
-        entity.add("birthPlace", row.pop("birth_place", None))
-        entity.add("nationality", row.pop("citizenship", None))
-        entity.add("position", row.pop("position", None))
-        entity.add("passportNumber", row.pop("passport_no", None))
-        for id in h.multi_split(row.pop("id_no", None), ID_SPLITS):
-            entity.add("idNumber", id)
+        entity.add("title", row.pop("title"))
+        h.apply_date(entity, "birthDate", row.pop("birth_date"))
+        entity.add("birthPlace", row.pop("birth_place"))
+        entity.add("nationality", row.pop("citizenship"))
+        entity.add("position", row.pop("position"))
+        passport_no = row.pop("passport_no")
+        entity.add("passportNumber", h.multi_split(passport_no, NUMBER_SPLITS))
+        entity.add("idNumber", h.multi_split(row.pop("id_no"), NUMBER_SPLITS))
 
     sanction = h.make_sanction(context, entity)
-    h.apply_date(sanction, "listingDate", row.pop("date_listed", None))
+    h.apply_date(sanction, "listingDate", row.pop("date_listed"))
     sanction.add("authorityId", reference)
 
     context.emit(entity)
@@ -76,60 +85,23 @@ def crawl_row(
     context.audit_data(row, ignore=["internal_no"])
 
 
-def page_settings(page: Page) -> tuple[Page, dict[str, Any]]:
-    # Crop top/bottom margins to focus on table area
-    cropped = page.crop((0, 75, page.width, page.height - 10))
-    settings = {
-        "vertical_strategy": "lines",
-        "horizontal_strategy": "lines",
-        "text_tolerance": 1,
-    }
-    return cropped, settings
-
-
-def crawl_pdf_url(context: Context) -> str:
-    validator = ".//*[contains(text(), 'LIST OF SANCTIONS UNDER THE MINISTRY OF HOME AFFAIRS (MOHA)')]"
+def crawl_xml_url(context: Context) -> str:
+    page_title_xpath = ".//*[contains(text(), 'LIST OF SANCTIONS UNDER THE MINISTRY OF HOME AFFAIRS (MOHA)')]"
     html = fetch_html(
-        context, context.data_url, validator, cache_days=5, absolute_links=True
+        context, context.data_url, page_title_xpath, cache_days=5, absolute_links=True
     )
-    source_url = h.xpath_string(
-        html,
-        ".//div[@class='uk-container']//a[contains(., 'sanctions list') and contains(@href, '.pdf')]/@href",
-    )
-    return source_url
+    xml_link_xpath = ".//div[@class='uk-container']//a[contains(., 'sanctions list') and contains(@href, '.xml')]/@href"
+    return h.xpath_string(html, xml_link_xpath)
 
 
 def crawl(context: Context) -> None:
-    pdf_url = crawl_pdf_url(context)
-    path = context.fetch_resource("source.pdf", pdf_url)
-    # If the PDF file has changed, check if the headers mappings are still on
-    h.assert_file_hash(path, "552f0197dfbdb04672f78173f0f5fe2ed981504b")
-    context.export_resource(path, PDF, title=context.SOURCE_TITLE)
+    xml_url = crawl_xml_url(context)
+    _, _, _, path = fetch_resource(
+        context, "source.xml", xml_url, expected_media_type=SOURCE_MEDIA_TYPE
+    )
+    context.export_resource(path, XML, title=context.SOURCE_TITLE)
 
-    for row in h.parse_pdf_table(
-        context,
-        path,
-        headers_per_page=True,
-        preserve_header_newlines=True,
-        skiprows=0,
-        page_settings=page_settings,
-    ):
-        row = {
-            k.split("\n")[-1].strip().lower(): clean_value(v)
-            for k, v in row.items()
-            if k and k.split("\n")[-1].strip()
-        }
-        # Decide schema based on number of columns in header
-        num_cols = len(row.keys())
-        if num_cols == 13:
-            schema, key = "Person", "person"
-            row = rename_headers(context, row, context.get_lookup("columns_person"))
-        elif num_cols == 7:
-            schema, key = "Organization", "group"
-            row = rename_headers(
-                context, row, context.get_lookup("columns_organization")
-            )
-        else:
-            context.log.warning(f"Unexpected number of columns: {num_cols}")
-            return
-        crawl_row(context, row, schema, key)
+    doc = context.parse_resource_xml(path)
+    entries = h.xpath_elements(doc.getroot(), ".//entry")
+    for entry in entries:
+        crawl_entry(context, entry)

--- a/datasets/my/moha_sanctions/my_moha_sanctions.yml
+++ b/datasets/my/moha_sanctions/my_moha_sanctions.yml
@@ -36,17 +36,12 @@ publisher:
 url: https://www.moha.gov.my/utama/index.php/en/component/content/article/350-list-of-ministries-of-home-affairs
 data:
   url: https://www.moha.gov.my/utama/index.php/en/component/content/article/350-list-of-ministries-of-home-affairs
-  format: PDF
-  lang: msa
+  format: XML
+  lang: eng
 http:
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.90 Safari/537.36" (zavod; opensanctions.org)
 dates:
   formats: ["%d %B %Y", "%d %b %Y", "%d.%m.%Y"]
-  months:
-    May: Mei
-    February: Februari
-    August: Ogos
-    January: Januari
 tags:
   - list.sanction
 
@@ -61,68 +56,54 @@ assertions:
       Organization: 50
 
 lookups:
-  columns_person:
-    options:
-      - match: 1
-        value: internal_no  # renaming this from 'no' to avoid consfusion with the falsy interpretation by the lookup
-      - match: 2
-        value: reference_no
-      - match: 3
-        value: name
-      - match: 4
-        value: title
-      - match: 5
-        value: position
-      - match: 6
-        value: birth_date
-      - match: 7
-        value: birth_place
-      - match: 8
-        value: other_name
-      - match: 9
-        value: citizenship
-      - match: 10
-        value: passport_no
-      - match: 11
-        value: id_no
-      - match: 12
-        value: address
-      - match: 13
-        value: date_listed
-  columns_organization:
-    options:
-      - match:
-          - 1
-          - "no"
-        value: internal_no
-      - match:
-          - 2
-          - reference
-        value: reference_no
-      - match:
-          - 3
-          - name
-        value: name
-      - match:
-          - 4
-          - alias
-        value: alias
-      - match:
-          - 5
-          - other_name
-        value: other_name
-      - match:
-          - 6
-          - address
-        value: address
-      - match:
-          - 7
-          - date_of_listed
-        value: date_listed
+  # The XML labels each field with its column number and heading. Both the
+  # individual and the group table are mapped here; headings are unique across
+  # the two because they carry the (differing) column number.
+  columns:
+    map:
+      # Individuals
+      "(1) No.": internal_no
+      "(2) Reference": reference_no
+      "(3) Name": name
+      "(4) Title": title
+      "(5) Designation": position
+      "(6) Date of Birth": birth_date
+      "(7) Place of Birth": birth_place
+      "(8) Other Names": other_name
+      "(9) Nationality": citizenship
+      "(10) Passport Number": passport_no
+      "(11) Identification Card Number": id_no
+      "(12) Address": address
+      "(13) Date 0f Listed": date_listed  # sic, typo in the source
+      "(13) Date of Listed": date_listed
+      # Groups
+      "(4) Alias": alias
+      "(5) Other Name": other_name
+      "(6) Address": address
+      "(7) Date of Listed": date_listed
   type.country:
     options:
       - match: 'Philippines (Permanent Resident in Malaysia)'
         value: Philippines
+  type.address:
+    options:
+      - match: Iraq Syria
+        values: ["Iraq", "Syria"]
+      - match: Algeria Mali Mauritania Morocco Niger Tunisia
+        values:
+          - Algeria
+          - Mali
+          - Mauritania
+          - Morocco
+          - Niger
+          - Tunisia
+  type.name:
+    options:
+      # Two names run together without the pipe the source uses elsewhere.
+      - match: Le Groupe Salafiste pour La Prédication et le Combat (GSPC) Salafist Group for Call and Combat
+        values:
+          - Le Groupe Salafiste pour La Prédication et le Combat (GSPC)
+          - Salafist Group for Call and Combat
   type.date:
     options:
       - match: 20.2.1976 13.2.1975 15.2.1976 7.1.1977


### PR DESCRIPTION
The pdf crawler needed further adjustment identified by duplicate column detection (https://github.com/opensanctions/opensanctions/issues/4933)

XML is available and needs much less hackery while only losing a sliver of fidelity (addresses aren't numbered lists, but they weren't split before in any case.)