### PR TITLE
[iq_aml_list] Move the data URL to the api.aml.iq host

### DIFF
--- a/datasets/iq/aml_list/iq_aml_list.yml
+++ b/datasets/iq/aml_list/iq_aml_list.yml
@@ -27,7 +27,7 @@ publisher:
   country: iq
 url: https://aml.iq
 data:
-  url: https://api.aml-iq.com/api/localsanctionslist/getall/1
+  url: https://api.aml.iq/api/localsanctionslist/getall/1
   format: JSON
 tags:
   - list.sanction


### PR DESCRIPTION
Fixes the failing `iq_aml_list` crawler, tracked at https://www.opensanctions.org/issues/iq_aml_list/.

The configured host `api.aml-iq.com` returns HTTP 500 for every request, at any page size (100, 1000, 5000, 10000, 100000). It is not a page-size or throttling problem — the host is dead.

The publisher moved the API. The site bundle at https://aml.iq/assets/index-BneSiQnl.js references `https://api.aml.iq` only. `https://api.aml.iq/api/localsanctionslist/getall/1?pageSize=100000` returns 200 in about 0.5s with 3.4 MB of data.

The payload shape is unchanged: `data.rowCount` is 6284, `data.pageCount` is 1, and the item fields are the same. That is 6257 Individuals and 27 Entities, inside the current assertion bounds. So the crawler code needs no change, and the `make_id` inputs stay the same — no entities get re-keyed.

I did not run the crawler locally. It transliterates about 6,300 Arabic names with an LLM and has no local cache.

🤖 Generated with Claude Code using Opus 5