### PR TITLE
Document handling eu journal PRs

### DIFF
--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -117,15 +117,29 @@ config:
   # The procedure for each warning is above the key that the procedure
   # changes. A comment block here holds a maximum of 32 lines: the YAML
   # check in CI rejects more before a key.
+  #
+  # The documentation is split by role. Maintainer is usually an LLM agent.
+  # Reviewer is usually an OpenSanctions data engineer.
+  key_just_to_allow_more_documentation: "whatever"
 
   # The consolidated version that each data/consolidated/{framework}.csv
   # snapshot comes from. The Makefile gives the same version to the parser.
+  #
+  # Role: Maintainer
   #
   # These two warnings show an error in this mapping. Correct the mapping.
   # - "Snapshot has no consolidation pin": a file in data/consolidated/ has no
   #   entry here. Add the pin, or delete the file.
   # - "Pinned consolidation is not published by CELLAR": the pin has an error,
   #   or CELLAR withdrew the version. Correct the pin.
+  #
+  # Role: Reviewer
+  #
+  # These warnings are deterministic cross-references - feedback to help the
+  # maintainer keep all references synchronised during an update. If they haven't
+  # been fixed in a pull request, it might be that the agent ran out of turns.
+  # A subsequent run should act on them and resolve the warnings. It's ok to
+  # merge a PR with these warnings but ensure they're resolved by a subsequent run.
   consolidation:
     32001R2580: 02001R2580-20260227
     32002R0881: 02002R0881-20260822
@@ -172,7 +186,10 @@ config:
     32024R0386: 02024R0386-20260528
     32024R1485: 02024R1485-20260713
     32024R2642: 02024R2642-20260713
+
   # ## Warning "Newer consolidated version published"
+  #
+  # Role: Maintainer
   #
   # CELLAR has a consolidated version of a framework act that is newer than the
   # pin in `consolidation`. The snapshot in data/consolidated/ is stale.
@@ -202,6 +219,23 @@ config:
   # The crawler stops to emit an amendment when the version here agrees with
   # the `consolidation` pin of its framework. The transcription stays in git
   # as provenance.
+  #
+  # Role: Reviewer
+  #
+  # Check that the maintainer's changes completely covers any consolidated act
+  # version pins that have been updated (i.e. it followed its instructions).
+  # It's ok if it hasn't resolved all the warnings, as long as it then hasn't
+  # marked those consolidated versions as up to date with an amendment if the
+  # consolidated CSV isn't up to date with that amendment.
+  #
+  # 1. Open the relevant consolidated version using the link in the warning.
+  # 2. Find a shortcut to the newly-consolidated amendment. Click
+  #    "Access initial legal act" then under Text click "Document information".
+  #    In the table of related documents, find the amendment whose date matches
+  #    the date suffix under 'latest' in the warning.
+  # 3. Find the amendment CSV using that CELEX and confirm that the modified
+  #    consolidated CSV rows match the amendment CSV rows (i.e. the consolidated
+  #    is now up to date with that amendment).
   consolidated_amendments:
     32026R1720: 02020R1998-20260730
     32026R1817: 02006R0765-20260724
@@ -212,7 +246,10 @@ config:
     32026R1895: 02020R1998-20260730
     32026R1940: 02014R0269-20260807
     32026R1960: 02002R0881-20260822
+
   # ## Warning "Amending act has no reviewed transcription"
+  #
+  # Role: Maintainer
   #
   # An act changes an annex of a framework act, and no reviewed file holds the
   # designations of that act. The designations are in no input of the dataset.
@@ -231,6 +268,13 @@ config:
   #    `python scripts/validate.py`.
   # 7. In the PR, name each annex you transcribed and the number of rows it
   #    gave. Name each annex that has no designated party.
+  #
+  # Role: Reviewer
+  #
+  # Check that the extraction to the amendment CSV is complete and accurate.
+  # It's ok if not all warnings have been resolved, but the existence of an
+  # amendment CSV indicates that its warning can be silenced, so it should only
+  # be added and merged if it is complete.
   #
   # Acts that the discovery check found and that a reviewer closed with no
   # transcription.

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -236,6 +236,9 @@ config:
   # 3. Find the amendment CSV using that CELEX and confirm that the modified
   #    consolidated CSV rows match the amendment CSV rows (i.e. the consolidated
   #    is now up to date with that amendment).
+  #
+  # No need to review the extraction script changes - it's just there to be reusable
+  # and for provenance.
   consolidated_amendments:
     32026R1720: 02020R1998-20260730
     32026R1817: 02006R0765-20260724

--- a/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
+++ b/datasets/eu/journal_sanctions/eu_journal_sanctions.yml
@@ -100,7 +100,15 @@ names:
 config:
   # This section is the registry of the EU legal acts the dataset covers. The
   # crawler compares the registry with CELLAR and gives a warning when the
-  # registry is behind the Official Journal. Two warnings ask for work here.
+  # registry is behind the Official Journal.
+  #
+  # The documentation is split by role. Maintainer is usually an LLM agent.
+  # Reviewer is usually an OpenSanctions data engineer. Additional documentation
+  # for reviewers is in the Zavod docs.
+
+  # Role: Reviewer
+  #
+  # Two warnings ask for work here.
   # Obey the full procedure for the warning you get.
   #
   # Before you write a CSV in data/, read data/FORMAT.md. It is the contract
@@ -117,14 +125,8 @@ config:
   # The procedure for each warning is above the key that the procedure
   # changes. A comment block here holds a maximum of 32 lines: the YAML
   # check in CI rejects more before a key.
-  #
-  # The documentation is split by role. Maintainer is usually an LLM agent.
-  # Reviewer is usually an OpenSanctions data engineer.
   key_just_to_allow_more_documentation: "whatever"
 
-  # The consolidated version that each data/consolidated/{framework}.csv
-  # snapshot comes from. The Makefile gives the same version to the parser.
-  #
   # Role: Maintainer
   #
   # These two warnings show an error in this mapping. Correct the mapping.
@@ -140,6 +142,9 @@ config:
   # been fixed in a pull request, it might be that the agent ran out of turns.
   # A subsequent run should act on them and resolve the warnings. It's ok to
   # merge a PR with these warnings but ensure they're resolved by a subsequent run.
+  #
+  # The consolidated version that each data/consolidated/{framework}.csv
+  # snapshot comes from. The Makefile gives the same version to the parser.
   consolidation:
     32001R2580: 02001R2580-20260227
     32002R0881: 02002R0881-20260822

--- a/zavod/docs/eu_journal_sanctions.md
+++ b/zavod/docs/eu_journal_sanctions.md
@@ -4,67 +4,44 @@ EU sanctions take legal effect the moment they are published in the EU Official 
 
 ## Watchful monitoring and agentic extraction
 
-> Skeleton. Expand as the new workflow settles.
+Watchful has an EU Journal task monitoring CELLAR for new sanctions frameworks, amendments, and consolidation updates.
+
+It kicks off crawler jobs which result in warnings for the issues agent to work on and for us to review.
 
 ### Operations
 
 ```mermaid
 flowchart TD
-    A[Watchful checks EUR-Lex / CELLAR<br>for amendments and consolidations] --> B[Watchful posts a Slack notification]
-    A --> C[Watchful starts a crawler job]
-    C --> D[Crawler logs warnings for new work]
-    D --> E[Watchful runs the issues agent on the warnings]
-    E --> F[Issues agent opens a PR with CSV changes]
-    F --> G[Dev team reviews the PR]
-    G --> H[Merged PR releases the data changes]
+    A["1. Watchful checks EUR-Lex / CELLAR<br>for amendments and consolidations"]
+    A --> B["2. Watchful posts a Slack notification"]
+    B --> C["3. Watchful starts a crawler job"]
+    C --> D["4. Crawler logs warnings for new work"]
+    D --> E["5. Watchful runs the issues agent"]
+    E --> F["6. Issues agent checks warnings and instructions in crawler yaml"]
+    F --> G["7. Issues agent opens a PR with changes per instructions"]
+    G --> H["8. Dev team reviews the PR"]
+    H --> I["9. Merged PR reruns the crawler"]
+    I --> D
 ```
 
 The crawler itself detects new amendments and drift from the consolidated text, and reports them as warnings. Expect these on the issues dashboard for `eu_journal_sanctions`:
 
 | Warning | Meaning | Action |
 |---------|---------|--------|
-| `Amending act has no reviewed transcription` | A new amendment is on EUR-Lex but has no transcribed data yet | Wait for the issues-agent PR, then review it (see below). Chase if no PR appears within a working day. |
+| `Amending act has no reviewed transcription` | A new amendment is on EUR-Lex but has no transcribed data yet | Wait for the issues-agent PR, then review it (see below). |
 | `Newer consolidated version published` | CELLAR published a consolidation newer than the one we pin | Expect an issues-agent PR re-pinning and re-parsing. Review it. |
-| `Name not found in consolidated regulation text` | A transcribed row no longer matches the consolidated text | Entity likely delisted or mistranscribed. Check the amendment and fix or remove the row. |
-| `Row … is also present in …` / `Rows … are in other datasets` | Entities have reached `eu_fsf` or another canonical feed | Remove the rows from this dataset. |
-| Other `Could not …` warnings | Parsing or lookup failure in the crawler or a parser script | Maintainer issue. File it. |
 
 #### PR review policy
 
+Generally, familiarise yourself with the instructions to the Maintainer in the dataset yaml - usually issues-agent (an LLM), to figure out what the intended changes are for a given warning. Additional review instructions are listed for the Reviewer in the dataset yaml.
+
+Furthermore
+
 - Check that every entity in the amendment is present, and that names, IDs, dates and program match the source.
 - If identifiers such as passport numbers appear in aliases **and** in the correct columns, accept. The alias noise gets cleaned in name-cleaning data reviews.
-- If identifiers are **not** in the correct columns, reject. The extraction for that amendment must put them in the right place.
-- Merged data is picked up by the next scheduled crawler run.
+  - Look out for data reviews following a PR merge.
+- If identifiers are **not** in the correct columns, reject. Comment on the PR with @claude for it to fix.
 
-### Maintainers
-
-```mermaid
-sequenceDiagram
-    participant W as Watchful
-    participant E as EUR-Lex / CELLAR
-    participant C as eu_journal_sanctions crawler
-    participant D as Issues dashboard
-    participant A as issues-agent (GitHub Action)
-    participant R as Reviewer
-
-    W->>E: Poll sanctionsmap.eu + EUR-Lex for new amendments
-    W->>C: Trigger crawler run
-    C->>E: Query amendments and consolidated versions
-    C->>D: Log warnings (missing transcription, stale pin, …)
-    A->>D: Read warnings
-    A->>E: Fetch amendment, extract tables
-    A->>R: Open PR with data and parser changes
-    R->>A: Review, request changes or merge
-    C->>C: Next run consumes merged data
-```
-
-Components:
-
-- **Watchful** (`operations/watchful/`): detects new amendments and triggers the crawler.
-- **Crawler** (`datasets/eu/journal_sanctions/crawler.py`): queries EUR-Lex and CELLAR, compares against transcribed data, logs warnings.
-- **Parser scripts** (`datasets/eu/journal_sanctions/scripts/`): one per framework act, parse the pinned consolidated text.
-- **issues-agent** (`.github/workflows/issues-agent.yml`): reads warnings, extracts and opens PRs.
-- **Reviewer**: applies the PR review policy above.
 
 ## eu_journal EUR-LEX SOAP and manual extraction
 

--- a/zavod/docs/eu_journal_sanctions.md
+++ b/zavod/docs/eu_journal_sanctions.md
@@ -1,11 +1,79 @@
 # EU Journal Sanctions: Operational Guide
 
-EU sanctions take legal effect the moment they are published in the EU Official Journal (EUR-Lex), but the consolidated XML feed consumed by the `eu_fsf` and `eu_sanctions_maps` crawlers has historically lagged by days or even weeks. OpenSanctions bridges this gap via a manual workflow: an operator extracts entity tables from EUR-Lex amendment pages and pastes them into a Google Sheet, which the `eu_journal_sanctions` crawler reads every two hours. See the [blog post](https://www.opensanctions.org/articles/2024-11-11-eu-sanctions/) for the public-facing explanation.
+EU sanctions take legal effect the moment they are published in the EU Official Journal (EUR-Lex), but the consolidated XML feed consumed by the `eu_fsf` and `eu_sanctions_maps` crawlers has historically lagged by days or even weeks. The `eu_journal_sanctions` dataset bridges that gap. See the [blog post](https://www.opensanctions.org/articles/2024-11-11-eu-sanctions/) for the public-facing explanation.
+
+## Watchful monitoring and agentic extraction
+
+> Skeleton. Expand as the new workflow settles.
+
+### Operations
+
+```mermaid
+flowchart TD
+    A[Watchful checks EUR-Lex / CELLAR<br>for amendments and consolidations] --> B[Watchful posts a Slack notification]
+    A --> C[Watchful starts a crawler job]
+    C --> D[Crawler logs warnings for new work]
+    D --> E[Watchful runs the issues agent on the warnings]
+    E --> F[Issues agent opens a PR with CSV changes]
+    F --> G[Dev team reviews the PR]
+    G --> H[Merged PR releases the data changes]
+```
+
+The crawler itself detects new amendments and drift from the consolidated text, and reports them as warnings. Expect these on the issues dashboard for `eu_journal_sanctions`:
+
+| Warning | Meaning | Action |
+|---------|---------|--------|
+| `Amending act has no reviewed transcription` | A new amendment is on EUR-Lex but has no transcribed data yet | Wait for the issues-agent PR, then review it (see below). Chase if no PR appears within a working day. |
+| `Newer consolidated version published` | CELLAR published a consolidation newer than the one we pin | Expect an issues-agent PR re-pinning and re-parsing. Review it. |
+| `Name not found in consolidated regulation text` | A transcribed row no longer matches the consolidated text | Entity likely delisted or mistranscribed. Check the amendment and fix or remove the row. |
+| `Row … is also present in …` / `Rows … are in other datasets` | Entities have reached `eu_fsf` or another canonical feed | Remove the rows from this dataset. |
+| Other `Could not …` warnings | Parsing or lookup failure in the crawler or a parser script | Maintainer issue. File it. |
+
+#### PR review policy
+
+- Check that every entity in the amendment is present, and that names, IDs, dates and program match the source.
+- If identifiers such as passport numbers appear in aliases **and** in the correct columns, accept. The alias noise gets cleaned in name-cleaning data reviews.
+- If identifiers are **not** in the correct columns, reject. The extraction for that amendment must put them in the right place.
+- Merged data is picked up by the next scheduled crawler run.
+
+### Maintainers
+
+```mermaid
+sequenceDiagram
+    participant W as Watchful
+    participant E as EUR-Lex / CELLAR
+    participant C as eu_journal_sanctions crawler
+    participant D as Issues dashboard
+    participant A as issues-agent (GitHub Action)
+    participant R as Reviewer
+
+    W->>E: Poll sanctionsmap.eu + EUR-Lex for new amendments
+    W->>C: Trigger crawler run
+    C->>E: Query amendments and consolidated versions
+    C->>D: Log warnings (missing transcription, stale pin, …)
+    A->>D: Read warnings
+    A->>E: Fetch amendment, extract tables
+    A->>R: Open PR with data and parser changes
+    R->>A: Review, request changes or merge
+    C->>C: Next run consumes merged data
+```
+
+Components:
+
+- **Watchful** (`operations/watchful/`): detects new amendments and triggers the crawler.
+- **Crawler** (`datasets/eu/journal_sanctions/crawler.py`): queries EUR-Lex and CELLAR, compares against transcribed data, logs warnings.
+- **Parser scripts** (`datasets/eu/journal_sanctions/scripts/`): one per framework act, parse the pinned consolidated text.
+- **issues-agent** (`.github/workflows/issues-agent.yml`): reads warnings, extracts and opens PRs.
+- **Reviewer**: applies the PR review policy above.
+
+## eu_journal EUR-LEX SOAP and manual extraction
+
+The original workflow: an operator extracts entity tables from EUR-Lex amendment pages and pastes them into a Google Sheet, which the `eu_journal_sanctions` crawler reads every two hours.
 
 The Google Sheet is at:
 <https://docs.google.com/spreadsheets/d/1rauQMdCYTjTwmSzqfUvur1SfkCGYwfRn6_e5_oX39EY/edit?gid=0>
 
-## Monitoring for amendments
+### Monitoring for amendments
 
 A cron job watches for new amendments to the legislation listed at <https://www.sanctionsmap.eu/#/main> and posts a Slack message when one is found, e.g.:
 
@@ -15,11 +83,11 @@ A cron job watches for new amendments to the legislation listed at <https://www.
 
 Previously seen amendments are stored at <https://github.com/opensanctions/eu_journal>.
 
-## Claiming work
+### Claiming work
 
 Add the 👀 emoji to the Slack message to signal that you are handling it. This prevents duplicate effort when multiple operators are watching the channel.
 
-## Evaluating an amendment
+### Evaluating an amendment
 
 Most amendment packages consist of a **Council Decision** and an **Implementing Regulation** published on the same day. Process the pair only once — prefer the Regulation over the Decision.
 
@@ -34,7 +102,7 @@ For each Slack message, decide:
 
 When all items in an amendment are fully handled, copy the new rows to the Context worksheet, and add ✅ to the Slack thread.
 
-## Extracting tables from EUR-Lex HTML
+### Extracting tables from EUR-Lex HTML
 
 EUR-Lex uses Cloudfront WAF that blocks direct HTTP fetches. Save the amendment page manually:
 
@@ -52,7 +120,7 @@ The script outputs one CSV per entity table: `{doc_reference}_table_{i}.csv`. It
 
 > **Note:** The script also supports `--url` for direct fetching, but this fails when Cloudfront blocks the request.
 
-## Adding data to the Google Sheet
+### Adding data to the Google Sheet
 
 Target worksheet: **Unconsolidated** (the first tab, `gid=0`).
 
@@ -63,6 +131,6 @@ Copy the rows from the CSV into the sheet, matching the column layout. Key rules
 - **Be careful with fill-down on source URLs.** Google Sheets auto-increments the last number in a URL when you drag-fill a cell. Hold **Ctrl** (Windows/Linux) or **Option** (Mac) while filling down to copy the value literally without incrementing.
 - **Check every row.** Pasting a value into the wrong column emits incorrect entity data. Double-check the column headers before and after pasting.
 
-## Verification
+### Verification
 
 The `eu_journal_sanctions` crawler runs on a `0 */2 * * *` schedule (every two hours). After the next run, check `data/datasets/eu_journal_sanctions/issues.log` for any parsing errors or unexpected warnings related to your new rows.

--- a/zavod/mkdocs.yml
+++ b/zavod/mkdocs.yml
@@ -40,7 +40,11 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - tables
 
 nav:


### PR DESCRIPTION
Closes https://github.com/opensanctions/operations/issues/2841

Documents most of "reviewer should kinda review whether the maintainer did what it was instructed to do" in the dataset yaml where the maintainer instructions are.

Adds a high level flow chart which I think is at least a bit helpful.

Reviewing is still hard - I think https://github.com/opensanctions/opensanctions/issues/5654 could take the edge off but it's out of scope here. 

A sanity check from either of pudo or leon would be smart, just so I don't instruct anyone totally incorrectly.

<img width="2492" height="10036" alt="localhost-eu_journal_sanctions" src="https://github.com/user-attachments/assets/a0113b62-9330-41d3-9201-1aa9db1a3023" />
