### PR TITLE
[ch_fiaa_freezes] Release into sanctions

### DIFF
--- a/datasets/_collections/sanctions.yml
+++ b/datasets/_collections/sanctions.yml
@@ -55,6 +55,7 @@ children:
   - ca_listed_terrorists
   - ca_named_research_orgs
   - ca_sema_sanctions_news
+  - ch_fiaa_freezes
   - ch_seco_sanctions
   - cn_sanctions
   - cz_national_sanctions

--- a/datasets/ch/fiaa_freezes/ch_fiaa_freezes.yml
+++ b/datasets/ch/fiaa_freezes/ch_fiaa_freezes.yml
@@ -3,7 +3,7 @@ entry_point: crawler.py
 prefix: ch-fiaa
 coverage:
   frequency: never
-  start: 2026-07-30
+  start: 2026-08-12
 deploy:
   schedule: "45 7 * * *"
 manual_check:


### PR DESCRIPTION
Releases the Swiss FIAA asset-freeze dataset (`ch_fiaa_freezes`) into the `sanctions` collection.

- Adds `ch_fiaa_freezes` to `datasets/_collections/sanctions.yml` (alphabetically sorted).
- Bumps `coverage.start` to the release date (2026-08-12).

`python contrib/check_hierarchy.py datasets` no longer reports the dataset as uncollected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)