### PR TITLE
Unify OJEU CELLAR access and related-act discovery

### DIFF
--- a/datasets/eu/journal_sanctions/crawler.py
+++ b/datasets/eu/journal_sanctions/crawler.py
@@ -8,11 +8,11 @@ from nomenklatura.resolver import Linker
 from normality import normalize
 from rigour.ids.ogrn import OGRN
 from zavod.integration import get_dataset_linker
+from zavod.shed.ojeu import cellar
+from zavod.shed.ojeu.celex import normalize as normalize_celex
 
 from zavod import Context, Entity, settings
 from zavod import helpers as h
-from zavod.shed.ojeu import cellar
-from zavod.shed.ojeu.celex import normalize as normalize_celex
 
 # Some Russia-related entries are sourced from the consolidated regulation text.
 SPECIAL_CASE_URL = (
@@ -54,7 +54,8 @@ def extract_program_code(context: Context, source_url: str) -> str | None:
         context.log.warning(f"Could not find CELEX in source URL: {source_url}")
         return None
     program_xpath = "//div[@class='eli-main-title']/p[@class='oj-doc-ti']"
-    expression = cellar.fetch_expression(context, celex, cache_days=365)
+    client = cellar.CellarClient(context.http, context.cache)
+    expression = client.fetch_expression(celex, cache_days=365)
     doc = html.fromstring(expression.content)
     title_nodes = h.xpath_elements(doc, program_xpath)
     if len(title_nodes) == 0:
@@ -85,7 +86,8 @@ def get_consolidated_act(context: Context, source_url: str) -> cellar.Act | None
     except ValueError:
         context.log.warning(f"Could not find CELEX in source URL: {source_url}")
         return None
-    act = cellar.query_act(context, celex, cache_days=1)
+    client = cellar.CellarClient(context.http, context.cache)
+    act = client.query_act(celex, cache_days=1)
     frameworks = list(act.amends)
     if len(frameworks) == 0:
         context.log.warning(
@@ -116,7 +118,8 @@ def get_consolidated_text(context: Context, act: cellar.Act) -> str | None:
     """
     celex = act.latest_consolidated
     assert celex is not None
-    expression = cellar.fetch_expression(context, celex, cache_days=1)
+    client = cellar.CellarClient(context.http, context.cache)
+    expression = client.fetch_expression(celex, cache_days=1)
     doc = html.fromstring(expression.content)
     text = h.element_text(doc)
     if not text:

--- a/zavod/zavod/runtime/http_.py
+++ b/zavod/zavod/runtime/http_.py
@@ -61,6 +61,7 @@ def request_hash(
     method: str = "GET",
     data: Any = None,
     encoding: str | None = None,
+    headers: _Headers = None,
 ) -> str:
     """
     Generate a unique fingerprint for an HTTP request.
@@ -70,12 +71,18 @@ def request_hash(
         method: The HTTP method of the request.
         data: The data to be sent in the request body.
         encoding: The character encoding used to decode the response body.
+        headers: Representation-varying headers to include in the fingerprint.
     Returns:
         A unique fingerprint for the request (url + hashed payload).
     """
     parts: tuple[Any, ...] = (auth, method, data)
     if encoding is not None:
         parts = (*parts, encoding)
+    if headers is not None:
+        normalized_headers = tuple(
+            sorted((key.lower(), value.strip()) for key, value in headers.items())
+        )
+        parts = (*parts, normalized_headers)
     hsh = hash_data(parts)
     return f"{url}[{hsh}]"
 

--- a/zavod/zavod/shed/ojeu/celex.py
+++ b/zavod/zavod/shed/ojeu/celex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import parse_qs, unquote, urlparse
 
@@ -121,12 +122,24 @@ def _celex_from_eli_path(path: str) -> str | None:
     type=click.Path(path_type=Path, dir_okay=False),
     help="Write the fetched expression to this path.",
 )
+@click.option(
+    "--related-since",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    help="Include acts related to this framework on or after YYYY-MM-DD.",
+)
+@click.option(
+    "--related-until",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    help="Bound related acts at YYYY-MM-DD (inclusive).",
+)
 def cli(
     celex: str,
     language: str,
     media_type: str,
     metadata_only: bool,
     save_expression: Path | None,
+    related_since: datetime | None,
+    related_until: datetime | None,
 ) -> None:
     """Print stable JSON for an act so agents can inspect it without a crawl."""
     from zavod.shed.ojeu.cellar import cli_client
@@ -136,6 +149,15 @@ def cli(
         with cli_client() as client:
             act = client.query_act(celex)
             output = act.to_dict()
+            if related_until is not None and related_since is None:
+                raise ValueError("--related-until requires --related-since")
+            if related_since is not None:
+                related = client.query_related_acts(
+                    celex,
+                    related_since.date(),
+                    related_until.date() if related_until is not None else None,
+                )
+                output["related_acts"] = [item.to_dict() for item in related]
             if not metadata_only:
                 expression = client.fetch_expression(
                     celex, language=language, media_type=media_type

--- a/zavod/zavod/shed/ojeu/celex.py
+++ b/zavod/zavod/shed/ojeu/celex.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from urllib.parse import parse_qs, unquote, urlparse
 
 import click
+import requests
 
 EUR_LEX_URL = "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:{celex}"
 
@@ -128,23 +129,26 @@ def cli(
     save_expression: Path | None,
 ) -> None:
     """Print stable JSON for an act so agents can inspect it without a crawl."""
-    from zavod.shed.ojeu.cellar import fetch_expression_http, query_act_http
+    from zavod.shed.ojeu.cellar import cli_client
 
     try:
         celex = normalize(celex)
-        act = query_act_http(celex)
-        output = act.to_dict()
-        if not metadata_only:
-            expression = fetch_expression_http(
-                celex, language=language, media_type=media_type
-            )
-            output["expression"] = expression.to_dict()
-            if save_expression is not None:
-                save_expression.write_bytes(expression.content)
-                output["expression"]["saved_to"] = str(save_expression)
-        elif save_expression is not None:
-            raise ValueError("--save-expression cannot be used with --metadata-only")
-    except (OSError, ValueError) as exc:
+        with cli_client() as client:
+            act = client.query_act(celex)
+            output = act.to_dict()
+            if not metadata_only:
+                expression = client.fetch_expression(
+                    celex, language=language, media_type=media_type
+                )
+                output["expression"] = expression.to_dict()
+                if save_expression is not None:
+                    save_expression.write_bytes(expression.content)
+                    output["expression"]["saved_to"] = str(save_expression)
+            elif save_expression is not None:
+                raise ValueError(
+                    "--save-expression cannot be used with --metadata-only"
+                )
+    except (OSError, ValueError, requests.RequestException) as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(json.dumps(output, indent=2, sort_keys=True, ensure_ascii=False))
 

--- a/zavod/zavod/shed/ojeu/cellar.py
+++ b/zavod/zavod/shed/ojeu/cellar.py
@@ -2,22 +2,28 @@
 
 from __future__ import annotations
 
+import base64
+import json
+from contextlib import contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from collections.abc import Iterator, Mapping
+from typing import Any, Protocol
 
-import requests
 import click
+import orjson
+import requests
 from lxml import etree, html
+from nomenklatura.cache import Cache
+from nomenklatura.db import make_session as make_db_session
+from requests import Session
 
 from zavod.helpers.html import xpath_element
+from zavod.meta import Dataset
+from zavod.meta.http import HTTP
+from zavod.runtime.http_ import make_session, request_hash
 from zavod.shed.ojeu.celex import eur_lex_url, normalize
-
-if TYPE_CHECKING:
-    from requests import Session
-
-    from zavod import Context
 
 CELLAR_RESOURCE_URL = "http://publications.europa.eu/resource/celex/{celex}"
 SPARQL_ENDPOINT = "https://publications.europa.eu/webapi/rdf/sparql"
@@ -68,6 +74,12 @@ class Request:
     url: str
     method: str = "GET"
     data: bytes | None = None
+    headers: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def header_map(self) -> dict[str, str]:
+        """Build headers for executing or fingerprinting this exact request."""
+        return dict(self.headers)
 
 
 @dataclass(frozen=True)
@@ -120,7 +132,7 @@ class Expression:
     @property
     def request(self) -> Request:
         """Return the exact GET request used to fetch this expression."""
-        return expression_request(self.celex)
+        return expression_request(self.celex, self.language, self.media_type)
 
     @property
     def sha256(self) -> str:
@@ -138,24 +150,164 @@ class Expression:
         }
 
 
+class CacheStore(Protocol):
+    """Provide the small text-cache surface needed by CELLAR clients."""
+
+    def get(self, key: str, max_age: int | None = None) -> str | None: ...
+
+    def set(self, key: str, value: str | None) -> None: ...
+
+    def delete(self, key: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class _Response:
+    final_url: str
+    media_type: str | None
+    content: bytes
+
+    def dump(self) -> str:
+        return json.dumps(
+            {
+                "content": base64.b64encode(self.content).decode("ascii"),
+                "final_url": self.final_url,
+                "media_type": self.media_type,
+            },
+            sort_keys=True,
+        )
+
+    @classmethod
+    def load(cls, value: str) -> _Response:
+        data = json.loads(value)
+        return cls(
+            final_url=str(data["final_url"]),
+            media_type=data.get("media_type"),
+            content=base64.b64decode(data["content"]),
+        )
+
+
+class CellarClient:
+    """Access CELLAR consistently from crawlers and standalone tools.
+
+    Use this with a crawler's HTTP session and cache, or with ephemeral CLI
+    dependencies, so metadata and expression requests share one implementation.
+    """
+
+    def __init__(self, session: Session, cache: CacheStore | None = None) -> None:
+        self.session = session
+        self.cache = cache
+
+    def _fingerprint(self, request: Request) -> str:
+        headers: Mapping[str, str] | None = request.header_map or None
+        return request_hash(
+            request.url,
+            method=request.method,
+            data=request.data,
+            headers=headers,
+        )
+
+    def clear(self, request: Request) -> None:
+        """Evict a request after its cached response fails validation."""
+        if self.cache is not None:
+            self.cache.delete(self._fingerprint(request))
+
+    def _fetch(self, request: Request, cache_days: int | None) -> _Response:
+        fingerprint = self._fingerprint(request)
+        if self.cache is not None and cache_days is not None:
+            cached = self.cache.get(fingerprint, max_age=cache_days)
+            if cached is not None:
+                return _Response.load(cached)
+
+        response = self.session.request(
+            request.method,
+            request.url,
+            data=request.data,
+            headers=request.header_map,
+        )
+        response.raise_for_status()
+        media_type = response.headers.get("Content-Type")
+        if media_type is not None:
+            media_type = media_type.split(";", 1)[0]
+        result = _Response(
+            final_url=response.url,
+            media_type=media_type,
+            content=response.content,
+        )
+        if self.cache is not None and cache_days is not None:
+            self.cache.set(fingerprint, result.dump())
+        return result
+
+    def query_act(self, value: str, cache_days: int | None = 1) -> Act:
+        """Load metadata when reviewing an act or resolving its consolidation."""
+        celex = normalize(value)
+        request = act_request(celex)
+        response = self._fetch(request, cache_days)
+        try:
+            result = orjson.loads(response.content)
+            return parse_act_results(celex, result, request)
+        except Exception:
+            self.clear(request)
+            raise
+
+    def fetch_expression(
+        self,
+        value: str,
+        language: str = "ENG",
+        media_type: str = "application/xhtml+xml",
+        cache_days: int | None = 1,
+    ) -> Expression:
+        """Fetch exact source bytes for provenance or legal-text extraction."""
+        celex = normalize(value)
+        request = expression_request(celex, language, media_type)
+        response = self._fetch(request, cache_days)
+        if not response.content:
+            self.clear(request)
+            raise ValueError(f"Empty CELLAR expression for {celex}")
+        return Expression(
+            celex=celex,
+            language=language.upper(),
+            media_type=response.media_type or media_type,
+            request_url=request.url,
+            final_url=response.final_url,
+            content=response.content,
+        )
+
+
 def cellar_url(value: str) -> str:
     """Build the content-negotiated CELLAR resource URL for a CELEX."""
     return CELLAR_RESOURCE_URL.format(celex=normalize(value))
 
 
 def expression_headers(language: str, media_type: str) -> dict[str, str]:
-    """Build identical content-negotiation headers for both transport adapters."""
+    """Select a language and representation when fetching a CELLAR expression."""
     return {"Accept": media_type, "Accept-Language": language.lower()}
 
 
-def expression_request(value: str) -> Request:
+def expression_request(
+    value: str,
+    language: str = "ENG",
+    media_type: str = "application/xhtml+xml",
+) -> Request:
     """Build the exact request used to fetch a CELEX expression."""
-    return Request(cellar_url(value))
+    return Request(
+        cellar_url(value),
+        headers=tuple(expression_headers(language, media_type).items()),
+    )
 
 
 def build_act_query(value: str) -> bytes:
     """Build the exact SPARQL request used for metadata and relationships."""
     return ACT_QUERY.replace("CELEX_ID", normalize(value)).encode("utf-8")
+
+
+def act_request(value: str) -> Request:
+    """Build the exact SPARQL request used to inspect an act."""
+    return Request(
+        SPARQL_ENDPOINT,
+        method="POST",
+        data=build_act_query(value),
+        headers=tuple(SPARQL_HEADERS.items()),
+    )
 
 
 def parse_act_results(value: str, result: Any, request: Request | None = None) -> Act:
@@ -183,7 +335,6 @@ def parse_act_results(value: str, result: Any, request: Request | None = None) -
     resource_type = first("type")
     if resource_type is not None:
         resource_type = resource_type.rstrip("/").rsplit("/", 1)[-1]
-    query = build_act_query(celex)
     return Act(
         celex=celex,
         title=first("title"),
@@ -193,96 +344,21 @@ def parse_act_results(value: str, result: Any, request: Request | None = None) -
         amends=values("amends_celex"),
         based_on=values("based_on_celex"),
         consolidated=values("cons_celex"),
-        request=request or Request(SPARQL_ENDPOINT, method="POST", data=query),
+        request=request or act_request(celex),
     )
 
 
-def query_act(context: Context, value: str, cache_days: int = 1) -> Act:
-    """Load act metadata through a crawler Context when crawl caching is needed."""
-    celex = normalize(value)
-    query = build_act_query(celex)
-    result = context.fetch_json(
-        SPARQL_ENDPOINT,
-        method="POST",
-        data=query,
-        headers=SPARQL_HEADERS,
-        cache_days=cache_days,
-    )
-    return parse_act_results(
-        celex, result, Request(SPARQL_ENDPOINT, method="POST", data=query)
-    )
-
-
-def query_act_http(value: str, session: Session | None = None) -> Act:
-    """Load act metadata without requiring dataset or Watchful configuration."""
-    celex = normalize(value)
-    query = build_act_query(celex)
-    client = session or requests
-    response = client.post(
-        SPARQL_ENDPOINT, data=query, headers=SPARQL_HEADERS, timeout=60
-    )
-    response.raise_for_status()
-    return parse_act_results(
-        celex,
-        response.json(),
-        Request(SPARQL_ENDPOINT, method="POST", data=query),
-    )
-
-
-def fetch_expression(
-    context: Context,
-    value: str,
-    language: str = "ENG",
-    media_type: str = "application/xhtml+xml",
-    cache_days: int = 1,
-) -> Expression:
-    """Fetch an expression through a crawler Context for cached source access."""
-    celex = normalize(value)
-    request = expression_request(celex)
-    text = context.fetch_text(
-        request.url,
-        headers=expression_headers(language, media_type),
-        cache_days=cache_days,
-        method=request.method,
-        data=request.data,
-    )
-    if not text:
-        raise ValueError(f"Empty CELLAR expression for {celex}")
-    return Expression(
-        celex=celex,
-        language=language.upper(),
-        media_type=media_type,
-        request_url=request.url,
-        final_url=request.url,
-        content=text.encode("utf-8"),
-    )
-
-
-def fetch_expression_http(
-    value: str,
-    language: str = "ENG",
-    media_type: str = "application/xhtml+xml",
-    session: Session | None = None,
-) -> Expression:
-    """Fetch an expression directly for standalone tools and agents."""
-    celex = normalize(value)
-    request = expression_request(celex)
-    client = session or requests
-    response = client.get(
-        request.url, headers=expression_headers(language, media_type), timeout=60
-    )
-    response.raise_for_status()
-    content_type = response.headers.get("Content-Type", media_type).split(";", 1)[0]
-    if not response.content:
-        raise ValueError(f"Empty CELLAR expression for {celex}")
-    return Expression(
-        celex=celex,
-        language=language.upper(),
-        media_type=content_type,
-        request_url=request.url,
-        final_url=response.url,
-        content=response.content,
-    )
+@contextmanager
+def cli_client() -> Iterator[CellarClient]:
+    """Create an isolated client for commands that run without a crawler Context."""
+    dataset = Dataset({"name": "ojeu_cli"})
+    db = make_db_session("sqlite:///:memory:")
+    session = make_session(HTTP({}))
+    try:
+        yield CellarClient(session, Cache(db, dataset, create=True))
+    finally:
+        session.close()
+        db.close()
 
 
 def extract_body_html(expression: Expression) -> bytes:
@@ -327,9 +403,10 @@ def cli(
 ) -> None:
     """Fetch source bytes for agents and humans without requiring a crawl."""
     try:
-        expression = fetch_expression_http(
-            celex, language=language, media_type=media_type
-        )
+        with cli_client() as client:
+            expression = client.fetch_expression(
+                celex, language=language, media_type=media_type
+            )
         content = extract_body_html(expression) if body_only else expression.content
         if output is None:
             click.get_binary_stream("stdout").write(content)

--- a/zavod/zavod/shed/ojeu/cellar.py
+++ b/zavod/zavod/shed/ojeu/cellar.py
@@ -6,9 +6,10 @@ import base64
 import json
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import date
 from hashlib import sha256
 from pathlib import Path
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from typing import Any, Protocol
 
 import click
@@ -66,6 +67,41 @@ SELECT DISTINCT ?title ?doc_date ?type ?eli ?amends_celex ?based_on_celex
 }
 """
 
+RELATED_ACTS_QUERY = """
+PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+PREFIX lang: <http://publications.europa.eu/resource/authority/language/>
+PREFIX rt: <http://publications.europa.eu/resource/authority/resource-type/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?celex ?framework_celex ?relation ?title ?doc_date ?type WHERE {
+  VALUES ?framework_celex { FRAMEWORK_VALUES }
+  ?framework cdm:resource_legal_id_celex ?framework_celex .
+  {
+    ?work cdm:resource_legal_amends_resource_legal ?framework .
+    BIND("amends" AS ?relation)
+  }
+  UNION
+  {
+    ?work cdm:resource_legal_based_on_resource_legal ?framework .
+    BIND("based_on" AS ?relation)
+  }
+  ?work cdm:resource_legal_id_celex ?celex ;
+        cdm:work_date_document ?doc_date ;
+        cdm:work_has_resource-type ?type .
+  OPTIONAL {
+    ?expression cdm:expression_belongs_to_work ?work ;
+                cdm:expression_uses_language lang:ENG ;
+                cdm:expression_title ?title .
+  }
+  FILTER (?doc_date >= "DATE_FROM"^^xsd:date)
+  DATE_TO_FILTER
+  FILTER (?type IN (RESOURCE_TYPES))
+}
+ORDER BY ?doc_date ?celex ?framework_celex ?relation
+"""
+
+RELATED_ACT_TYPES = ("REG_IMPL", "DEC_IMPL", "REG", "DEC")
+
 
 @dataclass(frozen=True)
 class Request:
@@ -114,6 +150,34 @@ class Act:
             "latest_consolidated": self.latest_consolidated,
             "resource_type": self.resource_type,
             "resource_url": cellar_url(self.celex),
+            "title": self.title,
+        }
+
+
+@dataclass(frozen=True)
+class RelatedAct:
+    """Represent one incoming legal relationship to a framework act.
+
+    Use this edge-oriented result for discovery so callers can distinguish an
+    amendment from a legal-basis relationship without re-querying CELLAR.
+    """
+
+    celex: str
+    framework_celex: str
+    relation: str
+    title: str | None
+    document_date: str
+    resource_type: str
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Return stable JSON fields for crawler issues and command output."""
+        return {
+            "celex": self.celex,
+            "document_date": self.document_date,
+            "eur_lex_url": eur_lex_url(self.celex),
+            "framework_celex": self.framework_celex,
+            "relation": self.relation,
+            "resource_type": self.resource_type,
             "title": self.title,
         }
 
@@ -249,6 +313,30 @@ class CellarClient:
             self.clear(request)
             raise
 
+    def query_related_acts(
+        self,
+        framework_celexes: str | Iterable[str],
+        date_from: date,
+        date_to: date | None = None,
+        resource_types: str | Iterable[str] = RELATED_ACT_TYPES,
+        cache_days: int | None = 1,
+    ) -> tuple[RelatedAct, ...]:
+        """Find acts that amend or use known frameworks as their legal basis.
+
+        Use this for bounded discovery runs. The default types cover regulations,
+        decisions, and their implementing acts; callers can choose a narrower set.
+        """
+        request = related_acts_request(
+            framework_celexes, date_from, date_to, resource_types
+        )
+        response = self._fetch(request, cache_days)
+        try:
+            result = orjson.loads(response.content)
+            return parse_related_act_results(result)
+        except Exception:
+            self.clear(request)
+            raise
+
     def fetch_expression(
         self,
         value: str,
@@ -310,6 +398,70 @@ def act_request(value: str) -> Request:
     )
 
 
+def build_related_acts_query(
+    framework_celexes: str | Iterable[str],
+    date_from: date,
+    date_to: date | None = None,
+    resource_types: str | Iterable[str] = RELATED_ACT_TYPES,
+) -> bytes:
+    """Build a bounded inverse-relationship query for framework discovery."""
+    values = _normalize_frameworks(framework_celexes)
+    if date_to is not None and date_to < date_from:
+        raise ValueError("date_to must not be before date_from")
+    framework_values = " ".join(f'"{celex}"^^xsd:string' for celex in values)
+    date_to_filter = ""
+    if date_to is not None:
+        date_to_filter = f'FILTER (?doc_date <= "{date_to.isoformat()}"^^xsd:date)'
+    type_values = ", ".join(f"rt:{value}" for value in _normalize_types(resource_types))
+    query = RELATED_ACTS_QUERY.replace("FRAMEWORK_VALUES", framework_values)
+    query = query.replace("DATE_FROM", date_from.isoformat())
+    query = query.replace("DATE_TO_FILTER", date_to_filter)
+    query = query.replace("RESOURCE_TYPES", type_values)
+    return query.encode("utf-8")
+
+
+def related_acts_request(
+    framework_celexes: str | Iterable[str],
+    date_from: date,
+    date_to: date | None = None,
+    resource_types: str | Iterable[str] = RELATED_ACT_TYPES,
+) -> Request:
+    """Build the exact request for discovering acts related to frameworks."""
+    return Request(
+        SPARQL_ENDPOINT,
+        method="POST",
+        data=build_related_acts_query(
+            framework_celexes, date_from, date_to, resource_types
+        ),
+        headers=tuple(SPARQL_HEADERS.items()),
+    )
+
+
+def _normalize_frameworks(
+    framework_celexes: str | Iterable[str],
+) -> tuple[str, ...]:
+    values = (
+        (framework_celexes,)
+        if isinstance(framework_celexes, str)
+        else tuple(framework_celexes)
+    )
+    normalized = tuple(sorted({normalize(value) for value in values}))
+    if not normalized:
+        raise ValueError("At least one framework CELEX is required")
+    return normalized
+
+
+def _normalize_types(resource_types: str | Iterable[str]) -> tuple[str, ...]:
+    values = (resource_types,) if isinstance(resource_types, str) else resource_types
+    normalized = tuple(sorted({value.strip().upper() for value in values if value}))
+    if not normalized:
+        raise ValueError("At least one resource type is required")
+    for value in normalized:
+        if not value.replace("_", "").isalnum():
+            raise ValueError(f"Invalid CELLAR resource type: {value}")
+    return normalized
+
+
 def parse_act_results(value: str, result: Any, request: Request | None = None) -> Act:
     """Parse CELLAR SPARQL JSON into deterministic, deduplicated act metadata."""
     celex = normalize(value)
@@ -345,6 +497,56 @@ def parse_act_results(value: str, result: Any, request: Request | None = None) -
         based_on=values("based_on_celex"),
         consolidated=values("cons_celex"),
         request=request or act_request(celex),
+    )
+
+
+def parse_related_act_results(result: Any) -> tuple[RelatedAct, ...]:
+    """Parse inverse CELLAR relationships into deterministic discovery edges."""
+    try:
+        bindings = result["results"]["bindings"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError("Invalid CELLAR SPARQL response") from exc
+
+    found: dict[tuple[str, str, str, str, str], set[str]] = {}
+    for binding in bindings:
+        try:
+            celex = normalize(str(binding["celex"]["value"]))
+            framework = normalize(str(binding["framework_celex"]["value"]))
+            relation = str(binding["relation"]["value"])
+            document_date = str(binding["doc_date"]["value"])
+            resource_type = str(binding["type"]["value"]).rstrip("/").rsplit("/", 1)[-1]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("Invalid related-act binding in CELLAR response") from exc
+        if relation not in {"amends", "based_on"}:
+            raise ValueError(f"Unsupported CELLAR relationship: {relation}")
+        key = (celex, framework, relation, document_date, resource_type)
+        title = str(binding.get("title", {}).get("value", "")).strip()
+        if title:
+            found.setdefault(key, set()).add(title)
+        else:
+            found.setdefault(key, set())
+
+    related = [
+        RelatedAct(
+            celex=key[0],
+            framework_celex=key[1],
+            relation=key[2],
+            document_date=key[3],
+            resource_type=key[4],
+            title=min(titles) if titles else None,
+        )
+        for key, titles in found.items()
+    ]
+    return tuple(
+        sorted(
+            related,
+            key=lambda act: (
+                act.document_date,
+                act.celex,
+                act.framework_celex,
+                act.relation,
+            ),
+        )
     )
 
 

--- a/zavod/zavod/tests/shed/fixtures/ojeu/related.json
+++ b/zavod/zavod/tests/shed/fixtures/ojeu/related.json
@@ -1,0 +1,48 @@
+{
+  "head": {
+    "vars": [
+      "celex",
+      "framework_celex",
+      "relation",
+      "title",
+      "doc_date",
+      "type"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "celex": {"type": "literal", "value": "32026R1708"},
+        "framework_celex": {"type": "literal", "value": "32024R1485"},
+        "relation": {"type": "literal", "value": "amends"},
+        "title": {"type": "literal", "value": "Implementing Regulation 1708/2026"},
+        "doc_date": {"type": "literal", "value": "2026-07-13"},
+        "type": {
+          "type": "uri",
+          "value": "http://publications.europa.eu/resource/authority/resource-type/REG_IMPL"
+        }
+      },
+      {
+        "celex": {"type": "literal", "value": "32026R1708"},
+        "framework_celex": {"type": "literal", "value": "32024R1485"},
+        "relation": {"type": "literal", "value": "based_on"},
+        "title": {"type": "literal", "value": "Implementing Regulation 1708/2026"},
+        "doc_date": {"type": "literal", "value": "2026-07-13"},
+        "type": {
+          "type": "uri",
+          "value": "http://publications.europa.eu/resource/authority/resource-type/REG_IMPL"
+        }
+      },
+      {
+        "celex": {"type": "literal", "value": "32025R1980"},
+        "framework_celex": {"type": "literal", "value": "32024R1485"},
+        "relation": {"type": "literal", "value": "amends"},
+        "doc_date": {"type": "literal", "value": "2025-10-03"},
+        "type": {
+          "type": "uri",
+          "value": "http://publications.europa.eu/resource/authority/resource-type/REG_IMPL"
+        }
+      }
+    ]
+  }
+}

--- a/zavod/zavod/tests/shed/test_ojeu.py
+++ b/zavod/zavod/tests/shed/test_ojeu.py
@@ -1,4 +1,5 @@
 import json
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,60 @@ def test_framework_results_include_own_consolidated_family() -> None:
     assert act.latest_consolidated == "02024R1485-20260713"
     query = cellar.build_act_query("32024R1485").decode("utf-8")
     assert "BIND(COALESCE(?amended_framework, ?work) AS ?framework)" in query
+
+
+def test_build_and_parse_related_acts_query() -> None:
+    query = cellar.build_related_acts_query(
+        ["32024R1485", "32024R1485"],
+        date(2025, 1, 1),
+        date(2026, 7, 31),
+    ).decode("utf-8")
+    assert query.count('"32024R1485"^^xsd:string') == 1
+    assert '?doc_date >= "2025-01-01"^^xsd:date' in query
+    assert '?doc_date <= "2026-07-31"^^xsd:date' in query
+    assert "resource_legal_amends_resource_legal" in query
+    assert "resource_legal_based_on_resource_legal" in query
+    assert (
+        "PREFIX rt: <http://publications.europa.eu/resource/authority/resource-type/>"
+        in query
+    )
+    assert "FILTER (?type IN (rt:DEC, rt:DEC_IMPL, rt:REG, rt:REG_IMPL))" in query
+
+    result = json.loads((FIXTURES / "related.json").read_text())
+    related = cellar.parse_related_act_results(result)
+    assert [item.celex for item in related] == [
+        "32025R1980",
+        "32026R1708",
+        "32026R1708",
+    ]
+    assert [item.relation for item in related] == ["amends", "amends", "based_on"]
+    assert related[0].title is None
+    assert related[1].resource_type == "REG_IMPL"
+
+
+def test_related_acts_query_rejects_invalid_bounds() -> None:
+    with pytest.raises(ValueError, match="date_to"):
+        cellar.build_related_acts_query(
+            "32024R1485", date(2026, 1, 2), date(2026, 1, 1)
+        )
+    with pytest.raises(ValueError, match="At least one"):
+        cellar.build_related_acts_query([], date(2026, 1, 1))
+    with pytest.raises(ValueError, match="resource type"):
+        cellar.build_related_acts_query(
+            "32024R1485", date(2026, 1, 1), resource_types=[]
+        )
+
+
+def test_cellar_client_queries_related_acts(requests_mock) -> None:
+    result = json.loads((FIXTURES / "related.json").read_text())
+    requests_mock.post(cellar.SPARQL_ENDPOINT, json=result)
+    client = cellar.CellarClient(requests.Session())
+
+    related = client.query_related_acts("32024R1485", date(2025, 1, 1))
+
+    assert len(related) == 3
+    assert related[-1].framework_celex == "32024R1485"
+    assert b'"32024R1485"^^xsd:string' in requests_mock.last_request.body
 
 
 def test_cellar_client_fetches_expression(requests_mock) -> None:
@@ -177,6 +232,29 @@ def test_cli_prints_stable_json_and_saves_expression(
         output
         == json.dumps(parsed, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
     )
+
+
+def test_celex_cli_includes_related_acts(requests_mock) -> None:
+    act = json.loads((FIXTURES / "framework.json").read_text())
+    related = json.loads((FIXTURES / "related.json").read_text())
+    requests_mock.post(cellar.SPARQL_ENDPOINT, [{"json": act}, {"json": related}])
+
+    result = CliRunner().invoke(
+        celex.cli,
+        [
+            "32024R1485",
+            "--metadata-only",
+            "--related-since",
+            "2025-01-01",
+            "--related-until",
+            "2026-07-31",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    output = json.loads(result.output)
+    assert len(output["related_acts"]) == 3
+    assert output["related_acts"][0]["celex"] == "32025R1980"
 
 
 def test_cellar_cli_writes_expression(

--- a/zavod/zavod/tests/shed/test_ojeu.py
+++ b/zavod/zavod/tests/shed/test_ojeu.py
@@ -66,7 +66,7 @@ def test_framework_results_include_own_consolidated_family() -> None:
     assert "BIND(COALESCE(?amended_framework, ?work) AS ?framework)" in query
 
 
-def test_fetch_expression_http(requests_mock) -> None:
+def test_cellar_client_fetches_expression(requests_mock) -> None:
     content = (FIXTURES / "expression.xhtml").read_bytes()
     requests_mock.get(
         cellar.cellar_url("32026R1708"),
@@ -74,7 +74,8 @@ def test_fetch_expression_http(requests_mock) -> None:
         headers={"Content-Type": "application/xhtml+xml; charset=utf-8"},
     )
 
-    expression = cellar.fetch_expression_http("32026R1708")
+    client = cellar.CellarClient(requests.Session())
+    expression = client.fetch_expression("32026R1708")
 
     assert expression.content == content
     assert expression.media_type == "application/xhtml+xml"
@@ -83,52 +84,83 @@ def test_fetch_expression_http(requests_mock) -> None:
     assert requests_mock.last_request.headers["Accept-Language"] == "eng"
 
 
-def test_context_adapters_share_requests_and_parsers() -> None:
+def test_cellar_client_caches_metadata_and_exact_expression_bytes(
+    requests_mock,
+) -> None:
     result = json.loads((FIXTURES / "act.json").read_text())
-    content = (FIXTURES / "expression.xhtml").read_text()
+    content = (FIXTURES / "expression.xhtml").read_bytes()
 
-    class FakeContext:
-        json_call = None
-        text_call = None
+    class FakeCache:
+        values: dict[str, str] = {}
 
-        def fetch_json(self, url, **kwargs):
-            self.json_call = (url, kwargs)
-            return result
+        def get(self, key: str, max_age: int | None = None) -> str | None:
+            return self.values.get(key)
 
-        def fetch_text(self, url, **kwargs):
-            self.text_call = (url, kwargs)
-            return content
+        def set(self, key: str, value: str | None) -> None:
+            assert value is not None
+            self.values[key] = value
 
-    context = FakeContext()
-    act = cellar.query_act(context, "32026R1708")  # type: ignore[arg-type]
-    expression = cellar.fetch_expression(context, "32026R1708")  # type: ignore[arg-type]
+        def delete(self, key: str) -> None:
+            self.values.pop(key, None)
+
+    requests_mock.post(cellar.SPARQL_ENDPOINT, json=result)
+    requests_mock.get(
+        cellar.cellar_url("32026R1708"),
+        content=content,
+        headers={"Content-Type": "application/xhtml+xml; charset=utf-8"},
+    )
+    client = cellar.CellarClient(requests.Session(), FakeCache())
+    act = client.query_act("32026R1708")
+    expression = client.fetch_expression("32026R1708")
+    cached_act = client.query_act("32026R1708")
+    cached_expression = client.fetch_expression("32026R1708")
 
     assert act.latest_consolidated == "02024R1485-20260713"
-    assert expression.content == content.encode("utf-8")
-    assert context.json_call[1]["data"] == act.request.data
-    assert context.json_call[1]["cache_days"] == 1
-    assert context.text_call[1]["headers"] == cellar.expression_headers(
-        "ENG", "application/xhtml+xml"
+    assert cached_act == act
+    assert expression.content == content
+    assert cached_expression == expression
+    assert requests_mock.call_count == 2
+
+
+def test_expression_cache_varies_by_content_negotiation(requests_mock) -> None:
+    requests_mock.get(
+        cellar.cellar_url("32026R1708"),
+        [
+            {"content": b"english"},
+            {"content": b"french"},
+        ],
     )
+
+    class FakeCache:
+        values: dict[str, str] = {}
+
+        def get(self, key: str, max_age: int | None = None) -> str | None:
+            return self.values.get(key)
+
+        def set(self, key: str, value: str | None) -> None:
+            assert value is not None
+            self.values[key] = value
+
+        def delete(self, key: str) -> None:
+            self.values.pop(key, None)
+
+    client = cellar.CellarClient(requests.Session(), FakeCache())
+    assert client.fetch_expression("32026R1708", language="ENG").content == b"english"
+    assert client.fetch_expression("32026R1708", language="FRA").content == b"french"
+    assert client.fetch_expression("32026R1708", language="ENG").content == b"english"
+    assert requests_mock.call_count == 2
 
 
 def test_cli_prints_stable_json_and_saves_expression(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    requests_mock, tmp_path: Path
 ) -> None:
     result = json.loads((FIXTURES / "act.json").read_text())
-    act = cellar.parse_act_results("32026R1708", result)
     content = (FIXTURES / "expression.xhtml").read_bytes()
-    expression = cellar.Expression(
-        celex="32026R1708",
-        language="ENG",
-        media_type="application/xhtml+xml",
-        request_url=cellar.cellar_url("32026R1708"),
-        final_url="https://publications.europa.eu/final.xhtml",
+    requests_mock.post(cellar.SPARQL_ENDPOINT, json=result)
+    requests_mock.get(
+        cellar.cellar_url("32026R1708"),
         content=content,
-    )
-    monkeypatch.setattr(cellar, "query_act_http", lambda value: act)
-    monkeypatch.setattr(
-        cellar, "fetch_expression_http", lambda value, language, media_type: expression
+        headers={"Content-Type": "application/xhtml+xml"},
     )
     output_path = tmp_path / "act.xhtml"
 
@@ -148,20 +180,14 @@ def test_cli_prints_stable_json_and_saves_expression(
 
 
 def test_cellar_cli_writes_expression(
-    monkeypatch: pytest.MonkeyPatch,
+    requests_mock,
     tmp_path: Path,
 ) -> None:
     content = (FIXTURES / "expression.xhtml").read_bytes()
-    expression = cellar.Expression(
-        celex="32026R1708",
-        language="ENG",
-        media_type="application/xhtml+xml",
-        request_url=cellar.cellar_url("32026R1708"),
-        final_url="https://publications.europa.eu/final.xhtml",
+    requests_mock.get(
+        cellar.cellar_url("32026R1708"),
         content=content,
-    )
-    monkeypatch.setattr(
-        cellar, "fetch_expression_http", lambda value, language, media_type: expression
+        headers={"Content-Type": "application/xhtml+xml"},
     )
     output_path = tmp_path / "act.xhtml"
 
@@ -173,20 +199,14 @@ def test_cellar_cli_writes_expression(
 
 
 def test_cellar_cli_extracts_body_with_tables(
-    monkeypatch: pytest.MonkeyPatch,
+    requests_mock,
     tmp_path: Path,
 ) -> None:
     content = (FIXTURES / "expression.xhtml").read_bytes()
-    expression = cellar.Expression(
-        celex="32026R1708",
-        language="ENG",
-        media_type="application/xhtml+xml",
-        request_url=cellar.cellar_url("32026R1708"),
-        final_url="https://publications.europa.eu/final.xhtml",
+    requests_mock.get(
+        cellar.cellar_url("32026R1708"),
         content=content,
-    )
-    monkeypatch.setattr(
-        cellar, "fetch_expression_http", lambda value, language, media_type: expression
+        headers={"Content-Type": "application/xhtml+xml"},
     )
     output_path = tmp_path / "act-body.html"
 
@@ -214,10 +234,10 @@ def test_expression_preserves_request() -> None:
         content=content,
     )
 
-    assert expression.request == cellar.Request(url)
+    assert expression.request == cellar.expression_request("32026R1708")
 
 
 def test_http_errors_are_not_hidden(requests_mock) -> None:
     requests_mock.post(cellar.SPARQL_ENDPOINT, status_code=503)
     with pytest.raises(requests.HTTPError):
-        cellar.query_act_http("32026R1708")
+        cellar.CellarClient(requests.Session()).query_act("32026R1708")

--- a/zavod/zavod/tests/test_context.py
+++ b/zavod/zavod/tests/test_context.py
@@ -74,6 +74,34 @@ def test_context_helpers(testdataset1: Dataset):
     context.close()
 
 
+def test_request_hash_optional_headers_preserve_existing_keys() -> None:
+    assert request_hash("https://example.com") == (
+        "https://example.com[f030bbbd32966cde41037b98a8849c46b76e4bc1]"
+    )
+    assert (
+        request_hash(
+            "https://example.com", method="POST", data=b"abc", encoding="utf-8"
+        )
+        == "https://example.com[7d8069fc46fae2067417cc17a091b7800cc1772c]"
+    )
+
+
+def test_request_hash_normalizes_optional_headers() -> None:
+    first = request_hash(
+        "https://example.com",
+        headers={"Accept": " application/xml ", "Accept-Language": "eng"},
+    )
+    second = request_hash(
+        "https://example.com",
+        headers={"accept-language": "eng", "accept": "application/xml"},
+    )
+    assert first == second
+    assert first != request_hash(
+        "https://example.com",
+        headers={"Accept": "application/json", "Accept-Language": "eng"},
+    )
+
+
 def test_context_dry_run(testdataset1: Dataset):
     context = Context(testdataset1, dry_run=True)
     assert context.dataset == testdataset1


### PR DESCRIPTION
## Summary

- unify crawler and standalone CELLAR access behind a session/cache-backed client
- preserve exact response bytes and content-negotiation metadata in the cache
- add opt-in header-aware request fingerprints without invalidating existing cache keys
- query acts that amend or use reviewed framework CELEXes as their legal basis
- expose bounded related-act discovery through the CELEX CLI

## Verification

- focused OJEU and Context tests pass
- Ruff and formatting pass
- strict mypy passes for the OJEU package
- repository pre-commit hooks pass
- live 14-day query across 91 frameworks completed in 0.595 seconds and returned 13 acts across 18 relationship edges
