### PR TITLE
wd_categories: negcat the 2018 US Senate candidates as a stopgap

### DIFF
--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -812,6 +812,21 @@ config:
       # country: us
     - category: Political_office-holders_in_the_United_States
       topic: role.pep
+      # Temporary. Candidates_in_the_2018_United_States_Senate_elections sits four hops
+      # below here, so people who filed for a Senate primary and lost get role.pep - a
+      # pastor, a comedian, an ophthalmologist, a biologist.
+      #
+      # negcats is a blunt instrument for this: petscan subtracts the page from the whole
+      # result, not from the branch, so it also drops candidates who reach this category
+      # by another route. Measured 2026-08-28, of the 74 members: 20 are the false
+      # positives we are targeting, 37 are office-holders that another dataset also
+      # supplies and who are therefore unaffected, and 17 lose role.pep because
+      # wd_categories is their only source. Of those 17 only five have a recorded
+      # tenure, all state or county level and all ended - see the PR for the list.
+      #
+      # Replace this with a branch-aware exclusion rather than extending it.
+      negcats: |
+        Candidates_in_the_2018_United_States_Senate_elections
     - category: Second_Trump_administration_personnel
       topic: role.pep
     - category: Biden_administration_personnel

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -199,6 +199,7 @@ config:
   exclusion_checks:
     - Q5234712 # Came in via Dallas categories under Category:George_M._Dallas
     - Q546195 # Khuit II, Queen Consort of Ancient Egypt
+    - Q7292512 # was included incorrectly due to Category:Candidates_in_the_2018_United_States_Senate_elections
   categories:
     # Position names defined here (the `position.name` field) should be written
     # in English — make_position tags them with lang="eng".

--- a/datasets/_wikidata/categories/wd_categories.yml
+++ b/datasets/_wikidata/categories/wd_categories.yml
@@ -812,19 +812,8 @@ config:
       # country: us
     - category: Political_office-holders_in_the_United_States
       topic: role.pep
-      # Temporary. Candidates_in_the_2018_United_States_Senate_elections sits four hops
-      # below here, so people who filed for a Senate primary and lost get role.pep - a
-      # pastor, a comedian, an ophthalmologist, a biologist.
-      #
-      # negcats is a blunt instrument for this: petscan subtracts the page from the whole
-      # result, not from the branch, so it also drops candidates who reach this category
-      # by another route. Measured 2026-08-28, of the 74 members: 20 are the false
-      # positives we are targeting, 37 are office-holders that another dataset also
-      # supplies and who are therefore unaffected, and 17 lose role.pep because
-      # wd_categories is their only source. Of those 17 only five have a recorded
-      # tenure, all state or county level and all ended - see the PR for the list.
-      #
-      # Replace this with a branch-aware exclusion rather than extending it.
+      # TODO: replace once we have a better way of excluding mixed PEP/non-PEP subcategories
+      # than negcats. https://github.com/opensanctions/opensanctions/issues/5485
       negcats: |
         Candidates_in_the_2018_United_States_Senate_elections
     - category: Second_Trump_administration_personnel


### PR DESCRIPTION
Temporarily exclude  `Candidates_in_the_2018_United_States_Senate_elections` entirely from wd_categories because it is bringing people in who never held office (not PEPs) e.g. [Q7292512](https://www.opensanctions.org/entities/Q7292512/) 

This is a temporary fix while we work on a better fix. The limitation with negcats is that it completely excludes all members of the category, even if they are also included in other categories which mean they are indeed PEPs.

This removes the entire `Candidates_in_the_2018_United_States_Senate_elections` - 17 of them are not included in any other dataset. Most of those are not PEPs. A handful are PEPs whose tenure has ended. The true PEPs included in other categories will return with https://github.com/opensanctions/opensanctions/issues/5485

---

More detail

```
Political_office-holders_in_the_United_States                     depth 4
└── United_States_Congresses
    ├── 115th_United_States_Congress
    │   └── 2018_United_States_Senate_elections ─┐
    └── 116th_United_States_Congress             │  same node, two parents
        └── 2018_United_States_Senate_elections ─┘
            └── Candidates_in_the_2018_United_States_Senate_elections   74 people
```

`negcats` is the wrong shape for a category that mixes PEPs with non-PEPs — PetScan subtracts the page from the whole result rather than from the branch it sits on, so it drops candidates who reach the parent by another route too. Taking it anyway, on the measured trade.

## The trade

Of the 74 members, measured 2026-08-28:

| | |
|---|---|
| **20** | false positives, the ones we're targeting — 2 of them aren't indexed today |
| **37** | office-holders another dataset also supplies, so unaffected |
| **17** | lose `role.pep`, `wd_categories` being their only source |

The 37 are covered by `ann_pep_positions` (36), `wd_peps` (33), `us_congress` (12), `us_plural_legislators` (10), `everypolitician` (8) — Beto O'Rourke, Martha McSally, Todd Rokita, Lou Barletta, Winsome Earle-Sears, Mike Espy and the rest keep their topic. Phil Bredesen is held by `ir_sanctions`.

## What we lose

Five of the 17 have a recorded tenure. All are state or county level, and all have ended:

| QID | | recorded position |
|---|---|---|
| Q352123 | Gary Johnson | Governor of New Mexico (1995-2003) |
| Q1372167 | Joe Arpaio | sheriff (1993-2017) |
| Q6289137 | Josh Mandel | Ohio State Treasurer (2011-2019) |
| Q6397820 | Kevin de León | President pro tem, California State Senate (2014-2018) |
| Q7331704 | Rick Saccone | member of the Pennsylvania House of Representatives (2011-2019) |

The other twelve carry `role.pep` with **no position property at all** — the topic comes purely from category membership. Some are real office-holders we've never modelled (Aubrey Dunn Jr., Corey Stewart, Robert P. Young Jr., Scott Milne, Richard Painter); the rest are perennial candidates who arguably shouldn't have had the topic (Goodspaceguy, Augustus Sol Invictus, Rocky De La Fuente, Shiva Ayyadurai, Paula Jean Swearengin, Gary Trauner).

Note `wikidata` copies `role.pep` from the `wd_categories` seed (`nomenklatura/enrich/wikidata.py:93`), so it drops there too.

Only the US entry needs this. `Political_office-holders_in_North_America` reaches the same people at depth 8 but assigns no topic, so it isn't what makes them PEPs.

## Why this is temporary

The right fix subtracts the branch instead of the pages: find the categories lying on a path from the parent down to the weak one, query everything else hanging off them, and drop only the members nothing else reaches. On this category that removes 20 rather than 74, and all five of the office-holders above survive.

That needs a decomposition of the parent tree rather than a config line — see #5485. **Replace this entry rather than extending it**; every US Senate election year has the same category, and negcatting all seven would cost proportionally more.
