### PR TITLE
Release four legislature PEP datasets into peps

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -70,6 +70,7 @@ children:
   - ch_parlament
   - ci_national_assembly
   - ci_senate
+  - cl_chamber_deputies
   - cl_info_probidad
   - cl_senate
   - cm_national_assembly
@@ -136,7 +137,9 @@ children:
   - ky_parliament
   - kz_mazhilis
   - kz_senate
+  - la_national_assembly
   - li_landtag
+  - lk_parliament
   - lt_seimas
   - lu_bourgmestres
   - lu_chamber
@@ -177,6 +180,7 @@ children:
   - pl_senate
   - pt_parliament
   - py_congreso
+  - qa_shura_council
   - ro_cdep_deputies
   - ro_fiu_declarations
   - ro_senate

--- a/datasets/cl/chamber_deputies/cl_chamber_deputies.yml
+++ b/datasets/cl/chamber_deputies/cl_chamber_deputies.yml
@@ -4,7 +4,7 @@ prefix: cl-cd
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-24
+  start: 2026-08-19
 load_statements: true
 # Sitting deputies' email and district come from Cloudflare-protected profile pages
 # fetched via Zyte, which CI has no credentials for. Run this crawler locally when

--- a/datasets/la/national_assembly/la_national_assembly.yml
+++ b/datasets/la/national_assembly/la_national_assembly.yml
@@ -4,7 +4,7 @@ prefix: la-na
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-08-19
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/lk/parliament/lk_parliament.yml
+++ b/datasets/lk/parliament/lk_parliament.yml
@@ -4,7 +4,7 @@ name: lk_parliament
 prefix: lk-parl
 coverage:
   frequency: monthly
-  start: 2026-07-23
+  start: 2026-08-19
 load_statements: true
 ci_test: true
 summary: >-

--- a/datasets/qa/shura_council/qa_shura_council.yml
+++ b/datasets/qa/shura_council/qa_shura_council.yml
@@ -4,7 +4,7 @@ prefix: qa-shura
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-07-24
+  start: 2026-08-19
 load_statements: true
 ci_test: true
 summary: >-


### PR DESCRIPTION
Add la_national_assembly, qa_shura_council, lk_parliament and cl_chamber_deputies to the peps collection and bump each dataset's coverage.start to the release date.