### PR TITLE
wd_categories: exclude non-PEPs found in defensible categories, add single-category CLI

### DIFF
--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -1,14 +1,20 @@
 import csv
+import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from io import StringIO
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
 
+import click
 from nomenklatura.wikidata import Claim, Item
 from nomenklatura.wikidata.value import clean_wikidata_name
 from rigour.time import iso_datetime
+from zavod.archive import clear_data_path
+from zavod.logs import configure_logging
+from zavod.meta import Dataset, load_dataset_from_path
 from zavod.shed.wikidata.client import WIKIDATA_QUERY_CACHE, create_wikidata_client
 from zavod.shed.wikidata.human import wikidata_basic_human
 from zavod.shed.wikidata.position import (
@@ -20,6 +26,7 @@ from zavod.stateful.positions import categorised_position_qids
 from zavod import Context, Entity
 from zavod import helpers as h
 
+DATASET_PATH = Path(__file__).parent / "wd_categories.yml"
 URL = "https://petscan.wmcloud.org/"
 QUERY = {
     "doit": "",
@@ -305,20 +312,98 @@ def crawl_persons(state: CrawlState) -> None:
     # raise RuntimeError("Crawler is in debug mode, do not release results")
 
 
-def crawl(context: Context) -> None:
-    state = CrawlState(context)
-    crawl_declarator(state)
-    category_crawl_specs: list[dict[str, Any]] = context.dataset.config.get(
-        "categories", []
-    )
-    for category_crawl_spec in category_crawl_specs:
-        crawl_category(state, category_crawl_spec)
-        state.context.flush()
+def category_crawl_specs(dataset: Dataset) -> list[dict[str, Any]]:
+    specs: list[dict[str, Any]] = dataset.config.get("categories", [])
+    return specs
 
+
+def warn_stale_exclusions(state: CrawlState) -> None:
+    """Report configured exclusions which no category produced.
+
+    Only meaningful after a full run - a partial run skips most categories, so every
+    exclusion not covered by the selected ones would look stale.
+    """
     stale = state.excluded_qids - state.excluded_qids_seen
     if len(stale) > 0:
-        context.log.warning(
+        state.context.log.warning(
             "Excluded QIDs no longer found in any category", qids=sorted(stale)
         )
 
+
+def crawl(context: Context) -> None:
+    state = CrawlState(context)
+    crawl_declarator(state)
+    for category_crawl_spec in category_crawl_specs(context.dataset):
+        crawl_category(state, category_crawl_spec)
+        state.context.flush()
+
+    warn_stale_exclusions(state)
     crawl_persons(state)
+
+
+@click.command()
+@click.argument("categories", nargs=-1, required=True)
+@click.option(
+    "--clear/--keep",
+    default=True,
+    help="Clear the dataset output directory before running.",
+)
+@click.option(
+    "-d",
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Log what would be emitted without writing statements.",
+)
+@click.option("--debug", is_flag=True, default=False)
+def cli(
+    categories: tuple[str, ...],
+    clear: bool = True,
+    dry_run: bool = False,
+    debug: bool = False,
+) -> None:
+    """Crawl only the named entries of the wd_categories category config.
+
+    A full run takes hours, which makes it useless for checking what one category
+    contributes, or what a `negcats` or `excluded_qids` change does to it. This runs the
+    real crawler against the real dataset config, but over the given categories only.
+    Declarator discovery is skipped.
+
+    Output lands in data/datasets/wd_categories/ like a normal run, so it replaces
+    whatever a previous local run left there unless you pass --keep.
+
+    CATEGORIES - one or more `category` values as spelled in wd_categories.yml, e.g.
+    Political_office-holders_in_the_United_States
+    """
+    configure_logging(level=logging.DEBUG if debug else logging.INFO)
+    dataset = load_dataset_from_path(DATASET_PATH)
+    if dataset is None:
+        raise click.ClickException(f"Cannot load dataset: {DATASET_PATH}")
+
+    specs = {s["category"].strip(): s for s in category_crawl_specs(dataset)}
+    unknown = [c for c in categories if c not in specs]
+    if len(unknown) > 0:
+        raise click.BadParameter(
+            f"Not in the category config: {', '.join(unknown)}",
+            param_hint="CATEGORIES",
+        )
+
+    if clear and not dry_run:
+        clear_data_path(dataset.name)
+
+    context = Context(dataset, dry_run=dry_run)
+    try:
+        context.begin(clear=clear)
+        state = CrawlState(context)
+        for category in categories:
+            crawl_category(state, specs[category])
+            context.flush()
+        crawl_persons(state)
+        context.flush()
+        context.finalize_statements()
+    finally:
+        context.close()
+
+
+if __name__ == "__main__":
+    cli()

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -343,25 +343,8 @@ def crawl(context: Context) -> None:
 
 @click.command()
 @click.argument("categories", nargs=-1, required=True)
-@click.option(
-    "--clear/--keep",
-    default=True,
-    help="Clear the dataset output directory before running.",
-)
-@click.option(
-    "-d",
-    "--dry-run",
-    is_flag=True,
-    default=False,
-    help="Log what would be emitted without writing statements.",
-)
 @click.option("--debug", is_flag=True, default=False)
-def cli(
-    categories: tuple[str, ...],
-    clear: bool = True,
-    dry_run: bool = False,
-    debug: bool = False,
-) -> None:
+def cli(categories: tuple[str, ...], debug: bool = False) -> None:
     """Crawl only the named entries of the wd_categories category config.
 
     A full run takes hours, which makes it useless for checking what one category
@@ -369,8 +352,8 @@ def cli(
     real crawler against the real dataset config, but over the given categories only.
     Declarator discovery is skipped.
 
-    Output lands in data/datasets/wd_categories/ like a normal run, so it replaces
-    whatever a previous local run left there unless you pass --keep.
+    Output lands in data/datasets/wd_categories/ like a normal run, replacing whatever a
+    previous local run left there.
 
     CATEGORIES - one or more `category` values as spelled in wd_categories.yml, e.g.
     Political_office-holders_in_the_United_States
@@ -388,12 +371,10 @@ def cli(
             param_hint="CATEGORIES",
         )
 
-    if clear and not dry_run:
-        clear_data_path(dataset.name)
-
-    context = Context(dataset, dry_run=dry_run)
+    clear_data_path(dataset.name)
+    context = Context(dataset)
     try:
-        context.begin(clear=clear)
+        context.begin(clear=True)
         state = CrawlState(context)
         for category in categories:
             crawl_category(state, specs[category])

--- a/datasets/_wikidata/categories/crawler.py
+++ b/datasets/_wikidata/categories/crawler.py
@@ -68,6 +68,9 @@ class CrawlState:
         self._crawled_officeholder_positions: set[str] = set()
         exc = [str(x) for x in context.dataset.config.get("exclusion_checks", [])]
         self.exclusion_checks: set[str] = set(exc)
+        excl = [str(x) for x in context.dataset.config.get("excluded_qids", [])]
+        self.excluded_qids: set[str] = set(excl)
+        self.excluded_qids_seen: set[str] = set()
         self.person_modified_at: dict[str, datetime] = {}
 
     def emit_position(self, position: Entity) -> None:
@@ -195,6 +198,9 @@ def crawl_category(state: CrawlState, category_crawl_spec: dict[str, Any]) -> No
                 "Regression on exclusion found", category=cat, qid=person_qid
             )
             continue
+        if person_qid in state.excluded_qids:
+            state.excluded_qids_seen.add(person_qid)
+            continue
         state.persons[person_qid].from_categories.add(cat)
 
         if person_qid not in state.person_topics:
@@ -308,5 +314,11 @@ def crawl(context: Context) -> None:
     for category_crawl_spec in category_crawl_specs:
         crawl_category(state, category_crawl_spec)
         state.context.flush()
+
+    stale = state.excluded_qids - state.excluded_qids_seen
+    if len(stale) > 0:
+        context.log.warning(
+            "Excluded QIDs no longer found in any category", qids=sorted(stale)
+        )
 
     crawl_persons(state)

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -52,6 +52,11 @@
 # them, so they are not emitted at all unless another route (declarator, P1308
 # officeholder) reaches them. A QID which stops showing up in any category is reported as
 # a warning so the list can be pruned.
+#
+# To check the effect of either on the entities we actually emit, without sitting through
+# a full run, crawl the affected category entries on their own:
+# python datasets/_wikidata/categories/crawler.py Political_office-holders_in_Gibraltar
+# See --help; note that it overwrites data/datasets/wd_categories/ like a normal run.
 
 title: Wikidata Persons in Relevant Categories
 entry_point: crawler.py

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -35,6 +35,23 @@
 # and add them one per line to a `negcats` entry in the category config.
 # Consider also adding the person's QID to `exclusion_checks` to detect if other
 # categories cause them to be included that aren't covered by the negcats arguments.
+#
+# Beware that petscan subtracts a `negcats` page from the whole result, not just from the
+# branch that the negative category sits on. Anyone who also reaches the queried category
+# by another route is dropped too, so a negcat on a category which mixes PEPs and non-PEPs
+# (election candidates, party members, alumni) costs real PEPs. Check what a candidate
+# negcat removes before adding it, e.g.
+# curl -G https://petscan.wmcloud.org/ --data-urlencode doit= --data-urlencode depth=4 \
+#   --data-urlencode format=csv --data-urlencode wikidata_item=with \
+#   --data-urlencode wikidata_prop_item_use=Q5 --data-urlencode categories=<CATEGORY> \
+#   --data-urlencode negcats=<NEGCAT>
+# and diff the Wikidata column against the same query without negcats.
+#
+# When the categories are all defensible and only one person is wrong, list their QID
+# under `excluded_qids` instead. Those people are skipped wherever a category discovers
+# them, so they are not emitted at all unless another route (declarator, P1308
+# officeholder) reaches them. A QID which stops showing up in any category is reported as
+# a warning so the list can be pruned.
 
 title: Wikidata Persons in Relevant Categories
 entry_point: crawler.py
@@ -199,6 +216,13 @@ config:
   exclusion_checks:
     - Q5234712 # Came in via Dallas categories under Category:George_M._Dallas
     - Q546195 # Khuit II, Queen Consort of Ancient Egypt
+  # Person QIDs which the categories legitimately contain, but who are not PEPs. Prefer a
+  # `negcats` entry where a whole category is wrong; use this only for one-off people.
+  excluded_qids:
+    # Pastor who filed for the 2018 Florida Democratic US Senate primary and lost it, so
+    # he sits in Category:Candidates_in_the_2018_United_States_Senate_elections, four hops
+    # under Political_office-holders_in_the_United_States. He has never held office.
+    - Q7292512
   categories:
     # Position names defined here (the `position.name` field) should be written
     # in English — make_position tags them with lang="eng".

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -56,7 +56,7 @@
 # To check the effect of either on the entities we actually emit, without sitting through
 # a full run, crawl the affected category entries on their own:
 # python datasets/_wikidata/categories/crawler.py Political_office-holders_in_Gibraltar
-# See --help; note that it overwrites data/datasets/wd_categories/ like a normal run.
+# Note that it overwrites data/datasets/wd_categories/ like a normal run.
 
 title: Wikidata Persons in Relevant Categories
 entry_point: crawler.py


### PR DESCRIPTION
Closes #5485

[Randy White (Q7292512)](https://www.opensanctions.org/entities/Q7292512/) is a Tampa pastor, co-founder of Without Walls International Church, carrying `role.pep` with no position and no occupancy.

## Why he is in the data

`wd_categories` finds him through the Wikipedia category tree:

```
Category:Political office-holders in the United States      (wd_categories.yml, depth 4)
  → Category:United States Congresses
    → Category:115th United States Congress
      → Category:2018 United States Senate elections
        → Category:Candidates in the 2018 United States Senate elections
          → Randy White (pastor)
```

Verified against PetScan directly — he is in the result set for both `Political_office-holders_in_the_United_States` at depth 4 and `Political_office-holders_in_North_America` at depth 8. The category membership is factually correct: he filed on 2018-03-14 to challenge Bill Nelson in the Florida Democratic Senate primary, and lost. He has never held office.

The second `role.pep` statement, on the `wikidata` dataset, is derivative — `wd_categories` is one of that dataset's inputs and `nomenklatura/enrich/wikidata.py:93-94` copies `role.pep` from the seed entity.

## Why not `negcats`

The header comment in `wd_categories.yml` prescribes a `negcats` entry, and that was the original plan here. It does not work for this case.

PetScan subtracts a `negcats` page from the whole result, not from the branch the negative category sits on. Adding `Candidates_in_the_2018_United_States_Senate_elections` (or the parent `2018_United_States_Senate_elections` — measured identical) as a negcat on `Political_office-holders_in_the_United_States` removes 74 people from the query, including everyone who reaches the category by another route:

> Beto O'Rourke, Martha McSally, Todd Rokita, Lou Barletta, Patrick Morrisey, Winsome Earle-Sears, Mike Espy, Josh Mandel, Gary Johnson, Phil Bredesen, Joe Arpaio, Kevin de León, …

Checking those against production, five are held in the product **only** by `wd_categories` — `wd_peps` does not carry them, presumably because their positions are historical:

| QID | Person | datasets |
|---|---|---|
| Q352123 | Gary Johnson (Governor of New Mexico) | `wd_categories`, `wikidata` |
| Q724001 | Phil Bredesen (Governor of Tennessee) | `wd_categories`, `wikidata`, `ir_sanctions` |
| Q6289137 | Josh Mandel (Ohio State Treasurer) | `wd_categories`, `wikidata` |
| Q1372167 | Joe Arpaio (Sheriff of Maricopa County) | `wd_categories`, `wikidata` |
| Q6397820 | Kevin de León (President pro tem, CA Senate) | `wd_categories`, `wikidata` |

The negcat would drop all five from the product. Election-candidate categories mix PEPs and non-PEPs by construction, so no negcat on that tree is safe — and since he arrives via the North America query too, the negcat would have to go on both top-level categories to have any effect at all.

## What this does instead

Adds an `excluded_qids` config key: person QIDs the categories legitimately contain but who are not PEPs. They are skipped where a category discovers them, so nothing is emitted for them at all unless another route (declarator, P1308 officeholder) reaches them independently. A listed QID that stops appearing in any category is logged as a warning so the list can be pruned.

Also documents the `negcats` caveat in the yml header, with the curl invocation to measure what a candidate negcat would remove before adding it.

## Notes for review

- `Q7292512` is the only QID added. Sampling 20 of the 74 turned up others that look like the same class of false positive and are likewise only in `wd_categories` — Goodspaceguy (Q16875944), John Melendez (Q3182082, the comedian), Rolando Toyos (Q20685341, an ophthalmologist), Augustus Sol Invictus (Q22278295). Happy to add them here or leave them for a follow-up; I did not sample the remaining 54.
- Not verified by a crawl — a full `wd_categories` run is ~7 hours. The yml parses, `ruff` and `mypy --strict` pass, and the skip is on the same code path as the existing `exclusion_checks` branch.

## Running one category at a time

A full `wd_categories` run is ~7 hours, which is why the `negcats` measurement above had to be done against PetScan by hand rather than against the entities we actually emit. Second commit adds a click entry point to the crawler for that:

```
python datasets/_wikidata/categories/crawler.py Political_office-holders_in_Gibraltar
```

It loads the real dataset and runs the real crawler over only the named entries of the category config, writing to `data/datasets/wd_categories/` as usual, replacing whatever a previous local run left there. Declarator discovery is skipped. Category names are validated against the config before anything is cleared, so a typo doesn't wipe a previous local run. The only option is `--debug`.

This is also how `excluded_qids` was verified: Gibraltar emits 764 statements, and adding one of its people to `excluded_qids` drops them to zero with the total falling to 750.
