### PR TITLE
us_nv / us_nc med_exclusions: provider schema and controlling-interest names

### DIFF
--- a/datasets/us/nc/med_exclusions/crawler.py
+++ b/datasets/us/nc/med_exclusions/crawler.py
@@ -1,15 +1,17 @@
+from normality import slugify
 from rigour.mime.types import XLSX
 from openpyxl import load_workbook
 
 from zavod import Context, helpers as h
 
 
-def crawl_item(row: dict[str, str | None], context: Context) -> None:
+def crawl_item(
+    row: dict[str, str | None], context: Context, owner_names: set[str]
+) -> None:
     entity = context.make("LegalEntity")
-    entity.id = context.make_id(
-        row.get("excluded_entity"), row.get("npi_atypical_id_excluded")
-    )
-    entity.add("name", row.pop("excluded_entity"))
+    name = row.pop("excluded_entity")
+    entity.id = context.make_id(name, row.get("npi_atypical_id_excluded"))
+    entity.add("name", name)
     entity.add("npiCode", row.pop("npi_atypical_id_excluded"))
     entity.add("topics", "debarment")
     address = h.format_address(
@@ -25,20 +27,31 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
     h.apply_date(sanction, "startDate", row.pop("effective_date"))
     sanction.add("reason", row.pop("reason_for_exclusion"))
 
-    owner = context.make("Person")
-    owner.id = context.make_id(row.get("ownership"))
-    owner.add("name", row.pop("ownership"))
+    owner_name = row.pop("ownership")
+    if slugify(name) in owner_names:
+        # Every provider is given an owner, and a practitioner is given as their own,
+        # so a provider the list names as an owner is a person. Owning yourself is no
+        # relationship, and only a business can be the asset of an Ownership: that
+        # expects an Asset, where a plain LegalEntity isn't one.
+        entity.add_schema("Person")
+    else:
+        entity.add_schema("Company")
 
-    ownership = context.make("Ownership")
-    ownership.id = context.make_id(owner.id, entity.id)
+        owner = context.make("Person")
+        owner.id = context.make_id(owner_name)
+        owner.add("name", owner_name)
 
-    ownership.add("asset", entity)
-    ownership.add("owner", owner)
+        ownership = context.make("Ownership")
+        ownership.id = context.make_id(owner.id, entity.id)
+
+        ownership.add("asset", entity)
+        ownership.add("owner", owner)
+
+        context.emit(owner)
+        context.emit(ownership)
 
     context.emit(entity)
     context.emit(sanction)
-    context.emit(owner)
-    context.emit(ownership)
 
     context.audit_data(row)
 
@@ -59,5 +72,10 @@ def crawl(context: Context) -> None:
     wb = load_workbook(path, read_only=True)
 
     assert wb.active is not None
-    for item in h.parse_xlsx_sheet(context, wb.active, skiprows=6):
-        crawl_item(item, context)
+    rows = list(h.parse_xlsx_sheet(context, wb.active, skiprows=6))
+    # The list marks a name as a person by putting it in the ownership column.
+    owner_names = {
+        slug for row in rows if (slug := slugify(row.get("ownership"))) is not None
+    }
+    for row in rows:
+        crawl_item(row, context, owner_names)

--- a/datasets/us/nc/med_exclusions/us_nc_med_exclusions.yml
+++ b/datasets/us/nc/med_exclusions/us_nc_med_exclusions.yml
@@ -31,18 +31,25 @@ data:
 
 dates:
   formats: ["%m/%d/%Y"]
-# Individual providers arrive twice, as the excluded LegalEntity and as the Person who
-# owns it, and dedupe merges the pair into a Person - so LegalEntity drains into Person.
+# A provider given as their own owner is a Person and the rest are Companies, so every
+# provider carries one of the two schemata and nothing is left in the LegalEntity bucket.
 assertions:
   min:
+    entity_count: 180
     schema_entities:
-      LegalEntity: 50
-      Person: 100
+      Person: 120
+      Company: 40
   max:
+    entity_count: 350
     schema_entities:
-      LegalEntity: 300
       Person: 250
+      Company: 150
 lookups:
+  type.name:
+    options:
+      # The ownership column names the person, and repeats what they trade as
+      - match: 'ROSALIND CURRENCE BLAND d\b\a ABUNDANT LOVE HOME CARE SERVICES'
+        value: ROSALIND CURRENCE BLAND
   type.identifier:
     options:
       - match: # NPI/ATYPICAL ID in the source

--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -8,6 +8,14 @@ from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 CONTROLLING_INTEREST = "persons_with_controlling_interest_of_5_or_more"
+# rigour reads each of these as a legal form, but on a medical provider they are a
+# generational suffix or a credential: "Claude Arthur Verbal II", "Gary Ridenour OD".
+PERSON_SUFFIXES = {"ii", "iii", "iv", "od", "pt"}
+
+
+def is_business(name: str) -> bool:
+    """Whether a name carries a legal form, which a person's name doesn't."""
+    return any(norm not in PERSON_SUFFIXES for _, norm in extract_org_types(name))
 
 
 def controlling_interest_holders(context: Context, value: str | None) -> list[str]:
@@ -68,7 +76,7 @@ def crawl_item(
 
         for holder in holders:
             # The column says persons, but a couple of cells name a business.
-            owner = context.make("Company" if extract_org_types(holder) else "Person")
+            owner = context.make("Company" if is_business(holder) else "Person")
             owner.id = context.make_id(holder, entity.id)
             owner.add("name", holder)
             owner.add("country", "us")
@@ -145,7 +153,7 @@ def crawl(context: Context) -> None:
         slug
         for row in rows
         for name in controlling_interest_holders(context, row.get(CONTROLLING_INTEREST))
-        if not extract_org_types(name) and (slug := slugify(name)) is not None
+        if not is_business(name) and (slug := slugify(name)) is not None
     }
     for row in rows:
         crawl_item(row, context, person_names)

--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -6,8 +6,12 @@ from pdfplumber.page import Page
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
+CONTROLLING_INTEREST = "persons_with_controlling_interest_of_5_or_more"
 
-def crawl_item(row: dict[str, str | None], context: Context) -> None:
+
+def crawl_item(
+    row: dict[str, str | None], context: Context, person_names: set[str]
+) -> None:
     # We already crawl the federal dataset on another crawler
     sanction_tier = row.pop("nevada_medicaid_sanction_tier")
     if (sanction_tier or "").lower() == "federal":
@@ -39,16 +43,12 @@ def crawl_item(row: dict[str, str | None], context: Context) -> None:
         context.emit(associated_entity)
         context.emit(link)
 
-    controlling_interest_name = row.pop(
-        "persons_with_controlling_interest_of_5_or_more"
-    )
-    # Individual providers are listed as holding the controlling interest in themselves,
-    # which is no relationship worth recording. A name other than the provider's own
-    # means the provider is a business, which is what lets it be the asset of an
-    # Ownership: that expects an Asset, and a plain LegalEntity isn't one.
-    if controlling_interest_name and slugify(controlling_interest_name) not in {
-        slugify(n) for n in names
-    }:
+    controlling_interest_name = row.pop(CONTROLLING_INTEREST)
+    # A provider the list names as a controlling-interest holder is a practitioner:
+    # nothing to own, and making them a Company would leave them unassemblable once
+    # resolution merges them with the Person another row emits.
+    is_individual = any(slugify(n) in person_names for n in names)
+    if controlling_interest_name and not is_individual:
         entity.add_schema("Company")
 
         person = context.make("Person")
@@ -115,10 +115,21 @@ def crawl(context: Context) -> None:
     )
     context.export_resource(path, PDF, title=context.SOURCE_TITLE)
 
-    for item in h.parse_pdf_table(
-        context,
-        path,
-        headers_per_page=True,
-        page_settings=page_settings,
-    ):
-        crawl_item(item, context)
+    rows = list(
+        h.parse_pdf_table(
+            context,
+            path,
+            headers_per_page=True,
+            page_settings=page_settings,
+        )
+    )
+    # The list marks a name as a person by putting it in this column, on any row.
+    person_names = {
+        slug
+        for row in rows
+        for part in (row.get(CONTROLLING_INTEREST) or "").split("\n")
+        for name in part.split(" aka ")
+        if (slug := slugify(name)) is not None
+    }
+    for row in rows:
+        crawl_item(row, context, person_names)

--- a/datasets/us/nv/med_exclusions/crawler.py
+++ b/datasets/us/nv/med_exclusions/crawler.py
@@ -1,12 +1,27 @@
 from typing import Any
 from normality import slugify
 from rigour.mime.types import PDF
+from rigour.names import extract_org_types
 from pdfplumber.page import Page
 
 from zavod import Context, helpers as h
 from zavod.extract import zyte_api
 
 CONTROLLING_INTEREST = "persons_with_controlling_interest_of_5_or_more"
+
+
+def controlling_interest_holders(context: Context, value: str | None) -> list[str]:
+    """Split a controlling-interest cell into one name per holder.
+
+    A cell names one holder per line, except where a line break falls inside a name
+    or where two names run together with no separator at all. The lookup spells those
+    out, since nothing in the cell distinguishes them.
+    """
+    if not value:
+        return []
+    result = context.lookup("controlling_interest", value)
+    names = result.values if result is not None else value.split("\n")
+    return [name.lstrip("&").strip() for name in names if name.strip("& ")]
 
 
 def crawl_item(
@@ -43,26 +58,28 @@ def crawl_item(
         context.emit(associated_entity)
         context.emit(link)
 
-    controlling_interest_name = row.pop(CONTROLLING_INTEREST)
+    holders = controlling_interest_holders(context, row.pop(CONTROLLING_INTEREST))
     # A provider the list names as a controlling-interest holder is a practitioner:
     # nothing to own, and making them a Company would leave them unassemblable once
     # resolution merges them with the Person another row emits.
     is_individual = any(slugify(n) in person_names for n in names)
-    if controlling_interest_name and not is_individual:
+    if holders and not is_individual:
         entity.add_schema("Company")
 
-        person = context.make("Person")
-        person.id = context.make_id(controlling_interest_name, entity.id)
-        person.add("name", controlling_interest_name.split(" aka "))
-        person.add("country", "us")
+        for holder in holders:
+            # The column says persons, but a couple of cells name a business.
+            owner = context.make("Company" if extract_org_types(holder) else "Person")
+            owner.id = context.make_id(holder, entity.id)
+            owner.add("name", holder)
+            owner.add("country", "us")
 
-        link = context.make("Ownership")
-        link.id = context.make_id(entity.id, "own", person.id)
-        link.add("asset", entity)
-        link.add("owner", person)
+            link = context.make("Ownership")
+            link.id = context.make_id(entity.id, "own", owner.id)
+            link.add("asset", entity)
+            link.add("owner", owner)
 
-        context.emit(link)
-        context.emit(person)
+            context.emit(link)
+            context.emit(owner)
 
     sanction = h.make_sanction(context, entity)
     sanction.add("provisions", f"Tier: {sanction_tier}")
@@ -127,9 +144,8 @@ def crawl(context: Context) -> None:
     person_names = {
         slug
         for row in rows
-        for part in (row.get(CONTROLLING_INTEREST) or "").split("\n")
-        for name in part.split(" aka ")
-        if (slug := slugify(name)) is not None
+        for name in controlling_interest_holders(context, row.get(CONTROLLING_INTEREST))
+        if not extract_org_types(name) and (slug := slugify(name)) is not None
     }
     for row in rows:
         crawl_item(row, context, person_names)

--- a/datasets/us/nv/med_exclusions/us_nv_med_exclusions.yml
+++ b/datasets/us/nv/med_exclusions/us_nv_med_exclusions.yml
@@ -48,6 +48,16 @@ assertions:
       Person: 600
 
 lookups:
+  # Cells where a line break isn't a separator between two holders, or where two
+  # holders aren't separated at all.
+  controlling_interest:
+    options:
+      - match: "Devin James\nAnthony Brooks"
+        value: Devin James Anthony Brooks
+      - match: Morton Hyson Nicole Hyson
+        values:
+          - Morton Hyson
+          - Nicole Hyson
   type.date:
     options:
       - match: "7/18/2017*"


### PR DESCRIPTION
Splits the `us_nv_med_exclusions` and `us_nc_med_exclusions` work out of #5484 so it can be reviewed on its own.

Both lists pair each excluded provider with the people who hold a controlling interest in it, and both were tripping `Ownership:asset should reference Asset`. Satisfying that by calling the provider a `Company` is a claim the source never makes — which is how Nevada ended up emitting a practitioner as both a `Company` and a `Person`, giving `No common schema: Company and Person` in the dataset run and in the `default` collection. Each commit here decides the schema from what the columns actually say.

### us_nv_med_exclusions

- **Don't make a practitioner a Company.** The self-ownership check compared names within a row, so Roderick Hill slipped through: he co-owns Zion Safe Haven with Joyce M. Hill, so his own row names her, not him, while the Zion row names him as a holder. The check now reads the controlling-interest column across the whole list — a provider the list names as a holder anywhere is a person, so no schema upgrade and no ownership edge. Of 470 rows with a holder, 8 providers appear in the column; only Roderick Hill's behaviour changes.
- **One holder per controlling-interest name.** Cells listing several holders arrived as one person carrying every name ("Jini Muhammad / Dominick Hurd", "Michael Hobbs / Regina Hobbs" — ten of them, each also short an ownership edge). They now split per line, 473 edges against 462. Two cells where the line break isn't a separator are spelled out in a lookup. Two cells name a business rather than a person ("PHC Hospice LLC", "OneCare Health Services, LLC"), so the holder's schema comes from `rigour`'s `extract_org_types` instead of the column heading.
- **Don't read a credential as a legal form.** `extract_org_types` reads a generational suffix as a legal form — "Claude Arthur Verbal II" comes back as `('II', 'ii')` — and `OD` and `PT` go the same way, both credentials a holder on a medical list plausibly carries. Filtered out; output unchanged on the current list.

### us_nc_med_exclusions

- **Give the provider the schema its row implies.** Both warnings were `Ownership:asset` pointing at a non-Asset, 88 references at a `Person` and 85 at a `LegalEntity`, with a different cause each. 91 of the 178 rows name the provider as their own owner (ALFRED KWASI FOLUKE owned by ALFRED KWASI FOLUKE); those are practitioners, which is what resolution was working out by merging each pair into a `Person`. The provider now carries `Person` directly and there's no ownership edge — one record per practitioner instead of two. The other 87 providers are unambiguously businesses (1ST CHOICE HEALTHCARE SERVICES LLC, ANGELS HOME HEALTH, MARCIA L REMENTER DMD PA), so they get `Company`, which is also an `Asset`. Both `LegalEntity` buckets are empty now, so the bounds move to the two schemata that hold providers plus `entity_count`.

### Verification

Crawl, validate and export clean on both, `issues.log` empty, `mypy --strict` and `ruff` clean.

| | before | after |
|---|---|---|
| us_nv | 6 assemble errors, 469 range warnings | none; 1758 things (LegalEntity 913, Person 470, Company 375) |
| us_nc | 2 range warnings over 173 refs | none; 233 things (Person 164, Company 69) |

Nevada was verified with the two Zyte calls substituted for direct fetches, since there's no API key locally.

### Known limits

The Nevada guard is exact-match evidence and sees only this dataset, so it narrows the `Company`/`Person` conflict rather than closing it: a holder spelled differently from their provider row still slips through (this very PDF has "Monteray Sellers" vs "Monteray Sellars"), and cross-dataset resolution can't be anticipated from within the file. Closing the class means dropping `Ownership` for `UnknownLink`, which trades away the ownership semantics for the ~460 rows that really are businesses — worth deciding once across the `us_*_med_exclusions` family rather than per state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)