### PR TITLE
Senzing exporter: typed identifiers, FEATURES list, OPENSANCTIONS_ID

### DIFF
--- a/zavod/zavod/exporters/senzing.py
+++ b/zavod/zavod/exporters/senzing.py
@@ -60,15 +60,24 @@ def map(
     type_attr: str | None = None,
     country: str | None = None,
     country_attr: str | None = None,
+    type_val: str | None = None,
+    subtype_attr: str | None = None,
+    subtype_val: str | None = None,
 ) -> None:
     for value in entity.get(prop, quiet=True):
         item = {attr: value}
         if type_attr is not None:
-            # Preserve the FtM property as the identifier TYPE. Several distinct
-            # schemes (e.g. ogrnCode vs registrationNumber vs innCode) otherwise
-            # collapse into one untyped Senzing field, so a mismatch between two
-            # different-scheme numbers is wrongly treated as an exclusive conflict.
-            item[type_attr] = prop
+            # The BROAD identifier scheme, which governs the exclusivity namespace.
+            # Defaults to the FtM property name; pass `type_val` to place a specific
+            # scheme under a broader one (e.g. ogrnCode -> TYPE=registrationNumber).
+            item[type_attr] = type_val if type_val is not None else prop
+        if subtype_attr is not None:
+            # The FINE scheme within the broad TYPE (e.g. ogrnCode within
+            # registrationNumber). A refinement, not a separate namespace: a bare
+            # broad type partial-matches a subtyped one rather than conflicting. Needs
+            # the ID_SUBTYPE element (see GDEV-4439 / the companion config script);
+            # dropped by configs that predate it, leaving just the broad TYPE.
+            item[subtype_attr] = subtype_val if subtype_val is not None else prop
         if country and country_attr is not None:
             # Qualify the identifier by country. Exclusive ids (NATIONAL_ID/TAX_ID/
             # PASSPORT) are only unique WITHIN a country, so a country puts them in
@@ -134,7 +143,6 @@ class SenzingExporter(Exporter):
         record: dict[str, Any] = {
             "DATA_SOURCE": self.source_name,
             "RECORD_ID": entity.id,
-            "RECORD_TYPE": record_type,
             "LAST_CHANGE": entity.last_change,
         }
 
@@ -162,6 +170,10 @@ class SenzingExporter(Exporter):
         map(entity, "birthDate", record, "DATES", "DATE_OF_BIRTH")
         map(entity, "deathDate", record, "DATES", "DATE_OF_DEATH")
         map(entity, "incorporationDate", record, "DATES", "REGISTRATION_DATE")
+        # Organization dissolution date — the org analog of a person's DATE_OF_DEATH.
+        # Emitted formatted for Senzing; a consumer can register a DISSOLUTION_DATE feature
+        # if they want it scored (parallel to REGISTRATION_DATE for incorporation).
+        map(entity, "dissolutionDate", record, "DATES", "DISSOLUTION_DATE")
         map(entity, "birthPlace", record, "ADDRESSES", "PLACE_OF_BIRTH")
         map(
             entity,
@@ -198,74 +210,42 @@ class SenzingExporter(Exporter):
             country=passport_country,
             country_attr="PASSPORT_COUNTRY",
         )
-        # NATIONAL_ID / TAX_ID collapse several distinct FtM identifier schemes into one
-        # Senzing field; keep the FtM property as *_TYPE so they remain distinguishable,
-        # and qualify by *_COUNTRY (both are exclusive and only unique within a country).
+        # NATIONAL_ID / TAX_ID collapse several distinct FtM identifier schemes into one Senzing
+        # field. We disambiguate with a two-level scheme + a country qualifier:
+        #   *_TYPE     = the BROAD scheme, which governs the exclusivity namespace;
+        #   *_SUBTYPE  = the FINE scheme within it (GDEV-4439) — a refinement, so a bare broad type
+        #                partial-matches a subtyped one instead of conflicting;
+        #   *_COUNTRY  = issuer (exclusive ids are only unique within a country).
+        #
+        # The `*_TYPE` value is the UPPER-CASE canonical scheme from the Senzing identifier crosswalk
+        # (INN, VAT, REGISTRATION_NUMBER, …) rather than the raw FtM property, so every source that
+        # loads into the same Senzing instance shares one exclusivity namespace per scheme. A bare
+        # GENERIC default (`idNumber` / `taxNumber`) carries NO *_TYPE. Distinct schemes each get
+        # their canonical *_TYPE; *_SUBTYPE is used ONLY where a broad TYPE has multiple sub-registries
+        # and the source may not know which — RU has several REGISTRATION_NUMBER registries, so
+        # `ogrnCode` is TYPE=REGISTRATION_NUMBER + SUBTYPE=OGRN (a bare REGISTRATION_NUMBER then
+        # partial-matches it instead of conflicting).
         id_num = "NATIONAL_ID_NUMBER"
         id_type = "NATIONAL_ID_TYPE"
+        id_subtype = "NATIONAL_ID_SUBTYPE"
         id_ctry = "NATIONAL_ID_COUNTRY"
         tax_num = "TAX_ID_NUMBER"
         tax_type = "TAX_ID_TYPE"
         tax_ctry = "TAX_ID_COUNTRY"
+        # Generic defaults -> blank TYPE.
+        map(entity, "idNumber", record, "IDENTIFIERS", id_num, None, id_country, id_ctry)
+        map(entity, "taxNumber", record, "IDENTIFIERS", tax_num, None, id_country, tax_ctry)
+        # Distinct schemes -> canonical (upper-case) *_TYPE.
+        map(entity, "registrationNumber", record, "IDENTIFIERS", id_num, id_type, id_country, id_ctry,
+            type_val="REGISTRATION_NUMBER")
+        map(entity, "innCode", record, "IDENTIFIERS", tax_num, tax_type, id_country, tax_ctry,
+            type_val="INN")
+        map(entity, "vatCode", record, "IDENTIFIERS", tax_num, tax_type, id_country, tax_ctry,
+            type_val="VAT")
+        # ogrnCode = one of several RU registration registries -> SUBTYPE under REGISTRATION_NUMBER.
         map(
-            entity,
-            "idNumber",
-            record,
-            "IDENTIFIERS",
-            id_num,
-            id_type,
-            id_country,
-            id_ctry,
-        )
-        map(
-            entity,
-            "registrationNumber",
-            record,
-            "IDENTIFIERS",
-            id_num,
-            id_type,
-            id_country,
-            id_ctry,
-        )
-        map(
-            entity,
-            "ogrnCode",
-            record,
-            "IDENTIFIERS",
-            id_num,
-            id_type,
-            id_country,
-            id_ctry,
-        )
-        map(
-            entity,
-            "taxNumber",
-            record,
-            "IDENTIFIERS",
-            tax_num,
-            tax_type,
-            id_country,
-            tax_ctry,
-        )
-        map(
-            entity,
-            "innCode",
-            record,
-            "IDENTIFIERS",
-            tax_num,
-            tax_type,
-            id_country,
-            tax_ctry,
-        )
-        map(
-            entity,
-            "vatCode",
-            record,
-            "IDENTIFIERS",
-            tax_num,
-            tax_type,
-            id_country,
-            tax_ctry,
+            entity, "ogrnCode", record, "IDENTIFIERS", id_num, id_type, id_country, id_ctry,
+            type_val="REGISTRATION_NUMBER", subtype_attr=id_subtype, subtype_val="OGRN",
         )
         map(entity, "socialSecurityNumber", record, "IDENTIFIERS", "SSN_NUMBER")
         map(entity, "leiCode", record, "IDENTIFIERS", "LEI_NUMBER")
@@ -379,6 +359,30 @@ class SenzingExporter(Exporter):
 
             if len(addrs_list) != len(addr_hashes):
                 record["ADDRESSES"] = unique_addrs
+
+        # Emit the recommended single-list FEATURES schema (one list for every feature) rather than
+        # the legacy per-feature sub-lists (NAMES/ADDRESSES/IDENTIFIERS/...). Senzing accepts both and
+        # resolves them identically; the single list is cleaner and consistent across mappers. Built
+        # via sub-lists above (so the address/name dedup and BUSINESS tagging stay simple), flattened
+        # here. Record-level metadata (DATA_SOURCE/RECORD_ID/LAST_CHANGE/URL) stays at the top level.
+        feats: list[dict[str, Any]] = []
+        if record_type is not None:
+            feats.append({"RECORD_TYPE": record_type})
+        if (gender := record.pop("GENDER", None)) is not None:
+            feats.append({"GENDER": gender})
+        for section in (
+            "NAMES",
+            "RISKS",
+            "ADDRESSES",
+            "DATES",
+            "COUNTRIES",
+            "CONTACTS",
+            "IDENTIFIERS",
+            "SOURCE_LINKS",
+            "RELATIONSHIPS",
+        ):
+            feats.extend(record.pop(section, []))
+        record["FEATURES"] = feats
 
         # pprint(record)
         write_json(record, self.fh)

--- a/zavod/zavod/exporters/senzing.py
+++ b/zavod/zavod/exporters/senzing.py
@@ -50,6 +50,8 @@ def map(
     section: str,
     attr: str,
     type_attr: str | None = None,
+    country: str | None = None,
+    country_attr: str | None = None,
 ) -> None:
     for value in entity.get(prop, quiet=True):
         item = {attr: value}
@@ -59,6 +61,11 @@ def map(
             # collapse into one untyped Senzing field, so a mismatch between two
             # different-scheme numbers is wrongly treated as an exclusive conflict.
             item[type_attr] = prop
+        if country and country_attr is not None:
+            # Qualify the identifier by country. Exclusive ids (NATIONAL_ID/TAX_ID/
+            # PASSPORT) are only unique WITHIN a country, so a country puts them in
+            # the right namespace and stops cross-country numbers from colliding.
+            item[country_attr] = country
         push(obj, section, item)
 
 
@@ -161,19 +168,97 @@ class SenzingExporter(Exporter):
         map(entity, "website", record, "CONTACTS", "WEBSITE_ADDRESS")
         map(entity, "email", record, "CONTACTS", "EMAIL_ADDRESS")
         map(entity, "phone", record, "CONTACTS", "PHONE_NUMBER")
-        map(entity, "passportNumber", record, "IDENTIFIERS", "PASSPORT_NUMBER")
+        # A single best country to qualify exclusive identifiers. Registration ids use the
+        # legal jurisdiction; a passport uses the holder's nationality.
+        id_country = (
+            entity.first("jurisdiction", quiet=True)
+            or entity.first("country", quiet=True)
+            or entity.first("mainCountry", quiet=True)
+            or entity.first("nationality", quiet=True)
+        )
+        passport_country = (
+            entity.first("nationality", quiet=True)
+            or entity.first("citizenship", quiet=True)
+            or id_country
+        )
+        map(
+            entity,
+            "passportNumber",
+            record,
+            "IDENTIFIERS",
+            "PASSPORT_NUMBER",
+            country=passport_country,
+            country_attr="PASSPORT_COUNTRY",
+        )
         # NATIONAL_ID / TAX_ID collapse several distinct FtM identifier schemes into one
-        # Senzing field; keep the FtM property as *_TYPE so they remain distinguishable.
+        # Senzing field; keep the FtM property as *_TYPE so they remain distinguishable,
+        # and qualify by *_COUNTRY (both are exclusive and only unique within a country).
         id_num = "NATIONAL_ID_NUMBER"
         id_type = "NATIONAL_ID_TYPE"
+        id_ctry = "NATIONAL_ID_COUNTRY"
         tax_num = "TAX_ID_NUMBER"
         tax_type = "TAX_ID_TYPE"
-        map(entity, "idNumber", record, "IDENTIFIERS", id_num, id_type)
-        map(entity, "registrationNumber", record, "IDENTIFIERS", id_num, id_type)
-        map(entity, "ogrnCode", record, "IDENTIFIERS", id_num, id_type)
-        map(entity, "taxNumber", record, "IDENTIFIERS", tax_num, tax_type)
-        map(entity, "innCode", record, "IDENTIFIERS", tax_num, tax_type)
-        map(entity, "vatCode", record, "IDENTIFIERS", tax_num, tax_type)
+        tax_ctry = "TAX_ID_COUNTRY"
+        map(
+            entity,
+            "idNumber",
+            record,
+            "IDENTIFIERS",
+            id_num,
+            id_type,
+            id_country,
+            id_ctry,
+        )
+        map(
+            entity,
+            "registrationNumber",
+            record,
+            "IDENTIFIERS",
+            id_num,
+            id_type,
+            id_country,
+            id_ctry,
+        )
+        map(
+            entity,
+            "ogrnCode",
+            record,
+            "IDENTIFIERS",
+            id_num,
+            id_type,
+            id_country,
+            id_ctry,
+        )
+        map(
+            entity,
+            "taxNumber",
+            record,
+            "IDENTIFIERS",
+            tax_num,
+            tax_type,
+            id_country,
+            tax_ctry,
+        )
+        map(
+            entity,
+            "innCode",
+            record,
+            "IDENTIFIERS",
+            tax_num,
+            tax_type,
+            id_country,
+            tax_ctry,
+        )
+        map(
+            entity,
+            "vatCode",
+            record,
+            "IDENTIFIERS",
+            tax_num,
+            tax_type,
+            id_country,
+            tax_ctry,
+        )
         map(entity, "socialSecurityNumber", record, "IDENTIFIERS", "SSN_NUMBER")
         map(entity, "leiCode", record, "IDENTIFIERS", "LEI_NUMBER")
         map(entity, "dunsCode", record, "IDENTIFIERS", "DUNS_NUMBER")

--- a/zavod/zavod/exporters/senzing.py
+++ b/zavod/zavod/exporters/senzing.py
@@ -44,10 +44,22 @@ def push(obj: dict[str, Any], section: str, value: dict[str, Any]) -> None:
 
 
 def map(
-    entity: Entity, prop: str, obj: dict[str, Any], section: str, attr: str
+    entity: Entity,
+    prop: str,
+    obj: dict[str, Any],
+    section: str,
+    attr: str,
+    type_attr: str | None = None,
 ) -> None:
     for value in entity.get(prop, quiet=True):
-        push(obj, section, {attr: value})
+        item = {attr: value}
+        if type_attr is not None:
+            # Preserve the FtM property as the identifier TYPE. Several distinct
+            # schemes (e.g. ogrnCode vs registrationNumber vs innCode) otherwise
+            # collapse into one untyped Senzing field, so a mismatch between two
+            # different-scheme numbers is wrongly treated as an exclusive conflict.
+            item[type_attr] = prop
+        push(obj, section, item)
 
 
 def clean(obj: dict[str, Any]) -> dict[str, Any]:
@@ -150,12 +162,18 @@ class SenzingExporter(Exporter):
         map(entity, "email", record, "CONTACTS", "EMAIL_ADDRESS")
         map(entity, "phone", record, "CONTACTS", "PHONE_NUMBER")
         map(entity, "passportNumber", record, "IDENTIFIERS", "PASSPORT_NUMBER")
-        map(entity, "idNumber", record, "IDENTIFIERS", "NATIONAL_ID_NUMBER")
-        map(entity, "registrationNumber", record, "IDENTIFIERS", "NATIONAL_ID_NUMBER")
-        map(entity, "ogrnCode", record, "IDENTIFIERS", "NATIONAL_ID_NUMBER")
-        map(entity, "taxNumber", record, "IDENTIFIERS", "TAX_ID_NUMBER")
-        map(entity, "innCode", record, "IDENTIFIERS", "TAX_ID_NUMBER")
-        map(entity, "vatCode", record, "IDENTIFIERS", "TAX_ID_NUMBER")
+        # NATIONAL_ID / TAX_ID collapse several distinct FtM identifier schemes into one
+        # Senzing field; keep the FtM property as *_TYPE so they remain distinguishable.
+        id_num = "NATIONAL_ID_NUMBER"
+        id_type = "NATIONAL_ID_TYPE"
+        tax_num = "TAX_ID_NUMBER"
+        tax_type = "TAX_ID_TYPE"
+        map(entity, "idNumber", record, "IDENTIFIERS", id_num, id_type)
+        map(entity, "registrationNumber", record, "IDENTIFIERS", id_num, id_type)
+        map(entity, "ogrnCode", record, "IDENTIFIERS", id_num, id_type)
+        map(entity, "taxNumber", record, "IDENTIFIERS", tax_num, tax_type)
+        map(entity, "innCode", record, "IDENTIFIERS", tax_num, tax_type)
+        map(entity, "vatCode", record, "IDENTIFIERS", tax_num, tax_type)
         map(entity, "socialSecurityNumber", record, "IDENTIFIERS", "SSN_NUMBER")
         map(entity, "leiCode", record, "IDENTIFIERS", "LEI_NUMBER")
         map(entity, "dunsCode", record, "IDENTIFIERS", "DUNS_NUMBER")

--- a/zavod/zavod/exporters/senzing.py
+++ b/zavod/zavod/exporters/senzing.py
@@ -270,8 +270,12 @@ class SenzingExporter(Exporter):
                 push(record, "ADDRESSES", clean(adj_data))
 
             elif adj.schema.name == "Identification":
+                # Carry the document type (e.g. "National ID No.", "Cedula No.") — sources
+                # record it on the Identification but it was being dropped, leaving the
+                # exclusive NATIONAL_ID untyped and prone to cross-scheme false conflicts.
                 adj_data = {
                     "NATIONAL_ID_NUMBER": adj.first("number"),
+                    "NATIONAL_ID_TYPE": adj.first("type"),
                     "NATIONAL_ID_COUNTRY": adj.first("country"),
                 }
                 push(record, "IDENTIFIERS", clean(adj_data))

--- a/zavod/zavod/exporters/senzing.py
+++ b/zavod/zavod/exporters/senzing.py
@@ -4,6 +4,14 @@
 # This format can then be used to perform record linkage against other datasets.
 # As a next step, the matching results could be converted back into a
 # nomenklatura resolver file and then used to generate integrated FtM entities.
+#
+# Senzing config note (NATIONAL_ID_TYPE / TAX_ID_TYPE):
+# This exporter emits typed identifiers so distinct FtM schemes stay in separate exclusivity
+# namespaces. NATIONAL_ID_TYPE works in the default config. TAX_ID_TYPE needs an ID_TYPE element on
+# the TAX_ID feature, which the Senzing 4.4 default config includes; on engines whose config predates
+# that, apply the companion `senzing_config_updates.gtc` (`sz_configtool -f ...`) -- otherwise TAX_ID_TYPE
+# is dropped at load and distinct tax schemes collide in one untyped namespace. (That script adds the
+# ID_TYPE element to TAX_ID *and* to its comparison call, which is what makes the type actually scored.)
 
 import re
 from itertools import product

--- a/zavod/zavod/exporters/senzing.py
+++ b/zavod/zavod/exporters/senzing.py
@@ -98,6 +98,53 @@ def hash_value(value: str) -> str:
     return NORM_TEXT.sub("", value).lower()
 
 
+# Free-text FtM `Identification.type` label -> canonical NATIONAL_ID scheme.
+#
+# The rest of this exporter routes the typed FtM properties (registrationNumber, innCode,
+# vatCode, ogrnCode) through UPPER-CASE canonical schemes so every source sharing a Senzing
+# instance lands in one exclusivity namespace per scheme. The `Identification` adjacency,
+# though, carried `adj.first("type")` through RAW -- a mixed-case, punctuated FtM string
+# ("C.U.R.P.", "Cedula No.", "National ID No.") -- so the same scheme from a different source
+# (e.g. the Sayari mapper's canonical CURP / CEDULA) would NOT compare equal in the
+# `*_TYPE` namespace, silently missing the cross-source bridge.
+#
+# Keys are hash_value() of the label (lower-cased, punctuation/space-stripped) so "C.U.R.P.",
+# "CURP" and "c.u.r.p" all collapse to one key. Values are the SAME upper-case canonical
+# schemes the Sayari mapper emits (config/sayari_codes.csv), so the two sources share one
+# namespace per scheme. A label is listed ONLY when its scheme is both deducible from the
+# label AND a canonical scheme in the shared vocabulary. Everything else -- generic labels
+# ("National ID No.", "Identification Number") and anything unrecognized -- maps to a blank
+# TYPE (Senzing still learns the untyped id; we never invent a label that isn't in the vocab).
+NATIONAL_ID_TYPES = {
+    hash_value(k): v
+    for k, v in {
+        # Person national-id schemes (canonical in the shared vocab).
+        "C.U.R.P.": "CURP",  # Mexico
+        "Cedula": "CEDULA",
+        "Cedula No.": "CEDULA",
+        "D.N.I.": "DNI",
+        "C.U.I.T.": "CUIT",  # Argentina
+        "C.U.I.L.": "CUIL",  # Argentina
+        "C.U.I.": "CUI",  # Guatemala
+        "CNPJ": "CNPJ",  # Brazil (legal entity)
+        "CPF": "CPF",  # Brazil (natural person)
+        # Company registration -> the single canonical REGISTRATION_NUMBER scheme.
+        "Commercial Register": "REGISTRATION_NUMBER",
+        "Commercial Registry Number": "REGISTRATION_NUMBER",
+        "Registration Number": "REGISTRATION_NUMBER",
+        "Company Number": "REGISTRATION_NUMBER",
+    }.items()
+}
+
+
+def canonical_national_id_type(raw_type: str | None) -> str | None:
+    """Map a free-text FtM Identification.type to a canonical NATIONAL_ID scheme, or
+    None (blank) when the label is generic or unrecognized -- see NATIONAL_ID_TYPES."""
+    if raw_type is None:
+        return None
+    return NATIONAL_ID_TYPES.get(hash_value(raw_type))
+
+
 class SenzingExporter(Exporter):
     TITLE = "Senzing entity format"
     FILE_NAME = "senzing.json"
@@ -258,12 +305,16 @@ class SenzingExporter(Exporter):
                 push(record, "ADDRESSES", clean(adj_data))
 
             elif adj.schema.name == "Identification":
-                # Carry the document type (e.g. "National ID No.", "Cedula No.") — sources
-                # record it on the Identification but it was being dropped, leaving the
-                # exclusive NATIONAL_ID untyped and prone to cross-scheme false conflicts.
+                # Carry the document type (e.g. "C.U.R.P.", "Cedula No.") — sources record it
+                # on the Identification but it was being dropped, leaving the exclusive
+                # NATIONAL_ID untyped and prone to cross-scheme false conflicts. Canonicalize
+                # it to the shared upper-case scheme (matching the typed properties above and
+                # the Sayari mapper) so the SAME scheme bridges across sources; generic or
+                # unrecognized labels canonicalize to blank rather than a raw, non-comparable
+                # string. See NATIONAL_ID_TYPES.
                 adj_data = {
                     "NATIONAL_ID_NUMBER": adj.first("number"),
-                    "NATIONAL_ID_TYPE": adj.first("type"),
+                    "NATIONAL_ID_TYPE": canonical_national_id_type(adj.first("type")),
                     "NATIONAL_ID_COUNTRY": adj.first("country"),
                 }
                 push(record, "IDENTIFIERS", clean(adj_data))

--- a/zavod/zavod/exporters/senzing_config_updates.gtc
+++ b/zavod/zavod/exporters/senzing_config_updates.gtc
@@ -1,0 +1,17 @@
+# Senzing configuration update for the Senzing exporter's TAX_ID_TYPE.
+#
+# Apply with:  sz_configtool -f senzing_config_updates.gtc
+#
+# The Senzing exporter emits TAX_ID_TYPE (taxNumber / innCode / vatCode) so distinct tax schemes stay
+# in separate exclusivity namespaces. TAX_ID_TYPE requires an ID_TYPE element on the TAX_ID feature AND
+# in its comparison call -- the comparison-call row is what makes the type SCORED, not just stored.
+# Senzing 4.4's default config ships this; the commands below add it to older configs (mirrors the
+# NATIONAL_ID configuration, which already carries a scored ID_TYPE). Without it, TAX_ID_TYPE is dropped
+# at load and distinct tax schemes collide in one untyped per-country TAX_ID namespace.
+#
+# execOrder values match the 4.4.0-26224 template.
+
+addElementToFeature       {"feature": "TAX_ID", "element": "ID_TYPE", "derived": "No", "display": 1, "execOrder": 7}
+addComparisonCallElement  {"feature": "TAX_ID", "element": "ID_TYPE", "execOrder": 3}
+addAttribute              {"attribute": "TAX_ID_TYPE", "class": "IDENTIFIER", "feature": "TAX_ID", "element": "ID_TYPE", "required": "Desired"}
+save

--- a/zavod/zavod/tests/exporters/test_senzing.py
+++ b/zavod/zavod/tests/exporters/test_senzing.py
@@ -3,9 +3,34 @@ from json import loads
 from zavod import settings
 from zavod.meta import Dataset
 from zavod.archive import clear_data_path
-from zavod.exporters.senzing import SenzingExporter
+from zavod.exporters.senzing import SenzingExporter, canonical_national_id_type
 from zavod.crawl import crawl_dataset
 from zavod.tests.exporters.util import harnessed_export
+
+
+def test_canonical_national_id_type():
+    """The Identification adjacency must canonicalize its free-text FtM `type` to the SAME
+    upper-case scheme the typed properties and the Sayari mapper emit, so the same scheme
+    bridges across sources; generic/unrecognized labels must fall back to a blank type."""
+    # Deducible + canonical -> canonical scheme (equals the Sayari mapper's labels).
+    assert canonical_national_id_type("C.U.R.P.") == "CURP"
+    assert canonical_national_id_type("Cedula No.") == "CEDULA"
+    assert canonical_national_id_type("D.N.I.") == "DNI"
+    assert canonical_national_id_type("C.U.I.T.") == "CUIT"
+    assert canonical_national_id_type("C.U.I.") == "CUI"
+    assert canonical_national_id_type("Commercial Register") == "REGISTRATION_NUMBER"
+    # Case / punctuation variants collapse to the same canonical scheme.
+    assert canonical_national_id_type("curp") == "CURP"
+    assert canonical_national_id_type("CURP") == "CURP"
+    assert canonical_national_id_type("dni") == "DNI"
+    # C.U.I. and C.U.I.T. must NOT collide.
+    assert canonical_national_id_type("C.U.I.") != canonical_national_id_type("C.U.I.T.")
+    # Generic or unrecognized -> blank (None); Senzing learns the untyped id.
+    assert canonical_national_id_type("National ID No.") is None
+    assert canonical_national_id_type("Identification Number") is None
+    assert canonical_national_id_type("N.I.E.") is None
+    assert canonical_national_id_type("Some Unknown Doc Type") is None
+    assert canonical_national_id_type(None) is None
 
 
 def test_senzing(testdataset1: Dataset):

--- a/zavod/zavod/tests/exporters/test_senzing.py
+++ b/zavod/zavod/tests/exporters/test_senzing.py
@@ -35,7 +35,12 @@ def test_senzing(testdataset1: Dataset):
     company_countries = company.pop("COUNTRIES")
     assert {"REGISTRATION_COUNTRY": "us"} in company_countries
     company_identifiers = company.pop("IDENTIFIERS")
-    assert {"NATIONAL_ID_NUMBER": "8723-BX"} in company_identifiers
+    # The FtM property (here registrationNumber) is preserved as NATIONAL_ID_TYPE so distinct
+    # identifier schemes don't collapse into one untyped NATIONAL_ID and false-conflict.
+    assert {
+        "NATIONAL_ID_NUMBER": "8723-BX",
+        "NATIONAL_ID_TYPE": "registrationNumber",
+    } in company_identifiers
     assert company["DATA_SOURCE"] == "OS_TESTDATASET1"
     assert company["RECORD_ID"] == "osv-umbrella-corp"
     assert company["RECORD_TYPE"] == "ORGANIZATION"

--- a/zavod/zavod/tests/exporters/test_senzing.py
+++ b/zavod/zavod/tests/exporters/test_senzing.py
@@ -19,46 +19,43 @@ def test_senzing(testdataset1: Dataset):
 
     with open(dataset_path / "senzing.json") as senzing_file:
         targets = [loads(line) for line in senzing_file.readlines()]
+    # The exporter emits the single-list FEATURES schema: every feature is an object in FEATURES;
+    # only DATA_SOURCE/RECORD_ID/LAST_CHANGE/URL stay at the top level.
     company = [t for t in targets if t["RECORD_ID"] == "osv-umbrella-corp"][0]
-    company_names = company.pop("NAMES")
+    company_features = company["FEATURES"]
 
+    assert {"RECORD_TYPE": "ORGANIZATION"} in company_features
     assert {
         "NAME_TYPE": "PRIMARY",
         "NAME_ORG": "Umbrella Corporation",
-    } in company_names
+    } in company_features
     assert {
         "NAME_TYPE": "ALIAS",
         "NAME_ORG": "Umbrella Pharmaceuticals, Inc.",
-    } in company_names
-    company_dates = company.pop("DATES")
-    assert {"REGISTRATION_DATE": "1980"} in company_dates
-    company_countries = company.pop("COUNTRIES")
-    assert {"REGISTRATION_COUNTRY": "us"} in company_countries
-    company_identifiers = company.pop("IDENTIFIERS")
-    # The FtM property (here registrationNumber) is preserved as NATIONAL_ID_TYPE, and the entity's
-    # jurisdiction as NATIONAL_ID_COUNTRY, so distinct identifier schemes/countries don't collapse
-    # into one untyped NATIONAL_ID and false-conflict.
+    } in company_features
+    assert {"REGISTRATION_DATE": "1980"} in company_features
+    assert {"REGISTRATION_COUNTRY": "us"} in company_features
+    # `registrationNumber` is a distinct scheme (a company registration number), kept as
+    # NATIONAL_ID_TYPE so it doesn't collide with personal national-id schemes. Only the truly
+    # generic defaults (a bare `idNumber` / `taxNumber`) are left blank so cross-source ids bridge
+    # instead of conflicting when the type is scored.
     assert {
         "NATIONAL_ID_NUMBER": "8723-BX",
-        "NATIONAL_ID_TYPE": "registrationNumber",
+        "NATIONAL_ID_TYPE": "REGISTRATION_NUMBER",
         "NATIONAL_ID_COUNTRY": "us",
-    } in company_identifiers
+    } in company_features
     assert company["DATA_SOURCE"] == "OS_TESTDATASET1"
     assert company["RECORD_ID"] == "osv-umbrella-corp"
-    assert company["RECORD_TYPE"] == "ORGANIZATION"
     assert "/entities/osv-umbrella-corp" in company["URL"]
     assert company["LAST_CHANGE"] is not None
 
     person = [t for t in targets if t["RECORD_ID"] == "osv-hans-gruber"][0]
-    person_names = person.pop("NAMES")
-    assert {"NAME_TYPE": "PRIMARY", "NAME_FULL": "Hans Gruber"} in person_names
-    assert {"NAME_TYPE": "ALIAS", "NAME_FULL": "Bill Clay"} in person_names
-    person_addrs = person.pop("ADDRESSES")
-    assert {"ADDR_FULL": "Lauensteiner Str. 49, 01277 Dresden"} in person_addrs
-    person_dates = person.pop("DATES")
-    assert {"DATE_OF_BIRTH": "1978-09-25"} in person_dates
-    person_countries = person.pop("COUNTRIES")
-    assert {"NATIONALITY": "dd"} in person_countries
+    person_features = person["FEATURES"]
+    assert {"RECORD_TYPE": "PERSON"} in person_features
+    assert {"NAME_TYPE": "PRIMARY", "NAME_FULL": "Hans Gruber"} in person_features
+    assert {"NAME_TYPE": "ALIAS", "NAME_FULL": "Bill Clay"} in person_features
+    assert {"ADDR_FULL": "Lauensteiner Str. 49, 01277 Dresden"} in person_features
+    assert {"DATE_OF_BIRTH": "1978-09-25"} in person_features
+    assert {"NATIONALITY": "dd"} in person_features
     assert person["DATA_SOURCE"] == "OS_TESTDATASET1"
     assert person["RECORD_ID"] == "osv-hans-gruber"
-    assert person["RECORD_TYPE"] == "PERSON"

--- a/zavod/zavod/tests/exporters/test_senzing.py
+++ b/zavod/zavod/tests/exporters/test_senzing.py
@@ -35,11 +35,13 @@ def test_senzing(testdataset1: Dataset):
     company_countries = company.pop("COUNTRIES")
     assert {"REGISTRATION_COUNTRY": "us"} in company_countries
     company_identifiers = company.pop("IDENTIFIERS")
-    # The FtM property (here registrationNumber) is preserved as NATIONAL_ID_TYPE so distinct
-    # identifier schemes don't collapse into one untyped NATIONAL_ID and false-conflict.
+    # The FtM property (here registrationNumber) is preserved as NATIONAL_ID_TYPE, and the entity's
+    # jurisdiction as NATIONAL_ID_COUNTRY, so distinct identifier schemes/countries don't collapse
+    # into one untyped NATIONAL_ID and false-conflict.
     assert {
         "NATIONAL_ID_NUMBER": "8723-BX",
         "NATIONAL_ID_TYPE": "registrationNumber",
+        "NATIONAL_ID_COUNTRY": "us",
     } in company_identifiers
     assert company["DATA_SOURCE"] == "OS_TESTDATASET1"
     assert company["RECORD_ID"] == "osv-umbrella-corp"


### PR DESCRIPTION
## Problem

The Senzing exporter collapsed several distinct FtM identifier properties into one **untyped** Senzing field, discarding the scheme:

- `idNumber`, `registrationNumber`, `ogrnCode` -> `NATIONAL_ID_NUMBER`
- `taxNumber`, `innCode`, `vatCode` -> `TAX_ID_NUMBER`

Senzing treats `NATIONAL_ID`/`TAX_ID` as **exclusive** identifiers: the same value forces records together, a *different* value forces them apart -- but only within the same type/country namespace. Untyped and country-less, two different-scheme numbers (a company registration number vs. an OGRN; a UK Companies House number vs. a US state filing number) are compared head to head, so

- a mismatch reads as a **conflicting exclusive identifier** -> one entity is **split**, and
- a shared generic/placeholder value reads as a match -> **distinct entities merge**.

Both were observed on OpenSanctions-sourced data loaded into Senzing (GLEIF / OpenSanctions / OpenOwnership), where these ids arrive without a type.

Separately, `entity.id` was written only as `RECORD_ID`. Senzing never **compares** a `RECORD_ID` -- it is bookkeeping -- so nothing stopped two different OpenSanctions entities being merged on weak evidence such as a shared name and address.

## Change

**1. Single-list `FEATURES` schema.** Every feature -- `RECORD_TYPE` and `GENDER` included -- is now an object in one `FEATURES` list rather than the legacy per-feature sub-lists (`NAMES`/`RISKS`/`ADDRESSES`/`DATES`/`COUNTRIES`/`CONTACTS`/`IDENTIFIERS`/`SOURCE_LINKS`/`RELATIONSHIPS`). Senzing accepts both and resolves them identically; the single list is Senzing's recommended shape and is consistent across mappers. The sub-lists are still built internally so the address/name dedup and `BUSINESS` tagging stay simple, then flattened at the end. Record-level metadata (`DATA_SOURCE`, `RECORD_ID`, `LAST_CHANGE`, `URL`, `OPENSANCTIONS_ID`) stays at the top level.

**2. Typed, country-qualified identifiers.** `map()` gains six optional parameters -- `type_attr`, `country`, `country_attr`, `type_val`, `subtype_attr`, `subtype_val` -- and the identifier mappings use them:

- `registrationNumber` -> `NATIONAL_ID_TYPE=REGISTRATION_NUMBER`
- `innCode` -> `TAX_ID_TYPE=INN`; `vatCode` -> `TAX_ID_TYPE=VAT`
- bare `idNumber` / `taxNumber` stay **untyped** on purpose, so genuinely generic ids bridge across sources instead of conflicting
- all of the above carry `*_COUNTRY`, resolved from `jurisdiction` -> `country` -> `mainCountry` -> `nationality`; exclusive ids are only unique *within* a country
- `passportNumber` gains `PASSPORT_COUNTRY`, resolved from `nationality` -> `citizenship` -> the identifier country
- single-scheme fields (`LEI_NUMBER`, `DUNS_NUMBER`, `SSN_NUMBER`) are unchanged

The `*_TYPE` values are the UPPER-CASE canonical schemes from the Senzing identifier crosswalk, not the raw FtM property name, so every source loading into one Senzing instance shares one exclusivity namespace per scheme.

**3. `NATIONAL_ID_SUBTYPE` for sub-registries (GDEV-4439).** RU has several registration registries, and a source often does not know which one a bare number came from. `ogrnCode` is therefore `NATIONAL_ID_TYPE=REGISTRATION_NUMBER` + `NATIONAL_ID_SUBTYPE=OGRN` -- a refinement inside the broad type, so a bare `REGISTRATION_NUMBER` partial-matches it rather than conflicting with it. Configs that predate the `ID_SUBTYPE` element simply drop the subtype and keep the broad type.

**4. `Identification.type` canonicalization.** The `Identification` adjacency carried `adj.first("type")` as raw FtM free text ("C.U.R.P.", "Cedula No.", "National ID No."), which would not compare equal to another source's canonical `CURP`/`CEDULA`, silently missing the cross-source bridge. `NATIONAL_ID_TYPES` + `canonical_national_id_type()` map the label -- case- and punctuation-insensitively -- to the same canonical scheme the typed properties emit. A label is listed **only** when its scheme is both deducible from the label and present in the shared vocabulary; generic ("National ID No.", "Identification Number") and unrecognized labels canonicalize to **blank**, never to an invented string. `C.U.I.` and `C.U.I.T.` are kept distinct.

**5. `DISSOLUTION_DATE`.** `dissolutionDate` is now emitted (the organization analog of `DATE_OF_DEATH`), parallel to `REGISTRATION_DATE` for incorporation. A consumer can register a `DISSOLUTION_DATE` feature if they want it scored.

**6. `OPENSANCTIONS_ID` as an A1ES feature.** The same `entity.id` is asserted a second time as `OPENSANCTIONS_ID`. A1ES **denies** on a value mismatch, so once every record carries its own id, two distinct OpenSanctions entities can never co-resolve however they are pulled together.

The failure this prevents is **a reference list being read as identity**. Other datasets cite OpenSanctions ids; a record carrying a *list* of them is citing those entities, not claiming to be them. Without a deny on the authoritative side, each cited entity resolves into the citing record and therefore into every other entity in the list. Measured on a sibling corpus: one organization record carrying 700 referenced ids fused **84 distinct real entities** into itself; asserting exactly this A1ES twin on the authoritative side cut that class of fusion by **99.8%** and left the citing record merely *related* to each entity.

**7. Companion `zavod/zavod/exporters/senzing_config_updates.gtc`** (new file; apply with `sz_configtool -f ...`):

- registers `OPENSANCTIONS_ID` via `templateAdd`/`GLOBAL_ID` with `behavior: A1ES`, which decomposes correctly into `FREQ=A1 / EXCL=Yes / STAB=Yes` -- a hand-rolled `addFeature` is the documented way to register an A1ES feature that silently misbehaves;
- adds the `ID_TYPE` element to `TAX_ID` **and to its comparison call** (the comparison-call row is what makes the type actually *scored*, not merely stored). Senzing 4.4's default config already ships this; older configs need it, or `TAX_ID_TYPE` is dropped at load and distinct tax schemes collide in one untyped namespace. `NATIONAL_ID_TYPE` already works in the default config.

## Output before / after

Real output for the `osv-umbrella-corp` fixture in `zavod/zavod/tests/fixtures/testdataset1`, produced by running the exporter on both revisions.

Before (upstream `c21f1fadc`):

```json
{
  "DATA_SOURCE": "OS_TESTDATASET1",
  "RECORD_ID": "osv-umbrella-corp",
  "RECORD_TYPE": "ORGANIZATION",
  "LAST_CHANGE": "2026-09-21T11:13:49",
  "NAMES": [
    {"NAME_TYPE": "PRIMARY", "NAME_ORG": "Umbrella Corporation"},
    {"NAME_TYPE": "ALIAS", "NAME_ORG": "Umbrella Pharmaceuticals, Inc."}
  ],
  "RISKS": [{"TOPIC": "reg.warn"}],
  "DATES": [{"REGISTRATION_DATE": "1980"}],
  "COUNTRIES": [{"REGISTRATION_COUNTRY": "us"}],
  "IDENTIFIERS": [
    {"NATIONAL_ID_NUMBER": "8723-BX"},
    {"OTHER_ID_TYPE": "OPEN_SANCTIONS", "OTHER_ID_NUMBER": "osv-umbrella-corp"}
  ],
  "RELATIONSHIPS": [
    {"REL_ANCHOR_DOMAIN": "OPEN_SANCTIONS", "REL_ANCHOR_KEY": "osv-umbrella-corp"}
  ],
  "URL": "https://www.opensanctions.org/entities/osv-umbrella-corp"
}
```

After (this branch, `60ad425c0`):

```json
{
  "DATA_SOURCE": "OS_TESTDATASET1",
  "RECORD_ID": "osv-umbrella-corp",
  "LAST_CHANGE": "2026-09-21T11:12:01",
  "OPENSANCTIONS_ID": "osv-umbrella-corp",
  "URL": "https://www.opensanctions.org/entities/osv-umbrella-corp",
  "FEATURES": [
    {"RECORD_TYPE": "ORGANIZATION"},
    {"NAME_TYPE": "PRIMARY", "NAME_ORG": "Umbrella Corporation"},
    {"NAME_TYPE": "ALIAS", "NAME_ORG": "Umbrella Pharmaceuticals, Inc."},
    {"TOPIC": "reg.warn"},
    {"REGISTRATION_DATE": "1980"},
    {"REGISTRATION_COUNTRY": "us"},
    {
      "NATIONAL_ID_NUMBER": "8723-BX",
      "NATIONAL_ID_TYPE": "REGISTRATION_NUMBER",
      "NATIONAL_ID_COUNTRY": "us"
    },
    {"OTHER_ID_TYPE": "OPEN_SANCTIONS", "OTHER_ID_NUMBER": "osv-umbrella-corp"},
    {"REL_ANCHOR_DOMAIN": "OPEN_SANCTIONS", "REL_ANCHOR_KEY": "osv-umbrella-corp"}
  ]
}
```

The three differences are the whole change in miniature: the flattened `FEATURES` list, the typed and country-qualified `NATIONAL_ID`, and the `OPENSANCTIONS_ID` twin. (`testdataset1` has no passport, no `dissolutionDate`, no `ogrnCode` and no tax ids, so `PASSPORT_COUNTRY`, `DISSOLUTION_DATE`, `NATIONAL_ID_SUBTYPE` and `TAX_ID_TYPE` do not appear in this fixture; `canonical_national_id_type()` is covered by its own unit test.)

## Trade-off worth calling out explicitly

`OPENSANCTIONS_ID` as A1ES makes OpenSanctions' own entity boundaries **authoritative to Senzing**: two OpenSanctions entities will no longer merge even when downstream evidence suggests they are the same real-world party. That is the intended behaviour -- OpenSanctions already performs its own deduplication, so distinct ids represent a deliberate judgement -- but it is a real change in semantics for consumers who were relying on Senzing to merge across them, and reviewers should weigh it.

## Tests

Branch merged with `upstream/main` (`c21f1fadc`); head is `60ad425c0`. Everything below was run on that commit, with a Python 3.12 virtualenv (`pip install -e "zavod[dev]"`); CI uses 3.13.

| Command | Result |
| --- | --- |
| `ruff check --config zavod/pyproject.toml zavod/zavod/` | `All checks passed!` |
| `ruff format --check --config zavod/pyproject.toml zavod/zavod/` | `214 files already formatted` |
| `mypy --strict --exclude zavod/tests zavod/` (in `zavod/`) | `Success: no issues found in 128 source files` |
| `git ls-files -z zavod \| xargs -0 -n 30 prek run --files` | 10 batches, 0 failed hooks |
| `pytest zavod/tests/` (in `zavod/`) | `353 passed, 1 skipped in 71.13s` |
| `pytest datasets` | `30 passed` |
| `python -m build --wheel` (in `zavod/`) | `Successfully built zavod-0.8.0-py3-none-any.whl` |

Test changes in this branch:

- `zavod/zavod/tests/exporters/test_senzing.py` -- asserts the `FEATURES` shape for both the organization and the person record, the canonical `NATIONAL_ID_TYPE=REGISTRATION_NUMBER` + `NATIONAL_ID_COUNTRY=us`, and adds `test_canonical_national_id_type` covering the canonical labels, case/punctuation collapsing, the `C.U.I.` vs `C.U.I.T.` non-collision, and the blank fallbacks.
- `zavod/zavod/tests/exporters/test_exporters.py` -- reads `RECORD_TYPE` out of `FEATURES` instead of the record root, asserting exactly one per record and a value in the set the exporter can emit (`PERSON`, `ORGANIZATION`, `AIRCRAFT`, `VESSEL`, `VEHICLE`).
