### PR TITLE
[ua_war_sanctions] Map person "Jurisdiction" to the property of the same name

### DIFF
--- a/datasets/ua/war_sanctions/crawler_zyte.py
+++ b/datasets/ua/war_sanctions/crawler_zyte.py
@@ -57,7 +57,13 @@ LIQUIDATED_RE = re.compile(r"\bLiquidated\b\s*(?P<date>[\d.]*)")
 
 # Person-page label aliases — they vary by section (war sections vs partner sanctions vs
 # executives). Each FtM property is fed from any of its aliases.
-PERSON_CITIZENSHIP_LABELS = ["Citizenship", "Jurisdiction"]
+PERSON_CITIZENSHIP_LABELS = ["Citizenship"]
+
+# Person sections carry a "Jurisdiction" field, which maps to the FtM property of the same
+# name: the country a person is listed as operating under. Some cells name two ("Israel,
+# russian federation"); the type.country lookups split those into components.
+PERSON_JURISDICTION_LABELS = ["Jurisdiction"]
+
 PERSON_DOB_LABELS = ["Date and place of birth", "DOB"]
 PERSON_POSITION_LABELS = [
     "Position",
@@ -533,6 +539,8 @@ def crawl_person_page(
     person.add("taxNumber", take_lines("TIN"))
     for label in PERSON_CITIZENSHIP_LABELS:
         person.add("citizenship", take_lines(label))
+    for label in PERSON_JURISDICTION_LABELS:
+        person.add("jurisdiction", take_lines(label))
     for label in PERSON_POSITION_LABELS:
         for position in take_lines(label):
             person.add("position", position)

--- a/datasets/ua/war_sanctions/ua_war_sanctions.yml
+++ b/datasets/ua/war_sanctions/ua_war_sanctions.yml
@@ -233,8 +233,7 @@ lookups:
       # Historical state; map to modern Yemen.
       - match: "People's Democratic Republic of Yemen"
         value: ye
-      # Multi-citizenship persons: the source lists several countries in one
-      # comma-separated citizenship line. Split each into its component countries.
+      # Cells naming more than one country, comma-separated. Split into components.
       - match: "Angola, Portugal"
         values:
           - "Angola"


### PR DESCRIPTION
## What

Person pages on the GUR War & Sanctions portal label their country field **"Jurisdiction"**. The crawler was aliasing that label onto FtM `citizenship`, alongside a `"Citizenship"` alias in the same list.

FtM already has the matching property on `LegalEntity`:

```yaml
jurisdiction:
  label: Jurisdiction
  type: country
  description: "Country or region in which this entity operates; prefer over broader `country` when relevant"
```

`country`'s own description defers to it — *"an association between the entity and a country that is not covered by a more specific property (e.g. `jurisdiction`, …)"* — so this is a label-to-property match on both name and meaning.

## Change

- `"Jurisdiction"` now feeds `jurisdiction`.
- `citizenship` is reserved for a `"Citizenship"` label, kept as a defensive alias.
- Tightened a stale comment on the `type.country` split-lookups, which apply either way (both properties are `type: country`).

## Verification

- Checked all six person sections the crawler walks — `sanctions`, `kidnappers`, `sport`, `propaganda`, `stolen` — against live pages. Every one renders `"Jurisdiction"`; none currently renders `"Citizenship"`.
- Ran the crawler's own `person_label_map` / `value_lines` over a live page: `citizenship` → `[]`, `jurisdiction` → `['russian federation']`.
- No new unmapped-label warnings (`"Go to site"` is already in the skip set).
- Scale: 4,887 statements in the dataset currently sit on `citizenship` and will move to `jurisdiction` on the next full crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)