### PR TITLE
Drop URL values that fail cleaning again

### DIFF
--- a/zavod/zavod/runtime/cleaning.py
+++ b/zavod/zavod/runtime/cleaning.py
@@ -189,19 +189,6 @@ def value_clean(
             yield prop_, item, origin
             continue
 
-        # HACK HACK HACK REMOVE BY AUG 2026
-        # We want to onboard new URL cleaning without dropping lots of invalid values
-        # as they're getting fixed.
-        if prop_.type == registry.url:
-            log.warning(
-                f"Invalid property value [{prop_.name}]: {value}",
-                entity_id=entity.id,
-                prop=prop_.name,
-                value=value,
-            )
-            yield prop_, item, origin
-            continue
-
         log.warning(
             f"Rejected property value [{prop_.name}]: {value}",
             entity_id=entity.id,


### PR DESCRIPTION
Removes the temporary pass-through in `value_clean` that kept url-typed values alive with a warning when they failed followthemoney 4.10.1's stricter host validation. Rejected URLs now fall through to the normal drop path.

### Sanity check on blast radius

Swept the latest archived run of all 494 catalog datasets for the grace-period warning. One dataset still hits it:

| dataset | values | examples |
| --- | --- | --- |
| `ee_ariregister` | 112 | `https:// 2fast.ee`, `http:// www.aiamees.ee`, `https://.airobothome.com` |

These are malformed in the source (space in the host, empty host) rather than a crawler bug, so dropping them is the intended outcome. If we want them kept, that's a separate normalisation step in the Estonian crawler.

Also restores dropping of `javascript:` / `data:` URLs, which the URL type rejects but the pass-through retained — those were rendered as raw `href`s on the website.

`pytest zavod/tests` (314 passed) and `mypy --strict` both clean.

Closes #5211

🤖 Generated with [Claude Code](https://claude.com/claude-code)