### PR TITLE
zavod: validate and normalize ISINs in make_security

### DIFF
--- a/datasets/_global/gleif/crawler.py
+++ b/datasets/_global/gleif/crawler.py
@@ -240,6 +240,8 @@ def parse_lei_record(
         proxy.add_schema("Company")
         proxy.add("topics", "corp.public")
         security = h.make_security(context, isin)
+        if security is None:
+            continue
         security.add("issuer", proxy.id)
         security.add("country", entity.findtext("LegalJurisdiction"))
         context.emit(security)

--- a/datasets/eu/esma_saris/crawler.py
+++ b/datasets/eu/esma_saris/crawler.py
@@ -66,6 +66,8 @@ def crawl(context: Context) -> None:
                 context.log.warn("No ISIN", row=row)
                 return
             entity = h.make_security(context, isin)
+            if entity is None:
+                continue
             entity.add("name", row.pop("instrumentFullName", isin))
 
             sanction = h.make_sanction(

--- a/datasets/ru/nsd_isin/crawler.py
+++ b/datasets/ru/nsd_isin/crawler.py
@@ -57,6 +57,8 @@ def crawl_item(context: Context, url: str) -> None:
         context.log.warn("No ISIN code on page", url=url)
         return
     security = h.make_security(context, isin_code)
+    if security is None:
+        return
     security.add("sourceUrl", url)
     security.add("topics", "invest.ban")
     for prop, prop_val in values["security"].items():

--- a/zavod/zavod/helpers/securities.py
+++ b/zavod/zavod/helpers/securities.py
@@ -1,3 +1,5 @@
+from rigour.ids import ISIN
+
 from zavod.constants import ORIGIN_INFERRED
 from zavod.context import Context
 from zavod.entity import Entity
@@ -5,13 +7,30 @@ from zavod.entity import Entity
 ISIN_NON_COUNTRY = ("XS", "XD", "XC", "XF", "CS", "QS")
 
 
-def make_security(context: Context, isin: str) -> Entity:
-    """Make a security entity."""
-    isin = isin.upper()
+def make_security(context: Context, isin: str) -> Entity | None:
+    """Make a security entity keyed on its ISIN.
+
+    The entity ID is minted in the global ``isin-`` namespace, which is shared
+    across datasets, so the ISIN is validated (checksum) and normalized
+    (whitespace and case) before it is used. Only a validated ISIN is used to
+    infer the security's country.
+
+    Args:
+        context: The runner context.
+        isin: The ISIN as it appears in the source.
+
+    Returns:
+        A new entity of type ``Security``, or ``None`` if the value is not a
+        valid ISIN. A warning is logged in that case.
+    """
+    normalized = ISIN.normalize(isin)
+    if normalized is None:
+        context.log.warning("Invalid ISIN", isin=isin)
+        return None
     entity = context.make("Security")
-    entity.id = f"isin-{isin}"
-    entity.add("isin", isin)
-    cc = isin[:2]
+    entity.id = f"isin-{normalized}"
+    entity.add("isin", normalized)
+    cc = normalized[:2]
     if cc not in ISIN_NON_COUNTRY:
         entity.add("country", cc, origin=ORIGIN_INFERRED)
     return entity

--- a/zavod/zavod/shed/firds.py
+++ b/zavod/zavod/shed/firds.py
@@ -27,6 +27,8 @@ def parse_element(context: Context, file_name: str, elem: etree._Element) -> Non
         # Skip OTC derivatives and other special case securities
         return
     security = h.make_security(context, isin)
+    if security is None:
+        return
     security.add("name", attr.findtext(f"./{NS}FullNm"))
     security.add("alias", attr.findtext(f"./{NS}ShrtNm"))
     security.add("classification", attr.findtext(f"./{NS}ClssfctnTp"))

--- a/zavod/zavod/tests/helpers/test_securities.py
+++ b/zavod/zavod/tests/helpers/test_securities.py
@@ -5,14 +5,36 @@ from zavod.helpers.securities import make_security
 
 def test_make_security(testdataset1: Dataset):
     context = Context(testdataset1)
-    entity = make_security(context, "XS1234567890")
-    assert entity.id == "isin-XS1234567890"
+    entity = make_security(context, "XS1234567896")
+    assert entity is not None
+    assert entity.id == "isin-XS1234567896"
     assert entity.schema.name == "Security"
-    assert entity.get("isin") == ["XS1234567890"]
+    assert entity.get("isin") == ["XS1234567896"]
     assert not len(entity.get("country"))
 
-    entity = make_security(context, "DE1234567890")
-    assert entity.id == "isin-DE1234567890"
+    entity = make_security(context, "DE0005140008")
+    assert entity is not None
+    assert entity.id == "isin-DE0005140008"
     assert entity.schema.name == "Security"
     assert entity.first("country") == "de"
+    context.close()
+
+
+def test_make_security_normalizes(testdataset1: Dataset):
+    context = Context(testdataset1)
+    # Whitespace, separators and case must not produce distinct global IDs.
+    for raw in [" US0378331005 ", "us0378331005", "US 0378 3310 05"]:
+        entity = make_security(context, raw)
+        assert entity is not None, raw
+        assert entity.id == "isin-US0378331005"
+        assert entity.get("isin") == ["US0378331005"]
+        assert entity.first("country") == "us"
+    context.close()
+
+
+def test_make_security_invalid(testdataset1: Dataset):
+    context = Context(testdataset1)
+    # Placeholders, empty values and checksum failures must not mint an ID.
+    for raw in ["N/A", "", "   ", "US0378331006", "DE1234567890", "not-an-isin"]:
+        assert make_security(context, raw) is None, raw
     context.close()


### PR DESCRIPTION
Closes #4941

`make_security` built the entity ID in the global `isin-` namespace straight from the source string. A placeholder like `N/A` collided across datasets, a trailing space or lowercase value never merged with the clean form, the country was inferred from the first two characters of whatever arrived, and FtM's `format: isin` then silently dropped the invalid value, leaving a Security with a garbage ID and no `isin` at all.

## Change
- Gate on `rigour.ids.ISIN.normalize` (strip, uppercase, checksum). Invalid input logs `Invalid ISIN` and returns `None`, mirroring the `make_address` contract. ID, `isin` and the inferred country all come from the normalized value.
- Callers get a `None` guard: `ru_nsd_isin`, `eu_esma_saris`, `gleif`, and `zavod/shed/firds.py` (not in the issue's list; it already pre-filters with `ISIN.is_valid` to skip OTC derivatives, so behaviour there is unchanged).
- Tests use checksum-valid ISINs (the old fixtures fail the checksum) and cover normalization and rejection.

## ID impact
Published `eu_esma_saris` (2,931 securities) and `ru_nsd_isin` (17,987) contain no invalid and no non-normalized ISIN ids, so this changes no existing entity IDs there. Any future bad row now warns instead of minting a global id.

## Validation
- zavod tests: 346 pass. `test_validate.py::test_property_range` fails on `main` as well since #5543 silenced the warning it asserts.
- `make typecheck`: only the pre-existing `shed/ojeu/cellar.py:691` error, same as `main`. `make lint` clean.
- Local crawl of `eu_esma_saris`: 2,931 Security, 0 issues, same count as production.

Noticed while here, not changed: `eu_esma_saris` uses `return` rather than `continue` when a row has no ISIN, which would stop the crawl at that row.
