### PR TITLE
Always use the last successful version when backfilling without specified version

### DIFF
--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -210,23 +210,38 @@ def get_artifact_object(
     dataset_name: str, resource: str, version: str | None = None
 ) -> ArchiveObject | None:
     backend = get_archive_backend()
+    if version is None:
+        versions_data = get_versions_data(dataset_name)
+        if versions_data is not None:
+            history = VersionHistory.from_json(versions_data)
+            version = history.last_successful.id if history.last_successful else None
+
     if version is not None:
         name = f"{ARTIFACTS}/{dataset_name}/{version}/{resource}"
         object = backend.get_object(name)
         if object.exists():
             return object
-    else:
-        for v in iter_dataset_versions(dataset_name):
-            name = f"{ARTIFACTS}/{dataset_name}/{v.id}/{resource}"
-            object = backend.get_object(name)
-            if object.exists():
-                return object
+
+    # Temporary fallback for datasets that haven't succeeded since last_successful
+    # TODO: Remove after the stragglers have succeeded or been removed.
+    # stragglers: lt_pep_declarations, hu_national_assembly, ps_local_freezing
+    for v in iter_dataset_versions(dataset_name):
+        # We could check if the index.json has a resources array here, but only
+        # lt_pep_declarations needs it, and it's being removed 2026-08-17
+        # so let's nto bother
+        name = f"{ARTIFACTS}/{dataset_name}/{v.id}/{resource}"
+        object = backend.get_object(name)
+        if object.exists():
+            return object
 
     # FIXME: legacy fallback option of using the latest release
     # REMOVE THIS AFTER MIGRATION
     name = f"{DATASETS}/{LATEST}/{dataset_name}/{resource}"
     object = backend.get_object(name)
     if object.exists():
+        log.warning(
+            f"Couldn't find artifact object the modern way {dataset_name} {resource}"
+        )
         return object
     return None
 

--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -222,14 +222,11 @@ def get_artifact_object(
         if object.exists():
             return object
 
-    # Temporary fallback for datasets that haven't succeeded since last_successful
-    # TODO: Remove after the stragglers have succeeded or been removed.
-    # stragglers: lt_pep_declarations, hu_national_assembly, ps_local_freezing
-    for v in iter_dataset_versions(dataset_name):
-        # We could check if the index.json has a resources array here, but only
-        # lt_pep_declarations needs it, and it's being removed 2026-08-17
-        # so let's nto bother
-        name = f"{ARTIFACTS}/{dataset_name}/{v.id}/{resource}"
+    # TODO: Remove after lt_pep_declarations is deleted.
+    # It hasn't succeeded since last_successful was added.
+    if dataset_name == "lt_pep_declarations":
+        version = "20250403160648-kkg"
+        name = f"{ARTIFACTS}/{dataset_name}/{version}/{resource}"
         object = backend.get_object(name)
         if object.exists():
             return object

--- a/zavod/zavod/archive/__init__.py
+++ b/zavod/zavod/archive/__init__.py
@@ -231,15 +231,6 @@ def get_artifact_object(
         if object.exists():
             return object
 
-    # FIXME: legacy fallback option of using the latest release
-    # REMOVE THIS AFTER MIGRATION
-    name = f"{DATASETS}/{LATEST}/{dataset_name}/{resource}"
-    object = backend.get_object(name)
-    if object.exists():
-        log.warning(
-            f"Couldn't find artifact object the modern way {dataset_name} {resource}"
-        )
-        return object
     return None
 
 

--- a/zavod/zavod/cli/etl.py
+++ b/zavod/zavod/cli/etl.py
@@ -11,7 +11,7 @@ from zavod.exc import RunFailedException
 from zavod.exporters import export_dataset
 from zavod.integration import get_dataset_linker
 from zavod.publish import publish_dataset, archive_failure
-from zavod.runtime.versions import make_version, set_last_successful_version
+from zavod.runtime.versions import make_version
 from zavod.store import get_store
 from zavod.tools.load_db import load_dataset_to_db
 from zavod.validators import validate_dataset
@@ -133,8 +133,6 @@ def run(
     # Export
     try:
         export_dataset(dataset, view)
-        # Set the version as successful in the version file, which will be archived by publish_dataset.
-        set_last_successful_version(dataset, settings.RUN_VERSION)
     except Exception:
         log.exception(f"Failed to export: {dataset_path}")
         archive_failure(dataset)

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -12,7 +12,7 @@ from zavod.archive import STATEMENTS_FILE, RESOURCES_FILE, STATISTICS_FILE
 from zavod.archive import VERSIONS_FILE, EXTRA_ARTIFACTS
 from zavod.archive import DELTA_EXPORT_FILE, DELTA_INDEX_FILE
 from zavod.runtime.resources import DatasetResources
-from zavod.runtime.versions import get_latest
+from zavod.runtime.versions import get_latest, set_last_successful_version
 from zavod.exporters import write_dataset_index
 
 log = get_logger(__name__)
@@ -68,7 +68,16 @@ def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
     Listed resources plus index and collection catalog are copied to
     /datasets/{RELEASE}/{dataset}/ backward compatibility and
     /datasets/{LATEST}/{dataset}/ for discovery without the full catalog.
+
+    Publishing is only reached once a run has succeeded (`archive_failure` is the
+    other way out), so this is where the version becomes the last successful one.
+    Artifact lookups resolve that pointer, so a publish which didn't move it
+    would leave every reader of the archive on the run before this one.
     """
+    version = get_latest(dataset.name, backfill=False)
+    if version is None:
+        raise ValueError(f"No working version found for dataset: {dataset.name}")
+    set_last_successful_version(dataset, version)
 
     extra_artifacts = []
     all_published_files: list[str] = [
@@ -83,9 +92,6 @@ def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
         all_published_files.append(CATALOG_FILE)
 
     _archive_artifacts(dataset, extra_artifacts)
-
-    version = get_latest(dataset.name, backfill=False)
-    assert version is not None
 
     if republish_to_latest:
         _warn_about_stale_latest_files(dataset, set(all_published_files))

--- a/zavod/zavod/publish.py
+++ b/zavod/zavod/publish.py
@@ -63,16 +63,13 @@ def _archive_artifacts(dataset: Dataset, extra_artifacts: list[str] = []) -> Non
 def publish_dataset(dataset: Dataset, republish_to_latest: bool = True) -> None:
     """Publish a dataset.
 
+    Only for successful runs. Also stamps this version as the last successful.
+
     Every file we persist about this run is uploaded to /artifacts/{dataset}/{version}/
 
     Listed resources plus index and collection catalog are copied to
     /datasets/{RELEASE}/{dataset}/ backward compatibility and
     /datasets/{LATEST}/{dataset}/ for discovery without the full catalog.
-
-    Publishing is only reached once a run has succeeded (`archive_failure` is the
-    other way out), so this is where the version becomes the last successful one.
-    Artifact lookups resolve that pointer, so a publish which didn't move it
-    would leave every reader of the archive on the run before this one.
     """
     version = get_latest(dataset.name, backfill=False)
     if version is None:

--- a/zavod/zavod/tests/conftest.py
+++ b/zavod/zavod/tests/conftest.py
@@ -44,8 +44,6 @@ def wrap_test():
     shutil.rmtree(settings.ARCHIVE_PATH, ignore_errors=True)
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
     settings.DATA_PATH = Path(mkdtemp()).resolve()
-    # The version file is cached by dataset name, and both the names and the
-    # version IDs recur across tests while the archive is emptied between them.
     get_versions_data.cache_clear()
     create_db()
     yield

--- a/zavod/zavod/tests/conftest.py
+++ b/zavod/zavod/tests/conftest.py
@@ -9,6 +9,7 @@ from nomenklatura import Resolver
 from nomenklatura.db import close_db, make_session, Session
 
 from zavod import settings
+from zavod.archive import get_versions_data
 from zavod.context import Context
 from zavod.entity import Entity
 from zavod.logs import configure_logging, reset_logging
@@ -43,6 +44,9 @@ def wrap_test():
     shutil.rmtree(settings.ARCHIVE_PATH, ignore_errors=True)
     shutil.rmtree(settings.DATA_PATH, ignore_errors=True)
     settings.DATA_PATH = Path(mkdtemp()).resolve()
+    # The version file is cached by dataset name, and both the names and the
+    # version IDs recur across tests while the archive is emptied between them.
+    get_versions_data.cache_clear()
     create_db()
     yield
     get_catalog.cache_clear()

--- a/zavod/zavod/tests/runtime/test_timestamps.py
+++ b/zavod/zavod/tests/runtime/test_timestamps.py
@@ -1,12 +1,15 @@
 from datetime import timedelta
-from shutil import copyfile
 from rigour.time import utc_now
 
 from zavod import settings
+from zavod.exporters import export_dataset
+from zavod.integration.dedupe import get_dataset_linker
 from zavod.meta import Dataset
 from zavod.crawl import crawl_dataset
 from zavod.archive import iter_dataset_statements
+from zavod.publish import publish_dataset
 from zavod.runtime.timestamps import TimeStampIndex
+from zavod.store import get_store
 
 
 def test_timestamps(testdataset1: Dataset):
@@ -36,14 +39,15 @@ def test_timestamps(testdataset1: Dataset):
 
 def test_backfill(testdataset1: Dataset):
     prev_time = settings.RUN_TIME_ISO
+    # Run the dataset once to output statements.pack
+    # Publish to archive statements and make them discoverable by the next run.
+    linker = get_dataset_linker(testdataset1)
     crawl_dataset(testdataset1)
-
-    archive_path = settings.ARCHIVE_PATH / "datasets/latest" / testdataset1.name
-    archive_path.mkdir(parents=True, exist_ok=True)
-    copyfile(
-        settings.DATA_PATH / "datasets" / testdataset1.name / "statements.pack",
-        archive_path / "statements.pack",
-    )
+    store = get_store(testdataset1, linker)
+    store.sync()
+    view = store.view(testdataset1)
+    export_dataset(testdataset1, view)
+    publish_dataset(testdataset1, republish_to_latest=False)
 
     settings.RUN_TIME = settings.RUN_TIME + timedelta(days=1)
     settings.RUN_TIME_ISO = settings.RUN_TIME.isoformat(sep="T", timespec="seconds")

--- a/zavod/zavod/tests/test_archive.py
+++ b/zavod/zavod/tests/test_archive.py
@@ -1,12 +1,17 @@
 import shutil
 
+from followthemoney.dataset import Version
+
 from zavod import settings
 from zavod.meta import Dataset
-from zavod.runtime.versions import make_version
+from zavod.runtime.versions import make_version, set_last_successful_version
 from zavod.archive import get_dataset_artifact, publish_artifact, archive_artifact
 from zavod.archive import clear_data_path, dataset_data_path, dataset_resource_path
 from zavod.archive import publish_version_history, get_archive_backend
+from zavod.archive import get_artifact_object
 from zavod.archive import ARTIFACTS, DATASETS, LATEST, VERSIONS_FILE
+
+RESOURCE_NAME = "foo.json"
 
 
 def test_archive_then_publish(testdataset1: Dataset):
@@ -55,6 +60,68 @@ def test_archive_then_publish(testdataset1: Dataset):
     assert not data_path.exists()
 
 
+def _archive_run(
+    dataset: Dataset,
+    version: Version,
+    successful: bool = True,
+    archive_resource: bool = True,
+) -> None:
+    """Archive a run of the dataset: its copy of the resource, and the version
+    history as it stands once the run is over."""
+    if archive_resource:
+        path = dataset_resource_path(dataset.name, RESOURCE_NAME)
+        with open(path, "w") as fh:
+            fh.write(version.id)
+        archive_artifact(path, dataset.name, version, RESOURCE_NAME)
+    make_version(dataset, version, append_new_version_to_history=True)
+    if successful:
+        set_last_successful_version(dataset, version)
+    publish_version_history(dataset.name)
+
+
+def test_get_artifact_object_uses_last_successful_version(testdataset1: Dataset):
+    """A lookup which doesn't name a version answers with the last successful
+    run, not the newest one - a failed run has an artifact directory, but no
+    data. See https://github.com/opensanctions/operations/issues/2762"""
+    succeeded = Version.from_string("20260101000000-aaa")
+    failed = Version.from_string("20260102000000-bbb")
+    _archive_run(testdataset1, succeeded)
+    # The failed run even has a copy of the resource, so this can only pass by
+    # consulting the version history, not by finding the newest copy:
+    _archive_run(testdataset1, failed, successful=False)
+
+    object = get_artifact_object(testdataset1.name, RESOURCE_NAME)
+    assert object is not None
+    prefix = f"{ARTIFACTS}/{testdataset1.name}"
+    assert object.name == f"{prefix}/{succeeded.id}/{RESOURCE_NAME}"
+
+    # A version the caller names explicitly is honoured, failed or not:
+    object = get_artifact_object(testdataset1.name, RESOURCE_NAME, version=failed.id)
+    assert object is not None
+    assert object.name == f"{prefix}/{failed.id}/{RESOURCE_NAME}"
+
+
+def test_get_artifact_object_without_successful_version(testdataset1: Dataset):
+    """Until a run has succeeded there is nothing to answer a lookup with. An
+    archived version alone is not a candidate - that's what makes moving the
+    pointer in publish_dataset() load-bearing."""
+    _archive_run(testdataset1, Version.from_string("20260101000000-aaa"), False)
+
+    assert get_artifact_object(testdataset1.name, RESOURCE_NAME) is None
+
+
+def test_get_artifact_object_does_not_mix_runs(testdataset1: Dataset):
+    """A resource the last successful run didn't archive is not substituted from
+    an earlier run, whose data the rest of the current metadata doesn't
+    describe."""
+    older = Version.from_string("20260101000000-aaa")
+    newer = Version.from_string("20260103000000-ccc")
+    _archive_run(testdataset1, older)
+    _archive_run(testdataset1, newer, archive_resource=False)
+
+    assert get_artifact_object(testdataset1.name, RESOURCE_NAME) is None
+
+
 def test_artifact_backfill(testdataset1: Dataset):
     name = "foo.json"
     local_path = dataset_resource_path(testdataset1.name, name)
@@ -72,6 +139,9 @@ def test_artifact_backfill(testdataset1: Dataset):
     assert not versions_file.exists()
     assert not local_path.exists()
     make_version(testdataset1, settings.RUN_VERSION)
+    # Backfill answers with the last successful run, so the run has to be
+    # recorded as one - publish_dataset() does this for a real run:
+    set_last_successful_version(testdataset1, settings.RUN_VERSION)
     publish_version_history(testdataset1.name)
     assert versions_file.exists()
     local_path = get_dataset_artifact(testdataset1.name, name)

--- a/zavod/zavod/tests/test_archive.py
+++ b/zavod/zavod/tests/test_archive.py
@@ -81,8 +81,7 @@ def _archive_run(
 
 def test_get_artifact_object_uses_last_successful_version(testdataset1: Dataset):
     """A lookup which doesn't name a version answers with the last successful
-    run, not the newest one - a failed run has an artifact directory, but no
-    data. See https://github.com/opensanctions/operations/issues/2762"""
+    run, not the newest one. See https://github.com/opensanctions/operations/issues/2762"""
     succeeded = Version.from_string("20260101000000-aaa")
     failed = Version.from_string("20260102000000-bbb")
     _archive_run(testdataset1, succeeded)
@@ -95,16 +94,15 @@ def test_get_artifact_object_uses_last_successful_version(testdataset1: Dataset)
     prefix = f"{ARTIFACTS}/{testdataset1.name}"
     assert object.name == f"{prefix}/{succeeded.id}/{RESOURCE_NAME}"
 
-    # A version the caller names explicitly is honoured, failed or not:
+    # A version the caller names explicitly is honoured, failed or not.
+    # Maybe this doesn't have a use case as of 2026-08-11 but it's documenting behaviour.
     object = get_artifact_object(testdataset1.name, RESOURCE_NAME, version=failed.id)
     assert object is not None
     assert object.name == f"{prefix}/{failed.id}/{RESOURCE_NAME}"
 
 
 def test_get_artifact_object_without_successful_version(testdataset1: Dataset):
-    """Until a run has succeeded there is nothing to answer a lookup with. An
-    archived version alone is not a candidate - that's what makes moving the
-    pointer in publish_dataset() load-bearing."""
+    """Until a run has succeeded there is nothing to answer a lookup with."""
     _archive_run(testdataset1, Version.from_string("20260101000000-aaa"), False)
 
     assert get_artifact_object(testdataset1.name, RESOURCE_NAME) is None
@@ -139,8 +137,8 @@ def test_artifact_backfill(testdataset1: Dataset):
     assert not versions_file.exists()
     assert not local_path.exists()
     make_version(testdataset1, settings.RUN_VERSION)
-    # Backfill answers with the last successful run, so the run has to be
-    # recorded as one - publish_dataset() does this for a real run:
+    # Backfill answers with the last successful run,
+    # so the run has to be recorded as one:
     set_last_successful_version(testdataset1, settings.RUN_VERSION)
     publish_version_history(testdataset1.name)
     assert versions_file.exists()

--- a/zavod/zavod/tests/test_publish.py
+++ b/zavod/zavod/tests/test_publish.py
@@ -17,6 +17,7 @@ from zavod.archive import HASH_FILE, DELTA_INDEX_FILE, CATALOG_FILE
 from zavod.crawl import crawl_dataset
 from zavod.store import get_store
 from zavod.exporters import export_dataset
+from zavod.exporters.metadata import get_catalog_dataset
 from zavod.integration import get_dataset_linker
 from zavod.publish import publish_dataset, archive_failure
 from zavod.exc import RunFailedException
@@ -221,6 +222,66 @@ def test_empty_crawl_does_not_resurrect_archived_statements(
     view = store.view(testdataset1, external=False)
     assert len(list(view.entities())) == 0
     store.close()
+
+
+def test_failed_run_does_not_replace_latest_metadata(
+    testdataset1: Dataset, monkeypatch: pytest.MonkeyPatch
+):
+    """A run failing after a successful one archives an index which lists no
+    resources. Everything reading the dataset's current metadata - the catalog
+    above all - has to keep answering with the last successful run.
+
+    https://github.com/opensanctions/operations/issues/2762
+    """
+    linker = get_dataset_linker(testdataset1)
+    crawl_dataset(testdataset1)
+    store = get_store(testdataset1, linker)
+    store.sync()
+    export_dataset(testdataset1, store.view(testdataset1))
+    publish_dataset(testdataset1, republish_to_latest=True)
+    store.close()
+    good_version = settings.RUN_VERSION
+
+    # A later run fails while crawling, as in a production `zavod run`:
+    clear_data_path(testdataset1.name)
+    monkeypatch.setattr(settings, "RUN_VERSION", Version.new())
+    failed_version = settings.RUN_VERSION
+    assert failed_version.id != good_version.id
+    assert testdataset1.data is not None
+    testdataset1.data.format = "FAIL"
+    with pytest.raises(RunFailedException):
+        crawl_dataset(testdataset1)
+    archive_failure(testdataset1)
+
+    # The failed run is the newest version of the dataset, and its index has no
+    # resources to offer:
+    history = _read_history(testdataset1.name)
+    assert history is not None
+    assert history.latest == failed_version
+    assert history.last_successful == good_version
+    failed_index = (
+        settings.ARCHIVE_PATH
+        / ARTIFACTS
+        / testdataset1.name
+        / failed_version.id
+        / INDEX_FILE
+    )
+    with open(failed_index) as fh:
+        assert json.load(fh)["resources"] == []
+
+    # Backfilling the index - as a catalog export in a fresh container does -
+    # skips it and lands on the last successful run:
+    clear_data_path(testdataset1.name)
+    with open(get_dataset_artifact(testdataset1.name, INDEX_FILE)) as fh:
+        index = json.load(fh)
+    assert index["version"] == good_version.id
+    assert index["result"] == "success"
+    assert len(index["resources"]) > 0
+
+    catalog_dataset = get_catalog_dataset(testdataset1)
+    assert catalog_dataset["version"] == good_version.id
+    assert catalog_dataset["last_change"] == index["last_change"]
+    assert {r["name"] for r in catalog_dataset["resources"]} >= STANDARD_EXPORTS
 
 
 def test_archive_failure(testdataset1: Dataset):


### PR DESCRIPTION
Fixes https://github.com/opensanctions/operations/issues/2762

When fetching an artifact from the archive without specifying a version, the last successful version is used, rather than merely the latest one with the same resource name.

Moves `set_last_successful_version` from `cli.etl.run` to `publish.publish_dataset` so that `zavod run` and `zavod publish` both update `last_successful`.

Doesn't require a specified version to be successful. That could be future work.

This fixes the issue where the catalog shows metadata for the latest dataset even if that was a failed run with no resources.

In the end, this felt like an important part that should be included in https://github.com/opensanctions/opensanctions/pull/4873 rather than a band-aid that wouldn't be needed if we did #4873. So let's do the small simple thing and then update and finish the bigger one.