### PR TITLE
Warn when Chinese registration number and USCC division codes disagree

### DIFF
--- a/zavod/zavod/runtime/china_ids.py
+++ b/zavod/zavod/runtime/china_ids.py
@@ -1,0 +1,121 @@
+"""Helpers for Chinese corporate identifier checks.
+
+See https://github.com/opensanctions/opensanctions/issues/5444
+
+Pre-2015 Chinese business registration numbers (注册号) are 15 digits:
+``AAAAAA`` (administrative division of the first registering authority)
++ 8-digit sequence + 1 check digit.
+
+The 18-character Unified Social Credit Code (USCC / 统一社会信用代码) embeds
+the same 6-digit division code in characters 3–8 (1-based).
+
+When a record carries both, the prefixes normally agree. They can
+legitimately differ after a re-registration in another division, so a
+mismatch is a maintenance flag (warning), not a hard reject.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from zavod.logs import get_logger
+
+if TYPE_CHECKING:
+    from zavod.entity import Entity
+
+log = get_logger(__name__)
+
+# Pre-2015 注册号: exactly 15 ASCII digits.
+_REG_NUMBER_RE = re.compile(r"^\d{15}$")
+# Compact USCC shape before check-digit validation (GB 32100-2015 charset
+# excludes I, O, Z, S, V). Length alone is enough for prefix extraction.
+_USCC_SHAPE_RE = re.compile(r"^[0-9A-HJ-NP-RT-UW-Y]{18}$")
+
+
+def division_code_from_registration_number(value: str) -> str | None:
+    """Return the 6-digit GB/T 2260 division prefix of a 15-digit 注册号."""
+    compact = value.strip()
+    if not _REG_NUMBER_RE.fullmatch(compact):
+        return None
+    return compact[:6]
+
+
+def division_code_from_uscc(value: str) -> str | None:
+    """Return the 6-digit division code embedded in an 18-char USCC (chars 3–8)."""
+    compact = value.strip().upper().replace(" ", "")
+    if not _USCC_SHAPE_RE.fullmatch(compact):
+        return None
+    return compact[2:8]
+
+
+def iter_china_division_mismatches(
+    registration_numbers: list[str],
+    usc_codes: list[str],
+) -> list[tuple[str, str, str, str]]:
+    """Pairs of (reg, uscc, reg_division, uscc_division) that disagree.
+
+    Only values that parse as 15-digit registration numbers and 18-char USCC
+    shapes participate; other identifier formats are ignored.
+    """
+    reg_divs: list[tuple[str, str]] = []
+    for reg in registration_numbers:
+        division = division_code_from_registration_number(reg)
+        if division is not None:
+            reg_divs.append((reg, division))
+
+    uscc_divs: list[tuple[str, str]] = []
+    for uscc in usc_codes:
+        division = division_code_from_uscc(uscc)
+        if division is not None:
+            uscc_divs.append((uscc, division))
+
+    mismatches: list[tuple[str, str, str, str]] = []
+    for reg, reg_division in reg_divs:
+        for uscc, uscc_division in uscc_divs:
+            if reg_division != uscc_division:
+                mismatches.append((reg, uscc, reg_division, uscc_division))
+    return mismatches
+
+
+def check_china_division_agreement(
+    entity: "Entity",
+    *,
+    pending_registration_number: str | None = None,
+    pending_uscc: str | None = None,
+) -> None:
+    """Warn when an entity's 15-digit 注册号 and USCC disagree on division code.
+
+    ``pending_*`` values are included so the check can run from property
+    cleaning before the new statement is stored on the entity.
+
+    No-op when either side is missing or not in the expected shape. Does not
+    reject values — re-registration can make a mismatch legitimate.
+    """
+    if not entity.schema.is_a("LegalEntity"):
+        return
+    if entity.schema.get("registrationNumber") is None:
+        return
+    if entity.schema.get("uscCode") is None:
+        return
+
+    registration_numbers = list(entity.get("registrationNumber"))
+    usc_codes = list(entity.get("uscCode"))
+    if pending_registration_number is not None:
+        registration_numbers.append(pending_registration_number)
+    if pending_uscc is not None:
+        usc_codes.append(pending_uscc)
+    if not registration_numbers or not usc_codes:
+        return
+
+    for reg, uscc, reg_division, uscc_division in iter_china_division_mismatches(
+        registration_numbers, usc_codes
+    ):
+        log.warning(
+            "Chinese registration number and USCC division codes disagree",
+            entity_id=entity.id,
+            registration_number=reg,
+            usc_code=uscc,
+            registration_division=reg_division,
+            uscc_division=uscc_division,
+        )

--- a/zavod/zavod/runtime/cleaning.py
+++ b/zavod/zavod/runtime/cleaning.py
@@ -11,6 +11,7 @@ from followthemoney.statement.util import NON_LANG_TYPE_NAMES
 from zavod.constants import ORIGIN_INFERRED, ORIGIN_LOOKUP
 from zavod.settings import RUN_TIME
 from zavod.logs import get_logger
+from zavod.runtime.china_ids import check_china_division_agreement
 from zavod.runtime.lookups import is_type_lookup_value, prop_lookup
 from zavod.runtime.safety import check_xss_html_smell
 
@@ -180,6 +181,15 @@ def value_clean(
             # it is making this aspect explicit in the data.
             if prop_.type == registry.topic and origin is None:
                 origin = ORIGIN_INFERRED
+
+            # Cross-check Chinese 注册号 vs USCC division prefixes when both
+            # are present. Mismatch is a warning only (#5444).
+            if prop_.name == "uscCode":
+                check_china_division_agreement(entity, pending_uscc=clean)
+            elif prop_.name == "registrationNumber":
+                check_china_division_agreement(
+                    entity, pending_registration_number=clean
+                )
 
             yield prop_, clean, origin
             continue

--- a/zavod/zavod/tests/runtime/test_china_ids.py
+++ b/zavod/zavod/tests/runtime/test_china_ids.py
@@ -1,0 +1,119 @@
+"""Tests for Chinese registration number / USCC division cross-check (#5444)."""
+
+from structlog.testing import capture_logs
+
+from zavod.runtime.china_ids import (
+    check_china_division_agreement,
+    division_code_from_registration_number,
+    division_code_from_uscc,
+    iter_china_division_mismatches,
+)
+
+
+# Yangzhou Yangjie example from #5444 / #4374
+MATCHING_REG = "321000400012591"
+MATCHING_USCC = "913210007908906337"
+# Same USCC shape but Beijing division (110000) vs Yangzhou (321000)
+MISMATCH_USCC = "91110000600037341L"
+
+
+def test_division_from_registration_number() -> None:
+    assert division_code_from_registration_number(MATCHING_REG) == "321000"
+    assert division_code_from_registration_number("12345") is None
+    assert division_code_from_registration_number(MATCHING_USCC) is None
+    assert division_code_from_registration_number(" 321000400012591 ") == "321000"
+
+
+def test_division_from_uscc() -> None:
+    assert division_code_from_uscc(MATCHING_USCC) == "321000"
+    assert division_code_from_uscc(MISMATCH_USCC) == "110000"
+    assert division_code_from_uscc(MATCHING_REG) is None
+    assert division_code_from_uscc("91 321000 7908906337") == "321000"
+
+
+def test_iter_mismatches_agree() -> None:
+    assert (
+        iter_china_division_mismatches([MATCHING_REG], [MATCHING_USCC]) == []
+    )
+
+
+def test_iter_mismatches_disagree() -> None:
+    assert iter_china_division_mismatches([MATCHING_REG], [MISMATCH_USCC]) == [
+        (MATCHING_REG, MISMATCH_USCC, "321000", "110000")
+    ]
+
+
+def test_iter_ignores_non_china_shapes() -> None:
+    assert (
+        iter_china_division_mismatches(
+            ["DE12345", MATCHING_REG],
+            ["not-a-uscc", MATCHING_USCC],
+        )
+        == []
+    )
+
+
+def test_check_warns_on_mismatch(vcontext) -> None:
+    entity = vcontext.make("Company")
+    entity.id = "test-cn-mismatch"
+    entity.add("registrationNumber", MATCHING_REG)
+    with capture_logs() as cap_logs:
+        check_china_division_agreement(entity, pending_uscc=MISMATCH_USCC)
+    events = [log["event"] for log in cap_logs if log["log_level"] == "warning"]
+    assert "Chinese registration number and USCC division codes disagree" in events
+
+
+def test_check_silent_when_agree(vcontext) -> None:
+    entity = vcontext.make("Company")
+    entity.id = "test-cn-agree"
+    entity.add("registrationNumber", MATCHING_REG)
+    with capture_logs() as cap_logs:
+        check_china_division_agreement(entity, pending_uscc=MATCHING_USCC)
+    warnings = [log for log in cap_logs if log["log_level"] == "warning"]
+    assert warnings == []
+
+
+def test_check_noop_without_sibling(vcontext) -> None:
+    entity = vcontext.make("Company")
+    entity.id = "test-cn-solo"
+    with capture_logs() as cap_logs:
+        check_china_division_agreement(entity, pending_uscc=MATCHING_USCC)
+        check_china_division_agreement(
+            entity, pending_registration_number=MATCHING_REG
+        )
+    warnings = [
+        log
+        for log in cap_logs
+        if log["log_level"] == "warning"
+        and "division codes disagree" in log["event"]
+    ]
+    assert warnings == []
+
+
+def test_check_noop_for_non_legal_entity(vcontext) -> None:
+    entity = vcontext.make("Address")
+    entity.id = "test-cn-address"
+    # Address is not a LegalEntity and has neither identifier prop.
+    with capture_logs() as cap_logs:
+        check_china_division_agreement(
+            entity,
+            pending_registration_number=MATCHING_REG,
+            pending_uscc=MISMATCH_USCC,
+        )
+    warnings = [
+        log
+        for log in cap_logs
+        if "division codes disagree" in log.get("event", "")
+    ]
+    assert warnings == []
+
+
+def test_cleaning_path_warns(vcontext) -> None:
+    """Adding both identifiers via entity.add triggers the cleaning hook."""
+    entity = vcontext.make("Company")
+    entity.id = "test-cn-clean-path"
+    entity.add("registrationNumber", MATCHING_REG)
+    with capture_logs() as cap_logs:
+        entity.add("uscCode", MISMATCH_USCC)
+    events = [log["event"] for log in cap_logs if log["log_level"] == "warning"]
+    assert "Chinese registration number and USCC division codes disagree" in events


### PR DESCRIPTION
## Summary
- Implements a warning-only cross-check for #5444: when a LegalEntity carries both a 15-digit Chinese 注册号 and an 18-char USCC, compare the embedded 6-digit administrative division codes.
- Mismatches log a warning (re-registration can legitimately diverge); values are not rejected.
- Adds unit tests for agree/disagree/missing-sibling/non-China shapes and the cleaning-path hook.

## Test plan
- [x] `pytest zavod/zavod/tests/runtime/test_china_ids.py` (10 passed)
- [ ] Reviewer: spot-check an entity that has both IDs (e.g. Yangzhou Yangjie `321000400012591` / `913210007908906337`) — should stay silent
- [ ] Optionally run a China-heavy dataset crawl and confirm mismatch warnings look actionable on the Issues page

Closes nothing automatically; please link #5444 if this fully addresses the first bullet there.
