### PR TITLE
[am_national_assembly] Release into peps

### DIFF
--- a/datasets/_collections/peps.yml
+++ b/datasets/_collections/peps.yml
@@ -32,6 +32,7 @@ children:
   - ad_consell_general
   - al_kuvendi
   - am_hetq_officials
+  - am_national_assembly
   - ann_pep_positions
   - ar_parliament
   - ar_senado

--- a/datasets/am/national_assembly/am_national_assembly.yml
+++ b/datasets/am/national_assembly/am_national_assembly.yml
@@ -4,7 +4,7 @@ prefix: am-na
 entry_point: crawler.py
 coverage:
   frequency: monthly
-  start: 2026-08-17
+  start: 2026-08-21
 load_statements: true
 
 ci_test: true


### PR DESCRIPTION
Add `am_national_assembly` to PEPs collection and update coverage start date.