### PR TITLE
tm_mejlis: account for every field on the deputy profile

### DIFF
--- a/datasets/tm/mejlis/crawler.py
+++ b/datasets/tm/mejlis/crawler.py
@@ -1,84 +1,97 @@
 import re
-from lxml.html import HtmlElement
 
 from zavod import Context, helpers as h
 from zavod.entity import Entity
-from zavod.stateful.positions import PositionCategorisation, categorise
 from zavod.extract.zyte_api import fetch_html
+from zavod.stateful.positions import PositionCategorisation, categorise
+from zavod.util import Element
 
+DEPUTY_LINK_XPATH = "//a[contains(@href, 'single-deputy/')]"
+# Deputy profile links look like ``single-deputy/168?lang=en``; the number is the
+# stable source id we key the person entity on.
 DEPUTY_RE = re.compile(r"single-deputy/(\d+)")
-YEAR_RE = re.compile(r"^\d{4}$")
 
 
-def parse_deputy_ids(doc: HtmlElement) -> list[str]:
-    """Collect the deputy ids linked from the convocation roster page, in order."""
-    ids: list[str] = []
-    for href in h.xpath_strings(doc, "//a[contains(@href, 'single-deputy/')]/@href"):
+def parse_deputy_links(doc: Element) -> dict[str, str]:
+    """Map the id of each deputy linked from the convocation roster to their profile."""
+    links: dict[str, str] = {}
+    for href in h.xpath_strings(doc, f"{DEPUTY_LINK_XPATH}/@href"):
         match = DEPUTY_RE.search(href)
-        if match is not None and match.group(1) not in ids:
-            ids.append(match.group(1))
-    return ids
+        assert match is not None, href
+        links.setdefault(match.group(1), href)
+    return links
 
 
-def field_value(right_block: HtmlElement, label: str) -> str | None:
-    """Return the text of the profile's `label:` row value, if present."""
+def parse_profile_fields(right_block: Element) -> dict[str, Element]:
+    """Read the profile's ``label:`` rows, keyed by label without the colon.
+
+    The profile is a vertical label/value list rather than a column-oriented table,
+    so `h.parse_html_table()` doesn't fit. The values keep their markup: both the
+    constituency and the biography are structured inside their own value block.
+    """
+    fields: dict[str, Element] = {}
     for row in h.xpath_elements(
         right_block, ".//div[contains(@class, 'key_value_wrapper')]"
     ):
-        key = h.element_text(h.xpath_element(row, ".//span[@class='key']")).rstrip(":")
-        if key == label:
-            return h.element_text(
-                h.xpath_element(row, ".//*[contains(@class, 'value')]")
-            )
-    return None
+        label = h.element_text(h.xpath_element(row, ".//span[@class='key']"))
+        value = h.xpath_element(row, ".//*[contains(@class, 'value')]")
+        fields[label.rstrip(":")] = value
+    return fields
 
 
 def crawl_deputy(
     context: Context,
+    url: str,
     deputy_id: str,
     position: Entity,
     categorisation: PositionCategorisation,
 ) -> None:
-    url = f"https://mejlis.gov.tm/single-deputy/{deputy_id}"
     right_block_xpath = "//div[contains(@class, 'right_block')]"
     doc = fetch_html(
         context,
-        f"{url}?lang=en",
+        url,
         unblock_validator=right_block_xpath,
         html_source="httpResponseBody",
+        geolocation="TM",
         cache_days=7,
     )
     right_block = h.xpath_element(doc, right_block_xpath)
-    name = h.element_text(h.xpath_element(right_block, ".//h3[@class='name']"))
+    fields = parse_profile_fields(right_block)
 
     person = context.make("Person")
     person.id = context.make_slug("deputy", deputy_id)
+    name = h.element_text(h.xpath_element(right_block, ".//h3[@class='name']"))
     h.apply_name(person, full=name, lang="eng")
-    person.add("sourceUrl", f"{url}?lang=en")
+    person.add("sourceUrl", url)
     # Deputies of the Mejlis must be citizens of Turkmenistan (Constitution art. 120).
     # https://www.constituteproject.org/constitution/Turkmenistan_2016
     person.add("citizenship", "tm")
+    h.apply_date(person, "birthDate", h.element_text(fields.pop("Year of Birth")))
 
-    year = field_value(right_block, "Year of Birth")
-    if year is not None and YEAR_RE.match(year) is not None:
-        h.apply_date(person, "birthDate", year)
+    biography = fields.pop("Biography")
+    paragraphs = h.xpath_elements(biography, ".//div[@class='deputy_bio_text']//p")
+    person.add(
+        "biography",
+        "\n".join(text for text in map(h.element_text, paragraphs) if len(text) > 0),
+    )
 
-    paragraphs = [
-        h.element_text(p)
-        for p in h.xpath_elements(right_block, ".//div[@class='deputy_bio_text']//p")
-    ]
-    person.add("biography", "\n".join(p for p in paragraphs if len(p) > 0))
+    # The value block spells the district out in Turkmen at length; the span holds just
+    # its name and number, e.g. "95th «Garlyk» election district".
+    district = h.xpath_element(
+        fields.pop("Constituency"), ".//span[@class='district_name']"
+    )
+    # "Position" holds an outside job title for some deputies and their committee role
+    # for others, so it maps to neither cleanly. A committee seat is a position of its
+    # own, which this crawler doesn't model.
+    context.audit_data(fields, ignore=["Position", "Committee"])
 
     occupancy = h.make_occupancy(
         context, person, position, categorisation=categorisation
     )
     if occupancy is None:
         return
+    occupancy.add("constituency", h.element_text(district))
 
-    # electoral constituency: the named election district
-    district = h.xpath_elements(right_block, ".//span[@class='district_name']")
-    if len(district) > 0:
-        occupancy.add("constituency", h.element_text(district[0]))
     context.emit(occupancy)
     context.emit(person)
 
@@ -98,10 +111,13 @@ def crawl(context: Context) -> None:
     doc = fetch_html(
         context,
         f"{context.data_url}?lang=en",
-        unblock_validator="//a[contains(@href, 'single-deputy/')]",
+        unblock_validator=DEPUTY_LINK_XPATH,
+        html_source="httpResponseBody",
+        geolocation="TM",
         cache_days=1,
     )
-    deputy_ids = parse_deputy_ids(doc)
+    deputies = parse_deputy_links(doc)
+    assert len(deputies) > 0, context.data_url
 
-    for deputy_id in deputy_ids:
-        crawl_deputy(context, deputy_id, position, categorisation)
+    for deputy_id, url in deputies.items():
+        crawl_deputy(context, url, deputy_id, position, categorisation)

--- a/datasets/tm/mejlis/tm_mejlis.yml
+++ b/datasets/tm/mejlis/tm_mejlis.yml
@@ -5,7 +5,7 @@ coverage:
   frequency: monthly
   start: 2026-07-27
 load_statements: true
-ci_test: false # Live external government website needing a browser UA, not in CI
+ci_test: false # Fetches route through the Zyte API, which needs a key CI doesn't have
 summary: >-
   Deputies of the Mejlis, the unicameral parliament of Turkmenistan
 description: |
@@ -13,9 +13,8 @@ description: |
   of Turkmenistan since the 2023 constitutional reform that abolished the upper Halk
   Maslahaty. The Mejlis has 125 deputies elected for five-year terms.
 
-  This dataset records each sitting deputy with their name, year of birth, role and
-  parliamentary committee, biography and electoral constituency, sourced from the
-  parliament's official website.
+  This dataset records each sitting deputy with their name, year of birth, biography
+  and electoral constituency, sourced from the parliament's official website.
 url: https://mejlis.gov.tm/
 publisher:
   name: Türkmenistanyň Mejlisi
@@ -29,10 +28,6 @@ data:
   url: https://mejlis.gov.tm/convocation
   format: HTML
   lang: eng
-
-http:
-  # The site rejects the default crawler user agent.
-  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
 
 tags:
   - list.pep


### PR DESCRIPTION
Splits the `tm_mejlis` refactor out of #5484 so it can be reviewed on its own. No output change — same 249 entity ids, no property-value differences.

### Strict interpretation

The profile's five `label:` rows were read one at a time by a helper that returned `None` when a label was missing, and only `Year of Birth` was ever asked for, so the other four went out silently. They now go into a `dict[str, Element]` keyed by label, each field is popped where it's used, and `context.audit_data(fields, ignore=["Position", "Committee"])` closes the record — a renamed or added label warns instead of vanishing. Values keep their markup, which lets the constituency and the biography come out of their own popped block rather than a second top-level selection.

Three more places went from silence to a signal:

- the birth year was filtered through `^\d{4}$` and dropped without a word, where `h.apply_date` warns and keeps `original_value`;
- the constituency was `if len(district) > 0`, now `h.xpath_element`, which raises;
- the id regex on each roster href was `if match is not None`, now an `assert`, since the selector already required `single-deputy/`.

All 124 profiles carry exactly one name, one district and five labelled rows today, so none of these fire.

### Structure and HTTP

`parse_deputy_links` returns the href the roster publishes instead of rebuilding it from a hardcoded host, and dedupes with `setdefault`. Both fetches now ask Zyte for `httpResponseBody` from `geolocation: TM`: the raw body carries all 124 links, so the roster was paying for a browser render it doesn't need, and the location is the open question behind the `421 /website/connection-error` that has failed the last three production runs. Types move to `zavod.util.Element`, which is what the `h.xpath_*` helpers and Zyte's `fetch_html` speak.

### Left unmapped, deliberately

`Position:` gives a committee role for 52 of the 124 deputies ("Member of the Committee on social policy of the Mejlis of Turkmenistan") and an outside job for the rest ("Therapist at Bayramaly etrap hospital"), with deputy 39 carrying both spliced into one string — one field, two meanings, so it stays in the `ignore` list with that written down. The dataset description claimed the dataset records the committee, which it never did, so that claim is gone. The `http.user_agent` block goes too: `zyte_api` sends its own agent, and the site serves a plain request with no agent at all, so the comment about it rejecting the default was wrong as well.

### Verification

Crawl, validate and export clean, `issues.log` empty, `ruff` and `mypy --strict` clean. Person 124, Position 1, `tm` 125 — all inside the assertions.

**Untested:** the Zyte transport. Every local run substituted `zyte_api.fetch_html` with a direct fetch, since there's no API key here, so `geolocation="TM"` against the live 421 wants one manual `zavod crawl` with the key before merge.

Follow-up worth having: each biography opens with `Date and place of birth: 7 January 1988, city of Ashgabat`, so the full birth date and birth place are there for the taking — both "essential when the source provides them" per the data priorities, against the year-only field used today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)