### PR TITLE
[zavod] Bump rigour 2.5.0, followthemoney 4.11.0, nomenklatura 4.15.0

### DIFF
--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -18,10 +18,10 @@ classifiers = [
 ]
 requires-python = ">= 3.12"
 dependencies = [
-    "followthemoney == 4.10.2",
-    "nomenklatura == 4.13.2",
+    "followthemoney == 4.11.0",
+    "nomenklatura == 4.15.0",
     "plyvel == 1.5.1", # Also update macOS install docs
-    "rigour == 2.3.1",
+    "rigour == 2.5.0",
     "datapatch >= 1.2.4, < 1.3",
     "banal >= 1.1.2, < 2.0",
     "certifi",

--- a/zavod/pyproject.toml
+++ b/zavod/pyproject.toml
@@ -71,7 +71,6 @@ dev = [
     "types-openpyxl",
     "types-xlrd",
     "types-google-cloud-ndb",
-    "types-redis",
     "types-PyYAML",
     "prek",
     "dspy == 3.3.1",

--- a/zavod/zavod/entity.py
+++ b/zavod/zavod/entity.py
@@ -69,9 +69,6 @@ class Entity(StatementEntity):
             format=format,
             origin=origin,
         ):
-            if original_value is None and clean != value:
-                original_value = value
-
             stmt = Statement(
                 entity_id=self.id,
                 prop=prop_.name,
@@ -80,7 +77,7 @@ class Entity(StatementEntity):
                 dataset=dataset or self.dataset.name,
                 lang=lang,
                 origin=origin_,
-                original_value=original_value,
+                original_value=original_value or value,
                 first_seen=seen,
                 external=external,
             )
@@ -104,7 +101,16 @@ class Entity(StatementEntity):
         """
         prop_ = self.schema.get(prop)
         if prop_ is not None:
-            return self.add(prop, values, cleaned=cleaned, fuzzy=fuzzy, format=format)
+            return self.add(
+                prop,
+                values,
+                cleaned=cleaned,
+                fuzzy=fuzzy,
+                format=format,
+                lang=lang,
+                original_value=original_value,
+                origin=origin,
+            )
 
         schema_ = model.get(schema)
         if schema_ is None:
@@ -122,15 +128,13 @@ class Entity(StatementEntity):
                 format=format,
                 origin=origin,
             ):
-                if original_value is None and clean != text:
-                    original_value = text
                 self.add_schema(schema)
                 self.unsafe_add(
                     norm_prop_,
                     clean,
                     cleaned=True,
                     lang=lang,
-                    original_value=original_value,
+                    original_value=original_value or text,
                     origin=origin_,
                 )
 

--- a/zavod/zavod/exporters/fragment.py
+++ b/zavod/zavod/exporters/fragment.py
@@ -65,7 +65,9 @@ class ViewFragment(View[Dataset, Entity]):
                 )
 
     def entities(
-        self, include_schemata: list[Schema] | None = None
+        self,
+        include_schemata: list[Schema] | None = None,
+        prefetch_nested: bool = False,
     ) -> Generator[Entity, None, None]:
         # Don't cache entities here
         raise NotImplementedError("This method should not be called on a ViewFragment!")


### PR DESCRIPTION
Bumps zavod's pinned dependencies:

| package | from | to |
|---|---|---|
| rigour | 2.3.1 | 2.5.0 |
| followthemoney | 4.10.2 | 4.11.0 |
| nomenklatura | 4.13.2 | 4.15.0 |

Code changes:

- `ViewFragment.entities` in `zavod/exporters/fragment.py` gains the `prefetch_nested` parameter that nomenklatura 4.14 added to the base `View.entities` (mypy `--strict` override check).
- `original_value` handling in `zavod/entity.py` is simplified: followthemoney 4.11 nulls `Statement.original_value` in the constructor when it equals the cleaned value, so `unsafe_add` and `add_cast` just pass the raw input through. `add_cast` no longer leaks one value's raw text into the `original_value` of later values in the same call.
- `add_cast` forwards `lang`, `original_value` and `origin` on the early return for a schema that already has the property, so both paths keep provenance. Closes #5614.

- `types-redis` is dropped from the dev dependencies: nomenklatura removed its Redis backends and zavod never imported redis itself.

Tests (344 passed) and mypy are clean against the new versions.

## What changed upstream

**rigour 2.4 / 2.5**
- New `compare_address`, `compare_address_many`, `match_addresses`, `address_fingerprint`, `Normalize.ADDRESS`, `Territory.places`.
- `remove_address_keywords` / `shorten_address_keywords` deprecated (zavod does not use them; `h.addresses` only uses `format_address_line`).
- `LangStr` equality now hinges on the language tag (zavod does not use `LangStr` directly).
- Address fingerprints, `compare_address` scores and territory lookup keys change; accent folding in `lookup_territory`; ~750 city/place names now resolve as territories.

**followthemoney 4.11**
- New `Control` schema (`controller` → `controlled`, both `LegalEntity`) for non-ownership control.
- New `Territory` schema; `Risk` gains `authority`, `program`, `programId`, `programUrl`.
- New topics `geo.risk` and `corp.clone` (both in `TopicType.RISKS`).
- `AddressType.compare` / `node_id` now use rigour's address scorer and fingerprint: **all `addr:` node IDs change**.
- `Statement.original_value` normalised to `None` in the constructor when equal to `value` or empty.

**nomenklatura 4.14 / 4.15**
- New `DuckDBBatchStore` and `nomenklatura.duck`; `View.entities(prefetch_nested=...)`.
- Redis store backends removed (`RedisStore`, `nomenklatura.kv`, `NOMENKLATURA_REDIS_URL`, `redis` extra).
- `SQLView` now honours `external=False` (previously leaked external statements); xref skips external-only pairs.
- Address matching in `LogicV1`/`LogicV2`/`compare` uses `match_addresses`; blocking index tokenises on `address_fingerprint`; `er-unstable` retrained without `address_match`.
- `Linker.apply()` and `SQLStore` entity-assembly fixes.

## Follow-ups (separate PRs)

- [ ] **Dedupe / xref thresholds**: address feature score distribution changed in `LogicV2` and `er-unstable`; re-check `auto_threshold` / `min_threshold` defaults in `zavod/integration/dedupe.py`, `zavod/cli/dedupe.py` and enricher configs.
- [ ] **Exporters**: try `view.entities(prefetch_nested=True)` in `zavod/exporters/__init__.py`, `zavod/integration/edges.py`, `zavod/runner/enrich.py` once a DuckDB-backed view is in use; no-op on `LevelDBStore`.
- [ ] **Graph / edge exports**: anything downstream keyed on `addr:` node IDs (e.g. `zavod/integration/edges.py`, delivery consumers) sees new IDs after this release.
- [ ] **`Control` schema**: migrate crawlers that cast controlled organisations to `Company` so they fit `Ownership.asset` (UK PSC, sanctions "owned or controlled by", UBO registers); add an `h.make_control`-style helper if a pattern emerges.
- [ ] **`Territory` + `Risk` designation fields**: model FATF grey/black lists, EU high-risk third countries, FinCEN 311 / GTOs as `Territory` + `Risk` (`geo.risk`), and adopt `corp.clone` for impersonator entities (e.g. `sg_mas_investor_alert`).
- [ ] **Docs**: no standalone update; `Territory` + `Risk` designation guidance goes into `zavod/docs/programs.md` alongside the first crawler that emits them, and `Control` into the crawler guide once a helper pattern exists.
- [ ] **SQL store `external`**: confirm nothing in zavod relied on external statements leaking through `SQLView` with `external=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
