### PR TITLE
[my_investor_alert_list] Ignore the bankInfo column

### DIFF
--- a/datasets/my/investor_alert_list/crawler.py
+++ b/datasets/my/investor_alert_list/crawler.py
@@ -59,15 +59,11 @@ def crawl_item(input_dict: dict[str, str], context: Context) -> None:
 
     entity.add("website", split_websites(input_dict.pop("website")))
 
-    # The bank info column is new and so far only ever holds "N/A" - drop that so
-    # audit_data still flags it once the source starts populating it.
-    if input_dict.get("bankInfo") == "N/A":
-        input_dict.pop("bankInfo")
-
     context.emit(entity)
 
-    # group is just the alphabetical order of the name
-    context.audit_data(input_dict, ignore=["group", "date"])
+    # group is just the alphabetical order of the name. bankInfo holds the bank
+    # account of the scheme, which we do not model.
+    context.audit_data(input_dict, ignore=["group", "date", "bankInfo"])
 
 
 def crawl(context: Context) -> None:


### PR DESCRIPTION
The source started to populate the `bankInfo` column with bank account numbers, which caused the warning `Unexpected data found in fields: ['bankInfo']` (https://www.opensanctions.org/issues/my_investor_alert_list/). We do not model the bank account of the scheme, so the column moves to the `audit_data` ignore list.

🤖 Generated with Claude Code using Opus 5