### PR TITLE
Bump followthemoney to 4.10.2 and nomenklatura to 4.13.2

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">= 3.12"
 dependencies = [
-    "followthemoney == 4.10.1",
+    "followthemoney == 4.10.2",
     "nomenklatura == 4.13.0",
     "plyvel == 1.5.1", # Also update macOS install docs
     "rigour == 2.3.1",

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">= 3.12"
 dependencies = [
     "followthemoney == 4.10.2",
-    "nomenklatura == 4.13.0",
+    "nomenklatura == 4.13.2",
     "plyvel == 1.5.1", # Also update macOS install docs
     "rigour == 2.3.1",
     "datapatch >= 1.2.4, < 1.3",


### PR DESCRIPTION
Dependency bump only, no code changes.

`nomenklatura` 4.13.2 brings two uses of the entity-level `external` aggregate added in `followthemoney` 4.10.2:

- **xref skips candidate pairs where both sides are external.** Merging two unverified enrichment suggestions anchors nothing into the graph, so the pair is worth neither an `algorithm.compare()` nor a slot in the review queue.
- **The dedupe TUI marks external candidates** in the comparison header, so a reviewer can see when they are judging a suggestion rather than published data.

`blocking_xref` needs no change — it already relies on xref's `external=True` default, and `zavod.Entity` inherits `.external` from `StatementEntity`.

Verified locally against both released versions: `mypy --strict` clean over 129 files, 345 zavod tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)