### PR TITLE
[eu_meps] Switch to the European Parliament Open Data API

### DIFF
--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -15,6 +15,70 @@ from zavod.stateful.positions import PositionCategorisation, categorise
 # One term roster fits in a single response; this bounds it and flags overflow.
 ROSTER_LIMIT = 10000
 
+# Fields each record type carries that the crawler deliberately leaves unmapped.
+# Every object the API returns has `id` (the JSON-LD node IRI) and `type` (the
+# JSON-LD @type tag).
+
+# A PeriodOfTime, as carried by `temporal` and `memberDuring`.
+PERIOD_IGNORE = ["id", "type"]
+
+# A parliamentary term, i.e. the `org/ep-{n}` corporate body.
+TERM_IGNORE = [
+    "id",  # JSON-LD node IRI
+    "type",  # JSON-LD @type tag
+    "identifier",  # term number, already the loop index
+    "label",  # term number as a label
+    "altLabel",  # always "European Parliament"
+    "prefLabel",  # always "European Parliament"
+    "classification",  # always EU_INSTITUTION
+    "represents",  # not set on the institution body
+    "source",  # EP provenance flag
+    "linkedTo",  # refs to related bodies
+    "isVersionOf",  # parent body ref
+    "notation_codictBodyId",  # internal EP id
+    "notation_providerTemporalBodyId",  # internal EP id
+]
+
+# A political group or national party, i.e. an `org/{id}` corporate body.
+ORG_IGNORE = [
+    "id",  # JSON-LD node IRI
+    "type",  # JSON-LD @type tag
+    "identifier",  # equals the local_id we already keep
+    "classification",  # group/committee type, not needed on the org
+    "temporal",  # the body's own date range, unused
+    "source",  # EP provenance flag
+    "linkedTo",  # refs to related bodies
+    "isVersionOf",  # term-invariant parent group ref (e.g. org/PPE)
+    "notation_codictBodyId",  # internal EP id
+    "notation_providerTemporalBodyId",  # internal EP id
+]
+
+# A membership of a political group or national party.
+MEMBERSHIP_IGNORE = [
+    "id",  # JSON-LD node IRI
+    "type",  # JSON-LD @type tag
+    "identifier",  # internal membership id
+    "notation_codictFunctionId",  # internal EP function id
+    "contactPoint",  # office address and phone, not modelled
+]
+
+# An MEP.
+MEP_IGNORE = [
+    "id",  # JSON-LD node IRI
+    "type",  # JSON-LD @type tag
+    "notation_codictPersonId",  # internal EP id, duplicate of identifier
+    "hasEmail",  # contact detail, not screening-relevant
+    "hasHonorificPrefix",  # honorific (Mr/Ms)
+    "homepage",  # personal website, not modelled
+    "account",  # social media accounts, not modelled
+    "img",  # portrait photo URL
+    "sortLabel",  # sorting key, redundant with the name
+    "upperFamilyName",  # uppercase form of familyName
+    "upperGivenName",  # uppercase form of givenName
+    "upperOfficialFamilyName",  # uppercase form of the native family name
+    "upperOfficialGivenName",  # uppercase form of the native given name
+]
+
 
 @dataclass
 class Term:
@@ -85,7 +149,7 @@ def fetch_data(
     if context.cache.get(fingerprint, max_age=cache_days) is None:
         rate_limiter.acquire()
     body = context.fetch_json(url, params=params, cache_days=cache_days)
-    return ensure_list(body.get("data"))
+    return ensure_list(body["data"])
 
 
 def fetch_terms(context: Context) -> list[Term]:
@@ -100,31 +164,13 @@ def fetch_terms(context: Context) -> list[Term]:
             if err.response is not None and err.response.status_code == 404:
                 break
             raise
-        body = rows[0] if rows else {}
-        temporal = body.pop("temporal", None)
-        temporal = temporal if isinstance(temporal, dict) else {}
-        term_start = temporal.pop("startDate", None)
+        assert len(rows) == 1, (number, len(rows))
+        body = rows[0]
+        temporal = body.pop("temporal")
+        term_start = temporal.pop("startDate")
         term_end = temporal.pop("endDate", None)
-        # temporal's id and type are JSON-LD boilerplate.
-        context.audit_data(temporal, ignore=["id", "type"])
-        context.audit_data(
-            body,
-            ignore=[
-                "id",  # JSON-LD node IRI
-                "type",  # JSON-LD @type tag
-                "identifier",  # term number, already the loop index
-                "label",  # term number as a label
-                "altLabel",  # always "European Parliament"
-                "prefLabel",  # always "European Parliament"
-                "classification",  # always EU_INSTITUTION
-                "represents",  # not set on the institution body
-                "source",  # EP provenance flag
-                "linkedTo",  # refs to related bodies
-                "isVersionOf",  # parent body ref
-                "notation_codictBodyId",  # internal EP id
-                "notation_providerTemporalBodyId",  # internal EP id
-            ],
-        )
+        context.audit_data(temporal, ignore=PERIOD_IGNORE)
+        context.audit_data(body, ignore=TERM_IGNORE)
         terms.append(Term(number, term_start, term_end))
     return terms
 
@@ -135,35 +181,21 @@ def fetch_org(context: Context, org_ref: str, cache: dict[str, OrgInfo]) -> OrgI
         return cache[org_ref]
     local_id = org_ref.split("/", 1)[-1]
     rows = fetch_data(context, f"/corporate-bodies/{local_id}")
-    data = rows[0] if rows else {}
+    assert len(rows) == 1, (org_ref, len(rows))
+    data = rows[0]
     countries = [
         c for c in map(last_segment, ensure_list(data.pop("represents", None))) if c
     ]
     # prefLabel is the body's full name; altLabel is a shorter form, used as fallback.
     # Pop both up front so audit_data does not flag the one the `or` would skip.
-    pref_name = pick_label(data.pop("prefLabel", None))
-    alt_name = pick_label(data.pop("altLabel", None))
+    pref_name = pick_label(data.pop("prefLabel"))
+    alt_name = pick_label(data.pop("altLabel"))
     name = pref_name or alt_name
-    acronym = data.pop("label", None)
-    acronym = acronym if isinstance(acronym, str) else None
+    acronym = data.pop("label")
     # The API uses "-" as a placeholder for a missing value.
     name = None if name == "-" else name
     acronym = None if acronym == "-" else acronym
-    context.audit_data(
-        data,
-        ignore=[
-            "id",  # JSON-LD node IRI
-            "type",  # JSON-LD @type tag
-            "identifier",  # equals the local_id we already keep
-            "classification",  # group/committee type, not needed on the org
-            "temporal",  # the body's own date range, unused
-            "source",  # EP provenance flag
-            "linkedTo",  # refs to related bodies
-            "isVersionOf",  # term-invariant parent group ref (e.g. org/PPE)
-            "notation_codictBodyId",  # internal EP id
-            "notation_providerTemporalBodyId",  # internal EP id
-        ],
-    )
+    context.audit_data(data, ignore=ORG_IGNORE)
     info = OrgInfo(local_id=local_id, name=name, acronym=acronym, countries=countries)
     cache[org_ref] = info
     return info
@@ -177,12 +209,13 @@ def crawl_group_membership(
     cache: dict[str, OrgInfo],
 ) -> None:
     """Emit the political group or national party and the person's membership in it."""
-    org_ref = membership.pop("organization", None)
-    if not isinstance(org_ref, str):
-        return
-    info = fetch_org(context, org_ref, cache)
+    info = fetch_org(context, membership.pop("organization"), cache)
 
     org = context.make("Organization")
+    # The API uses "-" where it records no party. A nameless organization, and
+    # a membership pointing at one, carry no information.
+    if info.name is None and info.acronym is None:
+        return
     # The API models a group as a distinct body per term. Key by name so the
     # same party or group is one entity across terms, not one per term.
     org.id = context.make_slug(
@@ -197,31 +230,20 @@ def crawl_group_membership(
     context.emit(org)
 
     # memberDuring carries the start and end dates of the membership period.
-    period = membership.pop("memberDuring", None)
-    period = period if isinstance(period, dict) else {}
+    period = membership.pop("memberDuring")
     entity = context.make("Membership")
     entity.id = context.make_id(
         person.id, org.id, period.get("startDate"), period.get("endDate")
     )
     entity.add("member", person)
     entity.add("organization", org)
-    role = last_segment(membership.pop("role", None))
+    role = last_segment(membership.pop("role"))
     if role is not None:
         entity.add("role", role.replace("_", " ").lower())
-    h.apply_date(entity, "startDate", period.pop("startDate", None))
+    h.apply_date(entity, "startDate", period.pop("startDate"))
     h.apply_date(entity, "endDate", period.pop("endDate", None))
-    # memberDuring's id and type are JSON-LD boilerplate.
-    context.audit_data(period, ignore=["id", "type"])
-    context.audit_data(
-        membership,
-        ignore=[
-            "id",  # JSON-LD node IRI
-            "type",  # JSON-LD @type tag
-            "identifier",  # internal membership id
-            "notation_codictFunctionId",  # internal EP function id
-            "contactPoint",  # office address and phone, not modelled
-        ],
-    )
+    context.audit_data(period, ignore=PERIOD_IGNORE)
+    context.audit_data(membership, ignore=MEMBERSHIP_IGNORE)
     context.emit(entity)
 
 
@@ -242,7 +264,7 @@ def crawl_mep(
     person = context.make("Person")
     person.id = context.make_slug(data.pop("identifier"))
     # Names are plain strings, but gender and citizenship are EU authority URIs.
-    person.add("name", pick_label(data.pop("label", None)))
+    person.add("name", pick_label(data.pop("label")))
     person.add("firstName", data.pop("givenName", None))
     person.add("lastName", data.pop("familyName", None))
     # Cyrillic- and Greek-name MEPs also carry their name in the native script.
@@ -259,24 +281,7 @@ def crawl_mep(
     h.apply_date(person, "deathDate", data.pop("deathDate", None))
     person.add("sourceUrl", f"https://www.europarl.europa.eu/meps/en/{mep_id}")
     memberships = ensure_list(data.pop("hasMembership", None))
-    context.audit_data(
-        data,
-        ignore=[
-            "id",  # JSON-LD node IRI
-            "type",  # JSON-LD @type tag
-            "notation_codictPersonId",  # internal EP id, duplicate of identifier
-            "hasEmail",  # contact detail, not screening-relevant
-            "hasHonorificPrefix",  # honorific (Mr/Ms)
-            "homepage",  # personal website, not modelled
-            "account",  # social media accounts, not modelled
-            "img",  # portrait photo URL
-            "sortLabel",  # sorting key, redundant with the name
-            "upperFamilyName",  # uppercase form of familyName
-            "upperGivenName",  # uppercase form of givenName
-            "upperOfficialFamilyName",  # uppercase form of the native family name
-            "upperOfficialGivenName",  # uppercase form of the native given name
-        ],
-    )
+    context.audit_data(data, ignore=MEP_IGNORE)
 
     # One occupancy per term: a mandate is an EU_INSTITUTION membership in
     # org/ep-{term}. make_occupancy decides PEP relevance from the end date and
@@ -286,17 +291,27 @@ def crawl_mep(
     for membership in memberships:
         # Consumed here to dispatch; popped so the group handler need not ignore it.
         group = last_segment(membership.pop("membershipClassification", None))
-        if group == "EU_INSTITUTION":
+        result = context.lookup("membership_classification", group)
+        if result is None:
+            context.log.warning(
+                "Unknown membership classification", group=group, mep_id=mep_id
+            )
+            continue
+        if result.value == "mandate":
             org_ref = membership.get("organization")
             if not isinstance(org_ref, str) or not org_ref.startswith("org/ep-"):
+                context.log.warning(
+                    "Mandate is not held in a parliamentary term",
+                    organization=org_ref,
+                    mep_id=mep_id,
+                )
                 continue
-            period = membership.get("memberDuring")
-            period = period if isinstance(period, dict) else {}
+            period = membership["memberDuring"]
             occupancy = h.make_occupancy(
                 context,
                 person,
                 position,
-                start_date=period.get("startDate"),
+                start_date=period["startDate"],
                 end_date=period.get("endDate"),
                 # The source always lists an end date for a past-term mandate, so a
                 # missing end date only ever means the current, ongoing term.
@@ -305,9 +320,9 @@ def crawl_mep(
             )
             if occupancy is not None:
                 occupancies.append(occupancy)
-        elif group == "EU_POLITICAL_GROUP":
+        elif result.value == "eu-group":
             groups.append((True, membership))
-        elif group == "NATIONAL_POLITICAL_GROUP":
+        elif result.value == "nat-party":
             groups.append((False, membership))
     if not occupancies:
         return

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -1,103 +1,326 @@
-from zavod.entity import Entity
-from zavod.extract.zyte_api import ZyteAPIRequest, ZyteScrapeType, fetch as zyte_fetch
-from zavod.stateful.positions import PositionCategorisation, categorise
-from zavod.util import Element
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from banal import ensure_list
+from requests.exceptions import HTTPError
+from rigour.urls import build_url
 
 from zavod import Context
 from zavod import helpers as h
+from zavod.entity import Entity
+from zavod.runtime.http_ import request_hash
+from zavod.stateful.positions import PositionCategorisation, categorise
+
+# One term roster fits in a single response; this bounds it and flags overflow.
+ROSTER_LIMIT = 10000
 
 
-def split_name(name: str) -> tuple[str, str] | tuple[None, None]:
-    """Returns (first_name, last_name), or (None, None) if no uppercase suffix found."""
-    for i in range(len(name)):
-        last_name = name[i:].strip()
-        if last_name == last_name.upper():
-            last_name = last_name.strip()
-            first_name = name[:i].strip()
-            return first_name, last_name
-    return None, None
+@dataclass
+class Term:
+    number: int
+    start: str | None
+    end: str | None
 
 
-def crawl_node(
+@dataclass
+class OrgInfo:
+    local_id: str
+    name: str | None
+    acronym: str | None
+    countries: list[str] = field(default_factory=list)
+
+
+class LeakyBucketRateLimiter:
+    """Leaky-bucket rate limiter: paces calls to `rate` per second by sleeping."""
+
+    def __init__(self, rate: float) -> None:
+        self._interval = 1.0 / rate
+        self._tat = time.monotonic()
+
+    def acquire(self) -> None:
+        now = time.monotonic()
+        self._tat = max(self._tat, now)
+        if self._tat > now:
+            time.sleep(self._tat - now)
+        self._tat += self._interval
+
+
+# The API allows 500 requests per 5 minutes (~1.67/s); 1.5/s keeps a safety margin.
+rate_limiter = LeakyBucketRateLimiter(1.5)
+
+
+def last_segment(value: Any) -> str | None:
+    """Return the last path segment of an EU authority URI, e.g.
+    `.../country/BEL` -> `BEL`, `.../human-sex/MALE` -> `MALE`."""
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if not isinstance(value, str) or not value:
+        return None
+    return value.rsplit("/", 1)[-1]
+
+
+def pick_label(value: Any) -> str | None:
+    """Return a label: an API string, or English (else any) from a language-keyed dict."""
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, dict):
+        return None
+    strings = [v for v in value.values() if isinstance(v, str)]
+    return (
+        value["en"] if isinstance(value.get("en"), str) else next(iter(strings), None)
+    )
+
+
+def fetch_data(
+    context: Context, path: str, cache_days: int = 7, **params: Any
+) -> list[Any]:
+    """Fetch a JSON-LD endpoint and return its `data` array."""
+    params.setdefault("format", "application/ld+json")
+    url = f"https://data.europarl.europa.eu/api/v2{path}"
+    # Ideally fetch_json would report whether this was a cache hit, or support rate
+    # limiting itself; absent that, recreate its cache fingerprint here so we only
+    # pace on a real network call.
+    fingerprint = request_hash(build_url(url, params))
+    if context.cache.get(fingerprint, max_age=cache_days) is None:
+        rate_limiter.acquire()
+    body = context.fetch_json(url, params=params, cache_days=cache_days)
+    return ensure_list(body.get("data"))
+
+
+def fetch_terms(context: Context) -> list[Term]:
+    """Walk the parliament institution bodies `org/ep-{n}` to learn each term's
+    date range. Stop at the first term that does not exist."""
+    terms: list[Term] = []
+    # 16 is far above any real term number; the loop stops at the first 404.
+    for number in range(1, 16):
+        try:
+            rows = fetch_data(context, f"/corporate-bodies/ep-{number}")
+        except HTTPError as err:
+            if err.response is not None and err.response.status_code == 404:
+                break
+            raise
+        body = rows[0] if rows else {}
+        temporal = body.pop("temporal", None)
+        temporal = temporal if isinstance(temporal, dict) else {}
+        term_start = temporal.pop("startDate", None)
+        term_end = temporal.pop("endDate", None)
+        # temporal's id and type are JSON-LD boilerplate.
+        context.audit_data(temporal, ignore=["id", "type"])
+        context.audit_data(
+            body,
+            ignore=[
+                "id",  # JSON-LD node IRI
+                "type",  # JSON-LD @type tag
+                "identifier",  # term number, already the loop index
+                "label",  # term number as a label
+                "altLabel",  # always "European Parliament"
+                "prefLabel",  # always "European Parliament"
+                "classification",  # always EU_INSTITUTION
+                "represents",  # not set on the institution body
+                "source",  # EP provenance flag
+                "linkedTo",  # refs to related bodies
+                "isVersionOf",  # parent body ref
+                "notation_codictBodyId",  # internal EP id
+                "notation_providerTemporalBodyId",  # internal EP id
+            ],
+        )
+        terms.append(Term(number, term_start, term_end))
+    return terms
+
+
+def fetch_org(context: Context, org_ref: str, cache: dict[str, OrgInfo]) -> OrgInfo:
+    """Resolve an `org/{id}` reference to its name, acronym and countries."""
+    if org_ref in cache:
+        return cache[org_ref]
+    local_id = org_ref.split("/", 1)[-1]
+    rows = fetch_data(context, f"/corporate-bodies/{local_id}")
+    data = rows[0] if rows else {}
+    countries = [
+        c for c in map(last_segment, ensure_list(data.pop("represents", None))) if c
+    ]
+    # prefLabel is the body's full name; altLabel is a shorter form, used as fallback.
+    # Pop both up front so audit_data does not flag the one the `or` would skip.
+    pref_name = pick_label(data.pop("prefLabel", None))
+    alt_name = pick_label(data.pop("altLabel", None))
+    name = pref_name or alt_name
+    acronym = data.pop("label", None)
+    acronym = acronym if isinstance(acronym, str) else None
+    # The API uses "-" as a placeholder for a missing value.
+    name = None if name == "-" else name
+    acronym = None if acronym == "-" else acronym
+    context.audit_data(
+        data,
+        ignore=[
+            "id",  # JSON-LD node IRI
+            "type",  # JSON-LD @type tag
+            "identifier",  # equals the local_id we already keep
+            "classification",  # group/committee type, not needed on the org
+            "temporal",  # the body's own date range, unused
+            "source",  # EP provenance flag
+            "linkedTo",  # refs to related bodies
+            "isVersionOf",  # term-invariant parent group ref (e.g. org/PPE)
+            "notation_codictBodyId",  # internal EP id
+            "notation_providerTemporalBodyId",  # internal EP id
+        ],
+    )
+    info = OrgInfo(local_id=local_id, name=name, acronym=acronym, countries=countries)
+    cache[org_ref] = info
+    return info
+
+
+def crawl_group_membership(
     context: Context,
-    node: Element,
+    person: Entity,
+    membership: dict[str, Any],
+    is_eu_group: bool,
+    cache: dict[str, OrgInfo],
+) -> None:
+    """Emit the political group or national party and the person's membership in it."""
+    org_ref = membership.pop("organization", None)
+    if not isinstance(org_ref, str):
+        return
+    info = fetch_org(context, org_ref, cache)
+
+    org = context.make("Organization")
+    # The API models a group as a distinct body per term. Key by name so the
+    # same party or group is one entity across terms, not one per term.
+    org.id = context.make_slug(
+        "eu-group" if is_eu_group else "nat-party", info.name or info.local_id
+    )
+    org.add("name", info.name)
+    org.add("name", info.acronym)
+    if is_eu_group:
+        org.add("country", "eu")
+    else:
+        org.add("country", info.countries)
+    context.emit(org)
+
+    # memberDuring carries the start and end dates of the membership period.
+    period = membership.pop("memberDuring", None)
+    period = period if isinstance(period, dict) else {}
+    entity = context.make("Membership")
+    entity.id = context.make_id(
+        person.id, org.id, period.get("startDate"), period.get("endDate")
+    )
+    entity.add("member", person)
+    entity.add("organization", org)
+    role = last_segment(membership.pop("role", None))
+    if role is not None:
+        entity.add("role", role.replace("_", " ").lower())
+    h.apply_date(entity, "startDate", period.pop("startDate", None))
+    h.apply_date(entity, "endDate", period.pop("endDate", None))
+    # memberDuring's id and type are JSON-LD boilerplate.
+    context.audit_data(period, ignore=["id", "type"])
+    context.audit_data(
+        membership,
+        ignore=[
+            "id",  # JSON-LD node IRI
+            "type",  # JSON-LD @type tag
+            "identifier",  # internal membership id
+            "notation_codictFunctionId",  # internal EP function id
+            "contactPoint",  # office address and phone, not modelled
+        ],
+    )
+    context.emit(entity)
+
+
+def crawl_mep(
+    context: Context,
+    mep_id: str,
     position: Entity,
     categorisation: PositionCategorisation,
+    cache: dict[str, OrgInfo],
 ) -> None:
-    mep_id = node.findtext(".//id")
+    """Fetch one MEP and emit the person, their mandates and group memberships."""
+    rows = fetch_data(context, f"/meps/{mep_id}")
+    if not rows:
+        context.log.warning("No data for MEP", mep_id=mep_id)
+        return
+    data = rows[0]
+
     person = context.make("Person")
-    person.id = context.make_slug(mep_id)
-    url = f"http://www.europarl.europa.eu/meps/en/{mep_id}"
-    person.add("sourceUrl", url)
-    name = node.findtext(".//fullName")
-    assert name is not None
-    person.add("name", name)
-    first_name, last_name = split_name(name)
-    person.add("firstName", first_name)
-    person.add("lastName", last_name)
-    person.add("citizenship", node.findtext(".//country"))
-    person.add("topics", "role.pep")
-
-    occupancy = h.make_occupancy(
-        context,
+    person.id = context.make_slug(data.pop("identifier"))
+    # Names are plain strings, but gender and citizenship are EU authority URIs.
+    person.add("name", pick_label(data.pop("label", None)))
+    person.add("firstName", data.pop("givenName", None))
+    person.add("lastName", data.pop("familyName", None))
+    # Cyrillic- and Greek-name MEPs also carry their name in the native script.
+    h.apply_name(
         person,
-        position,
-        categorisation=categorisation,
+        given_name=data.pop("officialGivenName", None),
+        last_name=data.pop("officialFamilyName", None),
     )
-    if occupancy is not None:
+    person.add("gender", last_segment(data.pop("hasGender", None)))
+    person.add("birthPlace", data.pop("placeOfBirth", None))
+    for citizenship in ensure_list(data.pop("citizenship", None)):
+        person.add("citizenship", last_segment(citizenship))
+    h.apply_date(person, "birthDate", data.pop("bday", None))
+    h.apply_date(person, "deathDate", data.pop("deathDate", None))
+    person.add("sourceUrl", f"https://www.europarl.europa.eu/meps/en/{mep_id}")
+    memberships = ensure_list(data.pop("hasMembership", None))
+    context.audit_data(
+        data,
+        ignore=[
+            "id",  # JSON-LD node IRI
+            "type",  # JSON-LD @type tag
+            "notation_codictPersonId",  # internal EP id, duplicate of identifier
+            "hasEmail",  # contact detail, not screening-relevant
+            "hasHonorificPrefix",  # honorific (Mr/Ms)
+            "homepage",  # personal website, not modelled
+            "account",  # social media accounts, not modelled
+            "img",  # portrait photo URL
+            "sortLabel",  # sorting key, redundant with the name
+            "upperFamilyName",  # uppercase form of familyName
+            "upperGivenName",  # uppercase form of givenName
+            "upperOfficialFamilyName",  # uppercase form of the native family name
+            "upperOfficialGivenName",  # uppercase form of the native given name
+        ],
+    )
+
+    # One occupancy per term: a mandate is an EU_INSTITUTION membership in
+    # org/ep-{term}. make_occupancy decides PEP relevance from the end date and
+    # drops stale ones, so a person is emitted only if a mandate is still relevant.
+    occupancies: list[Entity] = []
+    groups: list[tuple[bool, dict[str, Any]]] = []
+    for membership in memberships:
+        # Consumed here to dispatch; popped so the group handler need not ignore it.
+        group = last_segment(membership.pop("membershipClassification", None))
+        if group == "EU_INSTITUTION":
+            org_ref = membership.get("organization")
+            if not isinstance(org_ref, str) or not org_ref.startswith("org/ep-"):
+                continue
+            period = membership.get("memberDuring")
+            period = period if isinstance(period, dict) else {}
+            occupancy = h.make_occupancy(
+                context,
+                person,
+                position,
+                start_date=period.get("startDate"),
+                end_date=period.get("endDate"),
+                # The source always lists an end date for a past-term mandate, so a
+                # missing end date only ever means the current, ongoing term.
+                no_end_implies_current=True,
+                categorisation=categorisation,
+            )
+            if occupancy is not None:
+                occupancies.append(occupancy)
+        elif group == "EU_POLITICAL_GROUP":
+            groups.append((True, membership))
+        elif group == "NATIONAL_POLITICAL_GROUP":
+            groups.append((False, membership))
+    if not occupancies:
+        return
+
+    for occupancy in occupancies:
         context.emit(occupancy)
-
     context.emit(person)
-
-    party_name = node.findtext(".//nationalPoliticalGroup")
-    if party_name not in ["Independent"]:
-        party = context.make("Organization")
-        party.id = context.make_slug("npg", party_name)
-        if party.id is not None:
-            party.add("name", party_name)
-            party.add("country", node.findtext(".//country"))
-            context.emit(party)
-            membership = context.make("Membership")
-            membership.id = context.make_id(person.id, party.id)
-            membership.add("member", person)
-            membership.add("organization", party)
-            context.emit(membership)
-
-    group_name = node.findtext(".//politicalGroup")
-    group = context.make("Organization")
-    group.id = context.make_slug("pg", group_name)
-    if group.id is not None:
-        group.add("name", group_name)
-        group.add("country", "eu")
-        context.emit(group)
-        membership = context.make("Membership")
-        membership.id = context.make_id(person.id, group.id)
-        membership.add("member", person)
-        membership.add("organization", group)
-        context.emit(membership)
+    for is_eu_group, membership in groups:
+        crawl_group_membership(context, person, membership, is_eu_group, cache)
 
 
 def crawl(context: Context) -> None:
-    # The European Parliament put the MEP list endpoint behind an AWS WAF
-    # JavaScript challenge (HTTP 202 with an x-amzn-waf-action: challenge
-    # header), which neither a direct fetch nor Zyte's plain HTTP mode can
-    # pass. Solve the challenge in a Zyte browser session, then reuse the
-    # issued aws-waf-token cookie for the actual XML fetch.
-    page_result = zyte_fetch(
-        context,
-        ZyteAPIRequest(
-            url=context.data_url,
-            scrape_type=ZyteScrapeType.BROWSER_HTML,
-            response_cookies=True,
-        ),
-    )
-    for cookie in page_result.cookies or []:
-        context.http.cookies[cookie["name"]] = cookie["value"]
-
-    path = context.fetch_resource("source.xml", context.data_url)
-    context.export_resource(path, "text/xml", title=context.SOURCE_TITLE)
-    doc = context.parse_resource_xml(path)
-
+    """Crawl MEPs from every parliamentary term within the PEP relevance window."""
     position = h.make_position(
         context,
         "Member of the European Parliament",
@@ -107,6 +330,33 @@ def crawl(context: Context) -> None:
         lang="eng",
     )
     categorisation = categorise(context, position, default_is_pep=True)
+    # The position may have been un-flagged as a PEP position in the review UI.
+    if not categorisation.is_pep:
+        return
     context.emit(position)
-    for node in doc.findall(".//mep"):
-        crawl_node(context, node, position, categorisation)
+
+    # Keep terms that are ongoing or ended within the PEP relevance window.
+    cutoff = h.earliest_term_start(position.get("topics"))
+    terms = [t for t in fetch_terms(context) if t.end is None or t.end >= cutoff]
+    context.log.info(
+        "Crawling MEP terms within PEP relevance window",
+        cutoff=cutoff,
+        terms=[t.number for t in terms],
+    )
+
+    mep_ids: set[str] = set()
+    for term in terms:
+        rows = fetch_data(
+            context,
+            "/meps",
+            **{"parliamentary-term": term.number, "limit": ROSTER_LIMIT},
+        )
+        if len(rows) >= ROSTER_LIMIT:
+            context.log.warning("Term roster may be truncated", term=term.number)
+        for row in rows:
+            mep_ids.add(str(row["identifier"]))
+    context.log.info("Fetched MEP roster", count=len(mep_ids))
+
+    cache: dict[str, OrgInfo] = {}
+    for mep_id in sorted(mep_ids):
+        crawl_mep(context, mep_id, position, categorisation, cache)

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -79,6 +79,24 @@ MEP_IGNORE = [
     "upperOfficialGivenName",  # uppercase form of the native given name
 ]
 
+# `def/ep-entities` membership classifications the crawler does not model: the
+# committees, delegations and working groups a member sits on within the
+# parliament. The mandate itself already establishes political exposure. `None`
+# is the mandate re-published without a classification, plus a few memberships
+# the source has not classified yet. An unlisted value warns instead.
+UNMODELLED_CLASSIFICATIONS: set[str | None] = {
+    "COMMITTEE_PARLIAMENTARY_STANDING",
+    "COMMITTEE_PARLIAMENTARY_SUB",
+    "COMMITTEE_PARLIAMENTARY_SPECIAL",
+    "COMMITTEE_PARLIAMENTARY_TEMPORARY",
+    "DELEGATION_PARLIAMENTARY",
+    "DELEGATION_PARLIAMENTARY_ASSEMBLY",
+    "DELEGATION_JOINT_COMMITTEE",
+    "WORKING_GROUP",
+    "GOVERNING_BODY",
+    None,
+}
+
 
 @dataclass
 class Term:
@@ -291,13 +309,7 @@ def crawl_mep(
     for membership in memberships:
         # Consumed here to dispatch; popped so the group handler need not ignore it.
         group = last_segment(membership.pop("membershipClassification", None))
-        result = context.lookup("membership_classification", group)
-        if result is None:
-            context.log.warning(
-                "Unknown membership classification", group=group, mep_id=mep_id
-            )
-            continue
-        if result.value == "mandate":
+        if group == "EU_INSTITUTION":
             org_ref = membership.get("organization")
             if not isinstance(org_ref, str) or not org_ref.startswith("org/ep-"):
                 context.log.warning(
@@ -320,10 +332,14 @@ def crawl_mep(
             )
             if occupancy is not None:
                 occupancies.append(occupancy)
-        elif result.value == "eu-group":
+        elif group == "EU_POLITICAL_GROUP":
             groups.append((True, membership))
-        elif result.value == "nat-party":
+        elif group == "NATIONAL_POLITICAL_GROUP":
             groups.append((False, membership))
+        elif group not in UNMODELLED_CLASSIFICATIONS:
+            context.log.warning(
+                "Unknown membership classification", group=group, mep_id=mep_id
+            )
     if not occupancies:
         return
 

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -240,7 +240,7 @@ def crawl_group_membership(
         "eu-group" if is_eu_group else "nat-party", info.name or info.local_id
     )
     org.add("name", info.name)
-    org.add("name", info.acronym)
+    org.add("abbreviation", info.acronym)
     if is_eu_group:
         org.add("country", "eu")
     else:

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -255,7 +255,7 @@ def crawl_group_membership(
     )
     entity.add("member", person)
     entity.add("organization", org)
-    role = last_segment(membership.pop("role"))
+    role = last_segment(membership.pop("role", None))
     if role is not None:
         entity.add("role", role.replace("_", " ").lower())
     h.apply_date(entity, "startDate", period.pop("startDate"))

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -1,5 +1,5 @@
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from banal import ensure_list
@@ -39,12 +39,15 @@ TERM_IGNORE = [
     "notation_providerTemporalBodyId",  # internal EP id
 ]
 
-# A political group or national party, i.e. an `org/{id}` corporate body.
+# A political group or national party, i.e. an `org/{id}` corporate body. Only the
+# full name is kept.
 ORG_IGNORE = [
     "id",  # JSON-LD node IRI
     "type",  # JSON-LD @type tag
-    "identifier",  # equals the local_id we already keep
-    "classification",  # group/committee type, not needed on the org
+    "identifier",  # numeric body id, part of the URL already
+    "label",  # acronym, not kept
+    "classification",  # group/committee type
+    "represents",  # represented country, not kept
     "temporal",  # the body's own date range, unused
     "source",  # EP provenance flag
     "linkedTo",  # refs to related bodies
@@ -53,11 +56,13 @@ ORG_IGNORE = [
     "notation_providerTemporalBodyId",  # internal EP id
 ]
 
-# A membership of a political group or national party.
+# A membership of a political group or national party. Only the body and period
+# are kept; the group goes on the occupancy and the party on the person.
 MEMBERSHIP_IGNORE = [
     "id",  # JSON-LD node IRI
     "type",  # JSON-LD @type tag
     "identifier",  # internal membership id
+    "role",  # the member's function in the body, not kept
     "notation_codictFunctionId",  # internal EP function id
     "contactPoint",  # office address and phone, not modelled
 ]
@@ -112,14 +117,6 @@ class Term:
     number: int
     start: str | None
     end: str | None
-
-
-@dataclass
-class OrgInfo:
-    local_id: str
-    name: str | None
-    acronym: str | None
-    countries: list[str] = field(default_factory=list)
 
 
 class LeakyBucketRateLimiter:
@@ -202,76 +199,47 @@ def fetch_terms(context: Context) -> list[Term]:
     return terms
 
 
-def fetch_org(context: Context, org_ref: str, cache: dict[str, OrgInfo]) -> OrgInfo:
-    """Resolve an `org/{id}` reference to its name, acronym and countries."""
-    if org_ref in cache:
-        return cache[org_ref]
+def fetch_org_name(
+    context: Context, org_ref: str, org_names: dict[str, str | None]
+) -> str | None:
+    """Resolve an `org/{id}` reference to the body's full name.
+
+    `org_names` memoises `org/{id}` -> name for the run: the same group or party
+    is referenced by many members, so each body is resolved and audited once.
+    """
+    if org_ref in org_names:
+        return org_names[org_ref]
     local_id = org_ref.split("/", 1)[-1]
     rows = fetch_data(context, f"/corporate-bodies/{local_id}")
     assert len(rows) == 1, (org_ref, len(rows))
     data = rows[0]
-    countries = [
-        c for c in map(last_segment, ensure_list(data.pop("represents", None))) if c
-    ]
-    # prefLabel is the body's full name; altLabel is a shorter form, used as fallback.
-    # Pop both up front so audit_data does not flag the one the `or` would skip.
+    # prefLabel is the full name; altLabel is a fallback. Pop both so audit_data
+    # does not flag the one the `or` would skip. The source uses "-" to mean no name.
     pref_name = pick_label(data.pop("prefLabel"))
     alt_name = pick_label(data.pop("altLabel"))
     name = pref_name or alt_name
-    acronym = data.pop("label")
-    # The API uses "-" as a placeholder for a missing value.
     name = None if name == "-" else name
-    acronym = None if acronym == "-" else acronym
     context.audit_data(data, ignore=ORG_IGNORE)
-    info = OrgInfo(local_id=local_id, name=name, acronym=acronym, countries=countries)
-    cache[org_ref] = info
-    return info
+    org_names[org_ref] = name
+    return name
 
 
-def crawl_group_membership(
-    context: Context,
-    person: Entity,
-    membership: dict[str, Any],
-    is_eu_group: bool,
-    cache: dict[str, OrgInfo],
-) -> None:
-    """Emit the political group or national party and the person's membership in it."""
-    info = fetch_org(context, membership.pop("organization"), cache)
-
-    org = context.make("Organization")
-    # The API uses "-" where it records no party. A nameless organization, and
-    # a membership pointing at one, carry no information.
-    if info.name is None and info.acronym is None:
-        return
-    # The API models a group as a distinct body per term. Key by name so the
-    # same party or group is one entity across terms, not one per term.
-    org.id = context.make_slug(
-        "eu-group" if is_eu_group else "nat-party", info.name or info.local_id
-    )
-    org.add("name", info.name)
-    org.add("abbreviation", info.acronym)
-    if is_eu_group:
-        org.add("country", "eu")
-    else:
-        org.add("country", info.countries)
-    context.emit(org)
-
-    # memberDuring carries the start and end dates of the membership period.
+def membership_period(
+    context: Context, membership: dict[str, Any]
+) -> tuple[str, str | None]:
+    """Pop and audit a membership's period, returning its start and end dates."""
     period = membership.pop("memberDuring")
-    entity = context.make("Membership")
-    entity.id = context.make_id(
-        person.id, org.id, period.get("startDate"), period.get("endDate")
-    )
-    entity.add("member", person)
-    entity.add("organization", org)
-    role = last_segment(membership.pop("role", None))
-    if role is not None:
-        entity.add("role", role.replace("_", " ").lower())
-    h.apply_date(entity, "startDate", period.pop("startDate"))
-    h.apply_date(entity, "endDate", period.pop("endDate", None))
+    start = period.pop("startDate")
+    end = period.pop("endDate", None)
     context.audit_data(period, ignore=PERIOD_IGNORE)
-    context.audit_data(membership, ignore=MEMBERSHIP_IGNORE)
-    context.emit(entity)
+    return start, end
+
+
+def periods_overlap(
+    start: str, end: str | None, other_start: str, other_end: str | None
+) -> bool:
+    """Do two [start, end] date ranges overlap? A missing end is open-ended."""
+    return start <= (other_end or "9999") and other_start <= (end or "9999")
 
 
 def crawl_mep(
@@ -280,7 +248,7 @@ def crawl_mep(
     position: Entity,
     categorisation: PositionCategorisation,
     leadership_positions: dict[str, tuple[Entity, PositionCategorisation]],
-    cache: dict[str, OrgInfo],
+    org_names: dict[str, str | None],
 ) -> None:
     """Fetch one MEP and emit the person, their mandates and group memberships."""
     rows = fetch_data(context, f"/meps/{mep_id}")
@@ -311,13 +279,13 @@ def crawl_mep(
     memberships = ensure_list(data.pop("hasMembership", None))
     context.audit_data(data, ignore=MEP_IGNORE)
 
-    # One occupancy per term: a mandate is an EU_INSTITUTION membership in
-    # org/ep-{term}. make_occupancy decides PEP relevance from the end date and
-    # drops stale ones, so a person is emitted only if a mandate is still relevant.
+    # A mandate is an EU_INSTITUTION membership in org/ep-{term}. make_occupancy
+    # drops stale mandates, so a person is emitted only if one is still relevant.
     occupancies: list[Entity] = []
-    groups: list[tuple[bool, dict[str, Any]]] = []
+    mandate_occupancies: list[tuple[Entity, str, str | None]] = []
+    political_groups: list[tuple[str, str, str | None]] = []
     for membership in memberships:
-        # Consumed here to dispatch; popped so the group handler need not ignore it.
+        # Consumed here to dispatch; popped so the handlers need not ignore it.
         group = last_segment(membership.pop("membershipClassification", None))
         if group == "EU_INSTITUTION":
             org_ref = membership.get("organization")
@@ -333,11 +301,13 @@ def crawl_mep(
             end_date = period.get("endDate")
             # Everyone holds the mandate; a presidency role adds a second position
             # for the same period.
-            held = [(position, categorisation)]
+            held_positions = [(position, categorisation)]
             role = last_segment(membership.get("role"))
             if role is not None and role in leadership_positions:
-                held.append(leadership_positions[role])
-            for held_position, held_categorisation in held:
+                held_positions.append(leadership_positions[role])
+            for index, (held_position, held_categorisation) in enumerate(
+                held_positions
+            ):
                 # The source always lists an end date for a past-term mandate, so a
                 # missing end date only ever means the current, ongoing term.
                 occupancy = h.make_occupancy(
@@ -351,10 +321,25 @@ def crawl_mep(
                 )
                 if occupancy is not None:
                     occupancies.append(occupancy)
+                    if index == 0:
+                        mandate_occupancies.append((occupancy, start_date, end_date))
         elif group == "EU_POLITICAL_GROUP":
-            groups.append((True, membership))
+            # The parliamentary faction is recorded on each occupancy it covers.
+            group_name = fetch_org_name(
+                context, membership.pop("organization"), org_names
+            )
+            group_start, group_end = membership_period(context, membership)
+            context.audit_data(membership, ignore=MEMBERSHIP_IGNORE)
+            if group_name is not None:
+                political_groups.append((group_name, group_start, group_end))
         elif group == "NATIONAL_POLITICAL_GROUP":
-            groups.append((False, membership))
+            # The national party is a political affiliation on the person.
+            party_name = fetch_org_name(
+                context, membership.pop("organization"), org_names
+            )
+            membership_period(context, membership)
+            context.audit_data(membership, ignore=MEMBERSHIP_IGNORE)
+            person.add("political", party_name)
         elif group not in UNMODELLED_CLASSIFICATIONS:
             context.log.warning(
                 "Unknown membership classification", group=group, mep_id=mep_id
@@ -362,11 +347,14 @@ def crawl_mep(
     if not occupancies:
         return
 
+    # Attach each faction to the mandate occupancies its period overlaps.
+    for occupancy, start_date, end_date in mandate_occupancies:
+        for group_name, group_start, group_end in political_groups:
+            if periods_overlap(start_date, end_date, group_start, group_end):
+                occupancy.add("politicalGroup", group_name)
     for occupancy in occupancies:
         context.emit(occupancy)
     context.emit(person)
-    for is_eu_group, membership in groups:
-        crawl_group_membership(context, person, membership, is_eu_group, cache)
 
 
 def make_ep_position(
@@ -424,8 +412,8 @@ def crawl(context: Context) -> None:
             mep_ids.add(str(row["identifier"]))
     context.log.info("Fetched MEP roster", count=len(mep_ids))
 
-    cache: dict[str, OrgInfo] = {}
+    org_names: dict[str, str | None] = {}
     for mep_id in sorted(mep_ids):
         crawl_mep(
-            context, mep_id, position, categorisation, leadership_positions, cache
+            context, mep_id, position, categorisation, leadership_positions, org_names
         )

--- a/datasets/eu/meps/crawler.py
+++ b/datasets/eu/meps/crawler.py
@@ -12,7 +12,7 @@ from zavod.entity import Entity
 from zavod.runtime.http_ import request_hash
 from zavod.stateful.positions import PositionCategorisation, categorise
 
-# One term roster fits in a single response; this bounds it and flags overflow.
+# One term roster fits in a single response; a full page would mean truncation.
 ROSTER_LIMIT = 10000
 
 # Fields each record type carries that the crawler deliberately leaves unmapped.
@@ -95,6 +95,15 @@ UNMODELLED_CLASSIFICATIONS: set[str | None] = {
     "WORKING_GROUP",
     "GOVERNING_BODY",
     None,
+}
+
+# A member can hold a presidency role for part of a term alongside the mandate.
+# Each is emitted as its own Position, identified by Wikidata QID.
+LEADERSHIP_POSITIONS: dict[str, tuple[str, str]] = {
+    "PRESIDENT": ("President of the European Parliament", "Q740126"),
+    "PRESIDENT_ACTING": ("President of the European Parliament", "Q740126"),
+    "PRESIDENT_VICE": ("Vice-President of the European Parliament", "Q7925068"),
+    "QUAESTOR": ("Quaestor of the European Parliament", "Q7268455"),
 }
 
 
@@ -270,6 +279,7 @@ def crawl_mep(
     mep_id: str,
     position: Entity,
     categorisation: PositionCategorisation,
+    leadership_positions: dict[str, tuple[Entity, PositionCategorisation]],
     cache: dict[str, OrgInfo],
 ) -> None:
     """Fetch one MEP and emit the person, their mandates and group memberships."""
@@ -319,19 +329,28 @@ def crawl_mep(
                 )
                 continue
             period = membership["memberDuring"]
-            occupancy = h.make_occupancy(
-                context,
-                person,
-                position,
-                start_date=period["startDate"],
-                end_date=period.get("endDate"),
+            start_date = period["startDate"]
+            end_date = period.get("endDate")
+            # Everyone holds the mandate; a presidency role adds a second position
+            # for the same period.
+            held = [(position, categorisation)]
+            role = last_segment(membership.get("role"))
+            if role is not None and role in leadership_positions:
+                held.append(leadership_positions[role])
+            for held_position, held_categorisation in held:
                 # The source always lists an end date for a past-term mandate, so a
                 # missing end date only ever means the current, ongoing term.
-                no_end_implies_current=True,
-                categorisation=categorisation,
-            )
-            if occupancy is not None:
-                occupancies.append(occupancy)
+                occupancy = h.make_occupancy(
+                    context,
+                    person,
+                    held_position,
+                    start_date=start_date,
+                    end_date=end_date,
+                    no_end_implies_current=True,
+                    categorisation=held_categorisation,
+                )
+                if occupancy is not None:
+                    occupancies.append(occupancy)
         elif group == "EU_POLITICAL_GROUP":
             groups.append((True, membership))
         elif group == "NATIONAL_POLITICAL_GROUP":
@@ -350,21 +369,39 @@ def crawl_mep(
         crawl_group_membership(context, person, membership, is_eu_group, cache)
 
 
-def crawl(context: Context) -> None:
-    """Crawl MEPs from every parliamentary term within the PEP relevance window."""
+def make_ep_position(
+    context: Context, name: str, wikidata_id: str
+) -> tuple[Entity, PositionCategorisation]:
+    """Build a European Parliament position and its PEP categorisation."""
     position = h.make_position(
         context,
-        "Member of the European Parliament",
-        wikidata_id="Q27169",
+        name,
+        wikidata_id=wikidata_id,
         country="eu",
         topics=["gov.igo", "gov.legislative"],
         lang="eng",
     )
-    categorisation = categorise(context, position, default_is_pep=True)
+    return position, categorise(context, position, default_is_pep=True)
+
+
+def crawl(context: Context) -> None:
+    """Crawl MEPs from every parliamentary term within the PEP relevance window."""
+    position, categorisation = make_ep_position(
+        context, "Member of the European Parliament", "Q27169"
+    )
     # The position may have been un-flagged as a PEP position in the review UI.
     if not categorisation.is_pep:
         return
     context.emit(position)
+
+    leadership_positions: dict[str, tuple[Entity, PositionCategorisation]] = {}
+    for role, (name, wikidata_id) in LEADERSHIP_POSITIONS.items():
+        lead_position, lead_categorisation = make_ep_position(
+            context, name, wikidata_id
+        )
+        if lead_categorisation.is_pep:
+            context.emit(lead_position)
+            leadership_positions[role] = (lead_position, lead_categorisation)
 
     # Keep terms that are ongoing or ended within the PEP relevance window.
     cutoff = h.earliest_term_start(position.get("topics"))
@@ -382,12 +419,13 @@ def crawl(context: Context) -> None:
             "/meps",
             **{"parliamentary-term": term.number, "limit": ROSTER_LIMIT},
         )
-        if len(rows) >= ROSTER_LIMIT:
-            context.log.warning("Term roster may be truncated", term=term.number)
+        assert len(rows) < ROSTER_LIMIT, (term.number, len(rows))
         for row in rows:
             mep_ids.add(str(row["identifier"]))
     context.log.info("Fetched MEP roster", count=len(mep_ids))
 
     cache: dict[str, OrgInfo] = {}
     for mep_id in sorted(mep_ids):
-        crawl_mep(context, mep_id, position, categorisation, cache)
+        crawl_mep(
+            context, mep_id, position, categorisation, leadership_positions, cache
+        )

--- a/datasets/eu/meps/eu_meps.yml
+++ b/datasets/eu/meps/eu_meps.yml
@@ -1,6 +1,6 @@
 title: European Parliament Members
 entry_point: crawler.py
-ci_test: false  # fetched via the Zyte API (europarl.europa.eu is behind an AWS WAF challenge)
+ci_test: false  # ~4000 API requests per run is impractical for CI
 prefix: eu-meps
 coverage:
   frequency: weekly
@@ -14,6 +14,10 @@ description: |
   a European-wide election conducted in each member state. Member states have different
   contingents of MEPs based on their voting population. MEPs are organised into groups,
   which are formed from the representatives of national parties aligned with that group.
+
+  This dataset covers current MEPs and former MEPs.
+
+  This data source is licensed under the [Creative Commons Attribution license (CC-BY)](https://creativecommons.org/licenses/by/4.0/).
 tags:
   - list.pep
 publisher:
@@ -26,10 +30,10 @@ publisher:
   url: http://www.europarl.europa.eu/
   country: eu
   official: true
-url: http://www.europarl.europa.eu/meps/
+url: https://data.europarl.europa.eu/en/data/browse-data/mep
 data:
-  url: http://www.europarl.europa.eu/meps/en/full-list/xml
-  format: XML
+  url: https://data.europarl.europa.eu/api/v2/meps
+  format: JSON
 
 assertions:
   min:

--- a/datasets/eu/meps/eu_meps.yml
+++ b/datasets/eu/meps/eu_meps.yml
@@ -35,6 +35,37 @@ data:
   url: https://data.europarl.europa.eu/api/v2/meps
   format: JSON
 
+lookups:
+  # `def/ep-entities`: what kind of body a membership is held in. This decides
+  # how the membership is modelled, so a value missing here warns rather than
+  # being dropped.
+  membership_classification:
+    options:
+      - match: EU_INSTITUTION
+        # The parliament itself: the member's mandate for one term.
+        value: mandate
+      - match: EU_POLITICAL_GROUP
+        value: eu-group
+      - match: NATIONAL_POLITICAL_GROUP
+        value: nat-party
+      # Bodies a member sits on within the parliament. Out of scope: the mandate
+      # already establishes political exposure.
+      - match:
+          - COMMITTEE_PARLIAMENTARY_STANDING
+          - COMMITTEE_PARLIAMENTARY_SUB
+          - COMMITTEE_PARLIAMENTARY_SPECIAL
+          - COMMITTEE_PARLIAMENTARY_TEMPORARY
+          - DELEGATION_PARLIAMENTARY
+          - DELEGATION_PARLIAMENTARY_ASSEMBLY
+          - DELEGATION_JOINT_COMMITTEE
+          - WORKING_GROUP
+          - GOVERNING_BODY
+          # The mandate is published a second time without a classification,
+          # alongside the EU_INSTITUTION membership carrying the same dates. A
+          # few freshly created memberships are also still unclassified.
+          - null
+        value: null
+
 assertions:
   min:
     schema_entities:

--- a/datasets/eu/meps/eu_meps.yml
+++ b/datasets/eu/meps/eu_meps.yml
@@ -35,37 +35,6 @@ data:
   url: https://data.europarl.europa.eu/api/v2/meps
   format: JSON
 
-lookups:
-  # `def/ep-entities`: what kind of body a membership is held in. This decides
-  # how the membership is modelled, so a value missing here warns rather than
-  # being dropped.
-  membership_classification:
-    options:
-      - match: EU_INSTITUTION
-        # The parliament itself: the member's mandate for one term.
-        value: mandate
-      - match: EU_POLITICAL_GROUP
-        value: eu-group
-      - match: NATIONAL_POLITICAL_GROUP
-        value: nat-party
-      # Bodies a member sits on within the parliament. Out of scope: the mandate
-      # already establishes political exposure.
-      - match:
-          - COMMITTEE_PARLIAMENTARY_STANDING
-          - COMMITTEE_PARLIAMENTARY_SUB
-          - COMMITTEE_PARLIAMENTARY_SPECIAL
-          - COMMITTEE_PARLIAMENTARY_TEMPORARY
-          - DELEGATION_PARLIAMENTARY
-          - DELEGATION_PARLIAMENTARY_ASSEMBLY
-          - DELEGATION_JOINT_COMMITTEE
-          - WORKING_GROUP
-          - GOVERNING_BODY
-          # The mandate is published a second time without a classification,
-          # alongside the EU_INSTITUTION membership carrying the same dates. A
-          # few freshly created memberships are also still unclassified.
-          - null
-        value: null
-
 assertions:
   min:
     schema_entities:

--- a/datasets/eu/meps/eu_meps.yml
+++ b/datasets/eu/meps/eu_meps.yml
@@ -47,10 +47,8 @@ assertions:
   min:
     schema_entities:
       Person: 2300
-      Organization: 600
       Position: 1
   max:
     schema_entities:
       Person: 5000
-      Organization: 1500
       Position: 5

--- a/datasets/eu/meps/eu_meps.yml
+++ b/datasets/eu/meps/eu_meps.yml
@@ -7,19 +7,19 @@ coverage:
   start: 2018-04-11
 load_statements: true
 summary: >
-  A set of all the members of the European Union's parliament, which are
-  elected per member state.
+  Directly elected legislators of the European Union, elected per member state
 description: |
-  Members of the European Parliament (MEPs) are elected for a five-year term through
-  a European-wide election conducted in each member state. Member states have different
-  contingents of MEPs based on their voting population. MEPs are organised into groups,
-  which are formed from the representatives of national parties aligned with that group.
-
-  This dataset covers current MEPs and former MEPs.
+  Current and historical members of the European Parliament (MEPs), the directly
+  elected legislature of the European Union. Its 720 members are elected for a
+  five-year term by proportional representation in each member state, and hold the
+  Union's legislative power together with the Council of the European Union,
+  including passing laws and approving the budget. MEPs sit in Europe-wide political
+  groups formed from aligned national parties.
 
   This data source is licensed under the [Creative Commons Attribution license (CC-BY)](https://creativecommons.org/licenses/by/4.0/).
 tags:
   - list.pep
+  - juris.eu
 publisher:
   name: European Parliament
   acronym: EP
@@ -27,7 +27,7 @@ publisher:
     The European Parliament is the legislative branch of the European Union. Together with
     the Council of the European Union and the European Commission it devises and adopts
     European legislation.
-  url: http://www.europarl.europa.eu/
+  url: https://www.europarl.europa.eu/
   country: eu
   official: true
 url: https://data.europarl.europa.eu/en/data/browse-data/mep
@@ -46,11 +46,11 @@ lookups:
 assertions:
   min:
     schema_entities:
-      Person: 610
-      Organization: 180
+      Person: 2300
+      Organization: 600
       Position: 1
   max:
     schema_entities:
-      Person: 1440
-      Organization: 425
-      Position: 2
+      Person: 5000
+      Organization: 1500
+      Position: 5

--- a/datasets/eu/meps/eu_meps.yml
+++ b/datasets/eu/meps/eu_meps.yml
@@ -37,10 +37,9 @@ data:
 lookups:
   type.gender:
     options:
-      # The source records male and female directly and uses the human-sex
-      # code NKN for a member who is neither.
+      # The source records male and female directly; NKN ("not known") is dropped.
       - match: NKN
-        value: other
+        value: null
 
 assertions:
   min:

--- a/datasets/eu/meps/eu_meps.yml
+++ b/datasets/eu/meps/eu_meps.yml
@@ -19,7 +19,6 @@ description: |
   This data source is licensed under the [Creative Commons Attribution license (CC-BY)](https://creativecommons.org/licenses/by/4.0/).
 tags:
   - list.pep
-  - juris.eu
 publisher:
   name: European Parliament
   acronym: EP

--- a/datasets/eu/meps/eu_meps.yml
+++ b/datasets/eu/meps/eu_meps.yml
@@ -35,6 +35,14 @@ data:
   url: https://data.europarl.europa.eu/api/v2/meps
   format: JSON
 
+lookups:
+  type.gender:
+    options:
+      # The source records male and female directly and uses the human-sex
+      # code NKN for a member who is neither.
+      - match: NKN
+        value: other
+
 assertions:
   min:
     schema_entities:


### PR DESCRIPTION
## Why
The MEP list XML endpoint (`.../meps/en/full-list/xml`) is behind an AWS WAF challenge. The Zyte browser workaround stopped passing it, so `eu_meps` has failed every run since 2026-08-22.

## Background and timeline
This crawler has read the MEP list XML endpoint since 2018 (https://github.com/opensanctions/opensanctions/commit/f49f97788), and stayed on it in its current Zyte/WAF form. The European Parliament only launched its Open Data Portal and API in January 2023, years after the crawler started, which is why we never used it before. The old XML feed also lists current members only and carries no dates.

## What
Fetch from the European Parliament Open Data API v2 (https://data.europarl.europa.eu/api/v2, licensed CC BY 4.0) instead. No WAF bypass, no Zyte. The API is a clearly better source:

- Covers current and former MEPs (all terms since 1979); we keep the PEP-relevance window via `h.earliest_term_start`, not only sitting members.
- Emits one dated `Occupancy` per parliamentary term, with real start and end dates and status — the XML feed had none.
- Emits the presidency, vice-presidency and quaestorship a member holds alongside the mandate as their own dated Positions, by Wikidata QID.
- Adds gender, citizenship, birth date and birth place.
- Records the national party on `Person.political` and the parliamentary group on `Occupancy.politicalGroup`, following the house convention for legislature crawlers.

## Rate limiting
The API allows 500 requests per 5 minutes, and a full run makes ~4000 calls. A small leaky-bucket rate limiter paces requests, gated on the cache so a cached rerun is not slowed.

## Identifiers
Persons keep their `eu-meps-{id}` ids — the API MEP id equals the old XML `<id>`, so no person re-keying.

## Final counts
A full crawl emits 7,320 entities:

| schema | count | why |
|---|---|---|
| Person | 2,711 | of the 3,702 MEPs in terms 4-10, those with a mandate inside the ~20-year PEP window; ~1,000 pre-2006-only members drop out |
| Occupancy | 4,605 | ~1.7 per person: several terms, plus the presidency periods |
| Position | 4 | Member, President, Vice-President and Quaestor of the European Parliament |

Party and group are text on `Person.political` and `Occupancy.politicalGroup`, so there are no Organization or Membership entities. Largest contingents by country match the big member states plus historical UK MEPs: Italy 307, France 290, Germany 278, Spain 197, UK 185.

## Notes
- `ci_test` stays false: ~4000 API calls per run is too many for CI.
- Assertions are set from this crawl: Person 2300-5000, Position 1-5.

🤖 Generated with Claude Code using Opus 4.8
