### PR TITLE
[za_wanted] Skip listings that have no status

### DIFF
--- a/datasets/za/wanted/crawler.py
+++ b/datasets/za/wanted/crawler.py
@@ -49,8 +49,11 @@ def crawl_detail_page(context: Context, person: Entity, source_url: str) -> None
         for key, xpath in details.items()
     }
     status = doc.findtext(".//p[@align='center']/font[@color='blue']")
+    # The source sometimes publishes listings without a status. These are incomplete, and it's usually only a few at a time.
+    if not status:
+        return
     if status not in {"Wanted", "Suspect"}:
-        context.log.warning("Unknown or missing status", status=status, url=source_url)
+        context.log.warning("Unknown status", status=status, url=source_url)
         status = None
 
     if info.get("aliases"):


### PR DESCRIPTION
Replaces https://github.com/opensanctions/opensanctions/pull/5521, which handled the same 3 warnings with a `status` datapatch lookup and an empty note.

The source publishes some listings before it fills in the status and crime fields. Run `20260823150301-jsz` emitted 3 of them with a `"None - "` note and one warning each: `za-wanted-23111`, `za-wanted-23376`, `za-wanted-23378`. I re-fetched the 3 detail pages through Zyte. All 3 now show a real status (`Wanted`) and a real crime, so the empty status is temporary.

The crawler now skips a listing with an empty status instead of emitting an incomplete person. An unknown status label (for example `Arrested`) still gives a warning.

## Verification

- Against the live markup of https://www.saps.gov.za/crimestop/wanted/detail.php?bid=23378: a populated banner gives `'Wanted'` and is kept; an empty `<font color="blue">` gives `''` and is skipped; an absent banner gives `None` and is skipped.
- `contrib/lint_dataset.sh datasets/za/wanted/za_wanted.yml` → `lint_dataset: OK`.
- No full crawl run — the crawler needs about 434 Zyte fetches.

## Assertions

Checked, and unchanged. The entity count is 430–471 over the last 8 months, and 434 for the last 10 runs. `min: 400` is 7.8% below 434, which is tighter than the 10–20% in `zavod/docs/metadata.md`, and it fails if more than 34 listings are skipped. `max: 920` is 2.1× the current count, as the same guide asks for.

🤖 Generated with Claude Code using Claude Opus 5 (reasoning effort: low)
