### PR TITLE
[us_ofac] Emit the Company schema upgrade for owned organizations

### DIFF
--- a/datasets/us/ofac/ofac_advanced.py
+++ b/datasets/us/ofac/ofac_advanced.py
@@ -235,7 +235,7 @@ def parse_location(context: Context, refs: Element, location: Element) -> Featur
 
 
 def parse_relation(
-    context: Context, refs: Element, el: Element, parties: dict[str, Schema]
+    context: Context, refs: Element, el: Element, parties: dict[str, Entity]
 ) -> None:
     type_id = el.get("RelationTypeID")
     type_ = get_ref_text(refs, "RelationType", type_id)
@@ -282,8 +282,8 @@ def parse_relation(
         raise ValueError(msg)
 
     try:
-        get_relation_schema(parties[from_id], from_prop.range)
-        get_relation_schema(parties[to_id], to_prop.range)
+        get_relation_schema(parties[from_id].schema, from_prop.range)
+        get_relation_schema(parties[to_id].schema, to_prop.range)
     except InvalidData:
         # HACK: Looks like OFAC just has some link in a direction that makes no
         # semantic sense, so we're flipping them here.
@@ -296,15 +296,15 @@ def parse_relation(
         # )
         from_id, to_id = to_id, from_id
 
-    from_party = context.make(get_relation_schema(parties[from_id], from_prop.range))
-    from_party.id = from_id
-    if not parties[from_id].is_a(from_party.schema) and len(from_party.properties):
-        context.emit(from_party)
+    # Being a party to this relation implies a more specific schema for some
+    # parties: an Organization which is owned is a Company. The parties are only
+    # emitted once all relations have been seen, so the upgrade applies to the
+    # party entity itself rather than needing a second, partial entity.
+    from_party = parties[from_id]
+    from_party.add_schema(get_relation_schema(from_party.schema, from_prop.range))
 
-    to_party = context.make(get_relation_schema(parties[to_id], to_prop.range))
-    to_party.id = to_id
-    if not parties[to_id].is_a(to_party.schema) and len(to_party.properties):
-        context.emit(to_party)
+    to_party = parties[to_id]
+    to_party.add_schema(get_relation_schema(to_party.schema, to_prop.range))
 
     entity.id = context.make_id("Relation", from_party.id, to_party.id, el.get("ID"))
     entity.add(from_prop, from_party)
@@ -392,7 +392,6 @@ def parse_distinct_party(
         for feat_value in values:
             apply_feature(context, proxy, feat_label, feat_value)
 
-    context.emit(proxy)
     return proxy
 
 
@@ -842,11 +841,16 @@ def crawl(context: Context) -> None:
     # with open(clean_path, "wb") as fh:
     #     fh.write(tostring(doc, pretty_print=True, encoding="utf-8"))
 
-    parties: dict[str, Schema] = {}
+    parties: dict[str, Entity] = {}
     for distinct_party in doc.findall("./DistinctParties/DistinctParty"):
         proxy = parse_distinct_party(context, doc, refs, distinct_party)
-        if proxy.id is not None:
-            parties[proxy.id] = proxy.schema
+        assert proxy.id is not None, tostring(distinct_party)
+        parties[proxy.id] = proxy
 
     for relation in doc.findall(".//ProfileRelationship"):
         parse_relation(context, refs, relation, parties)
+
+    # Parties are emitted last because relations can imply a more specific schema
+    # for the parties involved (cf. parse_relation).
+    for party in parties.values():
+        context.emit(party)

--- a/datasets/us/ofac/us_ofac_cons.yml
+++ b/datasets/us/ofac/us_ofac_cons.yml
@@ -51,10 +51,12 @@ assertions:
   min:
     schema_entities:
       Address: 440
-      Organization: 300
+      # Most sanctioned organizations are owned or controlled by another party,
+      # which makes them Companies rather than plain Organizations.
+      Organization: 60
       Security: 200
       Person: 70
-      Company: 4
+      Company: 225
     # Set at roughly a quarter of the production fill rate: low enough that a
     # shift in the shape of the source data doesn't hold up the release, high
     # enough to catch a crawler that stopped parsing a field altogether.
@@ -62,6 +64,11 @@ assertions:
       Person:
         birthDate: 0.25
       Organization:
+        country: 0.25
+        address: 0.25
+      # Company carries the same guard as Organization: the owned organizations
+      # make up most of the schema's population.
+      Company:
         country: 0.25
         address: 0.25
       Security:
@@ -75,10 +82,10 @@ assertions:
   max:
     schema_entities:
       Address: 1030
-      Organization: 720
+      Organization: 160
       Security: 460
       Person: 160
-      Company: 50
+      Company: 560
 
 # Consolidated List
 # SDN List

--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -48,12 +48,14 @@ assertions:
   min:
     schema_entities:
       Address: 13720
-      Organization: 7330
+      # A large share of sanctioned organizations are owned or controlled by
+      # another party, which makes them Companies rather than plain Organizations.
+      Organization: 5385
       Person: 6245
       Vessel: 995
       CryptoWallet: 570
       Airplane: 320
-      Company: 20
+      Company: 2430
       Security: 5
       LegalEntity: 1
     # Set at roughly a quarter of the production fill rate: low enough that a
@@ -64,6 +66,10 @@ assertions:
         birthDate: 0.25
         nationality: 0.18
       Organization:
+        country: 0.25
+      # Company carries the same guard as Organization: owned organizations make
+      # up most of the schema's population.
+      Company:
         country: 0.25
       Vessel:
         imoNumber: 0.25
@@ -76,12 +82,12 @@ assertions:
   max:
     schema_entities:
       Address: 32280
-      Organization: 17245
+      Organization: 13470
       Person: 14690
       Vessel: 2345
       CryptoWallet: 1340
       Airplane: 750
-      Company: 100
+      Company: 6080
       Security: 100
       LegalEntity: 100
 # Program tags URL: https://ofac.treasury.gov/specially-designated-nationals-list-sdn-list/program-tag-definitions-for-ofac-sanctions-lists


### PR DESCRIPTION
Emit sanctioned entities only once they have both properties (no empty emits) and the schema's been upgraded to company for those with an owner (Owned organisation is a company).

Increase in memory consumption is within normal fluctuation:
entities: Maximum resident set size (kbytes): 1,761,536
schemata: Maximum resident set size (kbytes): 1,763,360

potentially disruptive - let's discuss - 3000 Organizations get a schema change and appear as MOD in delta. No other properties change.