### PR TITLE
[zavod] Fix two CI breakages on main (click 8.5.0 typecheck, stale validator test)

### DIFF
--- a/zavod/zavod/shed/ojeu/cellar.py
+++ b/zavod/zavod/shed/ojeu/cellar.py
@@ -688,7 +688,7 @@ def cli(
             )
         content = extract_body_html(expression) if body_only else expression.content
         if output is None:
-            click.get_binary_stream("stdout").write(content)
+            click.echo(content, nl=False)
         else:
             output.write_bytes(content)
     except (OSError, ValueError, requests.RequestException) as exc:

--- a/zavod/zavod/tests/test_validate.py
+++ b/zavod/zavod/tests/test_validate.py
@@ -1,5 +1,6 @@
 import uuid
 
+import pytest
 from structlog.testing import capture_logs
 
 from zavod import Entity
@@ -79,6 +80,10 @@ def test_dangling_references(testdataset3) -> None:
     assert validator.abort is False
 
 
+@pytest.mark.skip(
+    reason="Ownership:asset schema warning is silenced in e9a2327af until we are "
+    "ready to tackle this problem again after the team retreat in August 2026."
+)
 def test_property_range() -> None:
     # All of these have to be emitted through one context: each context run
     # replaces the dataset's statements rather than appending to them.


### PR DESCRIPTION
Two independent breakages have kept the `build` job red on main. This PR fixes both.

## 1. mypy error from click 8.5.0

`make typecheck` fails:

```
zavod/shed/ojeu/cellar.py:691: error: "object" not callable  [operator]
```

**Root cause:** not a code change — a dependency. CI installs `click` unpinned. click 8.5.0 deprecates `get_binary_stream` and re-exports it as a deprecation shim typed as `object`, so `click.get_binary_stream("stdout").write(content)` no longer type-checks under `mypy --strict`.

**When:** last green build was 2026-08-27 00:48 UTC (`click==8.4.2`); first failure was 2026-08-27 02:06 UTC (https://github.com/opensanctions/opensanctions/actions/runs/33032232546, `click==8.5.0`).

**Fix:** use `click.echo(content, nl=False)`, the click-recommended way to write bytes to stdout ("supports writing to binary outputs").

## 2. stale test after the validator warning was silenced

`make test` fails:

```
FAILED zavod/tests/test_validate.py::test_property_range
```

**Root cause:** https://github.com/opensanctions/opensanctions/commit/e9a2327af368f70a2098b7b4284a6eb8771cbf29 commented out the `Ownership:asset` schema warning, but `test_property_range` still asserts it. This has been red since 2026-08-26.

**Fix:** skip the test with the same rationale, so it re-enables together with the warning after the team retreat.

🤖 Generated with Claude Code using Claude Opus 4.8
