### PR TITLE
[us_ori_admin_actions] Add US ORI PHS Administrative Actions crawler

### DIFF
--- a/datasets/us/ori_admin_actions/crawler.py
+++ b/datasets/us/ori_admin_actions/crawler.py
@@ -1,0 +1,103 @@
+import re
+from html import unescape
+
+from rigour.mime.types import XML
+
+from zavod import Context
+from zavod import helpers as h
+
+# Each feed item describes one researcher and reads, after HTML unescaping:
+#   Administrative Actions:<br><ul><li>Debarment (until 06/18/2030)<li>No PHS
+#   Advisory (For life)</ul>Memo: Request Retraction of Article(s);
+# The <li> elements are never closed, so they are split on the opening tag.
+REGEX_ACTION = re.compile(r"^(?P<action>.+?)\s*\((?P<term>[^)]*)\)\s*$")
+REGEX_UNTIL = re.compile(r"^until\s*(?P<date>.*)$", re.IGNORECASE)
+
+
+def parse_description(description: str) -> tuple[list[str], str | None]:
+    """Split the feed item description into its action strings and the memo."""
+    text = unescape(description)
+    actions_part, _, memo = text.partition("Memo:")
+    _, _, items = actions_part.partition("<ul>")
+    items = items.replace("</ul>", "")
+    actions = [a.strip() for a in items.split("<li>") if a.strip()]
+    return actions, memo.strip() or None
+
+
+def parse_action(context: Context, action: str) -> tuple[str, str | None, bool]:
+    """Return (action name, end date, for_life) for one action string."""
+    match = REGEX_ACTION.match(action)
+    if match is None:
+        context.log.warning("Cannot parse administrative action", action=action)
+        return action, None, False
+    name = match.group("action").strip()
+    term = match.group("term").strip()
+    if term.lower() == "for life":
+        return name, None, True
+    until = REGEX_UNTIL.match(term)
+    if until is None:
+        context.log.warning("Unexpected action term", action=action, term=term)
+        return name, None, False
+    return name, until.group("date").strip() or None, False
+
+
+def crawl_item(context: Context, item: dict[str, str | None]) -> None:
+    guid = item.pop("guid")
+    title = item.pop("title")
+    link = item.pop("link")
+    if guid is None or title is None:
+        context.log.warning("Item without guid or title", item=item)
+        return
+
+    # Titles read "Last, First Middle"; the family name can contain spaces.
+    last_name, _, first_name = title.partition(",")
+    person = context.make("Person")
+    person.id = context.make_id(guid)
+    h.apply_name(
+        person,
+        first_name=first_name.strip() or None,
+        last_name=last_name.strip(),
+        lang="eng",
+    )
+    person.add("country", "us")
+    person.add("sourceUrl", link)
+
+    actions, memo = parse_description(item.pop("description") or "")
+    person.add("notes", memo)
+    if not actions:
+        context.log.warning("Item without administrative actions", title=title)
+
+    for action in actions:
+        name, end_date, for_life = parse_action(context, action)
+        sanction = h.make_sanction(
+            context,
+            person,
+            key=name,
+            program_key="US-HHS-ORI",
+        )
+        sanction.add("provisions", name)
+        sanction.add("sourceUrl", link)
+        if for_life:
+            sanction.add("description", "Imposed for life")
+        else:
+            h.apply_date(sanction, "endDate", end_date)
+        active = h.is_active(sanction)
+        sanction.add("status", "active" if active else "inactive")
+        if active:
+            if name == "Debarment":
+                person.add("topics", "debarment")
+            else:
+                person.add("topics", "reg.action")
+        context.emit(sanction)
+
+    context.emit(person)
+    context.audit_data(item, ignore=["pubDate"])
+
+
+def crawl(context: Context) -> None:
+    path = context.fetch_resource("source.rss", context.data_url)
+    context.export_resource(path, XML, title=context.SOURCE_TITLE)
+    doc = context.parse_resource_xml(path)
+    for node in doc.findall(".//item"):
+        item = {child.tag: child.text for child in node}
+        crawl_item(context, item)

--- a/datasets/us/ori_admin_actions/us_ori_admin_actions.yml
+++ b/datasets/us/ori_admin_actions/us_ori_admin_actions.yml
@@ -1,0 +1,70 @@
+title: US ORI PHS Administrative Actions
+entry_point: crawler.py
+prefix: us-ori
+coverage:
+  frequency: daily
+  start: "2026-08-26"
+load_statements: true
+summary: >-
+  Researchers currently subject to administrative actions imposed by the US Office of
+  Research Integrity for research misconduct in Public Health Service funded research
+description: |
+  The PHS Administrative Action Bulletin Board lists individuals who currently have
+  administrative actions imposed against them by the Office of Research Integrity
+  (ORI), the Assistant Secretary for Health and/or the Department of Health and
+  Human Services (HHS), following findings of research misconduct (fabrication,
+  falsification or plagiarism) in research supported by the US Public Health Service.
+
+  The actions imposed vary by case and are listed together with their expiry date.
+  They include:
+
+  * **Debarment** from eligibility for any contracting or subcontracting with any
+    agency of the United States Government, and from eligibility for or involvement
+    in non-procurement programs of the United States Government.
+  * **No PHS Advisory** - prohibition from serving in any advisory or consultant
+    capacity to PHS, including but not limited to service on any PHS advisory
+    committee, board, or peer review committee.
+  * **Supervision** of any PHS-supported research in which the individual participates.
+  * **Certification of work** - a requirement that the institution certify the
+    accuracy of the individual's contributions to PHS-supported research.
+
+  Some actions are imposed for life. Where an action has expired, it is still included
+  here as long as the individual remains on the bulletin board, and the corresponding
+  sanction record is marked as inactive.
+
+  The bulletin board only covers actions imposed by ORI, the Assistant Secretary for
+  Health and HHS. Separate lists of debarred or restricted clinical investigators are
+  maintained by the Food and Drug Administration.
+url: https://ori.hhs.gov/phs-administrative-action-bulletin-board
+tags:
+  - list.sanction
+  - juris.us
+publisher:
+  name: Office of Research Integrity
+  acronym: ORI
+  description: |
+    The Office of Research Integrity (ORI) is part of the Office of the Assistant
+    Secretary for Health within the US Department of Health and Human Services. ORI
+    oversees and directs Public Health Service (PHS) research integrity activities,
+    reviews institutional investigations of research misconduct, makes findings of
+    research misconduct and recommends administrative actions to the Assistant
+    Secretary for Health.
+  country: us
+  url: https://ori.hhs.gov/
+  official: true
+data:
+  url: https://ori.hhs.gov/ORI_PHS_alert.rss
+  format: XML
+  lang: eng
+
+dates:
+  formats: ["%m/%d/%Y"]
+
+assertions:
+  min:
+    schema_entities:
+      Person: 20
+    countries: 1
+  max:
+    schema_entities:
+      Person: 80

--- a/meta/issuers/us_hhs_ori.yml
+++ b/meta/issuers/us_hhs_ori.yml
@@ -1,0 +1,4 @@
+name: US Department of Health and Human Services Office of Research Integrity
+acronym: HHS-ORI
+organisation: US Department of Health and Human Services
+territory: us

--- a/meta/programs/US-HHS-ORI.yml
+++ b/meta/programs/US-HHS-ORI.yml
@@ -1,0 +1,18 @@
+title: PHS Administrative Actions
+key: US-HHS-ORI
+url: https://ori.hhs.gov/phs-administrative-action-bulletin-board
+summary: The Office of Research Integrity of the US Department of Health and Human
+  Services imposes administrative actions on researchers found to have committed
+  research misconduct (fabrication, falsification or plagiarism) in research
+  supported by the US Public Health Service. Actions are imposed for a fixed term
+  or for life and include debarment from contracting with and participating in
+  non-procurement programs of the US Government, a prohibition from serving in any
+  advisory capacity to PHS, and supervision and certification requirements for any
+  PHS-supported research the individual takes part in.
+issuer: us_hhs_ori
+dataset: us_ori_admin_actions
+aliases:
+  - PHS Administrative Action Bulletin Board
+  - ORI PHS Alert
+measures:
+  - Debarment


### PR DESCRIPTION
Adds a crawler for the **ORI PHS Administrative Action Bulletin Board**: researchers under administrative actions imposed by HHS's Office of Research Integrity for research misconduct. First contribution from me (Tamim), hello!

## Source
The bulletin board page renders its table client-side, and the CSV export only has name parts and expiry dates. The RSS export (`ORI_PHS_alert.rss`) carries the same actions plus a stable per-person GUID and a deep link to each case summary, so the crawler reads the RSS.

## Output
- One `Person` per listed researcher, ID from the feed GUID, `sourceUrl` pointing at the case summary. The board's memo column goes to `notes`.
- One `Sanction` per administrative action (Debarment, No PHS Advisory, Supervision, Certification of work): action as `provisions`, expiry as `endDate` or "Imposed for life", `status` active/inactive.
- Active debarments add `topics: debarment`; other active actions add `reg.action`. Expired actions stay as inactive sanctions while the person remains on the board.
- New program `US-HHS-ORI` and issuer `us_hhs_ori`.
- Names: `lastName` plus everything after the comma as `firstName`. Middle names are not split out; a first-token rule matches ORI's own CSV for 27 of 28 entries but breaks on "Hui Bin".

## Validation
- `zavod crawl`: 28 Person + 71 Sanction (68 active, 3 inactive), 0 issues.
- Cross-checked against the CSV export: all 28 people and every action/expiry date match.
- `zavod export` with assertions passes (Person 20-80, countries >= 1). `schema_entities` only counts Thing schemata, so a Sanction assertion always reads 0; the crawler-sanctions skill currently suggests adding one.
- ruff, mypy, yamllint clean.

Not covered: the per-person case summary pages (institution and misconduct narrative in free text). Happy to do that as a follow-up if useful.

Closes opensanctions/crawler-planning#641
