### PR TITLE
Document one-person-several-positions PEP pattern and required-lookup caveat

### DIFF
--- a/.claude/skills/crawler-pep/SKILL.md
+++ b/.claude/skills/crawler-pep/SKILL.md
@@ -28,8 +28,9 @@ context about the dataset.
 
 **Consult on demand** (open only when you actually need the section — don't pre-load):
 
-- `.claude/skills/crawler-pep/examples.md` — code examples (Patterns A/B/C, multi-term
-  sources, subnational variant, associates). Open when you're stuck on a pattern.
+- `.claude/skills/crawler-pep/examples.md` — code examples (Patterns A/B/C, one label
+  mapping to several held positions, multi-term sources, subnational variant,
+  associates). Open when you're stuck on a pattern.
 - `zavod/docs/peps.md` — the rest of it: position naming depth, `categorise()`, relatives.
 - `zavod/docs/metadata.md` — full YAML field reference. Open if you're using a field not
   covered by the template in `crawler-guide.md`.

--- a/.claude/skills/crawler-pep/examples.md
+++ b/.claude/skills/crawler-pep/examples.md
@@ -200,6 +200,56 @@ if not categorisation.is_pep:
 context.emit(position)
 ```
 
+### One label, several held positions
+
+When a role label implies more than one held office — a Speaker is elected from among
+the members and keeps their seat — map the label to every held position name with a
+multi-`values` lookup option, and make an occupancy for each
+(`zavod/docs/peps.md` → "One person, several positions"):
+
+```yaml
+lookups:
+  position:
+    required: true
+    options:
+      - match: Member of Parliament
+        value: Member of the Parliament of Examplia
+      - match: Speaker
+        values:
+          - Speaker of the Parliament of Examplia
+          - Member of the Parliament of Examplia
+```
+
+```python
+# Only the member seat has a Wikidata item.
+POSITION_QIDS = {"Member of the Parliament of Examplia": "Q..."}
+
+# required: true only halts the crawl via context.lookup —
+# context.lookup_value catches the exception and returns None.
+res = context.lookup("position", role)
+assert res is not None, role
+for title in res.values:
+    position = h.make_position(
+        context,
+        name=title,
+        country="xx",
+        topics=["gov.national", "gov.legislative"],
+        wikidata_id=POSITION_QIDS.get(title),
+        lang="eng",
+    )
+    categorisation = categorise(context, position)
+    if not categorisation.is_pep:
+        continue
+    occupancy = h.make_occupancy(
+        context, person, position, categorisation=categorisation
+    )
+    if occupancy is not None:
+        context.emit(occupancy)
+        # Repeated emits of the same position/person are fine.
+        context.emit(position)
+        context.emit(person)
+```
+
 ## Multi-term source
 
 The default shape whenever the source exposes past terms, not just the sitting roster.

--- a/zavod/docs/best_practices/datapatch_lookups.md
+++ b/zavod/docs/best_practices/datapatch_lookups.md
@@ -216,7 +216,7 @@ rel.add(res.link, link_type)
 
 Pass `warn_unmatched=True` to log a warning when a value matches no option — this surfaces values that need a new lookup entry rather than silently dropping data.
 
-For lookups where any unmatched value should halt the crawl, set `required: true` on the lookup itself. A miss then raises `LookupException`.
+For lookups where any unmatched value should halt the crawl, set `required: true` on the lookup itself. A miss then raises `LookupException` — but only through `context.lookup`: `context.lookup_value` catches the exception and returns its `default` argument instead, so pair `required: true` with `context.lookup`.
 
 
 ## Common runtime warnings involving lookups
@@ -268,7 +268,7 @@ Set under each named lookup (e.g. `lookups: type.country: …`):
 | `normalize` | `false` | Strip diacritics and collapse whitespace before matching. |
 | `lowercase` | `false` | Lowercase before matching. |
 | `asciify` | `true` | Transliterate to ASCII when normalizing. |
-| `required` | `false` | Raise `LookupException` when no option matches the input. |
+| `required` | `false` | Raise `LookupException` when no option matches the input (propagates via `context.lookup` only; `context.lookup_value` swallows it). |
 
 ### Option-level keys
 

--- a/zavod/docs/peps.md
+++ b/zavod/docs/peps.md
@@ -297,6 +297,19 @@ for role in person_data.pop("roles"):
         context.emit(person)
 ```
 
+### One person, several positions
+
+Some role labels imply more than one held office: a parliament's Speaker is typically
+elected from among the members and keeps their seat, so they hold the Speaker office
+and the plain membership at once. Create an occupancy for each held position, not just
+the most senior one — each is politically exposing in its own right.
+
+Where the source labels the role, a `position` lookup option with multiple `values`
+(see [result values](best_practices/datapatch_lookups.md#result-values)) maps the label
+to all held position names declaratively; the crawler then loops over
+`context.lookup(...).values`, applying the pattern above to each name. Worked example:
+`examples.md` → "One label, several held positions".
+
 ## Historical and multi-term sources
 
 Current office holders are the priority, but when a source also exposes past terms


### PR DESCRIPTION
Two documentation gaps surfaced while reviewing a legislature crawler, plus the matching skill example.

**`zavod/docs/peps.md`** — new "One person, several positions" subsection under *Creating occupancies*: some role labels imply more than one held office (a Speaker is elected from among the members and keeps their seat), and each held position gets its own occupancy. A multi-`values` lookup option maps the label to all held position names declaratively.

**`zavod/docs/best_practices/datapatch_lookups.md`** — the `required: true` docs claimed a miss halts the crawl, but `LookupException` only propagates through `context.lookup`; `context.lookup_value` catches it and returns its `default`, so the strictness silently disappears there. Prose and reference table now say so.

**`.claude/skills/crawler-pep`** — worked example for the multi-held-positions lookup shape (YAML + crawler loop over `res.values`), indexed from SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)