### PR TITLE
[ru_egrul] Consume the 2026-08-09 export

### DIFF
--- a/datasets/ru/egrul/crawler.py
+++ b/datasets/ru/egrul/crawler.py
@@ -11,7 +11,7 @@ from zavod import helpers as h
 from zavod.shed.internal_data import fetch_internal_data, list_internal_data
 
 LOCAL_BUCKET_PATH = "/Users/leon/internal-data/"
-PROCESSED_EGRUL_PREFIX = "ru_egrul/processed_2026-06-04/"
+PROCESSED_EGRUL_PREFIX = "ru_egrul/processed_2026-08-09/"
 
 
 def substitute_abbreviations(name: str | None) -> str | None:


### PR DESCRIPTION
Points the crawler at `ru_egrul/processed_2026-08-09/`, up from `processed_2026-06-04/`. Data now runs through 2026-07-30.

This is the first export built by the reworked EGRUL pipeline (https://github.com/opensanctions/opensanctions/pull/5192), so besides two more months of data, ownership and directorship end dates change: they now come from the nearest archive that stopped listing the relationship, rather than from wherever the yearly fold happened to land. Expect a fair number of end dates to move earlier, sometimes by months. Spot check on `ru-inn-9102285376`, a directorship dropped from the registry on 2026-03-11: previously dated 2026-05-05, now 2026-03-10.

The export also carries a new `origin` column naming the source zip and XML file each row was built from. Nothing consumes it — `csv.DictReader` ignores columns the crawler doesn't ask for — but it's there for debugging why a row looks the way it does.

Don't merge before the export is uploaded to the bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
