### PR TITLE
[zavod,us_ofac_*] Add config option to disable entity reference validator

### DIFF
--- a/datasets/us/ofac/us_ofac_cons.yml
+++ b/datasets/us/ofac/us_ofac_cons.yml
@@ -47,6 +47,11 @@ data:
   format: XML
   lang: eng
 
+validators:
+  # OFAC states ownership of parties it only describes as Organizations, so
+  # Ownership:asset references land outside the Asset range.
+  entity_reference: false
+
 assertions:
   min:
     schema_entities:

--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -44,6 +44,11 @@ data:
   format: XML
   lang: eng
 
+validators:
+  # OFAC states ownership of parties it only describes as Organizations, so
+  # Ownership:asset references land outside the Asset range.
+  entity_reference: false
+
 assertions:
   min:
     schema_entities:

--- a/zavod/docs/metadata.md
+++ b/zavod/docs/metadata.md
@@ -149,6 +149,26 @@ HTTP requests for GET requests are automatically retried for connection and HTTP
     - `retry_methods`: List of strings, [default](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.DEFAULT_ALLOWED_METHODS) `['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT', 'TRACE']`
     - `retry_statuses`: List of integers of HTTP error codes to retry, default `[413, 429, 500, 502, 503, 504]`.
 
+### Validators
+
+Besides the assertions below, `zavod validate` runs a set of validators over the whole
+dataset once it is in the store. They are all enabled by default; the `validators` block
+switches individual ones off for a dataset whose finding has been reviewed and accepted.
+Record the reason in a YAML comment — a disabled validator leaves no trace in the run
+output.
+
+- `validators`
+    - `entity_reference`: boolean, default `true`. Warns when an entity-type property
+      references an id that isn't in the dataset, or references an entity whose schema
+      doesn't match the property's declared range (e.g. an `Ownership:asset` pointing at a
+      plain `Organization` rather than a `Company`).
+
+```yaml
+validators:
+  # Source models owned entities as plain Organizations; upgrading them is tracked in #1234.
+  entity_reference: false
+```
+
 ### Data assertions
 
 Data assertions smoke-test the exported dataset against its expected shape. They run

--- a/zavod/zavod/meta/dataset.py
+++ b/zavod/zavod/meta/dataset.py
@@ -23,6 +23,7 @@ from zavod.meta.http import HTTP
 from zavod.meta.model import DataModel, ZavodDatasetModel
 from zavod.meta.names import NamesSpec
 from zavod.meta.numbers import NumbersSpec
+from zavod.meta.validators import ValidatorsSpec
 from zavod.runtime.urls import make_published_url
 
 if TYPE_CHECKING:
@@ -113,6 +114,11 @@ class Dataset(FollowTheMoneyDataset):
 
         self.numbers: NumbersSpec = NumbersSpec.model_validate(data.get("numbers", {}))
         """Number parsing configuration for this dataset."""
+
+        self.validators: ValidatorsSpec = ValidatorsSpec.model_validate(
+            data.get("validators", {})
+        )
+        """Which post-crawl validators are enabled for this dataset."""
 
     @cached_property
     def lookups(self) -> dict[str, Lookup]:

--- a/zavod/zavod/meta/validators.py
+++ b/zavod/zavod/meta/validators.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class ValidatorsSpec(BaseModel):
+    """Per-dataset switches for the validators run after a crawl.
+
+    Every validator here is on by default. Turn one off only when its finding is
+    understood and accepted for that specific dataset, and say why in a YAML
+    comment - a silenced validator is invisible in the run output.
+    """
+
+    entity_reference: bool = True
+    """Check that entity-type properties resolve, and point at an entity whose
+    schema matches the property's declared range."""

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -109,6 +109,19 @@ def test_property_range() -> None:
     assert validator.abort is False
 
 
+def test_entity_reference_toggle() -> None:
+    # Enabled unless the dataset metadata says otherwise.
+    ds = Dataset(BASE_DATASET_CONFIG)
+    assert EntityReferenceValidator.enabled(ds) is True
+
+    disabled = Dataset(
+        {**BASE_DATASET_CONFIG, "validators": {"entity_reference": False}}
+    )
+    assert EntityReferenceValidator.enabled(disabled) is False
+    # Validators without a switch keep running.
+    assert SelfReferenceValidator.enabled(disabled) is True
+
+
 def test_self_references(testdataset3) -> None:
     crawl_dataset(testdataset3)
     validator, logs = run_validator(SelfReferenceValidator, testdataset3)

--- a/zavod/zavod/validators/__init__.py
+++ b/zavod/zavod/validators/__init__.py
@@ -29,7 +29,14 @@ class EntityReferenceValidator(BaseValidator):
     the reference is made. Once the whole dataset is in the store, it becomes
     checkable - a company emitted as an `Organization` rather than a `Company`
     shows up here.
+
+    Enabled by default; set `validators.entity_reference` to `false` in the
+    dataset metadata to switch it off.
     """
+
+    @classmethod
+    def enabled(cls, dataset: Dataset) -> bool:
+        return dataset.validators.entity_reference
 
     def __init__(self, context: Context, view: View) -> None:
         super().__init__(context, view)
@@ -125,7 +132,11 @@ def validate_dataset(dataset: Dataset, view: View) -> None:
             path=dataset_data_path(dataset.name),
         )
 
-        validators = [validator(context, view) for validator in VALIDATORS]
+        validators = [
+            validator(context, view)
+            for validator in VALIDATORS
+            if validator.enabled(dataset)
+        ]
         for idx, entity in enumerate(view.entities()):
             if idx > 0 and idx % 10000 == 0:
                 context.log.info(f"Validated {idx} entities...", dataset=dataset.name)

--- a/zavod/zavod/validators/common.py
+++ b/zavod/zavod/validators/common.py
@@ -1,4 +1,5 @@
 from zavod.context import Context
+from zavod.meta.dataset import Dataset
 from zavod.store import View
 from zavod.entity import Entity
 
@@ -8,6 +9,13 @@ class BaseValidator:
         self.context = context
         self.view = view
         self.abort = False
+
+    @classmethod
+    def enabled(cls, dataset: Dataset) -> bool:
+        """Whether this validator should run for the given dataset. Validators
+        that can be switched off in the `validators:` metadata block override
+        this; the rest always run."""
+        return True
 
     def feed(self, entity: Entity) -> None:
         raise NotImplementedError()


### PR DESCRIPTION
Let's enable this warning for an existing schema misfit til we've rolled out the fix modifying 3000 OFAC SDN entities

https://github.com/opensanctions/opensanctions/pull/5289

Disabling this until we can deploy the fix reduces the risk of us ignoring a different warning on us_ofac_cons. If we end up with a conflicting schema we'll get warnings to that effect.