### PR TITLE
[us_ofac_sdn] Map the country value "Botswana False" to Botswana

### DIFF
--- a/datasets/us/ofac/us_ofac_sdn.yml
+++ b/datasets/us/ofac/us_ofac_sdn.yml
@@ -758,6 +758,8 @@ lookups:
         value: Mozambique
       - match: gambia (false)
         value: Gambia
+      - match: Botswana False
+        value: Botswana
   type.gender:
     lowercase: true
     normalize: true


### PR DESCRIPTION
The SDN list gives the flag of vessel ofac-58311 as `Botswana False`. This adds a `type.country` lookup that maps it to Botswana, next to the existing `mozambique (false)` and `gambia (false)` entries.

Issue: https://www.opensanctions.org/issues/us_ofac_sdn/

🤖 Generated with Claude Code using Opus 5