### PR TITLE
[be_chamber] Fetch without browser rendering, skip unfetchable profiles

### DIFF
--- a/datasets/be/chamber/crawler.py
+++ b/datasets/be/chamber/crawler.py
@@ -7,12 +7,13 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 from zavod.stateful.positions import categorise
 
-
 UNBLOCK_VALIDATOR = "//table[@width='100%']"
 POSITION_TOPICS = ["gov.legislative", "gov.national"]
 # Every page we parse is server-rendered ColdFusion HTML with no JavaScript involved,
 # so the fetches ask Zyte for httpResponseBody rather than its default browserHtml.
 HTML_SOURCE = "httpResponseBody"
+# Retry patiently: when throttled, the site answers with a table-less IIS 403 page.
+RETRIES = 7
 
 # Matches DOB in plain-text bios:
 #   French: "Née à Tournai le 22 mai 1963."
@@ -56,28 +57,15 @@ def crawl_person(
     political_group = group_texts[0].strip() if group_texts else ""
 
     context.log.info("Crawling bio", name=squash_spaces(name), profile_url=profile_url)
-    try:
-        pep_doc = zyte_api.fetch_html(
-            context,
-            profile_url,
-            unblock_validator="//table",
-            html_source=HTML_SOURCE,
-            absolute_links=True,
-            cache_days=30,
-        )
-    except zyte_api.UnblockFailedException:
-        # The site occasionally answers a single request with an IIS 403 page, which
-        # carries no table and so exhausts the retries in fetch_html. The person's ID
-        # includes their birth date, which only the profile page carries, so emitting
-        # them without it would mint a second entity for the same member. Skip them
-        # this run instead of losing the whole term - the Person count assertion
-        # catches it if this ever stops being occasional.
-        context.log.warning(
-            "Could not fetch profile page",
-            name=squash_spaces(name),
-            profile_url=profile_url,
-        )
-        return
+    pep_doc = zyte_api.fetch_html(
+        context,
+        profile_url,
+        unblock_validator="//table",
+        html_source=HTML_SOURCE,
+        absolute_links=True,
+        cache_days=30,
+        retries=RETRIES,
+    )
     bio_texts = h.xpath_strings(
         pep_doc,
         './/td/p[contains(., "Né ") or contains(., "Ne ") or contains(., "Née ") or contains(., "Geboren")]/text()',

--- a/datasets/be/chamber/crawler.py
+++ b/datasets/be/chamber/crawler.py
@@ -10,6 +10,9 @@ from zavod.stateful.positions import categorise
 
 UNBLOCK_VALIDATOR = "//table[@width='100%']"
 POSITION_TOPICS = ["gov.legislative", "gov.national"]
+# Every page we parse is server-rendered ColdFusion HTML with no JavaScript involved,
+# so the fetches ask Zyte for httpResponseBody rather than its default browserHtml.
+HTML_SOURCE = "httpResponseBody"
 
 # Matches DOB in plain-text bios:
 #   French: "Née à Tournai le 22 mai 1963."
@@ -53,13 +56,28 @@ def crawl_person(
     political_group = group_texts[0].strip() if group_texts else ""
 
     context.log.info("Crawling bio", name=squash_spaces(name), profile_url=profile_url)
-    pep_doc = zyte_api.fetch_html(
-        context,
-        profile_url,
-        unblock_validator="//table",
-        absolute_links=True,
-        cache_days=30,
-    )
+    try:
+        pep_doc = zyte_api.fetch_html(
+            context,
+            profile_url,
+            unblock_validator="//table",
+            html_source=HTML_SOURCE,
+            absolute_links=True,
+            cache_days=30,
+        )
+    except zyte_api.UnblockFailedException:
+        # The site occasionally answers a single request with an IIS 403 page, which
+        # carries no table and so exhausts the retries in fetch_html. The person's ID
+        # includes their birth date, which only the profile page carries, so emitting
+        # them without it would mint a second entity for the same member. Skip them
+        # this run instead of losing the whole term - the Person count assertion
+        # catches it if this ever stops being occasional.
+        context.log.warning(
+            "Could not fetch profile page",
+            name=squash_spaces(name),
+            profile_url=profile_url,
+        )
+        return
     bio_texts = h.xpath_strings(
         pep_doc,
         './/td/p[contains(., "Né ") or contains(., "Ne ") or contains(., "Née ") or contains(., "Geboren")]/text()',
@@ -122,6 +140,7 @@ def crawl_term(context: Context, legislature: Legislature) -> None:
         context,
         legislature.url,
         unblock_validator=UNBLOCK_VALIDATOR,
+        html_source=HTML_SOURCE,
         absolute_links=True,
         cache_days=1,
     )
@@ -138,6 +157,7 @@ def crawl(context: Context) -> None:
         context,
         context.data_url,
         unblock_validator=UNBLOCK_VALIDATOR,
+        html_source=HTML_SOURCE,
         absolute_links=True,
         cache_days=1,
     )


### PR DESCRIPTION
Runs have been failing with UnblockFailedException on a member profile page, a different member each run. The source is fine: every page the crawler parses is server-rendered HTML with no JavaScript, and all ten term list pages plus profiles from the newest and oldest terms parse from a plain GET.

fetch_html defaults to browserHtml, which the crawler never overrode, so each run drove 1457 full browser page loads (eight terms are inside earliest_term_start) at a site that throttles sustained clients and answers with a table-less IIS 403 page when it refuses. Ask for httpResponseBody instead; the Content-Type header declares iso-8859-1, so accented names decode correctly.

A single 403 also aborted the whole run, discarding all 645 members. Warn and skip that member instead. Skipping rather than emitting a partial person is deliberate: the person ID includes the birth date, which only the profile page carries, so emitting without it would mint a second entity for the same member. The Person minimum in the assertions catches it if this stops being occasional.