### PR TITLE
Track EU sanctions program inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.sqlite3
 *.perf
 *.csv
+!datasets/eu/sanctions_map/programs.csv
 *.sql
 .env
 .envrc

--- a/datasets/eu/sanctions_map/crawler.py
+++ b/datasets/eu/sanctions_map/crawler.py
@@ -1,3 +1,7 @@
+import csv
+from pathlib import Path
+from typing import Any
+
 import openpyxl
 
 from zavod import Context
@@ -5,6 +9,7 @@ from zavod import helpers as h
 
 DATA_URL = "https://www.sanctionsmap.eu/api/v1/data?"
 REGIME_URL = "https://www.sanctionsmap.eu/api/v1/regime"
+PROGRAMS_PATH = Path(__file__).parent / "programs.csv"
 
 # Why do we parse vessels separately?
 #   > Entities contained in Annex IV of Council Regulation (EU) No 833/2014 are subject to
@@ -37,8 +42,32 @@ PROGRAM_KEY = "EU-MARE"
 TYPES = {"E": "LegalEntity", "P": "Person"}
 
 
+def load_known_regime_ids() -> set[int]:
+    """Load the reviewed regime inventory used to detect newly introduced programs."""
+    with PROGRAMS_PATH.open(encoding="utf-8", newline="") as fh:
+        rows = csv.DictReader(fh)
+        return {int(row["regime_id"]) for row in rows}
+
+
+def warn_new_regimes(context: Context, regimes: list[dict[str, Any]]) -> None:
+    """Warn when the Sanctions Map exposes a regime absent from our snapshot."""
+    known_ids = load_known_regime_ids()
+    for regime in regimes:
+        regime_id = int(regime["id"])
+        if regime_id in known_ids:
+            continue
+        context.log.warning(
+            "New EU restrictive measures regime discovered",
+            regime_id=regime_id,
+            program_keys=regime.get("programme", []),
+            name=regime.get("specification"),
+            url=f"https://www.sanctionsmap.eu/#/main/details/{regime_id}",
+        )
+
+
 def crawl_regime(context: Context) -> None:
     regime = context.fetch_json(REGIME_URL, cache_days=1)
+    warn_new_regimes(context, regime["data"])
     for item in regime["data"]:
         regime_url = f"{REGIME_URL}/{item['id']}"
         regime_data = context.fetch_json(regime_url, cache_days=1)["data"]

--- a/datasets/eu/sanctions_map/programs.csv
+++ b/datasets/eu/sanctions_map/programs.csv
@@ -1,0 +1,56 @@
+regime_id,program_keys,has_lists,framework_celexes,name
+1,AFG,true,32011D0486;32011R0753,Restrictive measures imposed with respect to the Taliban
+2,BLR,true,32006R0765;32012D0642,Restrictive measures in view of the situation in Belarus and the involvement of Belarus in the Russian aggression against Ukraine
+4,,false,32011D0173,Restrictive measures in view of the situation in Bosnia and Herzegovina
+5,EUAQ;TAQA,true,32002R0881;32016D1693;32016R1686,Restrictive measures with respect to ISIL (Da'esh) and Al-Qaida
+6,TERR,true,32001E0931;32001R2580;32026D0455,Specific measures to combat terrorism
+7,BDI,true,32015D1763;32015R1755,Restrictive measures in view of the situation in Burundi
+8,MMR,true,32013D0184;32013R0401,Restrictive measures in view of the situation in Myanmar/Burma
+9,CAF,true,32013D0798;32014R0224,Restrictive measures in view of the situation in the Central African Republic
+10,,true,,Specific restrictive measures in relation to the events at the Tiananmen Square protests of 1989
+11,COD,true,32005R1183;32010D0788,Restrictive measures in view of the situation in the Democratic Republic of the Congo
+14,GIN,true,32009R1284;32010D0638,Restrictive measures in view of the situation in Guinea
+15,GNB,true,32012D0285;32012R0377,Restrictive measures in view of the situation in Guinea-Bissau
+16,,false,31994D0315;31994R1264,Prohibiting the satisfying of certain claims by the Haitian authorities
+17,IRN,true,32011D0235;32011R0359,Restrictive measures in relation to serious human rights violations in Iran
+18,IRN,true,32010D0413;32012R0267,Restrictive measures in relation to the non-proliferation of weapons of mass destruction
+19,IRQ,true,31992R3541;32003E0495;32003R1210,Restrictive measures on Iraq
+20,PRK,true,32016D0849;32017R1509,Restrictive measures in relation to the non-proliferation of the weapons of mass destruction
+21,,true,32006E0625;32006R1412,Restrictive measures in relation to the UN Security Council Resolution 1701 (2006) on Lebanon
+22,,true,32005E0888;32006R0305,"Restrictive measures in relation to the 14 February 2005 terrorist bombing in Beirut, Lebanon"
+23,LBY,true,32015D1333;32016R0044,Restrictive measures in view of the situation in Libya
+25,,true,32010D0573,Restrictive measures in relation to the campaign against Latinscript schools in the Transnistrian region
+26,,true,32014D0512;32014R0833,Restrictive measures in view of Russia's actions destabilising the situation in Ukraine (sectoral restrictive measures)
+27,,false,31994D0366;31994R1733,Prohibiting the satisfying of certain claims in relation to transactions that have been prohibited by the UN Security Council Resolution 757(1992) and related resolutions
+28,,false,31994D0366;31994R1733,Prohibiting the satisfying of certain claims in relation to transactions that have been prohibited by the UN Security Council Resolution  757(1992) and related resolutions
+29,SOM,true,32003R0147;32010D0231;32010R0356,Restrictive measures in view of the situation in Somalia
+30,SSD,true,32015D0740;32015R0735,Restrictive measures in view of the situation in South Sudan
+31,SDN,true,32014D0450;32014R0747,Restrictive measures in view of the situation in Sudan
+32,SYR,true,32012R0036;32013D0255,Restrictive measures against Syria
+33,TUN,true,32011D0072;32011R0101,Misappropriation of state funds of Tunisia
+34,,false,32005E0888;32006R0305,"Restrictive measures in relation to the 14 February 2005 terrorist bombing in Beirut, Lebanon"
+35,UKR,true,32014D0119;32014R0208,Misappropriation of state funds of Ukraine
+36,UKR,true,32014D0145;32014R0269,"Restrictive measures in respect of actions undermining or threatening the territorial integrity, sovereignty and independence of Ukraine"
+37,,false,32014D0386;32014R0692,Restrictive measures in response to the illegal annexation of Crimea and Sevastopol
+38,,false,31996E0668;31996R2271,Measures protecting against the effects of the extra-territorial application of certain legislation adopted by the US
+39,YEM,true,32014D0932;32014R1352,Restrictive measures in view of the situation in Yemen
+40,,true,32004R0314;32011D0101,Restrictive measures concerning an arms embargo in view of the situation in Zimbabwe
+42,MLI,true,32017D1775;32017R1770,Restrictive measures in view of the situation in Mali
+43,,false,31993R3275;32004E0698;32015D1333;32016R0044,Prohibiting the satisfying of certain claims in relation to transactions that have been prohibited by the UN Security Council Resolution 883 (1993) and related resolutions
+44,VEN,true,32017D2074;32017R2063,Restrictive measures in view of the situation in Venezuela
+46,CHEM,true,32018D1544;32018R1542,Restrictive measures against the proliferation and use of chemical weapons
+47,CYB,true,32019D0797;32019R0796,Restrictive measures against cyber-attacks threatening the Union or its Member States
+48,NIC,true,32019D1720;32019R1716,Restrictive measures in view of the situation in Nicaragua
+49,TUR,true,32019D1894;32019R1890,Restrictive measures in view of Türkiye’s  unauthorised drilling activities in the Eastern Mediterranean
+50,HR,true,32020D1999;32020R1998,Restrictive measures against serious human rights violations and abuses
+51,,false,32021D1277;32021R1275,Restrictive measures in view of the situation in Lebanon
+52,,false,32022D0266;32022R0263,"Restrictive measures in response to the illegal recognition, occupation or annexation by the Russian Federation of certain non-government controlled areas of Ukraine"
+54,HTI,true,32022D2319;32022R2309,Restrictive measures in view of the situation in Haiti
+55,MDA,true,32023D0891;32023R0888,Restrictive measures in view of actions destabilising the Republic of Moldova
+56,IRN,true,32023D1532;32023R1529,Restrictive measures in view of Iran’s military support to Russia’s war of aggression against Ukraine and to armed groups and entities in the Middle East and the Red Sea region
+57,SDNZ,true,32023D2135;32023R2147,Restrictive measures in view of activities undermining the stability and the political transition of Sudan
+58,,true,32023D2287;32023R2406,Restrictive measures in view of the situation in Niger
+59,GTM,true,32024D0254;32024R0287,Restrictive measures in view of the situation in Guatemala
+60,HAM,true,32024D0385;32024R0386,"Restrictive measures against those who support, facilitate or enable violent actions by Hamas and the Palestinian Islamic Jihad"
+61,RUS,true,32024D1484;32024R1485,Restrictive measures in view of the situation in Russia
+63,RUSDA,true,32024D2643;32024R2642,Restrictive measures in view of Russia's destabilising activities


### PR DESCRIPTION
## Summary

- commit a reviewed snapshot of EU Sanctions Map regimes and framework CELEXes
- warn when the crawler discovers a regime absent from the snapshot
- make the CSV available to downstream monitoring services

## Verification

- crawler compiles
- Ruff passes
- mypy-datasets passes via pre-commit
- snapshot matches all 55 live Sanctions Map regime IDs