### PR TITLE
Clean up publisher name/acronym across 13 datasets

### DIFF
--- a/datasets/az/parliament/az_parliament.yml
+++ b/datasets/az/parliament/az_parliament.yml
@@ -20,8 +20,8 @@ description: |
   by-elections; not every member's profile carries the full set of biographical fields.
 url: https://meclis.gov.az/cat-dep.php?cat=51&lang=en
 publisher:
-  name: National Assembly of the Republic of Azerbaijan
-  acronym: Milli Majlis
+  name: Azərbaycan Respublikasının Milli Məclisi
+  name_en: National Assembly of Azerbaijan
   description: >
     The Milli Majlis is the unicameral parliament of Azerbaijan, exercising legislative
     power under the Constitution. Its 125 deputies are elected for five-year terms.

--- a/datasets/bh/shura_council/bh_shura_council.yml
+++ b/datasets/bh/shura_council/bh_shura_council.yml
@@ -17,8 +17,8 @@ description: |
   legislative terms.
 url: https://shura.bh/en/open-data
 publisher:
-  name: Shura Council of Bahrain
-  acronym: Shura
+  name: مجلس الشورى
+  name_en: Consultative Council of Bahrain
   description: >
     The Shura Council is the appointed upper house of the National Assembly of
     the Kingdom of Bahrain.

--- a/datasets/fr/senat/fr_senat.yml
+++ b/datasets/fr/senat/fr_senat.yml
@@ -28,8 +28,8 @@ description: |
 tags:
   - list.pep
 publisher:
-  name: La plateforme des données ouvertes du Sénat
-  acronym: Sénat
+  name: Sénat
+  name_en: Senate of France
   description: |
     The French Senate publishes comprehensive information about
     current and past senators on an open data portal as a single

--- a/datasets/ge/ot_list/ge_ot_list.yml
+++ b/datasets/ge/ot_list/ge_ot_list.yml
@@ -24,7 +24,6 @@ data:
 publisher:
   name: საქართველოს საკანონმდებლო მაცნე
   name_en: Legislative Gazette of Georgia
-  acronym: Matsne
   country: ge
   url: https://matsne.gov.ge/en
   description: |

--- a/datasets/ki/maneaba/ki_maneaba.yml
+++ b/datasets/ki/maneaba/ki_maneaba.yml
@@ -22,7 +22,6 @@ url: https://www.parliament.gov.ki/
 publisher:
   name: Maneaba ni Maungatabu
   name_en: House of Assembly of Kiribati
-  acronym: Maneaba
   description: >
     The Maneaba ni Maungatabu is the House of Assembly of Kiribati, the country's
     unicameral national legislature.

--- a/datasets/li/landtag/li_landtag.yml
+++ b/datasets/li/landtag/li_landtag.yml
@@ -26,7 +26,6 @@ tags:
 publisher:
   name: Landtag des Fürstentums Liechtenstein
   name_en: Parliament of the Principality of Liechtenstein
-  acronym: Landtag
   description: |
     The Landtag is the legislative body of the Principality of Liechtenstein. It
     passes laws, approves the budget and oversees the government. It publishes a

--- a/datasets/lt/magnitsky_amendments/lt_magnitsky_amendments.yml
+++ b/datasets/lt/magnitsky_amendments/lt_magnitsky_amendments.yml
@@ -16,7 +16,6 @@ description: |
   Legal Status of Aliens.
 publisher:
   name: Migration Department under the Ministry of the Interior of the Republic of Lithuania
-  acronym: migracija
   description: |
     The Migration Department enforces restrictions on the entry or transit through the Republic of Lithuania
     for individuals under international sanctions. These individuals are added to the national list of foreigners

--- a/datasets/lt/seimas/lt_seimas.yml
+++ b/datasets/lt/seimas/lt_seimas.yml
@@ -23,8 +23,8 @@ description: |
   This dataset publishes the name, position, date of birth, place of birth and occupancy of
   Members of Seimas
 publisher:
-  name: Seimas of the Republic of Lithuania
-  acronym: Seimas
+  name: Lietuvos Respublikos Seimas
+  name_en: Parliament of Lithuania
   description: >
     The Seimas of the Republic of Lithuania exercises legislative power in Lithuania.
     The powers of the Seimas are defined by the Constitution and the laws of Lithuania.

--- a/datasets/lv/magnitsky_list/lv_magnitsky_list.yml
+++ b/datasets/lv/magnitsky_list/lv_magnitsky_list.yml
@@ -2,16 +2,16 @@ title: Latvia's Magnitsky Law Sanctions List
 entry_point: crawler.py
 prefix: lv-mag
 summary: >-
-  The sanctions list aims to prevent foreign individuals involved in serious human 
+  The sanctions list aims to prevent foreign individuals involved in serious human
   rights violations, corruption and other forms of crime from entering Latvia.
 coverage:
   frequency: daily
   start: 2024-07-09
 load_statements: true
 description: |
-  The dataset contains information on individuals targeted by the Republic of Latvia for serious 
-  human rights violations, corruption, and other crimes. Inspired by international precedents, including the US, 
-  Estonia, Canada, the UK, and Lithuania, Latvia aims to implement targeted sanctions such as travel bans and asset 
+  The dataset contains information on individuals targeted by the Republic of Latvia for serious
+  human rights violations, corruption, and other crimes. Inspired by international precedents, including the US,
+  Estonia, Canada, the UK, and Lithuania, Latvia aims to implement targeted sanctions such as travel bans and asset
   freezes. The goal is to prevent these individuals from entering Latvia, designating them as persona non grata.
 tags:
   - list.sanction
@@ -21,8 +21,8 @@ tags:
   - issuer.west
 url: https://likumi.lv/ta/id/297012-par-aicinajumu-noteikt-sankcijas-sergeja-magnitska-lieta-iesaistitajam-personam
 publisher:
-  name: Legal Acts Of The Republic Of Latvia
-  acronym: LIKUMI
+  name: Latvijas Vēstnesis
+  name_en: Latvian Official Gazette
   description: |
     Likumi.lv is a website of legal acts that ensures free access to systematised (consolidated) legal acts of the Republic of Latvia.
     [Source: Official Website](https://likumi.lv/about.php)

--- a/datasets/mh/nitijela/mh_nitijela.yml
+++ b/datasets/mh/nitijela/mh_nitijela.yml
@@ -17,8 +17,8 @@ description: |
   President, Speaker and ministers all sit as members alongside the backbench senators.
 url: https://www.rmiparliament.org/
 publisher:
-  name: Nitijela of the Marshall Islands
-  acronym: Nitijela
+  name: Nitijeļā
+  name_en: Legislature of the Marshall Islands
   description: >
     The Nitijela is the parliament of the Republic of the Marshall Islands, a unicameral
     legislature whose members are elected from the country's electoral districts.

--- a/datasets/ro/senate/ro_senate.yml
+++ b/datasets/ro/senate/ro_senate.yml
@@ -19,8 +19,7 @@ tags:
   - list.pep
 publisher:
   name: Senatul României
-  name_en: Romanian Senate
-  acronym: Senat
+  name_en: Senate of Romania
   description: |
     The Senate (Senatul) is the upper chamber of the bicameral Parliament of Romania,
     alongside the Chamber of Deputies. Senators are elected for four-year terms and are

--- a/datasets/to/legislative_assembly/to_legislative_assembly.yml
+++ b/datasets/to/legislative_assembly/to_legislative_assembly.yml
@@ -17,8 +17,8 @@ description: |
   power, including passing laws and approving the budget.
 url: https://www.parliament.gov.to/
 publisher:
-  name: Legislative Assembly of Tonga
-  acronym: Fale Alea
+  name: Fale Alea ʻo Tonga
+  name_en: Legislative Assembly of Tonga
   description: >
     The Fale Alea is the unicameral legislature of the Kingdom of Tonga, comprising
     directly elected People's Representatives and Nobles' Representatives elected by the

--- a/datasets/xk/assembly/xk_assembly.yml
+++ b/datasets/xk/assembly/xk_assembly.yml
@@ -20,8 +20,8 @@ description: |
   birth, gender, ethnicity, and education.
 url: https://www.kuvendikosoves.org/shq/deputetet/
 publisher:
-  name: Assembly of the Republic of Kosovo
-  acronym: Kuvendi
+  name: Kuvendi i Republikës së Kosovës
+  name_en: Assembly of Kosovo
   description: >
     The Assembly is the unicameral parliament of the Republic of Kosovo, exercising
     legislative power under the Constitution. Its 120 deputies are elected for


### PR DESCRIPTION
The `publisher.acronym` field must hold only an official initialism (see zavod/docs/metadata.md). In these datasets it held native-language names or full words instead. This PR fixes three groups. It does not change `hr/public_officials`.

**Group 1 — remove the acronym only.** The field held a redundant native word; `name`/`name_en` were already correct (except a small `name_en` wording fix on ro/senate).

| Dataset | `acronym` removed | `name` | `name_en` |
|---|---|---|---|
| ge/ot_list | Matsne | საქართველოს საკანონმდებლო მაცნე *(unchanged)* | Legislative Gazette of Georgia *(unchanged)* |
| li/landtag | Landtag | Landtag des Fürstentums Liechtenstein *(unchanged)* | Parliament of the Principality of Liechtenstein *(unchanged)* |
| ki/maneaba | Maneaba | Maneaba ni Maungatabu *(unchanged)* | House of Assembly of Kiribati *(unchanged)* |
| ro/senate | Senat | Senatul României *(unchanged)* | Romanian Senate → Senate of Romania |
| lt/magnitsky_amendments | migracija | Migration Department under the Ministry of the Interior of the Republic of Lithuania *(unchanged)* | *(none)* |

**Group 2 — native name in the wrong field.** The acronym held the native name while `name` held the English name. This PR sets `name` to the official native name (from Wikipedia), moves the English form to `name_en`, and removes the acronym. Each `name_en` names the country and uses a plain English term instead of a native word.

| Dataset | `acronym` removed | `name` | `name_en` |
|---|---|---|---|
| az/parliament | Milli Majlis | National Assembly of the Republic of Azerbaijan → Azərbaycan Respublikasının Milli Məclisi | National Assembly of Azerbaijan *(new)* |
| bh/shura_council | Shura | Shura Council of Bahrain → مجلس الشورى | Consultative Council of Bahrain *(new)* |
| lt/seimas | Seimas | Seimas of the Republic of Lithuania → Lietuvos Respublikos Seimas | Parliament of Lithuania *(new)* |
| mh/nitijela | Nitijela | Nitijela of the Marshall Islands → Nitijeļā | Legislature of the Marshall Islands *(new)* |
| to/legislative_assembly | Fale Alea | Legislative Assembly of Tonga → Fale Alea ʻo Tonga | Legislative Assembly of Tonga *(new)* |
| xk/assembly | Kuvendi | Assembly of the Republic of Kosovo → Kuvendi i Republikës së Kosovës | Assembly of Kosovo *(new)* |

**Group 3 — other fixes.**

| Dataset | `acronym` removed | `name` | `name_en` | Why |
|---|---|---|---|---|
| fr/senat | Sénat | La plateforme des données ouvertes du Sénat → Sénat | Senate of France *(new)* | Publisher was the open-data platform subdomain; make it the Senate itself. |
| lv/magnitsky_list | LIKUMI | Legal Acts Of The Republic Of Latvia → Latvijas Vēstnesis | Latvian Official Gazette *(new)* | "LIKUMI" is not an acronym and the name was a description; likumi.lv is the official Latvian gazette, operated by Latvijas Vēstnesis. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
