### PR TITLE
[ch_seco_sanctions] Add Ukraine ordinance annex variant to program lookup

### DIFF
--- a/datasets/ch/seco_sanctions/ch_seco_sanctions.yml
+++ b/datasets/ch/seco_sanctions/ch_seco_sanctions.yml
@@ -84,6 +84,7 @@ lookups:
       - match:
           - "Ordinance of 4 March 2022 on measures related to the situation in Ukraine (RS 946.231.176.72), annexes 2, 8, 9, 10, 11, 12,13, 14, 14a, 15, 15a, 15b, 25 and 33"
           - "Ordinance of 4 March 2022 on measures related to the situation in Ukraine (RS 946.231.176.72), annexes 2, 8, 9, 10, 11, 12,13, 14, 14a, 15, 15a, 15b, 15c, 25 and 33"
+          - "Ordinance of 4 March 2022 on measures related to the situation in Ukraine (RS 946.231.176.72), annexes 2, 8, 9, 10, 11, 12,13, 14, 14a, 15, 15a, 15b, 15c, 25, 33, 35, 36, 37, 39, 40 and 41"
         value: SECO-UKRAINE
       - match: "Ordinance of 14 March 2014  on measures against the Central African Republic (RS 946.231.123.6), annex"
         value: SECO-CAR


### PR DESCRIPTION
SECO expanded the annex list on the Ukraine ordinance (RS 946.231.176.72). The new program string was not in the `sanction.program` lookup, so every affected sanction fell through to a "Program key not found" warning (4696 hits in the run https://data.opensanctions.org/artifacts/ch_seco_sanctions/20260828113326-hdx/issues.json).

Added the new string as a third `match` variant under `SECO-UKRAINE`.

🤖 Generated with Claude Code using Claude Opus 4.8