### PR TITLE
[gem_energy_ownership] Fix Succession/Ownership entity ID collision

### DIFF
--- a/datasets/_global/gem_energy_ownership/crawler.py
+++ b/datasets/_global/gem_energy_ownership/crawler.py
@@ -216,7 +216,7 @@ def crawl_company(
             )
         elif successor_id not in SKIP_IDS:
             succession = context.make("Succession")
-            succession.id = context.make_id(id_, successor_id)
+            succession.id = context.make_id("succession", id_, successor_id)
             succession.add("predecessor", entity)
             succession.add("successor", context.make_slug(successor_id))
             if status_urls is not None:


### PR DESCRIPTION
Succession IDs were derived from make_id(predecessor, successor), which is the same pair make_id(asset, owner) hashes for the Ownership. Whenever an entity merged into the entity that also owns it, both got the same ID and assemble failed with "No common schema: Ownership and Succession".

Prefix the Succession ID with a discriminator, as done for Ownership in other crawlers. Re-crawl of the August 2026 workbook is clean: no issues, no ID carries both schemata, 83 Successions still emitted.