### PR TITLE
zavod: keep lang, original_value and origin in add_cast

### DIFF
--- a/zavod/zavod/entity.py
+++ b/zavod/zavod/entity.py
@@ -104,10 +104,6 @@ class Entity(StatementEntity):
         """
         prop_ = self.schema.get(prop)
         if prop_ is not None:
-            # The entity already carries the property, so no cast is needed. This
-            # path still has to pass on the provenance arguments, otherwise a
-            # value keeps or loses them depending on the entity's schema at the
-            # time of the call.
             return self.add(
                 prop,
                 values,

--- a/zavod/zavod/entity.py
+++ b/zavod/zavod/entity.py
@@ -104,7 +104,20 @@ class Entity(StatementEntity):
         """
         prop_ = self.schema.get(prop)
         if prop_ is not None:
-            return self.add(prop, values, cleaned=cleaned, fuzzy=fuzzy, format=format)
+            # The entity already carries the property, so no cast is needed. This
+            # path still has to pass on the provenance arguments, otherwise a
+            # value keeps or loses them depending on the entity's schema at the
+            # time of the call.
+            return self.add(
+                prop,
+                values,
+                cleaned=cleaned,
+                fuzzy=fuzzy,
+                format=format,
+                lang=lang,
+                original_value=original_value,
+                origin=origin,
+            )
 
         schema_ = model.get(schema)
         if schema_ is None:

--- a/zavod/zavod/tests/test_entity.py
+++ b/zavod/zavod/tests/test_entity.py
@@ -63,6 +63,44 @@ def test_extra_functions():
     assert entity.to_dict()["properties"]["birthDate"][0] == "1988"
 
 
+def test_add_cast_keeps_provenance():
+    catalog = get_catalog()
+    test_ds = catalog.make_dataset(TEST_DATASET)
+
+    # The entity is widened from LegalEntity to Person, so the cast happens.
+    cast = Entity(test_ds, {"schema": "LegalEntity"})
+    cast.id = "cast_entity"
+    cast.add_cast(
+        "Person",
+        "position",
+        "Minister",
+        lang="deu",
+        original_value="Minister (a. D.)",
+        origin="test",
+    )
+    (cast_stmt,) = cast.get_statements("position")
+    assert cast_stmt.lang == "deu", cast_stmt
+    assert cast_stmt.original_value == "Minister (a. D.)", cast_stmt
+    assert cast_stmt.origin == "test", cast_stmt
+
+    # Person already has the property, so no cast is needed. The provenance
+    # must not depend on the schema the entity happened to have.
+    direct = Entity(test_ds, {"schema": "Person"})
+    direct.id = "direct_entity"
+    direct.add_cast(
+        "Person",
+        "position",
+        "Minister",
+        lang="deu",
+        original_value="Minister (a. D.)",
+        origin="test",
+    )
+    (direct_stmt,) = direct.get_statements("position")
+    assert direct_stmt.lang == "deu", direct_stmt
+    assert direct_stmt.original_value == "Minister (a. D.)", direct_stmt
+    assert direct_stmt.origin == "test", direct_stmt
+
+
 def test_future_birth_date_rejected():
     catalog = get_catalog()
     test_ds = catalog.make_dataset(TEST_DATASET)


### PR DESCRIPTION
`Entity.add_cast` takes `lang`, `original_value` and `origin`, but only one of its two paths passes them on. When the entity's schema does not yet have the property, the method runs `value_clean` and calls `unsafe_add` with all three. When the schema already has the property, it returns early through `self.add` with only `cleaned`, `fuzzy` and `format` (zavod/zavod/entity.py:105), so the three provenance arguments are silently dropped. `lang` and `original_value` have never been forwarded there; `origin` was added to the signature in "Set origin on more non-source data prop values" and was not forwarded either.

So whether a value keeps its language, its original value and its origin depends on the schema the entity happens to carry at the moment of the call. That is not visible at the call site and it flips as a crawler grows: `gb_fcdo_sanctions` calls `add_cast("Company", prop, value, original_value=reg_number)` from `add_reg_property`, and it keeps the original value today only because `apply_reg_number` runs before the `entity.add_schema("Company")` further down `csv_make_legal_entity`. Move one of those and the provenance disappears with no error and no warning.

The fix forwards `lang`, `original_value` and `origin` on the early return, so both paths behave the same.

Verification, from `zavod/`:

`pytest zavod/tests/test_entity.py::test_add_cast_keeps_provenance` fails on main with `assert None == 'deu'` and passes with the change. The test makes the same `add_cast("Person", "position", ...)` call twice, once on a `LegalEntity` that gets cast and once on a `Person` that does not, and asserts both statements carry the language, the original value and the origin.

`pytest zavod/tests/` gives 345 passed, 1 skipped. `mypy --strict --exclude zavod/tests zavod/` gives "Success: no issues found in 128 source files". `ruff check zavod/` passes and `ruff format --check` reports both files already formatted.

No dataset output changes today: the only two crawlers that pass provenance into `add_cast` are `gb_fcdo_sanctions` and `sk_rpvs`, and both currently take the casting path.
