### PR TITLE
[us_nv_med_exclusions] Roll back the Company upgrade

### DIFF
--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -1,5 +1,4 @@
 from typing import Any
-from normality import slugify
 from rigour.mime.types import PDF
 from pdfplumber.page import Page
 
@@ -20,8 +19,7 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
 
     npi = row.pop("sanctioned_excluded_npi")
     entity.id = context.make_id(name, npi)
-    names = h.multi_split(name, [" aka ", " dba ", " DBA "])
-    entity.add("name", names)
+    entity.add("name", h.multi_split(name, [" aka ", " dba ", " DBA "]))
     entity.add("npiCode", (npi or "").split("\n"))
     entity.add("country", "us")
 
@@ -39,18 +37,9 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
         context.emit(associated_entity)
         context.emit(link)
 
-    controlling_interest_name = row.pop(
+    if controlling_interest_name := row.pop(
         "persons_with_controlling_interest_of_5_or_more"
-    )
-    # Individual providers are listed as holding the controlling interest in themselves,
-    # which is no relationship worth recording. A name other than the provider's own
-    # means the provider is a business, which is what lets it be the asset of an
-    # Ownership: that expects an Asset, and a plain LegalEntity isn't one.
-    if controlling_interest_name and slugify(controlling_interest_name) not in {
-        slugify(n) for n in names
-    }:
-        entity.add_schema("Company")
-
+    ):
         person = context.make("Person")
         person.id = context.make_id(controlling_interest_name, entity.id)
         person.add("name", controlling_interest_name.split(" aka "))

--- a/datasets/us/nv/med_exclusions/us_nv_med_exclusions.yml
+++ b/datasets/us/nv/med_exclusions/us_nv_med_exclusions.yml
@@ -35,8 +35,8 @@ data:
 dates:
   formats: ["%m/%d/%Y"]
 
-# Provider counts move with dedupe and split across LegalEntity/Company, so assert on
-# entity_count, which rolls up every thing and tracks the source instead.
+# Provider counts move with dedupe, so assert on entity_count, which rolls up every
+# thing and tracks the source instead.
 assertions:
   min:
     entity_count: 800


### PR DESCRIPTION
029852849 gave a provider the Company schema so it could be the asset of an Ownership, skipping the rows whose controlling-interest name matched the provider's own. Roderick Hill slips through that check: he co-owns Zion Safe Haven with Joyce M. Hill, so his own row names her, not him, while the Zion row names him as a holder. He arrives as both Company and Person, resolution merges the two, and the schemata have nothing in common, so the merged entity fails to assemble and every reference to it dangles. Six errors in the dataset's own run 20260819120306-lpu, and the single error in the default collection's 20260819125301-ndy.

Restore the crawler to its state before that commit: the provider stays a LegalEntity, and every row with a controlling-interest holder gets an ownership edge again. That brings back the Ownership:asset range warning the commit set out to fix - one warning covering 469 references - which is a warning rather than an error, and the state this dataset ran in until yesterday.

The assertion change from the same PR stays. It moved off the per-schema LegalEntity floor that was failing at 659, which this rollback doesn't bring back; only its comment loses the clause about the LegalEntity/Company split, which no longer happens.

Crawl, validate and export over the archived source.pdf: no errors, entity_count 1751 against a range of 800-2000, Person 469 against 250-600, and no Company entities left. Verified with the two Zyte calls substituted, no key locally.